### PR TITLE
Remove not needed files in Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,13 @@
+# Ingore all files which are not needed for building or running.
+
 .DS_Store
 integrations-registry
 
 .idea
+.git
+.ci
+
 build
-public/*
+public
+testdata
+docs

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,5 +16,9 @@ RUN go mod vendor
 RUN go get -u github.com/magefile/mage
 RUN mage build
 
+# This directory contains the packages at the moment but is only used during the build process
+# If we keep it, it means all packages exist twice.
+RUN rm -rf dev
+
 # Make sure it's accessible from outside the container
 ENTRYPOINT ["go", "run", ".", "--address=0.0.0.0:8080"]


### PR DESCRIPTION
Currently in the docker images all packages existed twice, in the `dev` directory which is need to build the packages and then under `public`. At the moment this does not amake a big difference but in the future with many packages, this would duplicate the size of the container. Because of this as a last step, the dev directory is removed.

I also took this opportunity to remove a few more files from the Docker image which are only used for testing or CI. Like this we ship an image with only the relevant files. In the future we might remove even more files like the Golang code and only ship the binary. But I keep this for a later point.