### PR TITLE
[WIP] Add a script to automatically import integrations from the Beats repo

### DIFF
--- a/dev/import_beats/main.go
+++ b/dev/import_beats/main.go
@@ -1,0 +1,217 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+
+	yaml "gopkg.in/yaml.v2"
+
+	"github.com/elastic/integrations-registry/util"
+)
+
+// BEAT_CATEGORIES maps beats to integration categories
+var BEAT_CATEGORIES = map[string]string{
+	"metricbeat":        "metrics",
+	"x-pack/metricbeat": "metrics",
+	"filebeat":          "logs",
+	"x-pack/filebeat":   "logs",
+}
+
+var IGNORE = map[string]interface{}{
+	"apache2": nil, // was renamed to apache
+}
+
+func main() {
+	// Beats repo directory
+	var beatsDir string
+	// Target public directory where the generated packages should end up in
+	var publicDir string
+
+	flag.StringVar(&beatsDir, "beatsDir", "", "Path to the beats repository")
+	flag.StringVar(&publicDir, "publicDir", "", "Path to the public directory ")
+	flag.Parse()
+
+	if beatsDir == "" || publicDir == "" {
+		log.Fatal("beatsDir and publicDir must be set")
+	}
+
+	integrations := NewIntegrations()
+	for beat, category := range BEAT_CATEGORIES {
+		dirs, err := ioutil.ReadDir(filepath.Join(beatsDir, beat, "module"))
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		for _, module := range dirs {
+			if !module.IsDir() {
+				continue
+			}
+
+			if _, ok := IGNORE[module.Name()]; ok {
+				continue
+			}
+
+			integrations.AddBeatModule(category, filepath.Join(beatsDir, beat, "module", module.Name()))
+		}
+	}
+
+	integrations.Write(publicDir)
+}
+
+type Integration struct {
+	util.Package
+	Path string
+}
+
+type Integrations struct {
+	list map[string]*Integration
+}
+
+// NewIntegrations returns an new empty list of integrations
+func NewIntegrations() *Integrations {
+	return &Integrations{
+		list: make(map[string]*Integration, 0),
+	}
+}
+
+// AddBeatModule reads info from the module folder into the integrations structure
+func (i *Integrations) AddBeatModule(category, path string) {
+	meta := readMeta(path)
+	if meta == nil {
+		return
+	}
+
+	integration, ok := i.list[meta.Key]
+	if !ok {
+		integration = &Integration{
+			Package: util.Package{
+				Name: meta.Key,
+				// TODO use stack version?
+				Version: "1.0.0",
+				Title:   &meta.Title,
+				Requirement: util.Requirement{
+					Kibana: util.Kibana{
+						Min: "6.7.0",
+						// TODO do we really require a max version?
+						Max: "7.6.0",
+					},
+				},
+			},
+			Path: path,
+		}
+		i.list[meta.Key] = integration
+	}
+
+	integration.Categories = append(integration.Categories, category)
+
+	// TODO come up with a general description
+	integration.Description = meta.Description
+}
+
+// Write integration files & manifests to the given destination folder
+func (i *Integrations) Write(destination string) {
+	log.Println("Writing integration manifests and files to " + destination)
+
+	for _, integration := range i.list {
+		path := filepath.Join(destination, integration.Name+"-"+integration.Version)
+		err := os.MkdirAll(path, 0755)
+		if err != nil {
+			log.Fatal("Could not create integration folder: ", err)
+		}
+
+		// Write manifest.yml
+		data, err := yaml.Marshal(integration.Package)
+		if err != nil {
+			log.Fatal("Could not marshal integration manifest.yaml: ", err)
+		}
+
+		err = ioutil.WriteFile(filepath.Join(path, "manifest.yml"), data, 0644)
+		if err != nil {
+			log.Fatal("Could not write integration manifest.yaml: ", err)
+		}
+
+		// Copy assets
+
+		// dashboards
+		srcDashboardPath := filepath.Join(integration.Path, "_meta/kibana/7/dashboard")
+		fmt.Println(srcDashboardPath)
+		srcDashboards, err := ioutil.ReadDir(srcDashboardPath)
+		if err != nil && !os.IsNotExist(err) {
+			log.Fatal(err)
+		}
+
+		if len(srcDashboards) > 0 {
+			dstDashboardPath := filepath.Join(path, "kibana", "dashboard")
+			err = os.MkdirAll(dstDashboardPath, 0755)
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			for _, dashboard := range srcDashboards {
+
+				fmt.Println(
+					filepath.Join(srcDashboardPath, dashboard.Name()),
+					filepath.Join(dstDashboardPath, dashboard.Name()))
+				copy(
+					filepath.Join(srcDashboardPath, dashboard.Name()),
+					filepath.Join(dstDashboardPath, dashboard.Name()),
+				)
+			}
+		}
+	}
+}
+
+func readMeta(path string) *fieldsYML {
+	file := filepath.Join(path, "_meta", "fields.yml")
+	data, err := ioutil.ReadFile(file)
+	if err != nil {
+		log.Println("Error reading "+file+", ignoring it: ", err)
+		return nil
+	}
+
+	res := []fieldsYML{}
+	err = yaml.Unmarshal(data, &res)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if len(res) < 1 {
+		log.Fatal("Wrong fields.yml:", file)
+	}
+
+	return &res[0]
+}
+
+type fieldsYML struct {
+	Key, Title, Description, Release string
+}
+
+func copy(src, dst string) (int64, error) {
+	sourceFileStat, err := os.Stat(src)
+	if err != nil {
+		return 0, err
+	}
+
+	if !sourceFileStat.Mode().IsRegular() {
+		return 0, fmt.Errorf("%s is not a regular file", src)
+	}
+
+	source, err := os.Open(src)
+	if err != nil {
+		return 0, err
+	}
+	defer source.Close()
+
+	destination, err := os.Create(dst)
+	if err != nil {
+		return 0, err
+	}
+	defer destination.Close()
+	nBytes, err := io.Copy(destination, source)
+	return nBytes, err
+}

--- a/dev/import_beats/main.go
+++ b/dev/import_beats/main.go
@@ -96,9 +96,11 @@ func (i *Integrations) AddBeatModule(category, path string) {
 				Title:   &meta.Title,
 				Requirement: util.Requirement{
 					Kibana: util.Kibana{
-						Min: "6.7.0",
-						// TODO do we really require a max version?
-						Max: "7.6.0",
+						Version: util.Version{
+							Min: "6.7.0",
+							// TODO do we really require a max version?
+							Max: "7.6.0",
+						},
 					},
 				},
 			},

--- a/dev/package-beats/aerospike-1.0.0/kibana/dashboard/Metricbeat-aerospike-overview.json
+++ b/dev/package-beats/aerospike-1.0.0/kibana/dashboard/Metricbeat-aerospike-overview.json
@@ -1,0 +1,1316 @@
+{
+  "objects": [
+    {
+      "attributes": {
+        "description": "This Aerospike dashboard visualizes the most important metrics for Aerospike namespaces.",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [
+              {
+                "$state": {
+                  "store": "appState"
+                },
+                "meta": {
+                  "alias": null,
+                  "controlledBy": "1565367993423",
+                  "disabled": false,
+                  "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                  "key": "aerospike.namespace.name",
+                  "negate": false,
+                  "params": {
+                    "query": "metricbeat"
+                  },
+                  "type": "phrase",
+                  "value": "metricbeat"
+                },
+                "query": {
+                  "match": {
+                    "aerospike.namespace.name": {
+                      "query": "metricbeat",
+                      "type": "phrase"
+                    }
+                  }
+                }
+              }
+            ],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "optionsJSON": {
+          "hidePanelTitles": false,
+          "useMargins": true
+        },
+        "panelsJSON": [
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 6,
+              "i": "1",
+              "w": 9,
+              "x": 0,
+              "y": 0
+            },
+            "panelIndex": "1",
+            "panelRefName": "panel_0",
+            "title": "Namespace Filter",
+            "version": "7.3.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 6,
+              "i": "2",
+              "w": 9,
+              "x": 0,
+              "y": 6
+            },
+            "panelIndex": "2",
+            "panelRefName": "panel_1",
+            "title": "Node Filter",
+            "version": "7.3.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 13,
+              "i": "3",
+              "w": 25,
+              "x": 23,
+              "y": 12
+            },
+            "panelIndex": "3",
+            "panelRefName": "panel_2",
+            "title": "Client Error Rates",
+            "version": "7.3.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 12,
+              "i": "4",
+              "w": 25,
+              "x": 23,
+              "y": 0
+            },
+            "panelIndex": "4",
+            "panelRefName": "panel_3",
+            "title": "Client Success Rates",
+            "version": "7.3.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 13,
+              "i": "5",
+              "w": 25,
+              "x": 23,
+              "y": 25
+            },
+            "panelIndex": "5",
+            "panelRefName": "panel_4",
+            "title": "Client Timeout Rates",
+            "version": "7.3.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 13,
+              "i": "6",
+              "w": 23,
+              "x": 0,
+              "y": 25
+            },
+            "panelIndex": "6",
+            "panelRefName": "panel_5",
+            "title": "Disk Space",
+            "version": "7.3.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 12,
+              "i": "7",
+              "w": 14,
+              "x": 9,
+              "y": 0
+            },
+            "panelIndex": "7",
+            "panelRefName": "panel_6",
+            "title": "Number of Objects",
+            "version": "7.3.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 13,
+              "i": "8",
+              "w": 12,
+              "x": 0,
+              "y": 12
+            },
+            "panelIndex": "8",
+            "panelRefName": "panel_7",
+            "title": "Writes per second",
+            "version": "7.3.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 13,
+              "i": "9",
+              "w": 11,
+              "x": 12,
+              "y": 12
+            },
+            "panelIndex": "9",
+            "panelRefName": "panel_8",
+            "title": "Reads per second",
+            "version": "7.3.0"
+          }
+        ],
+        "timeRestore": false,
+        "title": "[Metricbeat Aerospike] Database Overview ",
+        "version": 1
+      },
+      "id": "b15668d0-bac3-11e9-a579-f5c0a5d81340",
+      "migrationVersion": {
+        "dashboard": "7.3.0"
+      },
+      "references": [
+        {
+          "id": "metricbeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+          "type": "index-pattern"
+        },
+        {
+          "id": "72523510-bac3-11e9-a579-f5c0a5d81340",
+          "name": "panel_0",
+          "type": "visualization"
+        },
+        {
+          "id": "8c173130-bac3-11e9-a579-f5c0a5d81340",
+          "name": "panel_1",
+          "type": "visualization"
+        },
+        {
+          "id": "b5121f00-bac8-11e9-a579-f5c0a5d81340",
+          "name": "panel_2",
+          "type": "visualization"
+        },
+        {
+          "id": "5b9bf0d0-bac9-11e9-a579-f5c0a5d81340",
+          "name": "panel_3",
+          "type": "visualization"
+        },
+        {
+          "id": "23758d10-bac9-11e9-a579-f5c0a5d81340",
+          "name": "panel_4",
+          "type": "visualization"
+        },
+        {
+          "id": "bd767280-bac9-11e9-a579-f5c0a5d81340",
+          "name": "panel_5",
+          "type": "visualization"
+        },
+        {
+          "id": "9ce7ae20-baca-11e9-a579-f5c0a5d81340",
+          "name": "panel_6",
+          "type": "visualization"
+        },
+        {
+          "id": "3586e810-bac8-11e9-a579-f5c0a5d81340",
+          "name": "panel_7",
+          "type": "visualization"
+        },
+        {
+          "id": "eae846a0-bac7-11e9-a579-f5c0a5d81340",
+          "name": "panel_8",
+          "type": "visualization"
+        }
+      ],
+      "type": "dashboard",
+      "updated_at": "2019-08-19T14:43:04.899Z",
+      "version": "WzE1NTUsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Namespace Filter [Metricbeat Aerospike] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "controls": [
+              {
+                "fieldName": "aerospike.namespace.name",
+                "id": "1565367993423",
+                "indexPatternRefName": "control_0_index_pattern",
+                "label": "namespace",
+                "options": {
+                  "dynamicOptions": true,
+                  "multiselect": false,
+                  "order": "desc",
+                  "size": 5,
+                  "type": "terms"
+                },
+                "parent": "",
+                "type": "list"
+              }
+            ],
+            "pinFilters": false,
+            "updateFiltersOnChange": true,
+            "useTimeFilter": true
+          },
+          "title": "Namespace Filter [Metricbeat Aerospike] ECS",
+          "type": "input_control_vis"
+        }
+      },
+      "id": "72523510-bac3-11e9-a579-f5c0a5d81340",
+      "migrationVersion": {
+        "visualization": "7.3.0"
+      },
+      "references": [
+        {
+          "id": "metricbeat-*",
+          "name": "control_0_index_pattern",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-08-09T16:36:43.172Z",
+      "version": "WzEzNzIsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Node Filter [Metricbeat Aerospike] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "controls": [
+              {
+                "fieldName": "aerospike.namespace.node.host",
+                "id": "1565367993423",
+                "indexPatternRefName": "control_0_index_pattern",
+                "label": "node",
+                "options": {
+                  "dynamicOptions": true,
+                  "multiselect": false,
+                  "order": "desc",
+                  "size": 5,
+                  "type": "terms"
+                },
+                "parent": "",
+                "type": "list"
+              }
+            ],
+            "pinFilters": false,
+            "updateFiltersOnChange": true,
+            "useTimeFilter": true
+          },
+          "title": "Node Filter [Metricbeat Aerospike] ECS",
+          "type": "input_control_vis"
+        }
+      },
+      "id": "8c173130-bac3-11e9-a579-f5c0a5d81340",
+      "migrationVersion": {
+        "visualization": "7.3.0"
+      },
+      "references": [
+        {
+          "id": "metricbeat-*",
+          "name": "control_0_index_pattern",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-08-09T16:37:05.074Z",
+      "version": "WzEzNzUsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Client Error Rates [Metricbeat Aerospike] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "kuery",
+              "query": ""
+            },
+            "id": "8674fc30-bac8-11e9-986e-1d8d9532a1f1",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#3185FC",
+                "fill": "0.2",
+                "formatter": "number",
+                "id": "8674fc31-bac8-11e9-986e-1d8d9532a1f1",
+                "label": "read",
+                "line_width": "1",
+                "metrics": [
+                  {
+                    "field": "aerospike.namespace.client.read.error",
+                    "id": "8674fc32-bac8-11e9-986e-1d8d9532a1f1",
+                    "type": "max"
+                  },
+                  {
+                    "field": "8674fc32-bac8-11e9-986e-1d8d9532a1f1",
+                    "id": "8674fc34-bac8-11e9-986e-1d8d9532a1f1",
+                    "type": "derivative",
+                    "unit": "1s"
+                  },
+                  {
+                    "field": "8674fc34-bac8-11e9-986e-1d8d9532a1f1",
+                    "id": "8674fc33-bac8-11e9-986e-1d8d9532a1f1",
+                    "type": "positive_only"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#DB1374",
+                "fill": "0.2",
+                "formatter": "number",
+                "id": "86752340-bac8-11e9-986e-1d8d9532a1f1",
+                "label": "write",
+                "line_width": "1",
+                "metrics": [
+                  {
+                    "field": "aerospike.namespace.client.write.error",
+                    "id": "86752341-bac8-11e9-986e-1d8d9532a1f1",
+                    "type": "max"
+                  },
+                  {
+                    "field": "86752341-bac8-11e9-986e-1d8d9532a1f1",
+                    "id": "86752343-bac8-11e9-986e-1d8d9532a1f1",
+                    "type": "derivative",
+                    "unit": "1s"
+                  },
+                  {
+                    "field": "86752343-bac8-11e9-986e-1d8d9532a1f1",
+                    "id": "86752342-bac8-11e9-986e-1d8d9532a1f1",
+                    "type": "positive_only"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#00B3A4",
+                "fill": "0.2",
+                "formatter": "number",
+                "id": "86752344-bac8-11e9-986e-1d8d9532a1f1",
+                "label": "delete",
+                "line_width": "1",
+                "metrics": [
+                  {
+                    "field": "aerospike.namespace.client.delete.error",
+                    "id": "86752345-bac8-11e9-986e-1d8d9532a1f1",
+                    "type": "max"
+                  },
+                  {
+                    "field": "86752345-bac8-11e9-986e-1d8d9532a1f1",
+                    "id": "86752347-bac8-11e9-986e-1d8d9532a1f1",
+                    "type": "derivative",
+                    "unit": "1s"
+                  },
+                  {
+                    "field": "86752347-bac8-11e9-986e-1d8d9532a1f1",
+                    "id": "86752346-bac8-11e9-986e-1d8d9532a1f1",
+                    "type": "positive_only"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Client Error Rates [Metricbeat Aerospike] ECS",
+          "type": "metrics"
+        }
+      },
+      "id": "b5121f00-bac8-11e9-a579-f5c0a5d81340",
+      "migrationVersion": {
+        "visualization": "7.3.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-08-09T17:11:20.560Z",
+      "version": "WzEzODIsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Client Success Rates [Metricbeat Aerospike] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "kuery",
+              "query": ""
+            },
+            "id": "3b633120-bac9-11e9-9a9a-2f5e8f21d503",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#3185FC",
+                "fill": "0.2",
+                "formatter": "number",
+                "id": "3b633121-bac9-11e9-9a9a-2f5e8f21d503",
+                "label": "read",
+                "line_width": "1",
+                "metrics": [
+                  {
+                    "field": "aerospike.namespace.client.read.success",
+                    "id": "3b633122-bac9-11e9-9a9a-2f5e8f21d503",
+                    "type": "max"
+                  },
+                  {
+                    "field": "3b633122-bac9-11e9-9a9a-2f5e8f21d503",
+                    "id": "3b633124-bac9-11e9-9a9a-2f5e8f21d503",
+                    "type": "derivative",
+                    "unit": "1s"
+                  },
+                  {
+                    "field": "3b633124-bac9-11e9-9a9a-2f5e8f21d503",
+                    "id": "3b633123-bac9-11e9-9a9a-2f5e8f21d503",
+                    "type": "positive_only"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#DB1374",
+                "fill": "0.2",
+                "formatter": "number",
+                "id": "3b633125-bac9-11e9-9a9a-2f5e8f21d503",
+                "label": "write",
+                "line_width": "1",
+                "metrics": [
+                  {
+                    "field": "aerospike.namespace.client.write.success",
+                    "id": "3b633126-bac9-11e9-9a9a-2f5e8f21d503",
+                    "type": "max"
+                  },
+                  {
+                    "field": "3b633126-bac9-11e9-9a9a-2f5e8f21d503",
+                    "id": "3b633128-bac9-11e9-9a9a-2f5e8f21d503",
+                    "type": "derivative",
+                    "unit": "1s"
+                  },
+                  {
+                    "field": "3b633128-bac9-11e9-9a9a-2f5e8f21d503",
+                    "id": "3b633127-bac9-11e9-9a9a-2f5e8f21d503",
+                    "type": "positive_only"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#00B3A4",
+                "fill": "0.2",
+                "formatter": "number",
+                "id": "3b633129-bac9-11e9-9a9a-2f5e8f21d503",
+                "label": "delete",
+                "line_width": "1",
+                "metrics": [
+                  {
+                    "field": "aerospike.namespace.client.delete.success",
+                    "id": "3b63312a-bac9-11e9-9a9a-2f5e8f21d503",
+                    "type": "max"
+                  },
+                  {
+                    "field": "3b63312a-bac9-11e9-9a9a-2f5e8f21d503",
+                    "id": "3b63312c-bac9-11e9-9a9a-2f5e8f21d503",
+                    "type": "derivative",
+                    "unit": "1s"
+                  },
+                  {
+                    "field": "3b63312c-bac9-11e9-9a9a-2f5e8f21d503",
+                    "id": "3b63312b-bac9-11e9-9a9a-2f5e8f21d503",
+                    "type": "positive_only"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Client Success Rates [Metricbeat Aerospike] ECS",
+          "type": "metrics"
+        }
+      },
+      "id": "5b9bf0d0-bac9-11e9-a579-f5c0a5d81340",
+      "migrationVersion": {
+        "visualization": "7.3.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-08-09T17:15:59.965Z",
+      "version": "WzEzODQsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Client Timeout Rates [Metricbeat Aerospike] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "kuery",
+              "query": ""
+            },
+            "id": "ec962840-bac8-11e9-8c31-ed10485dacc9",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#3185FC",
+                "fill": "0.2",
+                "formatter": "number",
+                "id": "ec962841-bac8-11e9-8c31-ed10485dacc9",
+                "label": "read",
+                "line_width": "1",
+                "metrics": [
+                  {
+                    "field": "aerospike.namespace.client.read.timeout",
+                    "id": "ec962842-bac8-11e9-8c31-ed10485dacc9",
+                    "type": "max"
+                  },
+                  {
+                    "field": "ec962842-bac8-11e9-8c31-ed10485dacc9",
+                    "id": "ec962844-bac8-11e9-8c31-ed10485dacc9",
+                    "type": "derivative",
+                    "unit": "1s"
+                  },
+                  {
+                    "field": "ec962844-bac8-11e9-8c31-ed10485dacc9",
+                    "id": "ec962843-bac8-11e9-8c31-ed10485dacc9",
+                    "type": "positive_only"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#DB1374",
+                "fill": "0.2",
+                "formatter": "number",
+                "id": "ec962845-bac8-11e9-8c31-ed10485dacc9",
+                "label": "write",
+                "line_width": "1",
+                "metrics": [
+                  {
+                    "field": "aerospike.namespace.client.write.timeout",
+                    "id": "ec964f50-bac8-11e9-8c31-ed10485dacc9",
+                    "type": "max"
+                  },
+                  {
+                    "field": "ec964f50-bac8-11e9-8c31-ed10485dacc9",
+                    "id": "ec964f52-bac8-11e9-8c31-ed10485dacc9",
+                    "type": "derivative",
+                    "unit": "1s"
+                  },
+                  {
+                    "field": "ec964f52-bac8-11e9-8c31-ed10485dacc9",
+                    "id": "ec964f51-bac8-11e9-8c31-ed10485dacc9",
+                    "type": "positive_only"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#00B3A4",
+                "fill": "0.2",
+                "formatter": "number",
+                "id": "ec964f53-bac8-11e9-8c31-ed10485dacc9",
+                "label": "delete",
+                "line_width": "1",
+                "metrics": [
+                  {
+                    "field": "aerospike.namespace.client.delete.timeout",
+                    "id": "ec964f54-bac8-11e9-8c31-ed10485dacc9",
+                    "type": "max"
+                  },
+                  {
+                    "field": "ec964f54-bac8-11e9-8c31-ed10485dacc9",
+                    "id": "ec964f56-bac8-11e9-8c31-ed10485dacc9",
+                    "type": "derivative",
+                    "unit": "1s"
+                  },
+                  {
+                    "field": "ec964f56-bac8-11e9-8c31-ed10485dacc9",
+                    "id": "ec964f55-bac8-11e9-8c31-ed10485dacc9",
+                    "type": "positive_only"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Client Timeout Rates [Metricbeat Aerospike] ECS",
+          "type": "metrics"
+        }
+      },
+      "id": "23758d10-bac9-11e9-a579-f5c0a5d81340",
+      "migrationVersion": {
+        "visualization": "7.3.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-08-09T17:14:25.761Z",
+      "version": "WzEzODMsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Disk Space [Metricbeat Aerospike] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "kuery",
+              "query": ""
+            },
+            "id": "8f321e10-bac9-11e9-a715-c7f36757ae84",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(211,49,21,1)",
+                "fill": 0,
+                "formatter": "bytes",
+                "id": "8f321e11-bac9-11e9-a715-c7f36757ae84",
+                "label": "Total",
+                "line_width": 2,
+                "metrics": [
+                  {
+                    "field": "aerospike.namespace.device.total.bytes",
+                    "id": "8f321e12-bac9-11e9-a715-c7f36757ae84",
+                    "type": "max"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(22,165,165,1)",
+                "fill": "0.2",
+                "formatter": "bytes",
+                "id": "8f321e13-bac9-11e9-a715-c7f36757ae84",
+                "label": "Used",
+                "line_width": "1",
+                "metrics": [
+                  {
+                    "field": "aerospike.namespace.device.used.bytes",
+                    "id": "8f321e14-bac9-11e9-a715-c7f36757ae84",
+                    "type": "max"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Disk Space [Metricbeat Aerospike] ECS",
+          "type": "metrics"
+        }
+      },
+      "id": "bd767280-bac9-11e9-a579-f5c0a5d81340",
+      "migrationVersion": {
+        "visualization": "7.3.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-08-09T17:18:44.136Z",
+      "version": "WzEzODUsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Number of Objects [Metricbeat Aerospike] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "background_color_rules": [
+              {
+                "background_color": null,
+                "id": "689053c0-baca-11e9-a6e8-09b17988a9ca",
+                "value": 0
+              }
+            ],
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "kuery",
+              "query": ""
+            },
+            "gauge_color_rules": [
+              {
+                "id": "6a3d4070-baca-11e9-a6e8-09b17988a9ca"
+              }
+            ],
+            "gauge_inner_width": 10,
+            "gauge_style": "half",
+            "gauge_width": 10,
+            "id": "63159630-baca-11e9-b44b-b5d06880c15a",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#3185FC",
+                "fill": 0,
+                "formatter": "number",
+                "id": "63159631-baca-11e9-b44b-b5d06880c15a",
+                "label": "objects",
+                "line_width": 2,
+                "metrics": [
+                  {
+                    "field": "aerospike.namespace.objects.total",
+                    "id": "63159632-baca-11e9-b44b-b5d06880c15a",
+                    "type": "max"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "metric"
+          },
+          "title": "Number of Objects [Metricbeat Aerospike] ECS",
+          "type": "metrics"
+        }
+      },
+      "id": "9ce7ae20-baca-11e9-a579-f5c0a5d81340",
+      "migrationVersion": {
+        "visualization": "7.3.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-08-09T19:13:27.933Z",
+      "version": "WzE0MTMsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Client Write Rates [Metricbeat Aerospike] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "kuery",
+              "query": ""
+            },
+            "id": "0316eb50-bac8-11e9-a2f5-271fa90cc176",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#3185FC",
+                "fill": "0.2",
+                "formatter": "number",
+                "id": "0316eb51-bac8-11e9-a2f5-271fa90cc176",
+                "label": "success",
+                "line_width": "1",
+                "metrics": [
+                  {
+                    "field": "aerospike.namespace.client.write.success",
+                    "id": "0316eb52-bac8-11e9-a2f5-271fa90cc176",
+                    "type": "max"
+                  },
+                  {
+                    "field": "0316eb52-bac8-11e9-a2f5-271fa90cc176",
+                    "id": "0316eb54-bac8-11e9-a2f5-271fa90cc176",
+                    "type": "derivative",
+                    "unit": "1s"
+                  },
+                  {
+                    "field": "0316eb54-bac8-11e9-a2f5-271fa90cc176",
+                    "id": "0316eb53-bac8-11e9-a2f5-271fa90cc176",
+                    "type": "positive_only"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#DB1374",
+                "fill": "0.2",
+                "formatter": "number",
+                "id": "0316eb55-bac8-11e9-a2f5-271fa90cc176",
+                "label": "error",
+                "line_width": "1",
+                "metrics": [
+                  {
+                    "field": "aerospike.namespace.client.write.error",
+                    "id": "0316eb56-bac8-11e9-a2f5-271fa90cc176",
+                    "type": "max"
+                  },
+                  {
+                    "field": "0316eb56-bac8-11e9-a2f5-271fa90cc176",
+                    "id": "0316eb58-bac8-11e9-a2f5-271fa90cc176",
+                    "type": "derivative",
+                    "unit": "1s"
+                  },
+                  {
+                    "field": "0316eb58-bac8-11e9-a2f5-271fa90cc176",
+                    "id": "0316eb57-bac8-11e9-a2f5-271fa90cc176",
+                    "type": "positive_only"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#00B3A4",
+                "fill": "0.2",
+                "formatter": "number",
+                "id": "0316eb59-bac8-11e9-a2f5-271fa90cc176",
+                "label": "timeout",
+                "line_width": "1",
+                "metrics": [
+                  {
+                    "field": "aerospike.namespace.client.write.timeout",
+                    "id": "0316eb5a-bac8-11e9-a2f5-271fa90cc176",
+                    "type": "max"
+                  },
+                  {
+                    "field": "0316eb5a-bac8-11e9-a2f5-271fa90cc176",
+                    "id": "0316eb5c-bac8-11e9-a2f5-271fa90cc176",
+                    "type": "derivative",
+                    "unit": "1s"
+                  },
+                  {
+                    "field": "0316eb5c-bac8-11e9-a2f5-271fa90cc176",
+                    "id": "0316eb5b-bac8-11e9-a2f5-271fa90cc176",
+                    "type": "positive_only"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Client Write Rates [Metricbeat Aerospike] ECS",
+          "type": "metrics"
+        }
+      },
+      "id": "3586e810-bac8-11e9-a579-f5c0a5d81340",
+      "migrationVersion": {
+        "visualization": "7.3.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-08-09T17:07:46.577Z",
+      "version": "WzEzODAsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Client Read Rates [Metricbeat Aerospike] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "kuery",
+              "query": ""
+            },
+            "id": "98667320-bac7-11e9-9324-49d4f7fb9626",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#3185FC",
+                "fill": "0.2",
+                "formatter": "number",
+                "id": "98667321-bac7-11e9-9324-49d4f7fb9626",
+                "label": "success",
+                "line_width": "1",
+                "metrics": [
+                  {
+                    "field": "aerospike.namespace.client.read.success",
+                    "id": "98667322-bac7-11e9-9324-49d4f7fb9626",
+                    "type": "max"
+                  },
+                  {
+                    "field": "98667322-bac7-11e9-9324-49d4f7fb9626",
+                    "id": "98667324-bac7-11e9-9324-49d4f7fb9626",
+                    "type": "derivative",
+                    "unit": "1s"
+                  },
+                  {
+                    "field": "98667324-bac7-11e9-9324-49d4f7fb9626",
+                    "id": "98667323-bac7-11e9-9324-49d4f7fb9626",
+                    "type": "positive_only"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#DB1374",
+                "fill": "0.2",
+                "formatter": "number",
+                "id": "98667325-bac7-11e9-9324-49d4f7fb9626",
+                "label": "error",
+                "line_width": "1",
+                "metrics": [
+                  {
+                    "field": "aerospike.namespace.client.read.error",
+                    "id": "98667326-bac7-11e9-9324-49d4f7fb9626",
+                    "type": "max"
+                  },
+                  {
+                    "field": "98667326-bac7-11e9-9324-49d4f7fb9626",
+                    "id": "98667328-bac7-11e9-9324-49d4f7fb9626",
+                    "type": "derivative",
+                    "unit": "1s"
+                  },
+                  {
+                    "field": "98667328-bac7-11e9-9324-49d4f7fb9626",
+                    "id": "98667327-bac7-11e9-9324-49d4f7fb9626",
+                    "type": "positive_only"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#00B3A4",
+                "fill": "0.2",
+                "formatter": "number",
+                "id": "98667329-bac7-11e9-9324-49d4f7fb9626",
+                "label": "not_found",
+                "line_width": "1",
+                "metrics": [
+                  {
+                    "field": "aerospike.namespace.client.read.not_found",
+                    "id": "9866732a-bac7-11e9-9324-49d4f7fb9626",
+                    "type": "max"
+                  },
+                  {
+                    "field": "9866732a-bac7-11e9-9324-49d4f7fb9626",
+                    "id": "9866732c-bac7-11e9-9324-49d4f7fb9626",
+                    "type": "derivative",
+                    "unit": "1s"
+                  },
+                  {
+                    "field": "9866732c-bac7-11e9-9324-49d4f7fb9626",
+                    "id": "9866732b-bac7-11e9-9324-49d4f7fb9626",
+                    "type": "positive_only"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#490092",
+                "fill": "0.2",
+                "formatter": "number",
+                "id": "9866732d-bac7-11e9-9324-49d4f7fb9626",
+                "label": "timeout",
+                "line_width": "1",
+                "metrics": [
+                  {
+                    "field": "aerospike.namespace.client.read.timeout",
+                    "id": "9866732e-bac7-11e9-9324-49d4f7fb9626",
+                    "type": "max"
+                  },
+                  {
+                    "field": "9866732e-bac7-11e9-9324-49d4f7fb9626",
+                    "id": "98667330-bac7-11e9-9324-49d4f7fb9626",
+                    "type": "derivative",
+                    "unit": "1s"
+                  },
+                  {
+                    "field": "98667330-bac7-11e9-9324-49d4f7fb9626",
+                    "id": "9866732f-bac7-11e9-9324-49d4f7fb9626",
+                    "type": "positive_only"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Client Read Rates [Metricbeat Aerospike] ECS",
+          "type": "metrics"
+        }
+      },
+      "id": "eae846a0-bac7-11e9-a579-f5c0a5d81340",
+      "migrationVersion": {
+        "visualization": "7.3.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-08-09T17:05:41.386Z",
+      "version": "WzEzNzksMV0="
+    }
+  ],
+  "version": "7.3.0"
+}

--- a/dev/package-beats/aerospike-1.0.0/manifest.yml
+++ b/dev/package-beats/aerospike-1.0.0/manifest.yml
@@ -1,0 +1,13 @@
+name: aerospike
+title: Aerospike
+version: 1.0.0
+description: |
+  Aerospike module
+type: ""
+categories:
+- metrics
+requirement:
+  kibana:
+    version:
+      min: 6.7.0
+      max: 7.6.0

--- a/dev/package-beats/apache-1.0.0/kibana/dashboard/Filebeat-apache.json
+++ b/dev/package-beats/apache-1.0.0/kibana/dashboard/Filebeat-apache.json
@@ -1,0 +1,644 @@
+{
+    "objects": [
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "Apache-access-logs-ecs", 
+                "title": "Unique IPs map [Filebeat Apache] ECS", 
+                "uiStateJSON": {
+                    "mapCenter": [
+                        14.944784875088372, 
+                        5.09765625
+                    ]
+                }, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "field": "source.address"
+                            }, 
+                            "schema": "metric", 
+                            "type": "cardinality"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "autoPrecision": true, 
+                                "field": "source.geo.location"
+                            }, 
+                            "schema": "segment", 
+                            "type": "geohash_grid"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addTooltip": true, 
+                        "heatBlur": 15, 
+                        "heatMaxZoom": 16, 
+                        "heatMinOpacity": 0.1, 
+                        "heatNormalizeData": true, 
+                        "heatRadius": 25, 
+                        "isDesaturated": true, 
+                        "legendPosition": "bottomright", 
+                        "mapCenter": [
+                            15, 
+                            5
+                        ], 
+                        "mapType": "Scaled Circle Markers", 
+                        "mapZoom": 2, 
+                        "wms": {
+                            "enabled": false, 
+                            "options": {
+                                "attribution": "Maps provided by USGS", 
+                                "format": "image/png", 
+                                "layers": "0", 
+                                "styles": "", 
+                                "transparent": true, 
+                                "version": "1.3.0"
+                            }, 
+                            "url": "https://basemap.nationalmap.gov/arcgis/services/USGSTopo/MapServer/WMSServer"
+                        }
+                    }, 
+                    "title": "Apache access unique IPs map ECS", 
+                    "type": "tile_map"
+                }
+            }, 
+            "id": "Apache-access-unique-IPs-map-ecs", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "Apache-access-logs-ecs", 
+                "title": "Top URLs by response code [Filebeat Apache] ECS", 
+                "uiStateJSON": {
+                    "vis": {
+                        "colors": {
+                            "200": "#7EB26D", 
+                            "404": "#EF843C"
+                        }
+                    }
+                }, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "customLabel": "URL", 
+                                "field": "url.original", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "row": false, 
+                                "size": 5
+                            }, 
+                            "schema": "split", 
+                            "type": "terms"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "field": "http.response.status_code", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "segment", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTooltip": true, 
+                        "isDonut": false, 
+                        "legendPosition": "right", 
+                        "shareYAxis": true
+                    }, 
+                    "title": "Apache response codes of top URLs ECS", 
+                    "type": "pie"
+                }
+            }, 
+            "id": "Apache-response-codes-of-top-URLs-ecs", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "Apache-access-logs-ecs", 
+                "title": "Browsers breakdown [Filebeat Apache] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "field": "source.address"
+                            }, 
+                            "schema": "metric", 
+                            "type": "cardinality"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "field": "user_agent.name", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "segment", 
+                            "type": "terms"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "field": "user_agent.version", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "segment", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTooltip": true, 
+                        "isDonut": true, 
+                        "legendPosition": "bottom", 
+                        "shareYAxis": true
+                    }, 
+                    "title": "Apache browsers ECS", 
+                    "type": "pie"
+                }
+            }, 
+            "id": "Apache-browsers-ecs", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "Apache-access-logs-ecs", 
+                "title": "Operating systems breakdown [Filebeat Apache] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "field": "source.address"
+                            }, 
+                            "schema": "metric", 
+                            "type": "cardinality"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "field": "user_agent.os.name", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "segment", 
+                            "type": "terms"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "field": "user_agent.os.version", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "segment", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTooltip": true, 
+                        "isDonut": true, 
+                        "legendPosition": "bottom", 
+                        "shareYAxis": true
+                    }, 
+                    "title": "Apache operating systems ECS", 
+                    "type": "pie"
+                }
+            }, 
+            "id": "Apache-operating-systems-ecs", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "Apache-errors-log-ecs", 
+                "title": "Error logs over time [Filebeat Apache] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "field": "log.level", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "group", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "defaultYExtents": false, 
+                        "legendPosition": "right", 
+                        "mode": "stacked", 
+                        "scale": "linear", 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "times": [], 
+                        "yAxis": {}
+                    }, 
+                    "title": "Apache error logs over time ECS", 
+                    "type": "histogram"
+                }
+            }, 
+            "id": "Apache-error-logs-over-time-ecs", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "Apache-access-logs-ecs", 
+                "title": "Response codes over time [Filebeat Apache] ECS", 
+                "uiStateJSON": {
+                    "vis": {
+                        "colors": {
+                            "200": "#629E51", 
+                            "404": "#EF843C"
+                        }
+                    }
+                }, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "field": "http.response.status_code", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "group", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "defaultYExtents": false, 
+                        "legendPosition": "right", 
+                        "mode": "stacked", 
+                        "scale": "linear", 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "times": [], 
+                        "yAxis": {}
+                    }, 
+                    "title": "Apache response codes over time ECS", 
+                    "type": "histogram"
+                }
+            }, 
+            "id": "Apache-response-codes-over-time-ecs", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "columns": [
+                    "source.address", 
+                    "log.level", 
+                    "apache2.error.module", 
+                    "message"
+                ], 
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlight": {
+                            "fields": {
+                                "*": {}
+                            }, 
+                            "fragment_size": 2147483647, 
+                            "post_tags": [
+                                "@/kibana-highlighted-field@"
+                            ], 
+                            "pre_tags": [
+                                "@kibana-highlighted-field@"
+                            ], 
+                            "require_field_match": false
+                        }, 
+                        "index": "filebeat-*", 
+                        "query": {
+                            "language": "kuery",
+                                "query": "event.dataset:apache.error"
+                            }
+                    }
+                }, 
+                "sort": [
+                    "@timestamp", 
+                    "desc"
+                ], 
+                "title": "Apache errors log [Filebeat Apache] ECS", 
+                "version": 1
+            }, 
+            "id": "Apache-errors-log-ecs", 
+            "type": "search", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "columns": [
+                    "source.address", 
+                    "http.request.method", 
+                    "url.original", 
+                    "http.response.status_code"
+                ], 
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlight": {
+                            "fields": {
+                                "*": {}
+                            }, 
+                            "fragment_size": 2147483647, 
+                            "post_tags": [
+                                "@/kibana-highlighted-field@"
+                            ], 
+                            "pre_tags": [
+                                "@kibana-highlighted-field@"
+                            ], 
+                            "require_field_match": false
+                        }, 
+                        "index": "filebeat-*", 
+                        "query": {
+                            "language": "kuery",
+                                "query": "event.dataset:apache.access"
+                            }
+                    }
+                }, 
+                "sort": [
+                    "@timestamp", 
+                    "desc"
+                ], 
+                "title": "Apache access logs [Filebeat Apache] ECS", 
+                "version": 1
+            }, 
+            "id": "Apache-access-logs-ecs", 
+            "type": "search", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "Filebeat Apache module dashboard", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlightAll": true, 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "optionsJSON": {
+                    "darkTheme": false
+                }, 
+                "panelsJSON": [
+                    {
+                        "col": 1, 
+                        "id": "Apache-access-unique-IPs-map-ecs", 
+                        "panelIndex": 1, 
+                        "row": 1, 
+                        "size_x": 12, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "Apache-response-codes-of-top-URLs-ecs", 
+                        "panelIndex": 2, 
+                        "row": 6, 
+                        "size_x": 8, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 9, 
+                        "id": "Apache-browsers-ecs", 
+                        "panelIndex": 3, 
+                        "row": 6, 
+                        "size_x": 4, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 11, 
+                        "id": "Apache-operating-systems-ecs", 
+                        "panelIndex": 4, 
+                        "row": 4, 
+                        "size_x": 2, 
+                        "size_y": 2, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "Apache-error-logs-over-time-ecs", 
+                        "panelIndex": 5, 
+                        "row": 9, 
+                        "size_x": 12, 
+                        "size_y": 2, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "Apache-response-codes-over-time-ecs", 
+                        "panelIndex": 6, 
+                        "row": 4, 
+                        "size_x": 10, 
+                        "size_y": 2, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "columns": [
+                            "source.address", 
+                            "log.level", 
+                            "apache2.error.module", 
+                            "message"
+                        ], 
+                        "id": "Apache-errors-log-ecs", 
+                        "panelIndex": 7, 
+                        "row": 11, 
+                        "size_x": 12, 
+                        "size_y": 3, 
+                        "sort": [
+                            "@timestamp", 
+                            "desc"
+                        ], 
+                        "type": "search"
+                    }
+                ], 
+                "timeRestore": false, 
+                "title": "[Filebeat Apache] Access and error logs ECS", 
+                "uiStateJSON": {
+                    "P-1": {
+                        "mapBounds": {
+                            "bottom_right": {
+                                "lat": -3.864254615721396, 
+                                "lon": 205.3125
+                            }, 
+                            "top_left": {
+                                "lat": 67.7427590666639, 
+                                "lon": -205.6640625
+                            }
+                        }, 
+                        "mapCenter": [
+                            40.713955826286046, 
+                            -0.17578125
+                        ], 
+                        "mapCollar": {
+                            "bottom_right": {
+                                "lat": -39.667755, 
+                                "lon": 180
+                            }, 
+                            "top_left": {
+                                "lat": 90, 
+                                "lon": -180
+                            }, 
+                            "zoom": 2
+                        }, 
+                        "mapZoom": 2
+                    }
+                }, 
+                "version": 1
+            }, 
+            "id": "Filebeat-Apache-Dashboard-ecs", 
+            "type": "dashboard", 
+            "version": 2
+        }
+    ], 
+    "version": "6.0.0-beta1-SNAPSHOT"
+}

--- a/dev/package-beats/apache-1.0.0/kibana/dashboard/Metricbeat-apache-overview.json
+++ b/dev/package-beats/apache-1.0.0/kibana/dashboard/Metricbeat-apache-overview.json
@@ -1,0 +1,774 @@
+{
+    "objects": [
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "Apache-HTTPD-ecs", 
+                "title": "CPU usage [Metricbeat Apache] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "CPU load", 
+                                "field": "apache.status.cpu.load"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "id": "3", 
+                            "params": {
+                                "field": "apache.status.hostname", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "row": true, 
+                                "size": 5
+                            }, 
+                            "schema": "split", 
+                            "type": "terms"
+                        }, 
+                        {
+                            "id": "4", 
+                            "params": {
+                                "customLabel": "CPU user", 
+                                "field": "apache.status.cpu.user"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "id": "5", 
+                            "params": {
+                                "customLabel": "CPU system", 
+                                "field": "apache.status.cpu.system"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "id": "6", 
+                            "params": {
+                                "customLabel": "CPU children user", 
+                                "field": "apache.status.cpu.children_user"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "id": "7", 
+                            "params": {
+                                "customLabel": "CPU children system", 
+                                "field": "apache.status.cpu.children_system"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "defaultYExtents": false, 
+                        "drawLinesBetweenPoints": true, 
+                        "interpolate": "linear", 
+                        "radiusRatio": 9, 
+                        "scale": "linear", 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "showCircles": true, 
+                        "smoothLines": false, 
+                        "times": [], 
+                        "yAxis": {}
+                    }, 
+                    "title": "Apache HTTPD - CPU ECS", 
+                    "type": "line"
+                }
+            }, 
+            "id": "Apache-HTTPD-CPU-ecs", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "Apache-HTTPD-ecs", 
+                "title": "Hostname list [Metricbeat Apache] ECS", 
+                "uiStateJSON": {
+                    "vis": {
+                        "params": {
+                            "sort": {
+                                "columnIndex": null, 
+                                "direction": null
+                            }
+                        }
+                    }
+                }, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "Events count"
+                            }, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "id": "2", 
+                            "params": {
+                                "customLabel": "Apache HTTD Hostname", 
+                                "field": "apache.status.hostname", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "bucket", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "perPage": 10, 
+                        "showMeticsAtAllLevels": false, 
+                        "showPartialRows": false, 
+                        "sort": {
+                            "columnIndex": null, 
+                            "direction": null
+                        }
+                    }, 
+                    "title": "Apache HTTPD - Hostname list ECS", 
+                    "type": "table"
+                }
+            }, 
+            "id": "Apache-HTTPD-Hostname-list-ecs", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "Apache-HTTPD-ecs", 
+                "title": "Load1/5/15 [Metricbeat Apache] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "Load 5", 
+                                "field": "apache.status.load.5"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "id": "3", 
+                            "params": {
+                                "customLabel": "Load 1", 
+                                "field": "apache.status.load.1"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "id": "4", 
+                            "params": {
+                                "customLabel": "Load 15", 
+                                "field": "apache.status.load.15"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "id": "5", 
+                            "params": {
+                                "customLabel": "Hostname", 
+                                "field": "apache.status.hostname", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "row": true, 
+                                "size": 5
+                            }, 
+                            "schema": "split", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "defaultYExtents": false, 
+                        "drawLinesBetweenPoints": true, 
+                        "interpolate": "linear", 
+                        "radiusRatio": 9, 
+                        "scale": "linear", 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "showCircles": true, 
+                        "smoothLines": false, 
+                        "times": [], 
+                        "yAxis": {}
+                    }, 
+                    "title": "Apache HTTPD - Load1/5/15 ECS", 
+                    "type": "line"
+                }
+            }, 
+            "id": "Apache-HTTPD-Load1-slash-5-slash-15-ecs", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "Apache-HTTPD-ecs", 
+                "title": "Scoreboard [Metricbeat Apache] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "Closing connection", 
+                                "field": "apache.status.scoreboard.closing_connection"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "id": "3", 
+                            "params": {
+                                "customLabel": "Hostname", 
+                                "field": "apache.status.hostname", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "row": true, 
+                                "size": 5
+                            }, 
+                            "schema": "split", 
+                            "type": "terms"
+                        }, 
+                        {
+                            "id": "4", 
+                            "params": {
+                                "customLabel": "DNS lookup", 
+                                "field": "apache.status.scoreboard.dns_lookup"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "id": "5", 
+                            "params": {
+                                "customLabel": "Gracefully finishing", 
+                                "field": "apache.status.scoreboard.gracefully_finishing"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "id": "6", 
+                            "params": {
+                                "customLabel": "Idle cleanup", 
+                                "field": "apache.status.scoreboard.idle_cleanup"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "id": "7", 
+                            "params": {
+                                "customLabel": "Keepalive", 
+                                "field": "apache.status.scoreboard.keepalive"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "id": "8", 
+                            "params": {
+                                "customLabel": "Logging", 
+                                "field": "apache.status.scoreboard.logging"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "id": "9", 
+                            "params": {
+                                "customLabel": "Open slot", 
+                                "field": "apache.status.scoreboard.open_slot"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "id": "10", 
+                            "params": {
+                                "customLabel": "Reading request", 
+                                "field": "apache.status.scoreboard.reading_request"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "id": "11", 
+                            "params": {
+                                "customLabel": "Sending reply", 
+                                "field": "apache.status.scoreboard.sending_reply"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "id": "12", 
+                            "params": {
+                                "customLabel": "Starting up", 
+                                "field": "apache.status.scoreboard.starting_up"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "id": "13", 
+                            "params": {
+                                "customLabel": "Total", 
+                                "field": "apache.status.scoreboard.total"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "id": "14", 
+                            "params": {
+                                "customLabel": "Waiting for connection", 
+                                "field": "apache.status.scoreboard.waiting_for_connection"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "defaultYExtents": false, 
+                        "drawLinesBetweenPoints": true, 
+                        "interpolate": "linear", 
+                        "radiusRatio": 9, 
+                        "scale": "linear", 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "showCircles": true, 
+                        "smoothLines": false, 
+                        "times": [], 
+                        "yAxis": {}
+                    }, 
+                    "title": "Apache HTTPD - Scoreboard ECS", 
+                    "type": "line"
+                }
+            }, 
+            "id": "Apache-HTTPD-Scoreboard-ecs", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "Apache-HTTPD-ecs", 
+                "title": "Total accesses and kbytes [Metricbeat Apache] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "Total kbytes", 
+                                "field": "apache.status.total_kbytes"
+                            }, 
+                            "schema": "metric", 
+                            "type": "max"
+                        }, 
+                        {
+                            "id": "2", 
+                            "params": {
+                                "customLabel": "Total accesses", 
+                                "field": "apache.status.total_accesses"
+                            }, 
+                            "schema": "metric", 
+                            "type": "max"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "fontSize": 60, 
+                        "handleNoResults": true
+                    }, 
+                    "title": "Apache HTTPD - Total accesses and kbytes ECS", 
+                    "type": "metric"
+                }
+            }, 
+            "id": "Apache-HTTPD-Total-accesses-and-kbytes-ecs", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "Apache-HTTPD-ecs", 
+                "title": "Uptime [Metricbeat Apache] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "Uptime", 
+                                "field": "apache.status.uptime.uptime"
+                            }, 
+                            "schema": "metric", 
+                            "type": "max"
+                        }, 
+                        {
+                            "id": "2", 
+                            "params": {
+                                "customLabel": "Server uptime", 
+                                "field": "apache.status.uptime.server_uptime"
+                            }, 
+                            "schema": "metric", 
+                            "type": "max"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "fontSize": 60, 
+                        "handleNoResults": true
+                    }, 
+                    "title": "Apache HTTPD - Uptime ECS", 
+                    "type": "metric"
+                }
+            }, 
+            "id": "Apache-HTTPD-Uptime-ecs", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "Apache-HTTPD-ecs", 
+                "title": "Workers [Metricbeat Apache] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "Busy workers", 
+                                "field": "apache.status.workers.busy"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "id": "3", 
+                            "params": {
+                                "customLabel": "Hostname", 
+                                "field": "apache.status.hostname", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "row": true, 
+                                "size": 5
+                            }, 
+                            "schema": "split", 
+                            "type": "terms"
+                        }, 
+                        {
+                            "id": "4", 
+                            "params": {
+                                "customLabel": "Idle workers", 
+                                "field": "apache.status.workers.idle"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "defaultYExtents": false, 
+                        "drawLinesBetweenPoints": true, 
+                        "interpolate": "linear", 
+                        "radiusRatio": 9, 
+                        "scale": "linear", 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "showCircles": true, 
+                        "smoothLines": false, 
+                        "times": [], 
+                        "yAxis": {}
+                    }, 
+                    "title": "Apache HTTPD - Workers ECS", 
+                    "type": "line"
+                }
+            }, 
+            "id": "Apache-HTTPD-Workers-ecs", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "columns": [
+                    "_source"
+                ], 
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlight": {
+                            "fields": {
+                                "*": {}
+                            }, 
+                            "fragment_size": 2147483647, 
+                            "post_tags": [
+                                "@/kibana-highlighted-field@"
+                            ], 
+                            "pre_tags": [
+                                "@kibana-highlighted-field@"
+                            ], 
+                            "require_field_match": false
+                        }, 
+                        "index": "metricbeat-*", 
+                        "query": {
+                            "language": "kuery",
+                                "query": "event.module: apache"
+                            }
+                    }
+                }, 
+                "sort": [
+                    "@timestamp", 
+                    "desc"
+                ], 
+                "title": "Apache HTTPD ECS", 
+                "version": 1
+            }, 
+            "id": "Apache-HTTPD-ecs", 
+            "type": "search", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "Overview of Apache server status",
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlightAll": true, 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "optionsJSON": {
+                    "darkTheme": false
+                }, 
+                "panelsJSON": [
+                    {
+                        "col": 7, 
+                        "id": "Apache-HTTPD-CPU-ecs", 
+                        "panelIndex": 1, 
+                        "row": 10, 
+                        "size_x": 6, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "Apache-HTTPD-Hostname-list-ecs", 
+                        "panelIndex": 2, 
+                        "row": 1, 
+                        "size_x": 3, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "Apache-HTTPD-Load1-slash-5-slash-15-ecs", 
+                        "panelIndex": 3, 
+                        "row": 10, 
+                        "size_x": 6, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "Apache-HTTPD-Scoreboard-ecs", 
+                        "panelIndex": 4, 
+                        "row": 7, 
+                        "size_x": 12, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 7, 
+                        "id": "Apache-HTTPD-Total-accesses-and-kbytes-ecs", 
+                        "panelIndex": 5, 
+                        "row": 1, 
+                        "size_x": 6, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 4, 
+                        "id": "Apache-HTTPD-Uptime-ecs", 
+                        "panelIndex": 6, 
+                        "row": 1, 
+                        "size_x": 3, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "Apache-HTTPD-Workers-ecs", 
+                        "panelIndex": 7, 
+                        "row": 4, 
+                        "size_x": 12, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }
+                ], 
+                "timeRestore": false, 
+                "title": "[Metricbeat Apache] Overview ECS", 
+                "uiStateJSON": {
+                    "P-2": {
+                        "vis": {
+                            "params": {
+                                "sort": {
+                                    "columnIndex": null, 
+                                    "direction": null
+                                }
+                            }
+                        }
+                    }, 
+                    "P-5": {
+                        "vis": {
+                            "defaultColors": {
+                                "0 - 100": "rgb(0,104,55)"
+                            }
+                        }
+                    }, 
+                    "P-6": {
+                        "vis": {
+                            "defaultColors": {
+                                "0 - 100": "rgb(0,104,55)"
+                            }
+                        }
+                    }
+                }, 
+                "version": 1
+            }, 
+            "id": "Metricbeat-Apache-HTTPD-server-status-ecs", 
+            "type": "dashboard", 
+            "version": 3
+        }
+    ], 
+    "version": "6.0.0-beta1-SNAPSHOT"
+}

--- a/dev/package-beats/apache-1.0.0/manifest.yml
+++ b/dev/package-beats/apache-1.0.0/manifest.yml
@@ -1,0 +1,14 @@
+name: apache
+title: Apache
+version: 1.0.0
+description: |
+  Apache HTTPD server metricsets collected from the Apache web server.
+type: ""
+categories:
+- logs
+- metrics
+requirement:
+  kibana:
+    version:
+      min: 6.7.0
+      max: 7.6.0

--- a/dev/package-beats/appsearch-1.0.0/manifest.yml
+++ b/dev/package-beats/appsearch-1.0.0/manifest.yml
@@ -1,0 +1,13 @@
+name: appsearch
+title: appsearch
+version: 1.0.0
+description: |
+  appsearch module
+type: ""
+categories:
+- metrics
+requirement:
+  kibana:
+    version:
+      min: 6.7.0
+      max: 7.6.0

--- a/dev/package-beats/auditd-1.0.0/kibana/dashboard/Filebeat-auditd.json
+++ b/dev/package-beats/auditd-1.0.0/kibana/dashboard/Filebeat-auditd.json
@@ -1,0 +1,436 @@
+{
+    "objects": [
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "index": "filebeat-*", 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                }, 
+                "title": "Event types breakdown [Filebeat Auditd] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "field": "event.action", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 50
+                            }, 
+                            "schema": "segment", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTooltip": true, 
+                        "isDonut": true, 
+                        "legendPosition": "right"
+                    }, 
+                    "title": "Audit Event Types ECS", 
+                    "type": "pie"
+                }
+            }, 
+            "id": "6295bdd0-0a0e-11e7-825f-6748cda7d858-ecs", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "index": "filebeat-*", 
+                        "query": {
+                            "language": "kuery",
+                                "query": "event.action:EXECVE"
+                            }
+                    }
+                }, 
+                "title": "Top Exec Commands [Filebeat Auditd] ECS", 
+                "uiStateJSON": {
+                    "vis": {
+                        "params": {
+                            "sort": {
+                                "columnIndex": null, 
+                                "direction": null
+                            }
+                        }
+                    }
+                }, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customLabel": "Command (arg 0)", 
+                                "field": "auditd.log.a0", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 30
+                            }, 
+                            "schema": "bucket", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "perPage": 10, 
+                        "showMeticsAtAllLevels": false, 
+                        "showPartialRows": false, 
+                        "showTotal": false, 
+                        "sort": {
+                            "columnIndex": null, 
+                            "direction": null
+                        }, 
+                        "totalFunc": "sum"
+                    }, 
+                    "title": "Audit Top Exec Commands ECS", 
+                    "type": "table"
+                }
+            }, 
+            "id": "5ebdbe50-0a0f-11e7-825f-6748cda7d858-ecs", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "Event Results [Filebeat Auditd] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "expression": ".es(q=\"event.dataset:auditd.log NOT event.outcome:failure\").label(\"Success\"), .es(q=\"event.outcome:failed\").label(\"Failure\").title(\"Audit Event Results\")",
+                        "interval": "auto"
+                    }, 
+                    "title": "Event Results [Filebeat Auditd] ECS", 
+                    "type": "timelion"
+                }
+            }, 
+            "id": "2bb0fa70-0a11-11e7-9e84-43da493ad0c7-ecs", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "index": "filebeat-*", 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                }, 
+                "title": "Event Address Geo Location [Filebeat Auditd] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "autoPrecision": true, 
+                                "field": "source.geo.location", 
+                                "precision": 2
+                            }, 
+                            "schema": "segment", 
+                            "type": "geohash_grid"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addTooltip": true, 
+                        "heatBlur": 15, 
+                        "heatMaxZoom": 16, 
+                        "heatMinOpacity": 0.1, 
+                        "heatNormalizeData": true, 
+                        "heatRadius": 25, 
+                        "isDesaturated": true, 
+                        "legendPosition": "bottomright", 
+                        "mapCenter": [
+                            15, 
+                            5
+                        ], 
+                        "mapType": "Scaled Circle Markers", 
+                        "mapZoom": 2, 
+                        "wms": {
+                            "enabled": false, 
+                            "options": {
+                                "attribution": "Maps provided by USGS", 
+                                "format": "image/png", 
+                                "layers": "0", 
+                                "styles": "", 
+                                "transparent": true, 
+                                "version": "1.3.0"
+                            }, 
+                            "url": "https://basemap.nationalmap.gov/arcgis/services/USGSTopo/MapServer/WMSServer"
+                        }
+                    }, 
+                    "title": "Audit Event Address Geo Location ECS", 
+                    "type": "tile_map"
+                }
+            }, 
+            "id": "d1726930-0a7f-11e7-8b04-eb22a5669f27-ecs", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "index": "filebeat-*", 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                }, 
+                "title": "Event Account Tag Cloud [Filebeat Auditd] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "field": "user.name", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 15
+                            }, 
+                            "schema": "segment", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "hideLabel": false, 
+                        "maxFontSize": 42, 
+                        "minFontSize": 15, 
+                        "orientation": "single", 
+                        "scale": "linear"
+                    }, 
+                    "title": "Audit Event Account Tag Cloud ECS", 
+                    "type": "tagcloud"
+                }
+            }, 
+            "id": "c5411910-0a87-11e7-8b04-eb22a5669f27-ecs", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "columns": [
+                    "event.action", 
+                    "auditd.log.sequence", 
+                    "user.name"
+                ], 
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlightAll": true, 
+                        "index": "filebeat-*", 
+                        "query": {
+                            "language": "kuery",
+                                "query": "event.dataset:auditd.log"
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "sort": [
+                    "@timestamp", 
+                    "desc"
+                ], 
+                "title": "Audit Events [Filebeat Auditd] ECS", 
+                "version": 1
+            }, 
+            "id": "4ac0a370-0a11-11e7-8b04-eb22a5669f27-ecs", 
+            "type": "search", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "Dashboard for the Auditd Filebeat module", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlightAll": true, 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "optionsJSON": {
+                    "darkTheme": false
+                }, 
+                "panelsJSON": [
+                    {
+                        "col": 1, 
+                        "id": "6295bdd0-0a0e-11e7-825f-6748cda7d858-ecs", 
+                        "panelIndex": 1, 
+                        "row": 1, 
+                        "size_x": 4, 
+                        "size_y": 4, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 9, 
+                        "id": "5ebdbe50-0a0f-11e7-825f-6748cda7d858-ecs", 
+                        "panelIndex": 2, 
+                        "row": 1, 
+                        "size_x": 4, 
+                        "size_y": 4, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "2bb0fa70-0a11-11e7-9e84-43da493ad0c7-ecs", 
+                        "panelIndex": 3, 
+                        "row": 5, 
+                        "size_x": 6, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 7, 
+                        "id": "d1726930-0a7f-11e7-8b04-eb22a5669f27-ecs", 
+                        "panelIndex": 5, 
+                        "row": 5, 
+                        "size_x": 6, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 5, 
+                        "id": "c5411910-0a87-11e7-8b04-eb22a5669f27-ecs", 
+                        "panelIndex": 6, 
+                        "row": 1, 
+                        "size_x": 4, 
+                        "size_y": 4, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "columns": [
+                            "event.action", 
+                            "auditd.log.sequence", 
+                            "user.name"
+                        ], 
+                        "id": "4ac0a370-0a11-11e7-8b04-eb22a5669f27-ecs", 
+                        "panelIndex": 7, 
+                        "row": 8, 
+                        "size_x": 12, 
+                        "size_y": 3, 
+                        "sort": [
+                            "@timestamp", 
+                            "desc"
+                        ], 
+                        "type": "search"
+                    }
+                ], 
+                "timeRestore": false, 
+                "title": "[Filebeat Auditd] Audit Events ECS", 
+                "uiStateJSON": {
+                    "P-2": {
+                        "vis": {
+                            "params": {
+                                "sort": {
+                                    "columnIndex": null, 
+                                    "direction": null
+                                }
+                            }
+                        }
+                    }, 
+                    "P-5": {
+                        "mapBounds": {
+                            "bottom_right": {
+                                "lat": -43.580390855607845, 
+                                "lon": 102.65625
+                            }, 
+                            "top_left": {
+                                "lat": 43.58039085560784, 
+                                "lon": -102.3046875
+                            }
+                        }, 
+                        "mapCollar": {
+                            "bottom_right": {
+                                "lat": -87.16078, 
+                                "lon": 180
+                            }, 
+                            "top_left": {
+                                "lat": 87.16078, 
+                                "lon": -180
+                            }, 
+                            "zoom": 2
+                        }, 
+                        "mapZoom": 2
+                    }
+                }, 
+                "version": 1
+            }, 
+            "id": "dfbb49f0-0a0f-11e7-8a62-2d05eaaac5cb-ecs", 
+            "type": "dashboard", 
+            "version": 4
+        }
+    ], 
+    "version": "6.0.0-beta1-SNAPSHOT"
+}

--- a/dev/package-beats/auditd-1.0.0/manifest.yml
+++ b/dev/package-beats/auditd-1.0.0/manifest.yml
@@ -1,0 +1,13 @@
+name: auditd
+title: Auditd
+version: 1.0.0
+description: |
+  Module for parsing auditd logs.
+type: ""
+categories:
+- logs
+requirement:
+  kibana:
+    version:
+      min: 6.7.0
+      max: 7.6.0

--- a/dev/package-beats/aws-1.0.0/kibana/dashboard/Filebeat-aws-s3access-overview.json
+++ b/dev/package-beats/aws-1.0.0/kibana/dashboard/Filebeat-aws-s3access-overview.json
@@ -1,0 +1,458 @@
+{
+  "objects": [
+    {
+      "attributes": {
+        "description": "Filebeat AWS S3 Server Access Log Overview Dashboard",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "optionsJSON": {
+          "hidePanelTitles": false,
+          "useMargins": true
+        },
+        "panelsJSON": [
+          {
+            "embeddableConfig": {
+              "title": "Top URLs"
+            },
+            "gridData": {
+              "h": 15,
+              "i": "1",
+              "w": 24,
+              "x": 0,
+              "y": 0
+            },
+            "panelIndex": "1",
+            "panelRefName": "panel_0",
+            "title": "Top URLs",
+            "version": "7.4.0"
+          },
+          {
+            "embeddableConfig": {
+              "title": "Http Status over time"
+            },
+            "gridData": {
+              "h": 15,
+              "i": "2",
+              "w": 24,
+              "x": 24,
+              "y": 0
+            },
+            "panelIndex": "2",
+            "panelRefName": "panel_1",
+            "title": "Http Status over time",
+            "version": "7.4.0"
+          },
+          {
+            "embeddableConfig": {
+              "title": "Error Logs"
+            },
+            "gridData": {
+              "h": 15,
+              "i": "3",
+              "w": 48,
+              "x": 0,
+              "y": 15
+            },
+            "panelIndex": "3",
+            "panelRefName": "panel_2",
+            "title": "Error Logs",
+            "version": "7.4.0"
+          }
+        ],
+        "timeRestore": false,
+        "title": "[Filebeat AWS] S3 Server Access Log Overview",
+        "version": 1
+      },
+      "id": "4746e000-bacd-11e9-9f70-1f7bda85a5eb",
+      "migrationVersion": {
+        "dashboard": "7.3.0"
+      },
+      "references": [
+        {
+          "id": "99ffdb00-bacb-11e9-9f70-1f7bda85a5eb",
+          "name": "panel_0",
+          "type": "visualization"
+        },
+        {
+          "id": "5c93cd10-bac3-11e9-9f70-1f7bda85a5eb",
+          "name": "panel_1",
+          "type": "visualization"
+        },
+        {
+          "id": "5e5a3c90-bac0-11e9-9f70-1f7bda85a5eb",
+          "name": "panel_2",
+          "type": "search"
+        }
+      ],
+      "type": "dashboard",
+      "updated_at": "2019-09-11T15:17:53.090Z",
+      "version": "WzEyMDAsN10="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Top URLs [Filebeat AWS]",
+        "uiStateJSON": {
+          "vis": {
+            "colors": {
+              "404": "#EAB839"
+            }
+          }
+        },
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customLabel": "Request Uri",
+                "field": "aws.s3access.request_uri",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "row": false,
+                "size": 5
+              },
+              "schema": "split",
+              "type": "terms"
+            },
+            {
+              "enabled": true,
+              "id": "3",
+              "params": {
+                "customLabel": "HTTP Status",
+                "field": "aws.s3access.http_status",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 5
+              },
+              "schema": "segment",
+              "type": "terms"
+            }
+          ],
+          "params": {
+            "addLegend": true,
+            "addTooltip": true,
+            "dimensions": {
+              "buckets": [
+                {
+                  "accessor": 2,
+                  "aggType": "terms",
+                  "format": {
+                    "id": "terms",
+                    "params": {
+                      "id": "number",
+                      "missingBucketLabel": "Missing",
+                      "otherBucketLabel": "Other"
+                    }
+                  },
+                  "params": {}
+                }
+              ],
+              "metric": {
+                "accessor": 3,
+                "aggType": "count",
+                "format": {
+                  "id": "number"
+                },
+                "params": {}
+              },
+              "splitColumn": [
+                {
+                  "accessor": 0,
+                  "aggType": "terms",
+                  "format": {
+                    "id": "terms",
+                    "params": {
+                      "id": "string",
+                      "missingBucketLabel": "Missing",
+                      "otherBucketLabel": "Other"
+                    }
+                  },
+                  "params": {}
+                }
+              ]
+            },
+            "isDonut": false,
+            "labels": {
+              "last_level": true,
+              "show": false,
+              "truncate": 100,
+              "values": true
+            },
+            "legendPosition": "right",
+            "type": "pie"
+          },
+          "title": "Top URLs [Filebeat AWS]",
+          "type": "pie"
+        }
+      },
+      "id": "99ffdb00-bacb-11e9-9f70-1f7bda85a5eb",
+      "migrationVersion": {
+        "visualization": "7.3.1"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-09-11T15:11:59.518Z",
+      "version": "Wzk0Myw3XQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Http Status over time [Filebeat AWS]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "lucene",
+              "query": "event.module:aws AND fileset.name:s3access"
+            },
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "filebeat-*",
+            "interval": "auto",
+            "legend_position": "bottom",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "bar",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "number",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Http Status",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "count"
+                  }
+                ],
+                "point_size": 1,
+                "seperate_axis": 0,
+                "split_filters": [
+                  {
+                    "color": "#68BC00",
+                    "filter": {
+                      "language": "kuery",
+                      "query": "aws.s3access.http_status \u003c 300 and aws.s3access.http_status \u003e= 200"
+                    },
+                    "id": "5acdc750-a29d-11e7-a062-a1c3587f4874",
+                    "label": "200s"
+                  },
+                  {
+                    "color": "rgba(252,196,0,1)",
+                    "filter": {
+                      "language": "kuery",
+                      "query": "aws.s3access.http_status \u003c 400 and aws.s3access.http_status \u003e= 300"
+                    },
+                    "id": "6efd2ae0-a29d-11e7-a062-a1c3587f4874",
+                    "label": "300s"
+                  },
+                  {
+                    "color": "rgba(211,49,21,1)",
+                    "filter": {
+                      "language": "kuery",
+                      "query": "aws.s3access.http_status \u003c 500 and aws.s3access.http_status \u003e= 400"
+                    },
+                    "id": "76089a90-a29d-11e7-a062-a1c3587f4874",
+                    "label": "400s"
+                  },
+                  {
+                    "color": "rgba(171,20,158,1)",
+                    "filter": {
+                      "language": "kuery",
+                      "query": "aws.s3access.http_status \u003c 600 and aws.s3access.http_status \u003e= 500"
+                    },
+                    "id": "7c7929d0-a29d-11e7-a062-a1c3587f4874",
+                    "label": "500s"
+                  }
+                ],
+                "split_mode": "filters",
+                "stacked": "stacked",
+                "terms_field": "http.response.status_code",
+                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Http Status over time [Filebeat AWS]",
+          "type": "metrics"
+        }
+      },
+      "id": "5c93cd10-bac3-11e9-9f70-1f7bda85a5eb",
+      "migrationVersion": {
+        "visualization": "7.3.1"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-09-11T15:11:59.518Z",
+      "version": "Wzk0NCw3XQ=="
+    },
+    {
+      "attributes": {
+        "columns": [
+          "aws.s3access.http_status",
+          "aws.s3access.error_code",
+          "aws.s3access.operation",
+          "aws.s3access.request_uri"
+        ],
+        "description": "",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [
+              {
+                "$state": {
+                  "store": "appState"
+                },
+                "meta": {
+                  "alias": null,
+                  "disabled": false,
+                  "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                  "key": "aws.s3access.http_status",
+                  "negate": true,
+                  "params": {
+                    "query": "200"
+                  },
+                  "type": "phrase",
+                  "value": "200"
+                },
+                "query": {
+                  "match": {
+                    "aws.s3access.http_status": {
+                      "query": "200",
+                      "type": "phrase"
+                    }
+                  }
+                }
+              },
+              {
+                "$state": {
+                  "store": "appState"
+                },
+                "meta": {
+                  "alias": null,
+                  "disabled": false,
+                  "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[1].meta.index",
+                  "key": "fileset.name",
+                  "negate": false,
+                  "params": {
+                    "query": "s3access"
+                  },
+                  "type": "phrase",
+                  "value": "s3access"
+                },
+                "query": {
+                  "match": {
+                    "fileset.name": {
+                      "query": "s3access",
+                      "type": "phrase"
+                    }
+                  }
+                }
+              }
+            ],
+            "highlightAll": true,
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "language": "kuery",
+              "query": ""
+            },
+            "version": true
+          }
+        },
+        "sort": [
+          [
+            "@timestamp",
+            "desc"
+          ]
+        ],
+        "title": "Error Logs [Filebeat AWS]",
+        "version": 1
+      },
+      "id": "5e5a3c90-bac0-11e9-9f70-1f7bda85a5eb",
+      "migrationVersion": {
+        "search": "7.4.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        },
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+          "type": "index-pattern"
+        },
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[1].meta.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "search",
+      "updated_at": "2019-09-11T15:17:42.648Z",
+      "version": "WzExOTksN10="
+    }
+  ],
+  "version": "7.4.0"
+}

--- a/dev/package-beats/aws-1.0.0/kibana/dashboard/Metricbeat-aws-ebs-overview.json
+++ b/dev/package-beats/aws-1.0.0/kibana/dashboard/Metricbeat-aws-ebs-overview.json
@@ -1,0 +1,920 @@
+{
+  "objects": [
+    {
+      "attributes": {
+        "description": "[Metricbeat AWS] Overview of EBS Metrics",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "optionsJSON": {
+          "hidePanelTitles": false,
+          "useMargins": true
+        },
+        "panelsJSON": [
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 10,
+              "i": "1",
+              "w": 24,
+              "x": 24,
+              "y": 10
+            },
+            "panelIndex": "1",
+            "panelRefName": "panel_0",
+            "title": "Volume Write Ops",
+            "version": "7.4.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 10,
+              "i": "2",
+              "w": 24,
+              "x": 0,
+              "y": 10
+            },
+            "panelIndex": "2",
+            "panelRefName": "panel_1",
+            "title": "Volume Read Ops",
+            "version": "7.4.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 10,
+              "i": "3",
+              "w": 24,
+              "x": 24,
+              "y": 20
+            },
+            "panelIndex": "3",
+            "panelRefName": "panel_2",
+            "title": "Volume Write Bytes",
+            "version": "7.4.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 10,
+              "i": "4",
+              "w": 24,
+              "x": 0,
+              "y": 20
+            },
+            "panelIndex": "4",
+            "panelRefName": "panel_3",
+            "title": "Volume Read Bytes",
+            "version": "7.4.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 10,
+              "i": "5",
+              "w": 19,
+              "x": 8,
+              "y": 0
+            },
+            "panelIndex": "5",
+            "panelRefName": "panel_4",
+            "title": "Volume Queue Length",
+            "version": "7.4.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 10,
+              "i": "6",
+              "w": 24,
+              "x": 24,
+              "y": 30
+            },
+            "panelIndex": "6",
+            "panelRefName": "panel_5",
+            "title": "Volume Total Write Time",
+            "version": "7.4.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 10,
+              "i": "7",
+              "w": 24,
+              "x": 0,
+              "y": 30
+            },
+            "panelIndex": "7",
+            "panelRefName": "panel_6",
+            "title": "Volume Total Read Time",
+            "version": "7.4.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 10,
+              "i": "8",
+              "w": 21,
+              "x": 27,
+              "y": 0
+            },
+            "panelIndex": "8",
+            "panelRefName": "panel_7",
+            "title": "Volume Idle Time",
+            "version": "7.4.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 5,
+              "i": "9",
+              "w": 8,
+              "x": 0,
+              "y": 5
+            },
+            "panelIndex": "9",
+            "panelRefName": "panel_8",
+            "title": "EBS Volume ID Filter",
+            "version": "7.4.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 5,
+              "i": "10",
+              "w": 8,
+              "x": 0,
+              "y": 0
+            },
+            "panelIndex": "10",
+            "panelRefName": "panel_9",
+            "version": "7.4.0"
+          }
+        ],
+        "timeRestore": false,
+        "title": "[Metricbeat AWS] EBS Overview",
+        "version": 1
+      },
+      "id": "44ce4680-b7ba-11e9-8349-f15f850c5cd0",
+      "migrationVersion": {
+        "dashboard": "7.3.0"
+      },
+      "references": [
+        {
+          "id": "f6831f30-b7b6-11e9-8349-f15f850c5cd0",
+          "name": "panel_0",
+          "type": "visualization"
+        },
+        {
+          "id": "bb3a6cd0-b7b6-11e9-8349-f15f850c5cd0",
+          "name": "panel_1",
+          "type": "visualization"
+        },
+        {
+          "id": "c0e32d50-b7b8-11e9-8349-f15f850c5cd0",
+          "name": "panel_2",
+          "type": "visualization"
+        },
+        {
+          "id": "b00c4390-b7b8-11e9-8349-f15f850c5cd0",
+          "name": "panel_3",
+          "type": "visualization"
+        },
+        {
+          "id": "fe0581b0-b7b8-11e9-8349-f15f850c5cd0",
+          "name": "panel_4",
+          "type": "visualization"
+        },
+        {
+          "id": "25384bf0-b7b9-11e9-8349-f15f850c5cd0",
+          "name": "panel_5",
+          "type": "visualization"
+        },
+        {
+          "id": "12eff7e0-b7b9-11e9-8349-f15f850c5cd0",
+          "name": "panel_6",
+          "type": "visualization"
+        },
+        {
+          "id": "67f43080-b7b9-11e9-8349-f15f850c5cd0",
+          "name": "panel_7",
+          "type": "visualization"
+        },
+        {
+          "id": "d045d120-b7b9-11e9-8349-f15f850c5cd0",
+          "name": "panel_8",
+          "type": "visualization"
+        },
+        {
+          "id": "b5308940-7347-11e9-816b-07687310a99a",
+          "name": "panel_9",
+          "type": "visualization"
+        }
+      ],
+      "type": "dashboard",
+      "updated_at": "2019-09-12T16:35:04.005Z",
+      "version": "WzYwMDMsN10="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "EBS Volume Write Ops [Metricbeat AWS]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_min": "0",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "",
+            "interval": "5m",
+            "isModelInvalid": false,
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": "0",
+                "formatter": "number",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Number of Write Operation",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "aws.metrics.VolumeWriteOps.avg",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": "5",
+                "separate_axis": 0,
+                "split_color_mode": "rainbow",
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "aws.cloudwatch.dimensions.VolumeId",
+                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "",
+            "type": "timeseries"
+          },
+          "title": "EBS Volume Write Ops [Metricbeat AWS]",
+          "type": "metrics"
+        }
+      },
+      "id": "f6831f30-b7b6-11e9-8349-f15f850c5cd0",
+      "migrationVersion": {
+        "visualization": "7.3.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-09-12T16:31:45.681Z",
+      "version": "WzU5ODMsN10="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "EBS Volume Read Ops [Metricbeat AWS]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_min": "0",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "",
+            "interval": "5m",
+            "isModelInvalid": false,
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": "0",
+                "formatter": "number",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Number of Read Operation",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "aws.metrics.VolumeReadOps.avg",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": "5",
+                "separate_axis": 0,
+                "split_color_mode": "rainbow",
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "aws.cloudwatch.dimensions.VolumeId",
+                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "",
+            "type": "timeseries"
+          },
+          "title": "EBS Volume Read Ops [Metricbeat AWS]",
+          "type": "metrics"
+        }
+      },
+      "id": "bb3a6cd0-b7b6-11e9-8349-f15f850c5cd0",
+      "migrationVersion": {
+        "visualization": "7.3.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-09-12T16:31:31.261Z",
+      "version": "WzU5ODEsN10="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "EBS Volume Write Bytes [Metricbeat AWS]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_min": "0",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "",
+            "interval": "5m",
+            "isModelInvalid": false,
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": "0",
+                "formatter": "number",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Volume Write Bytes",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "aws.metrics.VolumeWriteBytes.avg",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": "5",
+                "separate_axis": 0,
+                "split_color_mode": "rainbow",
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "aws.cloudwatch.dimensions.VolumeId",
+                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "",
+            "type": "timeseries"
+          },
+          "title": "EBS Volume Write Bytes [Metricbeat AWS]",
+          "type": "metrics"
+        }
+      },
+      "id": "c0e32d50-b7b8-11e9-8349-f15f850c5cd0",
+      "migrationVersion": {
+        "visualization": "7.3.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-09-12T16:32:46.176Z",
+      "version": "WzU5OTAsN10="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "EBS Volume Read Bytes [Metricbeat AWS]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_min": "0",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "",
+            "interval": "5m",
+            "isModelInvalid": false,
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": "0",
+                "formatter": "number",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Volume Read Bytes",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "aws.metrics.VolumeReadBytes.avg",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": "5",
+                "separate_axis": 0,
+                "split_color_mode": "rainbow",
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "aws.cloudwatch.dimensions.VolumeId",
+                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "",
+            "type": "timeseries"
+          },
+          "title": "EBS Volume Read Bytes [Metricbeat AWS]",
+          "type": "metrics"
+        }
+      },
+      "id": "b00c4390-b7b8-11e9-8349-f15f850c5cd0",
+      "migrationVersion": {
+        "visualization": "7.3.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-09-12T16:32:02.907Z",
+      "version": "WzU5ODUsN10="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "EBS Volume Queue Length [Metricbeat AWS]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_min": "0",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "",
+            "interval": "5m",
+            "isModelInvalid": false,
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": "0",
+                "formatter": "number",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Volume Queue Length",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "aws.metrics.VolumeQueueLength.avg",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": "5",
+                "separate_axis": 0,
+                "split_color_mode": "rainbow",
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "aws.cloudwatch.dimensions.VolumeId",
+                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "",
+            "type": "timeseries"
+          },
+          "title": "EBS Volume Queue Length [Metricbeat AWS]",
+          "type": "metrics"
+        }
+      },
+      "id": "fe0581b0-b7b8-11e9-8349-f15f850c5cd0",
+      "migrationVersion": {
+        "visualization": "7.3.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-09-12T16:30:59.507Z",
+      "version": "WzU5NzgsN10="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "EBS Volume Total Write Time [Metricbeat AWS]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_min": "0",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "",
+            "interval": "5m",
+            "isModelInvalid": false,
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": "0",
+                "formatter": "s,s,3",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Volume Total Write Time",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "aws.metrics.VolumeTotalWriteTime.sum",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": "5",
+                "separate_axis": 0,
+                "split_color_mode": "rainbow",
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "aws.cloudwatch.dimensions.VolumeId",
+                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "",
+            "type": "timeseries"
+          },
+          "title": "EBS Volume Total Write Time [Metricbeat AWS]",
+          "type": "metrics"
+        }
+      },
+      "id": "25384bf0-b7b9-11e9-8349-f15f850c5cd0",
+      "migrationVersion": {
+        "visualization": "7.3.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-09-12T16:32:19.881Z",
+      "version": "WzU5ODcsN10="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "EBS Volume Total Read Time [Metricbeat AWS]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_min": "0",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "",
+            "interval": "5m",
+            "isModelInvalid": false,
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": "0",
+                "formatter": "s,s,3",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Volume Total Read Time",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "aws.metrics.VolumeTotalReadTime.sum",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": "5",
+                "separate_axis": 0,
+                "split_color_mode": "rainbow",
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "aws.cloudwatch.dimensions.VolumeId",
+                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "",
+            "type": "timeseries"
+          },
+          "title": "EBS Volume Total Read Time [Metricbeat AWS]",
+          "type": "metrics"
+        }
+      },
+      "id": "12eff7e0-b7b9-11e9-8349-f15f850c5cd0",
+      "migrationVersion": {
+        "visualization": "7.3.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-09-12T16:33:13.538Z",
+      "version": "WzU5OTMsN10="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "EBS Volume Idle Time [Metricbeat AWS]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_min": "0",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "",
+            "interval": "5m",
+            "series": [
+              {
+                "axis_min": "0",
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": "0",
+                "formatter": "s,s,1",
+                "hide_in_legend": 0,
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Volume Idle Time",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "aws.metrics.VolumeIdleTime.sum",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": "5",
+                "separate_axis": 0,
+                "split_color_mode": "rainbow",
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "aws.cloudwatch.dimensions.VolumeId",
+                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "",
+            "type": "timeseries"
+          },
+          "title": "EBS Volume Idle Time [Metricbeat AWS]",
+          "type": "metrics"
+        }
+      },
+      "id": "67f43080-b7b9-11e9-8349-f15f850c5cd0",
+      "migrationVersion": {
+        "visualization": "7.3.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-09-12T16:31:19.709Z",
+      "version": "WzU5ODAsN10="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "EBS Volume ID Filter [Metricbeat AWS]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "controls": [
+              {
+                "fieldName": "aws.cloudwatch.dimensions.VolumeId",
+                "id": "1565034367477",
+                "indexPatternRefName": "control_0_index_pattern",
+                "label": "volume id",
+                "options": {
+                  "dynamicOptions": true,
+                  "multiselect": true,
+                  "order": "desc",
+                  "size": 5,
+                  "type": "terms"
+                },
+                "parent": "",
+                "type": "list"
+              }
+            ],
+            "pinFilters": false,
+            "updateFiltersOnChange": true,
+            "useTimeFilter": true
+          },
+          "title": "EBS Volume ID Filter [Metricbeat AWS]",
+          "type": "input_control_vis"
+        }
+      },
+      "id": "d045d120-b7b9-11e9-8349-f15f850c5cd0",
+      "migrationVersion": {
+        "visualization": "7.3.0"
+      },
+      "references": [
+        {
+          "id": "metricbeat-*",
+          "name": "control_0_index_pattern",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-09-12T16:29:31.115Z",
+      "version": "WzU2MTIsN10="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Region Filter [Metricbeat AWS]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "controls": [
+              {
+                "fieldName": "cloud.region",
+                "id": "1549397251041",
+                "indexPatternRefName": "control_0_index_pattern",
+                "label": "region",
+                "options": {
+                  "dynamicOptions": true,
+                  "multiselect": true,
+                  "order": "desc",
+                  "size": 5,
+                  "type": "terms"
+                },
+                "parent": "",
+                "type": "list"
+              }
+            ],
+            "pinFilters": false,
+            "updateFiltersOnChange": true,
+            "useTimeFilter": false
+          },
+          "title": "AWS Region Filter",
+          "type": "input_control_vis"
+        }
+      },
+      "id": "b5308940-7347-11e9-816b-07687310a99a",
+      "migrationVersion": {
+        "visualization": "7.3.0"
+      },
+      "references": [
+        {
+          "id": "metricbeat-*",
+          "name": "control_0_index_pattern",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-09-12T16:29:35.238Z",
+      "version": "WzU2NTQsN10="
+    }
+  ],
+  "version": "7.4.0"
+}

--- a/dev/package-beats/aws-1.0.0/kibana/dashboard/Metricbeat-aws-ec2-overview.json
+++ b/dev/package-beats/aws-1.0.0/kibana/dashboard/Metricbeat-aws-ec2-overview.json
@@ -1,0 +1,778 @@
+{
+    "objects": [
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                },
+                "title": "EC2 DiskIO Write Bytes [Metricbeat AWS]",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "params": {
+                        "annotations": [],
+                        "axis_formatter": "number",
+                        "axis_position": "left",
+                        "axis_scale": "normal",
+                        "background_color_rules": [
+                            {
+                                "id": "23428b30-f7f2-11e8-bff8-21537b07dd44"
+                            }
+                        ],
+                        "bar_color_rules": [
+                            {
+                                "id": "2592bcc0-f7f2-11e8-bff8-21537b07dd44"
+                            }
+                        ],
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+                        "index_pattern": "metricbeat-*",
+                        "interval": "5m",
+                        "series": [
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "rgba(104,188,0,1)",
+                                "fill": "0",
+                                "filter": "",
+                                "formatter": "number",
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                                "label": "AWS EC2 DiskIO Write Bytes",
+                                "line_width": 1,
+                                "metrics": [
+                                    {
+                                        "field": "aws.ec2.diskio.write.bytes",
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                                        "type": "avg"
+                                    }
+                                ],
+                                "point_size": 1,
+                                "separate_axis": 0,
+                                "series_drop_last_bucket": 1,
+                                "split_color_mode": "rainbow",
+                                "split_mode": "terms",
+                                "stacked": "none",
+                                "steps": 0,
+                                "terms_field": "cloud.instance.id",
+                                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417",
+                                "terms_size": "5"
+                            }
+                        ],
+                        "show_grid": 1,
+                        "show_legend": 1,
+                        "time_field": "@timestamp",
+                        "type": "timeseries"
+                    },
+                    "title": "AWS EC2 DiskIO Write Bytes",
+                    "type": "metrics"
+                }
+            },
+            "id": "fed59380-f7f8-11e8-af03-c999c9dea608-ecs",
+            "type": "visualization",
+            "updated_at": "2019-02-08T23:15:16.726Z",
+            "version": 6
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                },
+                "title": "EC2 Status Check Failed [Metricbeat AWS]",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "params": {
+                        "axis_formatter": "number",
+                        "axis_position": "left",
+                        "axis_scale": "normal",
+                        "background_color_rules": [
+                            {
+                                "id": "d13f6b50-f7f6-11e8-bff8-21537b07dd44"
+                            }
+                        ],
+                        "bar_color_rules": [
+                            {
+                                "id": "ad6d62d0-f7f7-11e8-bff8-21537b07dd44"
+                            }
+                        ],
+                        "gauge_color_rules": [
+                            {
+                                "id": "b0c5b590-f7f7-11e8-bff8-21537b07dd44"
+                            }
+                        ],
+                        "gauge_inner_width": 10,
+                        "gauge_style": "half",
+                        "gauge_width": 10,
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+                        "index_pattern": "metricbeat-*",
+                        "interval": "auto",
+                        "series": [
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "#68BC00",
+                                "fill": 0.5,
+                                "formatter": "number",
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                                "label": "EC2 Status Check Failed",
+                                "line_width": 1,
+                                "metrics": [
+                                    {
+                                        "field": "aws.ec2.status.check_failed",
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                                        "type": "sum"
+                                    }
+                                ],
+                                "point_size": 1,
+                                "separate_axis": 0,
+                                "split_mode": "everything",
+                                "stacked": "none",
+                                "terms_field": "cloud.instance.id",
+                                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417"
+                            }
+                        ],
+                        "show_grid": 1,
+                        "show_legend": 1,
+                        "time_field": "@timestamp",
+                        "type": "metric"
+                    },
+                    "title": "AWS EC2 Status Check Failed",
+                    "type": "metrics"
+                }
+            },
+            "id": "9e8c6030-f7f8-11e8-af03-c999c9dea608-ecs",
+            "type": "visualization",
+            "updated_at": "2019-02-08T23:15:16.726Z",
+            "version": 6
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                },
+                "title": "EC2 Network In Bytes [Metricbeat AWS]",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "params": {
+                        "annotations": [],
+                        "axis_formatter": "number",
+                        "axis_position": "left",
+                        "axis_scale": "normal",
+                        "background_color_rules": [
+                            {
+                                "id": "23428b30-f7f2-11e8-bff8-21537b07dd44"
+                            }
+                        ],
+                        "bar_color_rules": [
+                            {
+                                "id": "2592bcc0-f7f2-11e8-bff8-21537b07dd44"
+                            }
+                        ],
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+                        "index_pattern": "metricbeat-*",
+                        "interval": "5m",
+                        "series": [
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "rgba(104,188,0,1)",
+                                "fill": "0",
+                                "filter": "",
+                                "formatter": "number",
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                                "label": "AWS EC2 Network In Bytes",
+                                "line_width": 1,
+                                "metrics": [
+                                    {
+                                        "field": "aws.ec2.network.in.bytes",
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                                        "type": "avg"
+                                    }
+                                ],
+                                "point_size": 1,
+                                "separate_axis": 0,
+                                "series_drop_last_bucket": 1,
+                                "split_color_mode": "rainbow",
+                                "split_mode": "terms",
+                                "stacked": "none",
+                                "steps": 0,
+                                "terms_field": "cloud.instance.id",
+                                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417",
+                                "terms_size": "5"
+                            }
+                        ],
+                        "show_grid": 1,
+                        "show_legend": 1,
+                        "time_field": "@timestamp",
+                        "type": "timeseries"
+                    },
+                    "title": "AWS EC2 Network In Bytes",
+                    "type": "metrics"
+                }
+            },
+            "id": "15818fd0-f7f9-11e8-af03-c999c9dea608-ecs",
+            "type": "visualization",
+            "updated_at": "2019-02-08T23:15:16.726Z",
+            "version": 6
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                },
+                "title": "EC2 Network Out Bytes [Metricbeat AWS]",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "params": {
+                        "annotations": [],
+                        "axis_formatter": "number",
+                        "axis_position": "left",
+                        "axis_scale": "normal",
+                        "background_color_rules": [
+                            {
+                                "id": "23428b30-f7f2-11e8-bff8-21537b07dd44"
+                            }
+                        ],
+                        "bar_color_rules": [
+                            {
+                                "id": "2592bcc0-f7f2-11e8-bff8-21537b07dd44"
+                            }
+                        ],
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+                        "index_pattern": "metricbeat-*",
+                        "interval": "5m",
+                        "series": [
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "rgba(104,188,0,1)",
+                                "fill": "0",
+                                "filter": "",
+                                "formatter": "number",
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                                "label": "AWS EC2 Network Out Bytes",
+                                "line_width": 1,
+                                "metrics": [
+                                    {
+                                        "field": "aws.ec2.network.out.bytes",
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                                        "type": "avg"
+                                    }
+                                ],
+                                "point_size": 1,
+                                "separate_axis": 0,
+                                "series_drop_last_bucket": 1,
+                                "split_color_mode": "rainbow",
+                                "split_mode": "terms",
+                                "stacked": "none",
+                                "steps": 0,
+                                "terms_field": "cloud.instance.id",
+                                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417",
+                                "terms_size": "5"
+                            }
+                        ],
+                        "show_grid": 1,
+                        "show_legend": 1,
+                        "time_field": "@timestamp",
+                        "type": "timeseries"
+                    },
+                    "title": "AWS EC2 Network Out Bytes",
+                    "type": "metrics"
+                }
+            },
+            "id": "233b3400-f7f9-11e8-af03-c999c9dea608-ecs",
+            "type": "visualization",
+            "updated_at": "2019-02-08T23:15:16.726Z",
+            "version": 6
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                },
+                "title": "EC2 DiskIO Read Bytes [Metricbeat AWS]",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "params": {
+                        "annotations": [],
+                        "axis_formatter": "number",
+                        "axis_position": "left",
+                        "axis_scale": "normal",
+                        "background_color_rules": [
+                            {
+                                "id": "23428b30-f7f2-11e8-bff8-21537b07dd44"
+                            }
+                        ],
+                        "bar_color_rules": [
+                            {
+                                "id": "2592bcc0-f7f2-11e8-bff8-21537b07dd44"
+                            }
+                        ],
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+                        "index_pattern": "metricbeat-*",
+                        "interval": "5m",
+                        "series": [
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "rgba(104,188,0,1)",
+                                "fill": "0",
+                                "filter": "",
+                                "formatter": "number",
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                                "label": "AWS EC2 DiskIO Read Bytes",
+                                "line_width": 1,
+                                "metrics": [
+                                    {
+                                        "field": "aws.ec2.diskio.read.bytes",
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                                        "type": "avg"
+                                    }
+                                ],
+                                "point_size": 1,
+                                "separate_axis": 0,
+                                "series_drop_last_bucket": 1,
+                                "split_color_mode": "rainbow",
+                                "split_mode": "terms",
+                                "stacked": "none",
+                                "steps": 0,
+                                "terms_field": "cloud.instance.id",
+                                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417",
+                                "terms_size": "5"
+                            }
+                        ],
+                        "show_grid": 1,
+                        "show_legend": 1,
+                        "time_field": "@timestamp",
+                        "type": "timeseries"
+                    },
+                    "title": "AWS EC2 DiskIO Read Bytes",
+                    "type": "metrics"
+                }
+            },
+            "id": "f1db6ec0-f7f8-11e8-af03-c999c9dea608-ecs",
+            "type": "visualization",
+            "updated_at": "2019-02-08T23:15:16.726Z",
+            "version": 6
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                },
+                "title": "EC2 CPU Utilization [Metricbeat AWS]",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "params": {
+                        "annotations": [],
+                        "axis_formatter": "number",
+                        "axis_position": "left",
+                        "axis_scale": "normal",
+                        "background_color_rules": [
+                            {
+                                "id": "23428b30-f7f2-11e8-bff8-21537b07dd44"
+                            }
+                        ],
+                        "bar_color_rules": [
+                            {
+                                "id": "2592bcc0-f7f2-11e8-bff8-21537b07dd44"
+                            }
+                        ],
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+                        "index_pattern": "metricbeat-*",
+                        "interval": "5m",
+                        "series": [
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "rgba(104,188,0,1)",
+                                "fill": "0",
+                                "filter": "",
+                                "formatter": "number",
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                                "label": "AWS EC2 CPU Utilization",
+                                "line_width": 1,
+                                "metrics": [
+                                    {
+                                        "field": "aws.ec2.cpu.total.pct",
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                                        "type": "avg"
+                                    }
+                                ],
+                                "point_size": 1,
+                                "separate_axis": 0,
+                                "series_drop_last_bucket": 1,
+                                "split_color_mode": "rainbow",
+                                "split_mode": "terms",
+                                "stacked": "none",
+                                "steps": 0,
+                                "terms_field": "cloud.instance.id",
+                                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417",
+                                "terms_size": "5"
+                            }
+                        ],
+                        "show_grid": 1,
+                        "show_legend": 1,
+                        "time_field": "@timestamp",
+                        "type": "timeseries"
+                    },
+                    "title": "AWS EC2 CPU Utilization",
+                    "type": "metrics"
+                }
+            },
+            "id": "be8828d0-f7f6-11e8-af03-c999c9dea608-ecs",
+            "type": "visualization",
+            "updated_at": "2019-02-08T23:15:16.726Z",
+            "version": 6
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                },
+                "title": "Filters [Metricbeat AWS]",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "params": {
+                        "controls": [
+                            {
+                                "fieldName": "cloud.region",
+                                "id": "1549397251041",
+                                "indexPattern": "metricbeat-*",
+                                "label": "region",
+                                "options": {
+                                    "dynamicOptions": true,
+                                    "multiselect": true,
+                                    "order": "desc",
+                                    "size": 5,
+                                    "type": "terms"
+                                },
+                                "parent": "",
+                                "type": "list"
+                            },
+                            {
+                                "fieldName": "cloud.availability_zone",
+                                "id": "1549512126406",
+                                "indexPattern": "metricbeat-*",
+                                "label": "availability zone",
+                                "options": {
+                                    "dynamicOptions": true,
+                                    "multiselect": true,
+                                    "order": "desc",
+                                    "size": 5,
+                                    "type": "terms"
+                                },
+                                "parent": "",
+                                "type": "list"
+                            },
+                            {
+                                "fieldName": "cloud.machine.type",
+                                "id": "1549512142947",
+                                "indexPattern": "metricbeat-*",
+                                "label": "machine type",
+                                "options": {
+                                    "dynamicOptions": true,
+                                    "multiselect": true,
+                                    "order": "desc",
+                                    "size": 5,
+                                    "type": "terms"
+                                },
+                                "parent": "",
+                                "type": "list"
+                            }
+                        ],
+                        "pinFilters": false,
+                        "updateFiltersOnChange": true,
+                        "useTimeFilter": false
+                    },
+                    "title": "AWS Filters",
+                    "type": "input_control_vis"
+                }
+            },
+            "id": "deab0260-2981-11e9-86eb-a3a07a77f530",
+            "type": "visualization",
+            "updated_at": "2019-02-08T23:32:53.876Z",
+            "version": 12
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "index": "metricbeat-*",
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                },
+                "title": "EC2 Instance State [Metricbeat AWS]",
+                "uiStateJSON": {
+                    "vis": {
+                        "colors": {
+                            "16": "#629E51",
+                            "272": "#DEDAF7",
+                            "80": "#E24D42",
+                            "running": "#7EB26D",
+                            "stopped": "#E24D42"
+                        },
+                        "legendOpen": true
+                    }
+                },
+                "version": 1,
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true,
+                            "id": "1",
+                            "params": {
+                                "customLabel": "EC2 Instance State"
+                            },
+                            "schema": "metric",
+                            "type": "count"
+                        },
+                        {
+                            "enabled": true,
+                            "id": "2",
+                            "params": {
+                                "customLabel": "",
+                                "field": "aws.ec2.instance.state.name",
+                                "missingBucket": false,
+                                "missingBucketLabel": "Missing",
+                                "order": "desc",
+                                "orderBy": "1",
+                                "otherBucket": false,
+                                "otherBucketLabel": "Other",
+                                "size": 5
+                            },
+                            "schema": "segment",
+                            "type": "terms"
+                        }
+                    ],
+                    "params": {
+                        "addLegend": true,
+                        "addTooltip": true,
+                        "isDonut": false,
+                        "labels": {
+                            "last_level": true,
+                            "show": true,
+                            "truncate": 100,
+                            "values": true
+                        },
+                        "legendPosition": "right",
+                        "type": "pie"
+                    },
+                    "title": "AWS EC2 Instance State",
+                    "type": "pie"
+                }
+            },
+            "id": "09db13f0-2bdd-11e9-9fe1-cde861544141",
+            "type": "visualization",
+            "updated_at": "2019-02-09T00:03:45.800Z",
+            "version": 5
+        },
+        {
+            "attributes": {
+                "description": "Overview of AWS EC2 Metrics",
+                "hits": 0,
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                },
+                "optionsJSON": {
+                    "darkTheme": false,
+                    "hidePanelTitles": false,
+                    "useMargins": true
+                },
+                "panelsJSON": [
+                    {
+                        "embeddableConfig": {},
+                        "gridData": {
+                            "h": 15,
+                            "i": "3",
+                            "w": 24,
+                            "x": 24,
+                            "y": 27
+                        },
+                        "id": "fed59380-f7f8-11e8-af03-c999c9dea608-ecs",
+                        "panelIndex": "3",
+                        "type": "visualization",
+                        "version": "6.5.0"
+                    },
+                    {
+                        "embeddableConfig": {},
+                        "gridData": {
+                            "h": 12,
+                            "i": "5",
+                            "w": 12,
+                            "x": 36,
+                            "y": 0
+                        },
+                        "id": "9e8c6030-f7f8-11e8-af03-c999c9dea608-ecs",
+                        "panelIndex": "5",
+                        "type": "visualization",
+                        "version": "6.5.0"
+                    },
+                    {
+                        "embeddableConfig": {},
+                        "gridData": {
+                            "h": 15,
+                            "i": "11",
+                            "w": 24,
+                            "x": 0,
+                            "y": 42
+                        },
+                        "id": "15818fd0-f7f9-11e8-af03-c999c9dea608-ecs",
+                        "panelIndex": "11",
+                        "type": "visualization",
+                        "version": "6.5.0"
+                    },
+                    {
+                        "embeddableConfig": {},
+                        "gridData": {
+                            "h": 15,
+                            "i": "12",
+                            "w": 24,
+                            "x": 24,
+                            "y": 42
+                        },
+                        "id": "233b3400-f7f9-11e8-af03-c999c9dea608-ecs",
+                        "panelIndex": "12",
+                        "type": "visualization",
+                        "version": "6.5.0"
+                    },
+                    {
+                        "embeddableConfig": {},
+                        "gridData": {
+                            "h": 15,
+                            "i": "15",
+                            "w": 24,
+                            "x": 0,
+                            "y": 27
+                        },
+                        "id": "f1db6ec0-f7f8-11e8-af03-c999c9dea608-ecs",
+                        "panelIndex": "15",
+                        "type": "visualization",
+                        "version": "6.5.0"
+                    },
+                    {
+                        "embeddableConfig": {},
+                        "gridData": {
+                            "h": 15,
+                            "i": "17",
+                            "w": 48,
+                            "x": 0,
+                            "y": 12
+                        },
+                        "id": "be8828d0-f7f6-11e8-af03-c999c9dea608-ecs",
+                        "panelIndex": "17",
+                        "type": "visualization",
+                        "version": "6.5.0"
+                    },
+                    {
+                        "embeddableConfig": {},
+                        "gridData": {
+                            "h": 12,
+                            "i": "18",
+                            "w": 17,
+                            "x": 0,
+                            "y": 0
+                        },
+                        "id": "deab0260-2981-11e9-86eb-a3a07a77f530",
+                        "panelIndex": "18",
+                        "type": "visualization",
+                        "version": "6.6.0"
+                    },
+                    {
+                        "embeddableConfig": {},
+                        "gridData": {
+                            "h": 12,
+                            "i": "19",
+                            "w": 19,
+                            "x": 17,
+                            "y": 0
+                        },
+                        "id": "09db13f0-2bdd-11e9-9fe1-cde861544141",
+                        "panelIndex": "19",
+                        "type": "visualization",
+                        "version": "6.6.0"
+                    }
+                ],
+                "timeRestore": false,
+                "title": "[Metricbeat AWS] EC2 Overview",
+                "version": 1
+            },
+            "id": "c5846400-f7fb-11e8-af03-c999c9dea608-ecs",
+            "type": "dashboard",
+            "updated_at": "2019-02-09T00:05:11.360Z",
+            "version": 9
+        }
+    ],
+    "version": "6.6.0"
+}

--- a/dev/package-beats/aws-1.0.0/kibana/dashboard/Metricbeat-aws-elb-overview.json
+++ b/dev/package-beats/aws-1.0.0/kibana/dashboard/Metricbeat-aws-elb-overview.json
@@ -1,0 +1,1010 @@
+{
+  "objects": [
+    {
+      "attributes": {
+        "description": "Overview of AWS ELB Metrics",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "optionsJSON": {
+          "hidePanelTitles": false,
+          "useMargins": true
+        },
+        "panelsJSON": [
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 9,
+              "i": "2",
+              "w": 25,
+              "x": 23,
+              "y": 32
+            },
+            "panelIndex": "2",
+            "panelRefName": "panel_0",
+            "title": "HTTP 5XX Errors",
+            "version": "7.4.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 11,
+              "i": "3",
+              "w": 37,
+              "x": 11,
+              "y": 0
+            },
+            "panelIndex": "3",
+            "panelRefName": "panel_1",
+            "title": "Request Count",
+            "version": "7.4.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 8,
+              "i": "4",
+              "w": 11,
+              "x": 0,
+              "y": 15
+            },
+            "panelIndex": "4",
+            "panelRefName": "panel_2",
+            "title": "Unhealthy Host Count",
+            "version": "7.4.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 8,
+              "i": "5",
+              "w": 11,
+              "x": 0,
+              "y": 7
+            },
+            "panelIndex": "5",
+            "panelRefName": "panel_3",
+            "title": "Healthy Host Count",
+            "version": "7.4.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 12,
+              "i": "6",
+              "w": 37,
+              "x": 11,
+              "y": 11
+            },
+            "panelIndex": "6",
+            "panelRefName": "panel_4",
+            "title": "Latency in Seconds",
+            "version": "7.4.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 9,
+              "i": "7",
+              "w": 23,
+              "x": 0,
+              "y": 32
+            },
+            "panelIndex": "7",
+            "panelRefName": "panel_5",
+            "title": "HTTP Backend 4XX Errors",
+            "version": "7.4.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 9,
+              "i": "8",
+              "w": 23,
+              "x": 0,
+              "y": 23
+            },
+            "panelIndex": "8",
+            "panelRefName": "panel_6",
+            "title": "Backend Connection Errors",
+            "version": "7.4.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 7,
+              "i": "9",
+              "w": 11,
+              "x": 0,
+              "y": 0
+            },
+            "panelIndex": "9",
+            "panelRefName": "panel_7",
+            "version": "7.4.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 9,
+              "i": "10",
+              "w": 25,
+              "x": 23,
+              "y": 23
+            },
+            "panelIndex": "10",
+            "panelRefName": "panel_8",
+            "title": "HTTP Backend 2XX",
+            "version": "7.4.0"
+          }
+        ],
+        "timeRestore": false,
+        "title": "[Metricbeat AWS] ELB Overview",
+        "version": 1
+      },
+      "id": "e74bf320-b3ce-11e9-87a4-078dbbae220d",
+      "migrationVersion": {
+        "dashboard": "7.2.0"
+      },
+      "references": [
+        {
+          "id": "b9703dd0-b3c9-11e9-87a4-078dbbae220d",
+          "name": "panel_0",
+          "type": "visualization"
+        },
+        {
+          "id": "d560de70-b3c7-11e9-87a4-078dbbae220d",
+          "name": "panel_1",
+          "type": "visualization"
+        },
+        {
+          "id": "6fc1efd0-b3c9-11e9-87a4-078dbbae220d",
+          "name": "panel_2",
+          "type": "visualization"
+        },
+        {
+          "id": "6392bc30-b3c9-11e9-87a4-078dbbae220d",
+          "name": "panel_3",
+          "type": "visualization"
+        },
+        {
+          "id": "b2ea15a0-b3c7-11e9-87a4-078dbbae220d",
+          "name": "panel_4",
+          "type": "visualization"
+        },
+        {
+          "id": "21f30090-b3ca-11e9-87a4-078dbbae220d",
+          "name": "panel_5",
+          "type": "visualization"
+        },
+        {
+          "id": "572d40e0-b3ca-11e9-87a4-078dbbae220d",
+          "name": "panel_6",
+          "type": "visualization"
+        },
+        {
+          "id": "b5308940-7347-11e9-816b-07687310a99a",
+          "name": "panel_7",
+          "type": "visualization"
+        },
+        {
+          "id": "1f528f50-b3ce-11e9-87a4-078dbbae220d",
+          "name": "panel_8",
+          "type": "visualization"
+        }
+      ],
+      "type": "dashboard",
+      "updated_at": "2019-09-12T02:24:38.326Z",
+      "version": "WzI0MTYsN10="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "ELB HTTP 5XX Errors [Metricbeat AWS]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_min": "0",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "background_color_rules": [
+              {
+                "id": "7e66beb0-b3c6-11e9-af6e-ef22c5680226"
+              }
+            ],
+            "bar_color_rules": [
+              {
+                "id": "7db91990-b3c6-11e9-af6e-ef22c5680226"
+              }
+            ],
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": "",
+            "gauge_color_rules": [
+              {
+                "id": "7d0b9b80-b3c6-11e9-af6e-ef22c5680226"
+              }
+            ],
+            "gauge_inner_width": 10,
+            "gauge_style": "half",
+            "gauge_width": 10,
+            "id": "35d3cbc0-b3c6-11e9-bf3f-29d51aa3d971",
+            "index_pattern": "metricbeat-*",
+            "interval": "5m",
+            "isModelInvalid": false,
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#3185FC",
+                "fill": 0,
+                "formatter": "number",
+                "id": "35d3cbc1-b3c6-11e9-bf3f-29d51aa3d971",
+                "label": "HTTP 5XX Errors",
+                "line_width": 2,
+                "metrics": [
+                  {
+                    "field": "aws.metrics.HTTPCode_ELB_5XX.sum",
+                    "id": "35d3cbc2-b3c6-11e9-bf3f-29d51aa3d971",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": "5",
+                "separate_axis": 0,
+                "split_color_mode": "rainbow",
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "aws.cloudwatch.dimensions.LoadBalancerName",
+                "terms_order_by": "35d3cbc2-b3c6-11e9-bf3f-29d51aa3d971",
+                "value_template": "{{value}}"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "ELB HTTP 5XX Errors [Metricbeat AWS]",
+          "type": "metrics"
+        }
+      },
+      "id": "b9703dd0-b3c9-11e9-87a4-078dbbae220d",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-09-12T02:24:22.066Z",
+      "version": "WzI0MTUsN10="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "ELB Request Count [Metricbeat AWS]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_min": "0",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "background_color_rules": [
+              {
+                "id": "7e66beb0-b3c6-11e9-af6e-ef22c5680226"
+              }
+            ],
+            "bar_color_rules": [
+              {
+                "id": "7db91990-b3c6-11e9-af6e-ef22c5680226"
+              }
+            ],
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": "",
+            "gauge_color_rules": [
+              {
+                "id": "7d0b9b80-b3c6-11e9-af6e-ef22c5680226"
+              }
+            ],
+            "gauge_inner_width": 10,
+            "gauge_style": "half",
+            "gauge_width": 10,
+            "id": "35d3cbc0-b3c6-11e9-bf3f-29d51aa3d971",
+            "index_pattern": "metricbeat-*",
+            "interval": "5m",
+            "isModelInvalid": false,
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#3185FC",
+                "fill": 0,
+                "formatter": "number",
+                "id": "35d3cbc1-b3c6-11e9-bf3f-29d51aa3d971",
+                "label": "Request Count",
+                "line_width": 2,
+                "metrics": [
+                  {
+                    "field": "aws.metrics.RequestCount.sum",
+                    "id": "35d3cbc2-b3c6-11e9-bf3f-29d51aa3d971",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": "5",
+                "separate_axis": 0,
+                "split_color_mode": "rainbow",
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "aws.cloudwatch.dimensions.LoadBalancerName",
+                "terms_order_by": "35d3cbc2-b3c6-11e9-bf3f-29d51aa3d971",
+                "type": "timeseries",
+                "value_template": "{{value}}"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "ELB Request Count [Metricbeat AWS]",
+          "type": "metrics"
+        }
+      },
+      "id": "d560de70-b3c7-11e9-87a4-078dbbae220d",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-09-12T02:22:46.781Z",
+      "version": "WzI0MDgsN10="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "ELB Unhealthy Host Count [Metricbeat AWS]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "background_color_rules": [
+              {
+                "background_color": "rgba(244,78,59,1)",
+                "color": "rgba(255,255,255,1)",
+                "id": "7e66beb0-b3c6-11e9-af6e-ef22c5680226",
+                "operator": "gt",
+                "value": 0
+              }
+            ],
+            "bar_color_rules": [
+              {
+                "id": "7db91990-b3c6-11e9-af6e-ef22c5680226"
+              }
+            ],
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": "",
+            "gauge_color_rules": [
+              {
+                "id": "7d0b9b80-b3c6-11e9-af6e-ef22c5680226"
+              }
+            ],
+            "gauge_inner_width": 10,
+            "gauge_style": "half",
+            "gauge_width": 10,
+            "id": "35d3cbc0-b3c6-11e9-bf3f-29d51aa3d971",
+            "index_pattern": "metricbeat-*",
+            "interval": "5m",
+            "isModelInvalid": false,
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#3185FC",
+                "fill": 0,
+                "formatter": "number",
+                "id": "35d3cbc1-b3c6-11e9-bf3f-29d51aa3d971",
+                "label": "Unhealthy Host Count",
+                "line_width": 2,
+                "metrics": [
+                  {
+                    "field": "aws.metrics.UnHealthyHostCount.max",
+                    "id": "35d3cbc2-b3c6-11e9-bf3f-29d51aa3d971",
+                    "type": "max"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_color_mode": "rainbow",
+                "split_mode": "everything",
+                "stacked": "none",
+                "terms_field": "aws.cloudwatch.dimensions.AvailabilityZone",
+                "terms_order_by": "35d3cbc2-b3c6-11e9-bf3f-29d51aa3d971",
+                "value_template": "{{value}}"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "metric"
+          },
+          "title": "ELB Unhealthy Host Count [Metricbeat AWS]",
+          "type": "metrics"
+        }
+      },
+      "id": "6fc1efd0-b3c9-11e9-87a4-078dbbae220d",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-09-12T01:00:47.505Z",
+      "version": "WzIzOTYsN10="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "ELB Healthy Host Count [Metricbeat AWS]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "background_color_rules": [
+              {
+                "background_color": "rgba(104,188,0,1)",
+                "color": "rgba(255,255,255,1)",
+                "id": "7e66beb0-b3c6-11e9-af6e-ef22c5680226",
+                "operator": "gt",
+                "value": 0
+              }
+            ],
+            "bar_color_rules": [
+              {
+                "id": "7db91990-b3c6-11e9-af6e-ef22c5680226"
+              }
+            ],
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": "",
+            "gauge_color_rules": [
+              {
+                "id": "7d0b9b80-b3c6-11e9-af6e-ef22c5680226"
+              }
+            ],
+            "gauge_inner_width": 10,
+            "gauge_style": "half",
+            "gauge_width": 10,
+            "id": "35d3cbc0-b3c6-11e9-bf3f-29d51aa3d971",
+            "index_pattern": "metricbeat-*",
+            "interval": "5m",
+            "isModelInvalid": false,
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#3185FC",
+                "fill": 0,
+                "formatter": "number",
+                "id": "35d3cbc1-b3c6-11e9-bf3f-29d51aa3d971",
+                "label": "Healthy Host Count",
+                "line_width": 2,
+                "metrics": [
+                  {
+                    "field": "aws.metrics.HealthyHostCount.max",
+                    "id": "35d3cbc2-b3c6-11e9-bf3f-29d51aa3d971",
+                    "type": "max"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_color_mode": "rainbow",
+                "split_mode": "everything",
+                "stacked": "none",
+                "terms_field": "aws.cloudwatch.dimensions.AvailabilityZone",
+                "terms_order_by": "35d3cbc2-b3c6-11e9-bf3f-29d51aa3d971",
+                "value_template": "{{value}}"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "metric"
+          },
+          "title": "ELB Healthy Host Count [Metricbeat AWS]",
+          "type": "metrics"
+        }
+      },
+      "id": "6392bc30-b3c9-11e9-87a4-078dbbae220d",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-09-12T01:00:18.978Z",
+      "version": "WzIzOTMsN10="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "ELB Latency in Seconds [Metricbeat AWS]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_min": "0",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "background_color_rules": [
+              {
+                "id": "7e66beb0-b3c6-11e9-af6e-ef22c5680226"
+              }
+            ],
+            "bar_color_rules": [
+              {
+                "id": "7db91990-b3c6-11e9-af6e-ef22c5680226"
+              }
+            ],
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": "",
+            "gauge_color_rules": [
+              {
+                "id": "7d0b9b80-b3c6-11e9-af6e-ef22c5680226"
+              }
+            ],
+            "gauge_inner_width": 10,
+            "gauge_style": "half",
+            "gauge_width": 10,
+            "id": "35d3cbc0-b3c6-11e9-bf3f-29d51aa3d971",
+            "index_pattern": "metricbeat-*",
+            "interval": "5m",
+            "isModelInvalid": false,
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#3185FC",
+                "fill": 0,
+                "formatter": "s,s,3",
+                "id": "35d3cbc1-b3c6-11e9-bf3f-29d51aa3d971",
+                "label": "Latency in seconds",
+                "line_width": 2,
+                "metrics": [
+                  {
+                    "field": "aws.metrics.Latency.avg",
+                    "id": "35d3cbc2-b3c6-11e9-bf3f-29d51aa3d971",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": "5",
+                "separate_axis": 0,
+                "split_color_mode": "rainbow",
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "aws.cloudwatch.dimensions.LoadBalancerName",
+                "terms_order_by": "35d3cbc2-b3c6-11e9-bf3f-29d51aa3d971",
+                "value_template": "{{value}}"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "ELB Latency in Seconds [Metricbeat AWS]",
+          "type": "metrics"
+        }
+      },
+      "id": "b2ea15a0-b3c7-11e9-87a4-078dbbae220d",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-09-12T02:23:16.083Z",
+      "version": "WzI0MTAsN10="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "ELB HTTP Backend 4XX Errors [Metricbeat AWS]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_min": "0",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "background_color_rules": [
+              {
+                "id": "7e66beb0-b3c6-11e9-af6e-ef22c5680226"
+              }
+            ],
+            "bar_color_rules": [
+              {
+                "id": "7db91990-b3c6-11e9-af6e-ef22c5680226"
+              }
+            ],
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": "",
+            "gauge_color_rules": [
+              {
+                "id": "7d0b9b80-b3c6-11e9-af6e-ef22c5680226"
+              }
+            ],
+            "gauge_inner_width": 10,
+            "gauge_style": "half",
+            "gauge_width": 10,
+            "id": "35d3cbc0-b3c6-11e9-bf3f-29d51aa3d971",
+            "index_pattern": "metricbeat-*",
+            "interval": "5m",
+            "isModelInvalid": false,
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#3185FC",
+                "fill": "0",
+                "formatter": "number",
+                "id": "35d3cbc1-b3c6-11e9-bf3f-29d51aa3d971",
+                "label": "HTTP Backend 4XX Errors",
+                "line_width": 2,
+                "metrics": [
+                  {
+                    "field": "aws.metrics.HTTPCode_Backend_4XX.sum",
+                    "id": "35d3cbc2-b3c6-11e9-bf3f-29d51aa3d971",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": "5",
+                "separate_axis": 0,
+                "split_color_mode": "rainbow",
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "aws.cloudwatch.dimensions.LoadBalancerName",
+                "terms_order_by": "35d3cbc2-b3c6-11e9-bf3f-29d51aa3d971",
+                "value_template": "{{value}}"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "ELB HTTP Backend 4XX Errors [Metricbeat AWS]",
+          "type": "metrics"
+        }
+      },
+      "id": "21f30090-b3ca-11e9-87a4-078dbbae220d",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-09-12T02:24:09.023Z",
+      "version": "WzI0MTQsN10="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "ELB Backend Connection Errors [Metricbeat AWS]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_min": "0",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "background_color_rules": [
+              {
+                "id": "7e66beb0-b3c6-11e9-af6e-ef22c5680226"
+              }
+            ],
+            "bar_color_rules": [
+              {
+                "id": "7db91990-b3c6-11e9-af6e-ef22c5680226"
+              }
+            ],
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": "",
+            "gauge_color_rules": [
+              {
+                "id": "7d0b9b80-b3c6-11e9-af6e-ef22c5680226"
+              }
+            ],
+            "gauge_inner_width": 10,
+            "gauge_style": "half",
+            "gauge_width": 10,
+            "id": "35d3cbc0-b3c6-11e9-bf3f-29d51aa3d971",
+            "index_pattern": "metricbeat-*",
+            "interval": "5m",
+            "isModelInvalid": false,
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#3185FC",
+                "fill": "00",
+                "formatter": "number",
+                "id": "35d3cbc1-b3c6-11e9-bf3f-29d51aa3d971",
+                "label": "Backend Connection Errors",
+                "line_width": 2,
+                "metrics": [
+                  {
+                    "field": "aws.metrics.BackendConnectionErrors.sum",
+                    "id": "35d3cbc2-b3c6-11e9-bf3f-29d51aa3d971",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": "5",
+                "separate_axis": 0,
+                "split_color_mode": "rainbow",
+                "split_mode": "terms",
+                "stacked": "none",
+                "steps": 0,
+                "terms_field": "aws.cloudwatch.dimensions.LoadBalancerName",
+                "terms_order_by": "35d3cbc2-b3c6-11e9-bf3f-29d51aa3d971",
+                "value_template": "{{value}}"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "ELB Backend Connection Errors [Metricbeat AWS]",
+          "type": "metrics"
+        }
+      },
+      "id": "572d40e0-b3ca-11e9-87a4-078dbbae220d",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-09-12T02:22:28.366Z",
+      "version": "WzI0MDcsN10="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Region Filter [Metricbeat AWS]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "controls": [
+              {
+                "fieldName": "cloud.region",
+                "id": "1549397251041",
+                "indexPatternRefName": "control_0_index_pattern",
+                "label": "region",
+                "options": {
+                  "dynamicOptions": true,
+                  "multiselect": true,
+                  "order": "desc",
+                  "size": 5,
+                  "type": "terms"
+                },
+                "parent": "",
+                "type": "list"
+              }
+            ],
+            "pinFilters": false,
+            "updateFiltersOnChange": true,
+            "useTimeFilter": false
+          },
+          "title": "AWS Region Filter",
+          "type": "input_control_vis"
+        }
+      },
+      "id": "b5308940-7347-11e9-816b-07687310a99a",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [
+        {
+          "id": "metricbeat-*",
+          "name": "control_0_index_pattern",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-09-12T00:55:22.007Z",
+      "version": "WzIwNjgsN10="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "ELB HTTP Backend 2XX [Metricbeat AWS]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_min": "0",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "background_color_rules": [
+              {
+                "id": "7e66beb0-b3c6-11e9-af6e-ef22c5680226"
+              }
+            ],
+            "bar_color_rules": [
+              {
+                "id": "7db91990-b3c6-11e9-af6e-ef22c5680226"
+              }
+            ],
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": "",
+            "gauge_color_rules": [
+              {
+                "id": "7d0b9b80-b3c6-11e9-af6e-ef22c5680226"
+              }
+            ],
+            "gauge_inner_width": 10,
+            "gauge_style": "half",
+            "gauge_width": 10,
+            "id": "35d3cbc0-b3c6-11e9-bf3f-29d51aa3d971",
+            "index_pattern": "metricbeat-*",
+            "interval": "5m",
+            "isModelInvalid": false,
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#3185FC",
+                "fill": 0,
+                "formatter": "number",
+                "id": "35d3cbc1-b3c6-11e9-bf3f-29d51aa3d971",
+                "label": "HTTP Backend 2XX",
+                "line_width": 2,
+                "metrics": [
+                  {
+                    "field": "aws.metrics.HTTPCode_Backend_2XX.sum",
+                    "id": "35d3cbc2-b3c6-11e9-bf3f-29d51aa3d971",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": "5",
+                "separate_axis": 0,
+                "split_color_mode": "rainbow",
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "aws.cloudwatch.dimensions.LoadBalancerName",
+                "terms_order_by": "35d3cbc2-b3c6-11e9-bf3f-29d51aa3d971",
+                "value_template": "{{value}}"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "ELB HTTP Backend 2XX [Metricbeat AWS]",
+          "type": "metrics"
+        }
+      },
+      "id": "1f528f50-b3ce-11e9-87a4-078dbbae220d",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-09-12T02:23:38.069Z",
+      "version": "WzI0MTIsN10="
+    }
+  ],
+  "version": "7.4.0"
+}

--- a/dev/package-beats/aws-1.0.0/kibana/dashboard/Metricbeat-aws-overview.json
+++ b/dev/package-beats/aws-1.0.0/kibana/dashboard/Metricbeat-aws-overview.json
@@ -1,0 +1,1508 @@
+{
+    "objects": [
+        {
+            "attributes": {
+                "description": "Overview of AWS Metrics",
+                "hits": 0,
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                },
+                "optionsJSON": {
+                    "hidePanelTitles": false,
+                    "useMargins": true
+                },
+                "panelsJSON": [
+                    {
+                        "embeddableConfig": {},
+                        "gridData": {
+                            "h": 7,
+                            "i": "2",
+                            "w": 9,
+                            "x": 0,
+                            "y": 0
+                        },
+                        "panelIndex": "2",
+                        "panelRefName": "panel_0",
+                        "version": "7.0.0"
+                    },
+                    {
+                        "embeddableConfig": {},
+                        "gridData": {
+                            "h": 7,
+                            "i": "3",
+                            "w": 10,
+                            "x": 9,
+                            "y": 0
+                        },
+                        "panelIndex": "3",
+                        "panelRefName": "panel_1",
+                        "version": "7.0.0"
+                    },
+                    {
+                        "embeddableConfig": {},
+                        "gridData": {
+                            "h": 7,
+                            "i": "4",
+                            "w": 29,
+                            "x": 19,
+                            "y": 0
+                        },
+                        "panelIndex": "4",
+                        "panelRefName": "panel_2",
+                        "version": "7.0.0"
+                    },
+                    {
+                        "embeddableConfig": {},
+                        "gridData": {
+                            "h": 7,
+                            "i": "6",
+                            "w": 9,
+                            "x": 0,
+                            "y": 7
+                        },
+                        "panelIndex": "6",
+                        "panelRefName": "panel_3",
+                        "version": "7.0.0"
+                    },
+                    {
+                        "embeddableConfig": {},
+                        "gridData": {
+                            "h": 7,
+                            "i": "7",
+                            "w": 9,
+                            "x": 9,
+                            "y": 7
+                        },
+                        "panelIndex": "7",
+                        "panelRefName": "panel_4",
+                        "version": "7.0.0"
+                    },
+                    {
+                        "embeddableConfig": {},
+                        "gridData": {
+                            "h": 7,
+                            "i": "9",
+                            "w": 15,
+                            "x": 18,
+                            "y": 7
+                        },
+                        "panelIndex": "9",
+                        "panelRefName": "panel_5",
+                        "version": "7.0.0"
+                    },
+                    {
+                        "embeddableConfig": {},
+                        "gridData": {
+                            "h": 7,
+                            "i": "10",
+                            "w": 15,
+                            "x": 33,
+                            "y": 7
+                        },
+                        "panelIndex": "10",
+                        "panelRefName": "panel_6",
+                        "version": "7.0.0"
+                    },
+                    {
+                        "embeddableConfig": {},
+                        "gridData": {
+                            "h": 7,
+                            "i": "12",
+                            "w": 13,
+                            "x": 0,
+                            "y": 14
+                        },
+                        "panelIndex": "12",
+                        "panelRefName": "panel_7",
+                        "version": "7.0.0"
+                    },
+                    {
+                        "embeddableConfig": {},
+                        "gridData": {
+                            "h": 7,
+                            "i": "14",
+                            "w": 20,
+                            "x": 13,
+                            "y": 14
+                        },
+                        "panelIndex": "14",
+                        "panelRefName": "panel_8",
+                        "version": "7.0.0"
+                    },
+                    {
+                        "embeddableConfig": {},
+                        "gridData": {
+                            "h": 7,
+                            "i": "15",
+                            "w": 15,
+                            "x": 33,
+                            "y": 14
+                        },
+                        "panelIndex": "15",
+                        "panelRefName": "panel_9",
+                        "version": "7.0.0"
+                    },
+                    {
+                        "embeddableConfig": {},
+                        "gridData": {
+                            "h": 7,
+                            "i": "17",
+                            "w": 16,
+                            "x": 15,
+                            "y": 21
+                        },
+                        "panelIndex": "17",
+                        "panelRefName": "panel_10",
+                        "version": "7.0.0"
+                    },
+                    {
+                        "embeddableConfig": {},
+                        "gridData": {
+                            "h": 7,
+                            "i": "18",
+                            "w": 15,
+                            "x": 0,
+                            "y": 21
+                        },
+                        "panelIndex": "18",
+                        "panelRefName": "panel_11",
+                        "version": "7.0.0"
+                    },
+                    {
+                        "embeddableConfig": {},
+                        "gridData": {
+                            "h": 7,
+                            "i": "19",
+                            "w": 17,
+                            "x": 31,
+                            "y": 21
+                        },
+                        "panelIndex": "19",
+                        "panelRefName": "panel_12",
+                        "version": "7.0.0"
+                    },
+                    {
+                        "embeddableConfig": {},
+                        "gridData": {
+                            "h": 9,
+                            "i": "24",
+                            "w": 24,
+                            "x": 0,
+                            "y": 28
+                        },
+                        "panelIndex": "24",
+                        "panelRefName": "panel_13",
+                        "version": "7.2.0"
+                    },
+                    {
+                        "embeddableConfig": {},
+                        "gridData": {
+                            "h": 9,
+                            "i": "25",
+                            "w": 24,
+                            "x": 24,
+                            "y": 28
+                        },
+                        "panelIndex": "25",
+                        "panelRefName": "panel_14",
+                        "version": "7.2.0"
+                    }
+                ],
+                "timeRestore": false,
+                "title": "[Metricbeat AWS] Overview",
+                "version": 1
+            },
+            "id": "fac28650-7349-11e9-816b-07687310a99a",
+            "migrationVersion": {
+                "dashboard": "7.0.0"
+            },
+            "references": [
+                {
+                    "id": "b5308940-7347-11e9-816b-07687310a99a",
+                    "name": "panel_0",
+                    "type": "visualization"
+                },
+                {
+                    "id": "09db13f0-2bdd-11e9-9fe1-cde861544141",
+                    "name": "panel_1",
+                    "type": "visualization"
+                },
+                {
+                    "id": "be8828d0-f7f6-11e8-af03-c999c9dea608-ecs",
+                    "name": "panel_2",
+                    "type": "visualization"
+                },
+                {
+                    "id": "81d83c70-4762-11e9-8062-c98a86cb6f94",
+                    "name": "panel_3",
+                    "type": "visualization"
+                },
+                {
+                    "id": "58e17c10-7349-11e9-816b-07687310a99a",
+                    "name": "panel_4",
+                    "type": "visualization"
+                },
+                {
+                    "id": "4658f540-734a-11e9-816b-07687310a99a",
+                    "name": "panel_5",
+                    "type": "visualization"
+                },
+                {
+                    "id": "95b322f0-734a-11e9-816b-07687310a99a",
+                    "name": "panel_6",
+                    "type": "visualization"
+                },
+                {
+                    "id": "b2191dd0-734c-11e9-816b-07687310a99a",
+                    "name": "panel_7",
+                    "type": "visualization"
+                },
+                {
+                    "id": "42016bf0-728f-11e9-9a7b-4d62d5bcf4fc",
+                    "name": "panel_8",
+                    "type": "visualization"
+                },
+                {
+                    "id": "9121ac90-734d-11e9-816b-07687310a99a",
+                    "name": "panel_9",
+                    "type": "visualization"
+                },
+                {
+                    "id": "128fd450-734e-11e9-816b-07687310a99a",
+                    "name": "panel_10",
+                    "type": "visualization"
+                },
+                {
+                    "id": "54e88a40-734e-11e9-816b-07687310a99a",
+                    "name": "panel_11",
+                    "type": "visualization"
+                },
+                {
+                    "id": "398d12d0-7352-11e9-816b-07687310a99a",
+                    "name": "panel_12",
+                    "type": "visualization"
+                },
+                {
+                    "id": "4bf62a10-8310-11e9-ac83-47df3568ff90",
+                    "name": "panel_13",
+                    "type": "visualization"
+                },
+                {
+                    "id": "d2f46190-830f-11e9-ac83-47df3568ff90",
+                    "name": "panel_14",
+                    "type": "visualization"
+                }
+            ],
+            "type": "dashboard",
+            "updated_at": "2019-06-14T17:28:35.266Z",
+            "version": "WzI5MjYsNF0="
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                },
+                "title": "Region Filter [Metricbeat AWS]",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "params": {
+                        "controls": [
+                            {
+                                "fieldName": "cloud.region",
+                                "id": "1549397251041",
+                                "indexPatternRefName": "control_0_index_pattern",
+                                "label": "region",
+                                "options": {
+                                    "dynamicOptions": true,
+                                    "multiselect": true,
+                                    "order": "desc",
+                                    "size": 5,
+                                    "type": "terms"
+                                },
+                                "parent": "",
+                                "type": "list"
+                            }
+                        ],
+                        "pinFilters": false,
+                        "updateFiltersOnChange": true,
+                        "useTimeFilter": false
+                    },
+                    "title": "AWS Region Filter",
+                    "type": "input_control_vis"
+                }
+            },
+            "id": "b5308940-7347-11e9-816b-07687310a99a",
+            "migrationVersion": {
+                "visualization": "7.2.0"
+            },
+            "references": [
+                {
+                    "id": "metricbeat-*",
+                    "name": "control_0_index_pattern",
+                    "type": "index-pattern"
+                }
+            ],
+            "type": "visualization",
+            "updated_at": "2019-06-14T17:02:27.742Z",
+            "version": "WzI2NzQsNF0="
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                },
+                "title": "EC2 Instance State [Metricbeat AWS] ECS",
+                "uiStateJSON": {
+                    "vis": {
+                        "colors": {
+                            "16": "#629E51",
+                            "272": "#DEDAF7",
+                            "80": "#E24D42",
+                            "running": "#7EB26D",
+                            "stopped": "#E24D42"
+                        },
+                        "legendOpen": true
+                    }
+                },
+                "version": 1,
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true,
+                            "id": "1",
+                            "params": {
+                                "customLabel": "EC2 Instance State"
+                            },
+                            "schema": "metric",
+                            "type": "count"
+                        },
+                        {
+                            "enabled": true,
+                            "id": "2",
+                            "params": {
+                                "customLabel": "",
+                                "field": "aws.ec2.instance.state.name",
+                                "missingBucket": false,
+                                "missingBucketLabel": "Missing",
+                                "order": "desc",
+                                "orderBy": "1",
+                                "otherBucket": false,
+                                "otherBucketLabel": "Other",
+                                "size": 5
+                            },
+                            "schema": "segment",
+                            "type": "terms"
+                        }
+                    ],
+                    "params": {
+                        "addLegend": true,
+                        "addTooltip": true,
+                        "isDonut": false,
+                        "labels": {
+                            "last_level": true,
+                            "show": true,
+                            "truncate": 100,
+                            "values": true
+                        },
+                        "legendPosition": "right",
+                        "type": "pie"
+                    },
+                    "title": "EC2 Instance State [Metricbeat AWS] ECS",
+                    "type": "pie"
+                }
+            },
+            "id": "09db13f0-2bdd-11e9-9fe1-cde861544141",
+            "migrationVersion": {
+                "visualization": "7.2.0"
+            },
+            "references": [
+                {
+                    "id": "metricbeat-*",
+                    "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+                    "type": "index-pattern"
+                }
+            ],
+            "type": "visualization",
+            "updated_at": "2019-06-14T17:02:27.742Z",
+            "version": "WzI2NzUsNF0="
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                },
+                "title": "EC2 CPU Utilization [Metricbeat AWS] ECS",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "params": {
+                        "annotations": [],
+                        "axis_formatter": "number",
+                        "axis_position": "left",
+                        "axis_scale": "normal",
+                        "background_color_rules": [
+                            {
+                                "id": "23428b30-f7f2-11e8-bff8-21537b07dd44"
+                            }
+                        ],
+                        "bar_color_rules": [
+                            {
+                                "id": "2592bcc0-f7f2-11e8-bff8-21537b07dd44"
+                            }
+                        ],
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+                        "index_pattern": "metricbeat-*",
+                        "interval": "5m",
+                        "series": [
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "rgba(104,188,0,1)",
+                                "fill": "0",
+                                "filter": "",
+                                "formatter": "number",
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                                "label": "AWS EC2 CPU Utilization ECS",
+                                "line_width": 1,
+                                "metrics": [
+                                    {
+                                        "field": "aws.ec2.cpu.total.pct",
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                                        "type": "avg"
+                                    }
+                                ],
+                                "point_size": 1,
+                                "separate_axis": 0,
+                                "series_drop_last_bucket": 1,
+                                "split_color_mode": "rainbow",
+                                "split_mode": "terms",
+                                "stacked": "none",
+                                "steps": 0,
+                                "terms_field": "cloud.instance.id",
+                                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417",
+                                "terms_size": "5"
+                            }
+                        ],
+                        "show_grid": 1,
+                        "show_legend": 1,
+                        "time_field": "@timestamp",
+                        "type": "timeseries"
+                    },
+                    "title": "AWS EC2 CPU Utilization ECS",
+                    "type": "metrics"
+                }
+            },
+            "id": "be8828d0-f7f6-11e8-af03-c999c9dea608-ecs",
+            "migrationVersion": {
+                "visualization": "7.2.0"
+            },
+            "references": [],
+            "type": "visualization",
+            "updated_at": "2019-06-14T17:02:27.742Z",
+            "version": "WzI2NzYsNF0="
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                },
+                "title": "S3 Total Error 4xx [Metricbeat AWS]",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "params": {
+                        "axis_formatter": "number",
+                        "axis_position": "left",
+                        "axis_scale": "normal",
+                        "background_color_rules": [
+                            {
+                                "id": "59207fe0-4762-11e9-bf81-69a4e579cab5"
+                            }
+                        ],
+                        "bar_color_rules": [
+                            {
+                                "id": "5ad9a190-4762-11e9-bf81-69a4e579cab5"
+                            }
+                        ],
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+                        "index_pattern": "metricbeat-*",
+                        "interval": "auto",
+                        "series": [
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "#68BC00",
+                                "fill": 0.5,
+                                "formatter": "number",
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                                "label": "Total # of HTTP 4xx Errors",
+                                "line_width": 1,
+                                "metrics": [
+                                    {
+                                        "field": "aws.s3_request.errors.4xx",
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                                        "type": "sum"
+                                    }
+                                ],
+                                "point_size": 1,
+                                "separate_axis": 0,
+                                "split_mode": "everything",
+                                "stacked": "none"
+                            }
+                        ],
+                        "show_grid": 1,
+                        "show_legend": 1,
+                        "time_field": "@timestamp",
+                        "type": "metric"
+                    },
+                    "title": "AWS S3 Total Error 4xx",
+                    "type": "metrics"
+                }
+            },
+            "id": "81d83c70-4762-11e9-8062-c98a86cb6f94",
+            "migrationVersion": {
+                "visualization": "7.2.0"
+            },
+            "references": [],
+            "type": "visualization",
+            "updated_at": "2019-06-14T17:02:28.760Z",
+            "version": "WzI2OTUsNF0="
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                },
+                "title": "S3 Total Error 5xx [Metricbeat AWS]",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "params": {
+                        "axis_formatter": "number",
+                        "axis_position": "left",
+                        "axis_scale": "normal",
+                        "background_color_rules": [
+                            {
+                                "id": "59207fe0-4762-11e9-bf81-69a4e579cab5"
+                            }
+                        ],
+                        "bar_color_rules": [
+                            {
+                                "id": "5ad9a190-4762-11e9-bf81-69a4e579cab5"
+                            }
+                        ],
+                        "default_index_pattern": "metricbeat-*",
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+                        "index_pattern": "metricbeat-*",
+                        "interval": "auto",
+                        "series": [
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "#68BC00",
+                                "fill": 0.5,
+                                "formatter": "number",
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                                "label": "Total # of HTTP 5xx Errors",
+                                "line_width": 1,
+                                "metrics": [
+                                    {
+                                        "field": "aws.s3_request.errors.5xx",
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                                        "type": "sum"
+                                    }
+                                ],
+                                "point_size": 1,
+                                "separate_axis": 0,
+                                "split_mode": "everything",
+                                "stacked": "none"
+                            }
+                        ],
+                        "show_grid": 1,
+                        "show_legend": 1,
+                        "time_field": "@timestamp",
+                        "type": "metric"
+                    },
+                    "title": "AWS S3 Total Error 5xx",
+                    "type": "metrics"
+                }
+            },
+            "id": "58e17c10-7349-11e9-816b-07687310a99a",
+            "migrationVersion": {
+                "visualization": "7.2.0"
+            },
+            "references": [],
+            "type": "visualization",
+            "updated_at": "2019-06-14T17:02:27.742Z",
+            "version": "WzI2NzgsNF0="
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                },
+                "title": "SQS Empty Receives Top5 [Metricbeat AWS]",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "params": {
+                        "axis_formatter": "number",
+                        "axis_position": "left",
+                        "axis_scale": "normal",
+                        "bar_color_rules": [
+                            {
+                                "id": "23be77d0-734a-11e9-a683-47ca322fa6f9"
+                            }
+                        ],
+                        "default_index_pattern": "metricbeat-*",
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+                        "index_pattern": "",
+                        "interval": "auto",
+                        "series": [
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "#68BC00",
+                                "fill": 0.5,
+                                "formatter": "number",
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                                "label": "AWS SQS Empty Receives",
+                                "line_width": 1,
+                                "metrics": [
+                                    {
+                                        "field": "aws.sqs.empty_receives",
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                                        "type": "avg"
+                                    }
+                                ],
+                                "point_size": 1,
+                                "separate_axis": 0,
+                                "split_mode": "terms",
+                                "stacked": "none",
+                                "terms_field": "aws.sqs.queue.name",
+                                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417",
+                                "terms_size": "5"
+                            }
+                        ],
+                        "show_grid": 1,
+                        "show_legend": 1,
+                        "time_field": "@timestamp",
+                        "type": "top_n"
+                    },
+                    "title": "AWS SQS Empty Receives Top5",
+                    "type": "metrics"
+                }
+            },
+            "id": "4658f540-734a-11e9-816b-07687310a99a",
+            "migrationVersion": {
+                "visualization": "7.2.0"
+            },
+            "references": [],
+            "type": "visualization",
+            "updated_at": "2019-06-14T17:02:27.742Z",
+            "version": "WzI2NzksNF0="
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                },
+                "title": "SQS Messages Delayed Top5 [Metricbeat AWS]",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "params": {
+                        "axis_formatter": "number",
+                        "axis_position": "left",
+                        "axis_scale": "normal",
+                        "bar_color_rules": [
+                            {
+                                "id": "23be77d0-734a-11e9-a683-47ca322fa6f9"
+                            }
+                        ],
+                        "default_index_pattern": "metricbeat-*",
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+                        "index_pattern": "",
+                        "interval": "auto",
+                        "series": [
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "#68BC00",
+                                "fill": 0.5,
+                                "formatter": "number",
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                                "label": "AWS SQS Messages Delayed",
+                                "line_width": 1,
+                                "metrics": [
+                                    {
+                                        "field": "aws.sqs.messages.delayed",
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                                        "type": "avg"
+                                    }
+                                ],
+                                "point_size": 1,
+                                "separate_axis": 0,
+                                "split_mode": "terms",
+                                "stacked": "none",
+                                "terms_field": "aws.sqs.queue.name",
+                                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417",
+                                "terms_size": "5"
+                            }
+                        ],
+                        "show_grid": 1,
+                        "show_legend": 1,
+                        "time_field": "@timestamp",
+                        "type": "top_n"
+                    },
+                    "title": "AWS SQS Messages Delayed Top5",
+                    "type": "metrics"
+                }
+            },
+            "id": "95b322f0-734a-11e9-816b-07687310a99a",
+            "migrationVersion": {
+                "visualization": "7.2.0"
+            },
+            "references": [],
+            "type": "visualization",
+            "updated_at": "2019-06-14T17:02:27.742Z",
+            "version": "WzI2ODAsNF0="
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                },
+                "title": "Cloudwatch ELB Request Count Top5 [Metricbeat AWS]",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "params": {
+                        "axis_formatter": "number",
+                        "axis_position": "left",
+                        "axis_scale": "normal",
+                        "bar_color_rules": [
+                            {
+                                "id": "94f2ce40-734c-11e9-a683-47ca322fa6f9"
+                            }
+                        ],
+                        "default_index_pattern": "metricbeat-*",
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+                        "index_pattern": "",
+                        "interval": "auto",
+                        "series": [
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "#68BC00",
+                                "fill": 0.5,
+                                "formatter": "number",
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                                "label": "ELB Request Count Top5",
+                                "line_width": 1,
+                                "metrics": [
+                                    {
+                                        "field": "aws.cloudwatch.metrics.RequestCount",
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                                        "type": "sum"
+                                    }
+                                ],
+                                "point_size": 1,
+                                "separate_axis": 0,
+                                "split_mode": "terms",
+                                "stacked": "none",
+                                "terms_field": "aws.cloudwatch.dimensions.LoadBalancerName",
+                                "terms_size": "5"
+                            }
+                        ],
+                        "show_grid": 1,
+                        "show_legend": 1,
+                        "time_field": "@timestamp",
+                        "type": "top_n"
+                    },
+                    "title": "AWS Cloudwatch ELB Request Count Top5",
+                    "type": "metrics"
+                }
+            },
+            "id": "b2191dd0-734c-11e9-816b-07687310a99a",
+            "migrationVersion": {
+                "visualization": "7.2.0"
+            },
+            "references": [],
+            "type": "visualization",
+            "updated_at": "2019-06-14T17:02:27.742Z",
+            "version": "WzI2ODEsNF0="
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                },
+                "title": "Cloudwatch ELB Latency [Metricbeat AWS]",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "params": {
+                        "annotations": [],
+                        "axis_formatter": "number",
+                        "axis_position": "left",
+                        "axis_scale": "normal",
+                        "background_color_rules": [
+                            {
+                                "id": "23428b30-f7f2-11e8-bff8-21537b07dd44"
+                            }
+                        ],
+                        "bar_color_rules": [
+                            {
+                                "id": "2592bcc0-f7f2-11e8-bff8-21537b07dd44"
+                            }
+                        ],
+                        "default_index_pattern": "metricbeat-8*",
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+                        "index_pattern": "metricbeat-*",
+                        "interval": "5m",
+                        "series": [
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "rgba(104,188,0,1)",
+                                "fill": "0",
+                                "filter": "",
+                                "formatter": "number",
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                                "label": "AWS Cloudwatch ELB Latency",
+                                "line_width": 1,
+                                "metrics": [
+                                    {
+                                        "field": "aws.cloudwatch.metrics.Latency",
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                                        "type": "avg"
+                                    }
+                                ],
+                                "point_size": 1,
+                                "separate_axis": 0,
+                                "series_drop_last_bucket": 1,
+                                "split_color_mode": "rainbow",
+                                "split_mode": "terms",
+                                "stacked": "none",
+                                "steps": 0,
+                                "terms_field": "aws.cloudwatch.dimensions.LoadBalancerName",
+                                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417",
+                                "terms_size": "5"
+                            }
+                        ],
+                        "show_grid": 1,
+                        "show_legend": 1,
+                        "time_field": "@timestamp",
+                        "type": "timeseries"
+                    },
+                    "title": "AWS Cloudwatch ELB Latency",
+                    "type": "metrics"
+                }
+            },
+            "id": "42016bf0-728f-11e9-9a7b-4d62d5bcf4fc",
+            "migrationVersion": {
+                "visualization": "7.2.0"
+            },
+            "references": [],
+            "type": "visualization",
+            "updated_at": "2019-06-14T17:02:27.742Z",
+            "version": "WzI2ODIsNF0="
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                },
+                "title": "Cloudwatch ELB Unhealthy Host Count [Metricbeat AWS]",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "params": {
+                        "axis_formatter": "number",
+                        "axis_position": "left",
+                        "axis_scale": "normal",
+                        "background_color_rules": [
+                            {
+                                "id": "cbb498f0-734c-11e9-a683-47ca322fa6f9"
+                            }
+                        ],
+                        "bar_color_rules": [
+                            {
+                                "id": "94f2ce40-734c-11e9-a683-47ca322fa6f9"
+                            }
+                        ],
+                        "default_index_pattern": "metricbeat-*",
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+                        "index_pattern": "",
+                        "interval": "5m",
+                        "series": [
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "#68BC00",
+                                "fill": "0",
+                                "formatter": "number",
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                                "label": "ELB Unhealthy Host Count",
+                                "line_width": 1,
+                                "metrics": [
+                                    {
+                                        "field": "aws.cloudwatch.metrics.UnHealthyHostCount",
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                                        "type": "sum"
+                                    }
+                                ],
+                                "point_size": 1,
+                                "separate_axis": 0,
+                                "split_mode": "terms",
+                                "stacked": "none",
+                                "terms_field": "aws.cloudwatch.dimensions.LoadBalancerName",
+                                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417",
+                                "terms_size": "5"
+                            }
+                        ],
+                        "show_grid": 1,
+                        "show_legend": 1,
+                        "time_field": "@timestamp",
+                        "type": "top_n"
+                    },
+                    "title": "AWS Cloudwatch ELB Unhealthy Host Count",
+                    "type": "metrics"
+                }
+            },
+            "id": "9121ac90-734d-11e9-816b-07687310a99a",
+            "migrationVersion": {
+                "visualization": "7.2.0"
+            },
+            "references": [],
+            "type": "visualization",
+            "updated_at": "2019-06-14T17:02:27.742Z",
+            "version": "WzI2ODMsNF0="
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                },
+                "title": "Cloudwatch Lambda Invocations Top5 [Metricbeat AWS]",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "params": {
+                        "axis_formatter": "number",
+                        "axis_position": "left",
+                        "axis_scale": "normal",
+                        "background_color_rules": [
+                            {
+                                "id": "cbb498f0-734c-11e9-a683-47ca322fa6f9"
+                            }
+                        ],
+                        "bar_color_rules": [
+                            {
+                                "id": "94f2ce40-734c-11e9-a683-47ca322fa6f9"
+                            }
+                        ],
+                        "default_index_pattern": "metricbeat-*",
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+                        "index_pattern": "",
+                        "interval": "5m",
+                        "series": [
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "#68BC00",
+                                "fill": "0",
+                                "formatter": "number",
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                                "label": "Lambda Invocations",
+                                "line_width": 1,
+                                "metrics": [
+                                    {
+                                        "field": "aws.cloudwatch.metrics.Invocations",
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                                        "type": "avg"
+                                    }
+                                ],
+                                "point_size": 1,
+                                "separate_axis": 0,
+                                "split_mode": "terms",
+                                "stacked": "none",
+                                "terms_field": "aws.cloudwatch.dimensions.FunctionName",
+                                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417",
+                                "terms_size": "5"
+                            }
+                        ],
+                        "show_grid": 1,
+                        "show_legend": 1,
+                        "time_field": "@timestamp",
+                        "type": "top_n"
+                    },
+                    "title": "AWS Cloudwatch Lambda Invocations Top5",
+                    "type": "metrics"
+                }
+            },
+            "id": "128fd450-734e-11e9-816b-07687310a99a",
+            "migrationVersion": {
+                "visualization": "7.2.0"
+            },
+            "references": [],
+            "type": "visualization",
+            "updated_at": "2019-06-14T17:02:27.742Z",
+            "version": "WzI2ODQsNF0="
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                },
+                "title": "Cloudwatch Lambda Errors Top5 [Metricbeat AWS]",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "params": {
+                        "axis_formatter": "number",
+                        "axis_position": "left",
+                        "axis_scale": "normal",
+                        "background_color_rules": [
+                            {
+                                "id": "cbb498f0-734c-11e9-a683-47ca322fa6f9"
+                            }
+                        ],
+                        "bar_color_rules": [
+                            {
+                                "id": "94f2ce40-734c-11e9-a683-47ca322fa6f9"
+                            }
+                        ],
+                        "default_index_pattern": "metricbeat-*",
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+                        "index_pattern": "",
+                        "interval": "5m",
+                        "series": [
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "#68BC00",
+                                "fill": "0",
+                                "formatter": "number",
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                                "label": "Lambda Errors",
+                                "line_width": 1,
+                                "metrics": [
+                                    {
+                                        "field": "aws.cloudwatch.metrics.Errors",
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                                        "type": "avg"
+                                    }
+                                ],
+                                "point_size": 1,
+                                "separate_axis": 0,
+                                "split_mode": "terms",
+                                "stacked": "none",
+                                "terms_field": "aws.cloudwatch.dimensions.FunctionName",
+                                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417",
+                                "terms_size": "5"
+                            }
+                        ],
+                        "show_grid": 1,
+                        "show_legend": 1,
+                        "time_field": "@timestamp",
+                        "type": "top_n"
+                    },
+                    "title": "AWS Cloudwatch Lambda Errors Top5",
+                    "type": "metrics"
+                }
+            },
+            "id": "54e88a40-734e-11e9-816b-07687310a99a",
+            "migrationVersion": {
+                "visualization": "7.2.0"
+            },
+            "references": [],
+            "type": "visualization",
+            "updated_at": "2019-06-14T17:02:27.742Z",
+            "version": "WzI2ODUsNF0="
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                },
+                "title": "Cloudwatch Lambda Throttles Top5 [Metricbeat AWS]",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "params": {
+                        "axis_formatter": "number",
+                        "axis_position": "left",
+                        "axis_scale": "normal",
+                        "background_color_rules": [
+                            {
+                                "id": "cbb498f0-734c-11e9-a683-47ca322fa6f9"
+                            }
+                        ],
+                        "bar_color_rules": [
+                            {
+                                "id": "94f2ce40-734c-11e9-a683-47ca322fa6f9"
+                            }
+                        ],
+                        "default_index_pattern": "metricbeat-*",
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+                        "index_pattern": "",
+                        "interval": "5m",
+                        "series": [
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "#68BC00",
+                                "fill": "0",
+                                "formatter": "number",
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                                "label": "Lambda Throttles",
+                                "line_width": 1,
+                                "metrics": [
+                                    {
+                                        "field": "aws.cloudwatch.metrics.Throttles",
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                                        "type": "avg"
+                                    }
+                                ],
+                                "point_size": 1,
+                                "separate_axis": 0,
+                                "split_mode": "terms",
+                                "stacked": "none",
+                                "terms_field": "aws.cloudwatch.dimensions.FunctionName",
+                                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417",
+                                "terms_size": "5"
+                            }
+                        ],
+                        "show_grid": 1,
+                        "show_legend": 1,
+                        "time_field": "@timestamp",
+                        "type": "top_n"
+                    },
+                    "title": "AWS Cloudwatch Lambda Throttles Top5",
+                    "type": "metrics"
+                }
+            },
+            "id": "398d12d0-7352-11e9-816b-07687310a99a",
+            "migrationVersion": {
+                "visualization": "7.2.0"
+            },
+            "references": [],
+            "type": "visualization",
+            "updated_at": "2019-06-14T17:02:27.742Z",
+            "version": "WzI2ODYsNF0="
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                },
+                "title": "Cloudwatch ECS CPU Available [Metricbeat AWS]",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "params": {
+                        "axis_formatter": "number",
+                        "axis_position": "left",
+                        "axis_scale": "normal",
+                        "background_color_rules": [
+                            {
+                                "id": "bb21d180-830d-11e9-9c4c-391fa0a2e15f"
+                            }
+                        ],
+                        "default_index_pattern": "metricbeat-*",
+                        "default_timefield": "@timestamp",
+                        "filter": "",
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+                        "index_pattern": "",
+                        "interval": "5m",
+                        "series": [
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "#68BC00",
+                                "fill": "0",
+                                "filter": "(aws.cloudwatch.namespace:\"AWS/ECS\") AND (_exists_: aws.cloudwatch.metrics.CPUReservation) AND (_exists_: aws.cloudwatch.metrics.CPUUtilization)",
+                                "formatter": "percent",
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                                "label": "",
+                                "line_width": 1,
+                                "metrics": [
+                                    {
+                                        "field": "aws.cloudwatch.metrics.CPUUtilization",
+                                        "id": "17f8ddf0-830d-11e9-9f3d-ed346f48a007",
+                                        "type": "sum"
+                                    },
+                                    {
+                                        "field": "aws.cloudwatch.metrics.CPUReservation",
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                                        "type": "sum"
+                                    },
+                                    {
+                                        "id": "68a93050-830e-11e9-9c4c-391fa0a2e15f",
+                                        "script": "(params.res - params.util) / 100",
+                                        "type": "math",
+                                        "variables": [
+                                            {
+                                                "field": "17f8ddf0-830d-11e9-9f3d-ed346f48a007",
+                                                "id": "6f338920-830e-11e9-9c4c-391fa0a2e15f",
+                                                "name": "util"
+                                            },
+                                            {
+                                                "field": "61ca57f2-469d-11e7-af02-69e470af7417",
+                                                "id": "7ab9f9a0-830e-11e9-9c4c-391fa0a2e15f",
+                                                "name": "res"
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "point_size": 1,
+                                "separate_axis": 0,
+                                "split_mode": "terms",
+                                "stacked": "none",
+                                "terms_field": "aws.cloudwatch.dimensions.ClusterName",
+                                "terms_order_by": "_key",
+                                "terms_size": "5"
+                            }
+                        ],
+                        "show_grid": 1,
+                        "show_legend": 1,
+                        "time_field": "",
+                        "type": "timeseries"
+                    },
+                    "title": "AWS Cloudwatch ECS CPU Available",
+                    "type": "metrics"
+                }
+            },
+            "id": "4bf62a10-8310-11e9-ac83-47df3568ff90",
+            "migrationVersion": {
+                "visualization": "7.2.0"
+            },
+            "references": [],
+            "type": "visualization",
+            "updated_at": "2019-06-14T17:48:26.084Z",
+            "version": "WzI5NDEsNF0="
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                },
+                "title": "Cloudwatch ECS Memory Available [Metricbeat AWS]",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "params": {
+                        "axis_formatter": "number",
+                        "axis_position": "left",
+                        "axis_scale": "normal",
+                        "background_color_rules": [
+                            {
+                                "id": "bb21d180-830d-11e9-9c4c-391fa0a2e15f"
+                            }
+                        ],
+                        "default_index_pattern": "metricbeat-*",
+                        "default_timefield": "@timestamp",
+                        "filter": "",
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+                        "index_pattern": "",
+                        "interval": "5m",
+                        "series": [
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "#68BC00",
+                                "fill": "0",
+                                "filter": "(aws.cloudwatch.namespace:\"AWS/ECS\") AND (_exists_: aws.cloudwatch.metrics.MemoryReservation) AND (_exists_: aws.cloudwatch.metrics.MemoryUtilization)",
+                                "formatter": "percent",
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                                "label": "",
+                                "line_width": 1,
+                                "metrics": [
+                                    {
+                                        "field": "aws.cloudwatch.metrics.MemoryUtilization",
+                                        "id": "17f8ddf0-830d-11e9-9f3d-ed346f48a007",
+                                        "type": "sum"
+                                    },
+                                    {
+                                        "field": "aws.cloudwatch.metrics.MemoryReservation",
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                                        "type": "sum"
+                                    },
+                                    {
+                                        "id": "68a93050-830e-11e9-9c4c-391fa0a2e15f",
+                                        "script": "(params.res - params.util) / 100",
+                                        "type": "math",
+                                        "variables": [
+                                            {
+                                                "field": "17f8ddf0-830d-11e9-9f3d-ed346f48a007",
+                                                "id": "6f338920-830e-11e9-9c4c-391fa0a2e15f",
+                                                "name": "util"
+                                            },
+                                            {
+                                                "field": "61ca57f2-469d-11e7-af02-69e470af7417",
+                                                "id": "7ab9f9a0-830e-11e9-9c4c-391fa0a2e15f",
+                                                "name": "res"
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "point_size": 1,
+                                "separate_axis": 0,
+                                "split_mode": "terms",
+                                "stacked": "none",
+                                "terms_field": "aws.cloudwatch.dimensions.ClusterName",
+                                "terms_order_by": "_key",
+                                "terms_size": "5",
+                                "value_template": "{{value}}"
+                            }
+                        ],
+                        "show_grid": 1,
+                        "show_legend": 1,
+                        "time_field": "",
+                        "type": "timeseries"
+                    },
+                    "title": "AWS Cloudwatch ECS Memory Available",
+                    "type": "metrics"
+                }
+            },
+            "id": "d2f46190-830f-11e9-ac83-47df3568ff90",
+            "migrationVersion": {
+                "visualization": "7.2.0"
+            },
+            "references": [],
+            "type": "visualization",
+            "updated_at": "2019-06-14T17:47:50.042Z",
+            "version": "WzI5NDAsNF0="
+        }
+    ],
+    "version": "7.2.0"
+}

--- a/dev/package-beats/aws-1.0.0/kibana/dashboard/Metricbeat-aws-rds-overview.json
+++ b/dev/package-beats/aws-1.0.0/kibana/dashboard/Metricbeat-aws-rds-overview.json
@@ -1,0 +1,847 @@
+{
+  "objects": [
+    {
+      "attributes": {
+        "description": "Overview of AWS RDS Metrics",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "optionsJSON": {
+          "hidePanelTitles": false,
+          "useMargins": true
+        },
+        "panelsJSON": [
+          {
+            "embeddableConfig": {
+              "title": "Database Connections"
+            },
+            "gridData": {
+              "h": 6,
+              "i": "1",
+              "w": 19,
+              "x": 10,
+              "y": 0
+            },
+            "panelIndex": "1",
+            "panelRefName": "panel_0",
+            "title": "Database Connections",
+            "version": "7.4.0"
+          },
+          {
+            "embeddableConfig": {
+              "title": "Insert Latency in Milliseconds"
+            },
+            "gridData": {
+              "h": 10,
+              "i": "3",
+              "w": 24,
+              "x": 0,
+              "y": 6
+            },
+            "panelIndex": "3",
+            "panelRefName": "panel_1",
+            "title": "Insert Latency in Milliseconds",
+            "version": "7.4.0"
+          },
+          {
+            "embeddableConfig": {
+              "title": "Select Latency in Milliseconds"
+            },
+            "gridData": {
+              "h": 10,
+              "i": "4",
+              "w": 24,
+              "x": 24,
+              "y": 6
+            },
+            "panelIndex": "4",
+            "panelRefName": "panel_2",
+            "title": "Select Latency in Milliseconds",
+            "version": "7.4.0"
+          },
+          {
+            "embeddableConfig": {
+              "title": "Transaction Blocked"
+            },
+            "gridData": {
+              "h": 6,
+              "i": "5",
+              "w": 19,
+              "x": 29,
+              "y": 0
+            },
+            "panelIndex": "5",
+            "panelRefName": "panel_3",
+            "title": "Transaction Blocked",
+            "version": "7.4.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 6,
+              "i": "6",
+              "w": 10,
+              "x": 0,
+              "y": 0
+            },
+            "panelIndex": "6",
+            "panelRefName": "panel_4",
+            "version": "7.4.0"
+          },
+          {
+            "embeddableConfig": {
+              "title": "Insert Throughput in Count/Second"
+            },
+            "gridData": {
+              "h": 11,
+              "i": "7",
+              "w": 24,
+              "x": 0,
+              "y": 16
+            },
+            "panelIndex": "7",
+            "panelRefName": "panel_5",
+            "title": "Insert Throughput in Count/Second",
+            "version": "7.4.0"
+          },
+          {
+            "embeddableConfig": {
+              "title": "Select Throughput in Count/Second"
+            },
+            "gridData": {
+              "h": 11,
+              "i": "8",
+              "w": 24,
+              "x": 24,
+              "y": 16
+            },
+            "panelIndex": "8",
+            "panelRefName": "panel_6",
+            "title": "Select Throughput in Count/Second",
+            "version": "7.4.0"
+          },
+          {
+            "embeddableConfig": {
+              "title": "Disk Queue Depth"
+            },
+            "gridData": {
+              "h": 12,
+              "i": "132653bc-2669-4e8c-b536-06c680e9acf0",
+              "w": 48,
+              "x": 0,
+              "y": 27
+            },
+            "panelIndex": "132653bc-2669-4e8c-b536-06c680e9acf0",
+            "panelRefName": "panel_7",
+            "title": "Disk Queue Depth",
+            "version": "7.4.0"
+          }
+        ],
+        "timeRestore": false,
+        "title": "[Metricbeat AWS] RDS Overview",
+        "version": 1
+      },
+      "id": "3367c170-921f-11e9-aa19-159bf182e06f",
+      "migrationVersion": {
+        "dashboard": "7.3.0"
+      },
+      "references": [
+        {
+          "id": "17fcda50-921b-11e9-aa19-159bf182e06f",
+          "name": "panel_0",
+          "type": "visualization"
+        },
+        {
+          "id": "8b8a7f80-921c-11e9-aa19-159bf182e06f",
+          "name": "panel_1",
+          "type": "visualization"
+        },
+        {
+          "id": "cc3a1950-921c-11e9-aa19-159bf182e06f",
+          "name": "panel_2",
+          "type": "visualization"
+        },
+        {
+          "id": "00b29040-921d-11e9-aa19-159bf182e06f",
+          "name": "panel_3",
+          "type": "visualization"
+        },
+        {
+          "id": "b5308940-7347-11e9-816b-07687310a99a",
+          "name": "panel_4",
+          "type": "visualization"
+        },
+        {
+          "id": "c1afd130-921e-11e9-aa19-159bf182e06f",
+          "name": "panel_5",
+          "type": "visualization"
+        },
+        {
+          "id": "e06e4cf0-921e-11e9-aa19-159bf182e06f",
+          "name": "panel_6",
+          "type": "visualization"
+        },
+        {
+          "id": "966ae990-d979-11e9-9458-bbef63ad717b",
+          "name": "panel_7",
+          "type": "visualization"
+        }
+      ],
+      "type": "dashboard",
+      "updated_at": "2019-09-17T18:35:03.575Z",
+      "version": "WzExNTk3LDhd"
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "RDS Database Connections [Metricbeat AWS]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "background_color_rules": [
+              {
+                "id": "10bc2760-d978-11e9-aff2-99c15d8b7da1"
+              }
+            ],
+            "bar_color_rules": [
+              {
+                "id": "f8196690-921a-11e9-badf-4b42bd1ef543"
+              }
+            ],
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "",
+            "interval": "1m",
+            "isModelInvalid": false,
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "bar",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "number",
+                "hide_in_legend": 0,
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Database Connections",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "aws.rds.database_connections",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "sum"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "terms_field": "aws.rds.db_instance.identifier",
+                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "",
+            "type": "metric"
+          },
+          "title": "RDS Database Connections [Metricbeat AWS]",
+          "type": "metrics"
+        }
+      },
+      "id": "17fcda50-921b-11e9-aa19-159bf182e06f",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-09-17T18:22:36.018Z",
+      "version": "WzExNTc3LDhd"
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "RDS Insert Latency in Milliseconds [Metricbeat AWS]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_min": "0",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "background_color_rules": [
+              {
+                "id": "28cacdf0-921c-11e9-badf-4b42bd1ef543"
+              }
+            ],
+            "bar_color_rules": [
+              {
+                "id": "f8196690-921a-11e9-badf-4b42bd1ef543"
+              }
+            ],
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "",
+            "interval": "1m",
+            "isModelInvalid": false,
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": "0",
+                "formatter": "ms,ms,",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Insert Latency in Milliseconds",
+                "line_width": "2",
+                "metrics": [
+                  {
+                    "field": "aws.rds.latency.insert",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": "5",
+                "separate_axis": 0,
+                "split_color_mode": "rainbow",
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "aws.rds.db_instance.identifier",
+                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "",
+            "type": "timeseries"
+          },
+          "title": "RDS Insert Latency in Milliseconds [Metricbeat AWS]",
+          "type": "metrics"
+        }
+      },
+      "id": "8b8a7f80-921c-11e9-aa19-159bf182e06f",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-09-17T18:27:15.143Z",
+      "version": "WzExNTg1LDhd"
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "RDS Select Latency in Milliseconds [Metricbeat AWS]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "background_color_rules": [
+              {
+                "id": "28cacdf0-921c-11e9-badf-4b42bd1ef543"
+              }
+            ],
+            "bar_color_rules": [
+              {
+                "id": "f8196690-921a-11e9-badf-4b42bd1ef543"
+              }
+            ],
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "",
+            "interval": "1m",
+            "isModelInvalid": false,
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": "0",
+                "formatter": "ms,ms,",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Select Latency in Milliseconds",
+                "line_width": "2",
+                "metrics": [
+                  {
+                    "field": "aws.rds.latency.select",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": "5",
+                "separate_axis": 0,
+                "split_color_mode": "rainbow",
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "aws.rds.db_instance.identifier",
+                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "",
+            "type": "timeseries"
+          },
+          "title": "RDS Select Latency in Milliseconds [Metricbeat AWS]",
+          "type": "metrics"
+        }
+      },
+      "id": "cc3a1950-921c-11e9-aa19-159bf182e06f",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-09-17T18:26:36.223Z",
+      "version": "WzExNTgzLDhd"
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "RDS Transaction Blocked [Metricbeat AWS]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "background_color_rules": [
+              {
+                "background_color": "rgba(164,221,0,1)",
+                "id": "27aaf910-d978-11e9-aff2-99c15d8b7da1",
+                "operator": "lte",
+                "value": 0
+              },
+              {
+                "color": "rgba(244,78,59,1)",
+                "id": "3526a9e0-d978-11e9-aff2-99c15d8b7da1",
+                "operator": "gt",
+                "value": 0
+              }
+            ],
+            "bar_color_rules": [
+              {
+                "bar_color": "rgba(211,49,21,1)",
+                "id": "f8196690-921a-11e9-badf-4b42bd1ef543",
+                "operator": "gt",
+                "value": 0
+              }
+            ],
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "drilldown_url": "",
+            "filter": "",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "",
+            "interval": "1m",
+            "isModelInvalid": false,
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "bar",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "number",
+                "hide_in_legend": 0,
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Transaction Blocked",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "aws.rds.transactions.blocked",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "sum"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "terms_field": "aws.rds.db_instance.identifier",
+                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "",
+            "type": "metric"
+          },
+          "title": "RDS Transaction Blocked [Metricbeat AWS]",
+          "type": "metrics"
+        }
+      },
+      "id": "00b29040-921d-11e9-aa19-159bf182e06f",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-09-17T18:23:33.361Z",
+      "version": "WzExNTc5LDhd"
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Region Filter [Metricbeat AWS]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "controls": [
+              {
+                "fieldName": "cloud.region",
+                "id": "1549397251041",
+                "indexPatternRefName": "control_0_index_pattern",
+                "label": "region",
+                "options": {
+                  "dynamicOptions": true,
+                  "multiselect": true,
+                  "order": "desc",
+                  "size": 5,
+                  "type": "terms"
+                },
+                "parent": "",
+                "type": "list"
+              }
+            ],
+            "pinFilters": false,
+            "updateFiltersOnChange": true,
+            "useTimeFilter": false
+          },
+          "title": "AWS Region Filter",
+          "type": "input_control_vis"
+        }
+      },
+      "id": "b5308940-7347-11e9-816b-07687310a99a",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [
+        {
+          "id": "metricbeat-*",
+          "name": "control_0_index_pattern",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-09-17T18:20:56.488Z",
+      "version": "WzExMjUzLDhd"
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "RDS Insert Throughput in Count/Second [Metricbeat AWS]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_min": "0",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "background_color_rules": [
+              {
+                "id": "28cacdf0-921c-11e9-badf-4b42bd1ef543"
+              }
+            ],
+            "bar_color_rules": [
+              {
+                "id": "f8196690-921a-11e9-badf-4b42bd1ef543"
+              }
+            ],
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "",
+            "interval": "1m",
+            "isModelInvalid": false,
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": "0",
+                "formatter": "'0.0'",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Insert Throughput Count/Second",
+                "line_width": "2",
+                "metrics": [
+                  {
+                    "field": "aws.rds.throughput.insert",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": "5",
+                "separate_axis": 0,
+                "split_color_mode": "rainbow",
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "aws.rds.db_instance.identifier",
+                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "",
+            "type": "timeseries"
+          },
+          "title": "RDS Insert Throughput in Count/Second [Metricbeat AWS]",
+          "type": "metrics"
+        }
+      },
+      "id": "c1afd130-921e-11e9-aa19-159bf182e06f",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-09-17T18:31:36.123Z",
+      "version": "WzExNTkzLDhd"
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "RDS Select Throughput in Count/Second [Metricbeat AWS]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_min": "",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "background_color_rules": [
+              {
+                "id": "28cacdf0-921c-11e9-badf-4b42bd1ef543"
+              }
+            ],
+            "bar_color_rules": [
+              {
+                "id": "f8196690-921a-11e9-badf-4b42bd1ef543"
+              }
+            ],
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "",
+            "interval": "1m",
+            "isModelInvalid": false,
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": "0",
+                "formatter": "'0.0'",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Select Throughput Count/Second",
+                "line_width": "2",
+                "metrics": [
+                  {
+                    "field": "aws.rds.throughput.select",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": "5",
+                "separate_axis": 0,
+                "split_color_mode": "rainbow",
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "aws.rds.db_instance.identifier",
+                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "",
+            "type": "timeseries"
+          },
+          "title": "RDS Select Throughput in Count/Second [Metricbeat AWS]",
+          "type": "metrics"
+        }
+      },
+      "id": "e06e4cf0-921e-11e9-aa19-159bf182e06f",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-09-17T18:31:01.587Z",
+      "version": "WzExNTkyLDhd"
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "RDS Disk Queue Depth [Metricbeat AWS]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_min": "0",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "background_color_rules": [
+              {
+                "id": "28cacdf0-921c-11e9-badf-4b42bd1ef543"
+              }
+            ],
+            "bar_color_rules": [
+              {
+                "id": "f8196690-921a-11e9-badf-4b42bd1ef543"
+              }
+            ],
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "",
+            "interval": "1m",
+            "isModelInvalid": false,
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": "0",
+                "formatter": "'0.000'",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Select Throughput Count/Second",
+                "line_width": "2",
+                "metrics": [
+                  {
+                    "field": "aws.rds.disk_queue_depth",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": "5",
+                "separate_axis": 0,
+                "split_color_mode": "rainbow",
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "aws.rds.db_instance.identifier",
+                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417",
+                "type": "timeseries"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "",
+            "type": "timeseries"
+          },
+          "title": "RDS Disk Queue Depth [Metricbeat AWS]",
+          "type": "metrics"
+        }
+      },
+      "id": "966ae990-d979-11e9-9458-bbef63ad717b",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-09-17T18:33:04.936Z",
+      "version": "WzExNTk1LDhd"
+    }
+  ],
+  "version": "7.4.0"
+}

--- a/dev/package-beats/aws-1.0.0/kibana/dashboard/Metricbeat-aws-s3-overview.json
+++ b/dev/package-beats/aws-1.0.0/kibana/dashboard/Metricbeat-aws-s3-overview.json
@@ -1,0 +1,717 @@
+{
+  "objects": [
+    {
+      "attributes": {
+        "description": "Overview of AWS S3 Metrics",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "optionsJSON": {
+          "hidePanelTitles": false,
+          "useMargins": true
+        },
+        "panelsJSON": [
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 7,
+              "i": "1",
+              "w": 24,
+              "x": 0,
+              "y": 6
+            },
+            "panelIndex": "1",
+            "panelRefName": "panel_0",
+            "version": "7.4.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 7,
+              "i": "2",
+              "w": 24,
+              "x": 24,
+              "y": 6
+            },
+            "panelIndex": "2",
+            "panelRefName": "panel_1",
+            "version": "7.4.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 7,
+              "i": "3",
+              "w": 24,
+              "x": 0,
+              "y": 13
+            },
+            "panelIndex": "3",
+            "panelRefName": "panel_2",
+            "version": "7.4.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 6,
+              "i": "4",
+              "w": 13,
+              "x": 24,
+              "y": 0
+            },
+            "panelIndex": "4",
+            "panelRefName": "panel_3",
+            "version": "7.4.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 6,
+              "i": "5",
+              "w": 11,
+              "x": 37,
+              "y": 0
+            },
+            "panelIndex": "5",
+            "panelRefName": "panel_4",
+            "version": "7.4.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 6,
+              "i": "6",
+              "w": 24,
+              "x": 0,
+              "y": 0
+            },
+            "panelIndex": "6",
+            "panelRefName": "panel_5",
+            "version": "7.4.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 7,
+              "i": "7",
+              "w": 24,
+              "x": 24,
+              "y": 13
+            },
+            "panelIndex": "7",
+            "panelRefName": "panel_6",
+            "version": "7.4.0"
+          }
+        ],
+        "timeRestore": false,
+        "title": "[Metricbeat AWS] S3 Overview",
+        "version": 1
+      },
+      "id": "a096b830-4762-11e9-8062-c98a86cb6f94",
+      "migrationVersion": {
+        "dashboard": "7.3.0"
+      },
+      "references": [
+        {
+          "id": "2dbb8f90-4760-11e9-8062-c98a86cb6f94",
+          "name": "panel_0",
+          "type": "visualization"
+        },
+        {
+          "id": "3a3914d0-4761-11e9-8062-c98a86cb6f94",
+          "name": "panel_1",
+          "type": "visualization"
+        },
+        {
+          "id": "2b2d58b0-4762-11e9-8062-c98a86cb6f94",
+          "name": "panel_2",
+          "type": "visualization"
+        },
+        {
+          "id": "81d83c70-4762-11e9-8062-c98a86cb6f94",
+          "name": "panel_3",
+          "type": "visualization"
+        },
+        {
+          "id": "8b34a100-4762-11e9-8062-c98a86cb6f94",
+          "name": "panel_4",
+          "type": "visualization"
+        },
+        {
+          "id": "6e3285d0-4763-11e9-8062-c98a86cb6f94",
+          "name": "panel_5",
+          "type": "visualization"
+        },
+        {
+          "id": "d186fd50-4763-11e9-8062-c98a86cb6f94",
+          "name": "panel_6",
+          "type": "visualization"
+        }
+      ],
+      "type": "dashboard",
+      "updated_at": "2019-09-12T21:18:24.987Z",
+      "version": "Wzc3NjAsN10="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "S3 Daily Storage Bucket Size in Bytes [Metricbeat AWS]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "background_color_rules": [
+              {
+                "id": "f679e680-475f-11e9-a9de-e776805ecfc9"
+              }
+            ],
+            "bar_color_rules": [
+              {
+                "id": "f703aff0-475f-11e9-a9de-e776805ecfc9"
+              }
+            ],
+            "drop_last_bucket": 0,
+            "gauge_color_rules": [
+              {
+                "id": "f8388670-475f-11e9-a9de-e776805ecfc9"
+              }
+            ],
+            "gauge_inner_width": 10,
+            "gauge_style": "half",
+            "gauge_width": 10,
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "metricbeat-*",
+            "interval": "1d",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": "0",
+                "formatter": "bytes",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "aws.s3_daily_storage.bucket.size.bytes",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "aws.s3_daily_storage.bucket.name",
+                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417",
+                "terms_size": "5"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "top_n"
+          },
+          "title": "AWS S3 Daily Storage Bucket Size in Bytes",
+          "type": "metrics"
+        }
+      },
+      "id": "2dbb8f90-4760-11e9-8062-c98a86cb6f94",
+      "migrationVersion": {
+        "visualization": "7.0.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-09-12T21:13:42.937Z",
+      "version": "Wzc0MzQsN10="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "S3 Daily Storage Number of Objects [Metricbeat AWS]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "background_color_rules": [
+              {
+                "id": "167ea870-4761-11e9-bf81-69a4e579cab5"
+              }
+            ],
+            "bar_color_rules": [
+              {
+                "id": "01dad830-4761-11e9-bf81-69a4e579cab5"
+              }
+            ],
+            "drop_last_bucket": 0,
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "metricbeat-*",
+            "interval": "1d",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "number",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "aws.s3_daily_storage.number_of_objects",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "aws.s3_daily_storage.bucket.name",
+                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417",
+                "terms_size": "5"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "top_n"
+          },
+          "title": "AWS S3 Daily Storage Number of Objects",
+          "type": "metrics"
+        }
+      },
+      "id": "3a3914d0-4761-11e9-8062-c98a86cb6f94",
+      "migrationVersion": {
+        "visualization": "7.0.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-09-12T21:13:42.937Z",
+      "version": "Wzc0MzUsN10="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "S3 Request Latency Total Request in ms [Metricbeat AWS]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "background_color_rules": [
+              {
+                "id": "c0d11b00-4761-11e9-bf81-69a4e579cab5"
+              }
+            ],
+            "bar_color_rules": [
+              {
+                "id": "67cb0930-4761-11e9-bf81-69a4e579cab5"
+              }
+            ],
+            "drop_last_bucket": 0,
+            "gauge_color_rules": [
+              {
+                "id": "6eafde10-4761-11e9-bf81-69a4e579cab5"
+              }
+            ],
+            "gauge_inner_width": 10,
+            "gauge_style": "half",
+            "gauge_width": 10,
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "metricbeat-*",
+            "interval": "1d",
+            "pivot_id": "aws.s3_request.bucket.name",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "color_rules": [
+                  {
+                    "id": "ac2ef870-4761-11e9-bf81-69a4e579cab5"
+                  }
+                ],
+                "fill": 0.5,
+                "formatter": "number",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Latency in ms",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "aws.s3_request.latency.total_request.ms",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "aws.s3_request.bucket.name",
+                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417",
+                "terms_size": "5"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "top_n"
+          },
+          "title": "AWS S3 Request Latency Total Request in ms",
+          "type": "metrics"
+        }
+      },
+      "id": "2b2d58b0-4762-11e9-8062-c98a86cb6f94",
+      "migrationVersion": {
+        "visualization": "7.0.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-09-12T21:13:42.937Z",
+      "version": "Wzc0MzYsN10="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "S3 Total Error 4xx [Metricbeat AWS]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "background_color_rules": [
+              {
+                "id": "59207fe0-4762-11e9-bf81-69a4e579cab5"
+              }
+            ],
+            "bar_color_rules": [
+              {
+                "id": "5ad9a190-4762-11e9-bf81-69a4e579cab5"
+              }
+            ],
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "number",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Total # of HTTP 4xx Errors",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "aws.s3_request.errors.4xx",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "sum"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "metric"
+          },
+          "title": "AWS S3 Total Error 4xx",
+          "type": "metrics"
+        }
+      },
+      "id": "81d83c70-4762-11e9-8062-c98a86cb6f94",
+      "migrationVersion": {
+        "visualization": "7.0.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-09-12T21:13:42.937Z",
+      "version": "Wzc0MzcsN10="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "S3 Total Error 5xx [Metricbeat AWS]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "background_color_rules": [
+              {
+                "id": "59207fe0-4762-11e9-bf81-69a4e579cab5"
+              }
+            ],
+            "bar_color_rules": [
+              {
+                "id": "5ad9a190-4762-11e9-bf81-69a4e579cab5"
+              }
+            ],
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "number",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Total # of HTTP 5xx Errors",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "aws.s3_request.errors.5xx",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "sum"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "metric"
+          },
+          "title": "AWS S3 Total Error 5xx",
+          "type": "metrics"
+        }
+      },
+      "id": "8b34a100-4762-11e9-8062-c98a86cb6f94",
+      "migrationVersion": {
+        "visualization": "7.0.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-09-12T21:13:42.937Z",
+      "version": "Wzc0MzgsN10="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "S3 Filters [Metricbeat AWS]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "controls": [
+              {
+                "fieldName": "cloud.region",
+                "id": "1549397251041",
+                "indexPattern": "metricbeat-*",
+                "label": "region",
+                "options": {
+                  "dynamicOptions": true,
+                  "multiselect": true,
+                  "order": "desc",
+                  "size": 5,
+                  "type": "terms"
+                },
+                "parent": "",
+                "type": "list"
+              },
+              {
+                "fieldName": "aws.s3.bucket.name",
+                "id": "1549512142947",
+                "indexPattern": "metricbeat-*",
+                "label": "s3 bucket name",
+                "options": {
+                  "dynamicOptions": true,
+                  "multiselect": true,
+                  "order": "desc",
+                  "size": 5,
+                  "type": "terms"
+                },
+                "parent": "",
+                "type": "list"
+              }
+            ],
+            "pinFilters": false,
+            "updateFiltersOnChange": true,
+            "useTimeFilter": false
+          },
+          "title": "AWS S3 Filters",
+          "type": "input_control_vis"
+        }
+      },
+      "id": "6e3285d0-4763-11e9-8062-c98a86cb6f94",
+      "migrationVersion": {
+        "visualization": "7.0.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-09-12T21:18:08.498Z",
+      "version": "Wzc3NTgsN10="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "S3 Total Requests [Metricbeat AWS]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "background_color_rules": [
+              {
+                "id": "c03c4320-4763-11e9-b811-fd5d24a641d7"
+              }
+            ],
+            "bar_color_rules": [
+              {
+                "id": "c7b9fca0-4763-11e9-b811-fd5d24a641d7"
+              }
+            ],
+            "drop_last_bucket": 0,
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "metricbeat-*",
+            "interval": "1d",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": "0",
+                "formatter": "number",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "aws.s3_request.requests.total",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  }
+                ],
+                "offset_time": "",
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "aws.s3_request.bucket.name",
+                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417",
+                "terms_size": "5"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "top_n"
+          },
+          "title": "AWS S3 Total Requests",
+          "type": "metrics"
+        }
+      },
+      "id": "d186fd50-4763-11e9-8062-c98a86cb6f94",
+      "migrationVersion": {
+        "visualization": "7.0.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-09-12T21:13:42.937Z",
+      "version": "Wzc0NDAsN10="
+    }
+  ],
+  "version": "7.4.0"
+}

--- a/dev/package-beats/aws-1.0.0/kibana/dashboard/Metricbeat-aws-sqs-overview.json
+++ b/dev/package-beats/aws-1.0.0/kibana/dashboard/Metricbeat-aws-sqs-overview.json
@@ -1,0 +1,813 @@
+{
+  "objects": [
+    {
+      "attributes": {
+        "description": "Overview of AWS SQS Metrics",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "optionsJSON": {
+          "hidePanelTitles": false,
+          "useMargins": true
+        },
+        "panelsJSON": [
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 8,
+              "i": "1",
+              "w": 12,
+              "x": 12,
+              "y": 0
+            },
+            "panelIndex": "1",
+            "panelRefName": "panel_0",
+            "version": "7.0.0-beta1"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 8,
+              "i": "2",
+              "w": 12,
+              "x": 36,
+              "y": 0
+            },
+            "panelIndex": "2",
+            "panelRefName": "panel_1",
+            "version": "7.0.0-beta1"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 8,
+              "i": "3",
+              "w": 24,
+              "x": 0,
+              "y": 8
+            },
+            "panelIndex": "3",
+            "panelRefName": "panel_2",
+            "version": "7.0.0-beta1"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 8,
+              "i": "4",
+              "w": 24,
+              "x": 24,
+              "y": 8
+            },
+            "panelIndex": "4",
+            "panelRefName": "panel_3",
+            "version": "7.0.0-beta1"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 8,
+              "i": "7",
+              "w": 24,
+              "x": 0,
+              "y": 16
+            },
+            "panelIndex": "7",
+            "panelRefName": "panel_4",
+            "version": "7.0.0-beta1"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 8,
+              "i": "8",
+              "w": 24,
+              "x": 24,
+              "y": 16
+            },
+            "panelIndex": "8",
+            "panelRefName": "panel_5",
+            "version": "7.0.0-beta1"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 8,
+              "i": "9",
+              "w": 12,
+              "x": 0,
+              "y": 0
+            },
+            "panelIndex": "9",
+            "panelRefName": "panel_6",
+            "version": "7.0.0-beta1"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 8,
+              "i": "10",
+              "w": 12,
+              "x": 24,
+              "y": 0
+            },
+            "panelIndex": "10",
+            "panelRefName": "panel_7",
+            "version": "7.0.0"
+          }
+        ],
+        "timeRestore": false,
+        "title": "[Metricbeat AWS] SQS Overview",
+        "version": 1
+      },
+      "id": "234aeda0-43b7-11e9-8697-530f39afc6eb",
+      "migrationVersion": {
+        "dashboard": "7.0.0"
+      },
+      "references": [
+        {
+          "id": "f74eb760-41e8-11e9-b7a0-c99d9d127b61",
+          "name": "panel_0",
+          "type": "visualization"
+        },
+        {
+          "id": "53730d20-437e-11e9-8697-530f39afc6eb",
+          "name": "panel_1",
+          "type": "visualization"
+        },
+        {
+          "id": "1235fe50-41e7-11e9-b7a0-c99d9d127b61",
+          "name": "panel_2",
+          "type": "visualization"
+        },
+        {
+          "id": "be6c4180-41e6-11e9-b7a0-c99d9d127b61",
+          "name": "panel_3",
+          "type": "visualization"
+        },
+        {
+          "id": "dcd31cd0-41e5-11e9-b7a0-c99d9d127b61",
+          "name": "panel_4",
+          "type": "visualization"
+        },
+        {
+          "id": "dd2f2a10-41e6-11e9-b7a0-c99d9d127b61",
+          "name": "panel_5",
+          "type": "visualization"
+        },
+        {
+          "id": "b0afd3e0-43b7-11e9-8697-530f39afc6eb",
+          "name": "panel_6",
+          "type": "visualization"
+        },
+        {
+          "id": "bb82c4d0-6c25-11e9-81bc-7f4cd8b3d892",
+          "name": "panel_7",
+          "type": "visualization"
+        }
+      ],
+      "type": "dashboard",
+      "updated_at": "2019-05-29T14:11:54.211Z",
+      "version": "WzI4NywxXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "SQS Messages Visible [Metricbeat AWS]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "background_color_rules": [
+              {
+                "id": "d5b83c70-41e8-11e9-9e94-11d4d21d3f4b"
+              }
+            ],
+            "bar_color_rules": [
+              {
+                "id": "d2d14920-41e8-11e9-9e94-11d4d21d3f4b"
+              }
+            ],
+            "default_index_pattern": "metricbeat-*",
+            "gauge_color_rules": [
+              {
+                "id": "d2163680-41e8-11e9-9e94-11d4d21d3f4b"
+              }
+            ],
+            "gauge_inner_width": 10,
+            "gauge_style": "half",
+            "gauge_width": 10,
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "metricbeat-*",
+            "interval": "5m",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": "0",
+                "formatter": "number",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "SQS Message Visible",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "aws.sqs.messages.visible",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "aws.sqs.queue.name.keyword",
+                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417",
+                "terms_size": "5"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "top_n"
+          },
+          "title": "AWS SQS Messages Visible",
+          "type": "metrics"
+        }
+      },
+      "id": "f74eb760-41e8-11e9-b7a0-c99d9d127b61",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-05-29T14:11:54.211Z",
+      "version": "WzI4OCwxXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "SQS Oldest Message Age in Seconds [Metricbeat AWS]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "bar_color_rules": [
+              {
+                "id": "3e3d3610-437e-11e9-a35d-972620e4f790"
+              }
+            ],
+            "default_index_pattern": "metricbeat-*",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "metricbeat-*",
+            "interval": "5m",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "number",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "AWS SQS Oldest Message Age in Seconds",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "aws.sqs.oldest_message_age.sec",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "max"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "aws.sqs.queue.name.keyword",
+                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417",
+                "terms_size": "5"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "top_n"
+          },
+          "title": "AWS SQS Oldest Message Age in Seconds",
+          "type": "metrics"
+        }
+      },
+      "id": "53730d20-437e-11e9-8697-530f39afc6eb",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-05-29T14:11:54.211Z",
+      "version": "WzI4OSwxXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "SQS Messages Received [Metricbeat AWS]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "background_color_rules": [
+              {
+                "id": "1ccb6710-43b3-11e9-8c70-d17a67455a84"
+              }
+            ],
+            "bar_color_rules": [
+              {
+                "id": "57cc0200-43b5-11e9-84e9-a97a63579915"
+              }
+            ],
+            "default_index_pattern": "metricbeat-*",
+            "drop_last_bucket": 1,
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "metricbeat-*",
+            "interval": "5m",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": "0",
+                "formatter": "number",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "aws.sqs.messages.received",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "sum"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "series_drop_last_bucket": 1,
+                "split_color_mode": "rainbow",
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "aws.sqs.queue.name.keyword",
+                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417",
+                "terms_size": "5"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "AWS SQS Messages Received",
+          "type": "metrics"
+        }
+      },
+      "id": "1235fe50-41e7-11e9-b7a0-c99d9d127b61",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-05-29T14:11:54.211Z",
+      "version": "WzI5MCwxXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "SQS Messages Deleted [Metricbeat AWS]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "drop_last_bucket": 1,
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "metricbeat-*",
+            "interval": "5m",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": "0",
+                "formatter": "number",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "aws.sqs.messages.deleted",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_color_mode": "rainbow",
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "aws.sqs.queue.name.keyword",
+                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417",
+                "terms_size": "5"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "AWS SQS Messages Deleted",
+          "type": "metrics"
+        }
+      },
+      "id": "be6c4180-41e6-11e9-b7a0-c99d9d127b61",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-05-29T14:11:54.211Z",
+      "version": "WzI5MSwxXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "SQS Messages Delayed [Metricbeat AWS]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "drop_last_bucket": 1,
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "metricbeat-*",
+            "interval": "5m",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": "0",
+                "formatter": "number",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "aws.sqs.messages.delayed",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_color_mode": "rainbow",
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "aws.sqs.queue.name.keyword",
+                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417",
+                "terms_size": "5"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "AWS SQS Messages Delayed",
+          "type": "metrics"
+        }
+      },
+      "id": "dcd31cd0-41e5-11e9-b7a0-c99d9d127b61",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-05-29T14:11:54.211Z",
+      "version": "WzI5MiwxXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "SQS Messages Sent [Metricbeat AWS]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "background_color_rules": [
+              {
+                "id": "d95adba0-6b8a-11e9-98b0-9b2c3d14a4c1"
+              }
+            ],
+            "default_index_pattern": "metricbeat-*",
+            "drop_last_bucket": 1,
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "metricbeat-*",
+            "interval": "5m",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": "0",
+                "formatter": "number",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "aws.sqs.messages.sent",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_color_mode": "rainbow",
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "aws.sqs.queue.name.keyword",
+                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417",
+                "terms_size": "5"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "AWS SQS Messages Sent",
+          "type": "metrics"
+        }
+      },
+      "id": "dd2f2a10-41e6-11e9-b7a0-c99d9d127b61",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-05-29T14:11:54.211Z",
+      "version": "WzI5MywxXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "SQS Filters [Metricbeat AWS]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "controls": [
+              {
+                "fieldName": "cloud.region",
+                "id": "1549397251041",
+                "indexPatternRefName": "control_0_index_pattern",
+                "label": "region",
+                "options": {
+                  "dynamicOptions": true,
+                  "multiselect": true,
+                  "order": "desc",
+                  "size": 5,
+                  "type": "terms"
+                },
+                "parent": "",
+                "type": "list"
+              },
+              {
+                "fieldName": "aws.sqs.queue.name",
+                "id": "1549512142947",
+                "indexPatternRefName": "control_1_index_pattern",
+                "label": "queue name",
+                "options": {
+                  "dynamicOptions": true,
+                  "multiselect": true,
+                  "order": "desc",
+                  "size": 5,
+                  "type": "terms"
+                },
+                "parent": "",
+                "type": "list"
+              }
+            ],
+            "pinFilters": false,
+            "updateFiltersOnChange": true,
+            "useTimeFilter": false
+          },
+          "title": "AWS SQS Filters",
+          "type": "input_control_vis"
+        }
+      },
+      "id": "b0afd3e0-43b7-11e9-8697-530f39afc6eb",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [
+        {
+          "id": "metricbeat-*",
+          "name": "control_0_index_pattern",
+          "type": "index-pattern"
+        },
+        {
+          "id": "metricbeat-*",
+          "name": "control_1_index_pattern",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-05-29T14:13:49.585Z",
+      "version": "WzQ5NCwxXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "SQS Empty Receives [Metricbeat AWS]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "background_color_rules": [
+              {
+                "id": "d95adba0-6b8a-11e9-98b0-9b2c3d14a4c1"
+              }
+            ],
+            "bar_color_rules": [
+              {
+                "id": "a7e8c370-6c25-11e9-9cd1-3bdb0c7db024"
+              }
+            ],
+            "default_index_pattern": "metricbeat-*",
+            "gauge_color_rules": [
+              {
+                "id": "a778eaa0-6c25-11e9-9cd1-3bdb0c7db024"
+              }
+            ],
+            "gauge_inner_width": 10,
+            "gauge_style": "half",
+            "gauge_width": 10,
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "metricbeat-*",
+            "interval": "5m",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": "0",
+                "formatter": "number",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "aws.sqs.empty_receives",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "numerator": "",
+                    "percentiles": [
+                      {
+                        "id": "74323cf0-6c25-11e9-9cd1-3bdb0c7db024",
+                        "mode": "line",
+                        "shade": 0.2,
+                        "value": 50
+                      }
+                    ],
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_color_mode": "rainbow",
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "aws.sqs.queue.name.keyword",
+                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417",
+                "terms_size": "5"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "top_n"
+          },
+          "title": "AWS SQS Empty Receives",
+          "type": "metrics"
+        }
+      },
+      "id": "bb82c4d0-6c25-11e9-81bc-7f4cd8b3d892",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-05-29T14:11:54.211Z",
+      "version": "WzI5NSwxXQ=="
+    }
+  ],
+  "version": "7.2.0"
+}

--- a/dev/package-beats/aws-1.0.0/manifest.yml
+++ b/dev/package-beats/aws-1.0.0/manifest.yml
@@ -1,0 +1,14 @@
+name: aws
+title: aws
+version: 1.0.0
+description: |
+  Module for handling logs from AWS.
+type: ""
+categories:
+- metrics
+- logs
+requirement:
+  kibana:
+    version:
+      min: 6.7.0
+      max: 7.6.0

--- a/dev/package-beats/azure-1.0.0/kibana/dashboard/Metricbeat-azure-vm-guestmetrics-overview.json
+++ b/dev/package-beats/azure-1.0.0/kibana/dashboard/Metricbeat-azure-vm-guestmetrics-overview.json
@@ -1,0 +1,999 @@
+{
+  "objects": [
+    {
+      "attributes": {
+        "description": "This dashboards shows ASP.NET and SQL Server specific metrics extracted from the azure.vm.windows.guestmetrics namespace",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "optionsJSON": {
+          "hidePanelTitles": false,
+          "useMargins": true
+        },
+        "panelsJSON": [
+          {
+            "embeddableConfig": {
+              "title": "Filters"
+            },
+            "gridData": {
+              "h": 12,
+              "i": "b7b8bcc1-f776-45cf-a149-36665f2de746",
+              "w": 6,
+              "x": 0,
+              "y": 0
+            },
+            "panelIndex": "b7b8bcc1-f776-45cf-a149-36665f2de746",
+            "panelRefName": "panel_0",
+            "title": "Filters",
+            "version": "7.4.0"
+          },
+          {
+            "embeddableConfig": {
+              "title": "Applications Running"
+            },
+            "gridData": {
+              "h": 12,
+              "i": "bc65dd87-08f6-49f7-b8bf-0d371431ad4d",
+              "w": 18,
+              "x": 6,
+              "y": 0
+            },
+            "panelIndex": "bc65dd87-08f6-49f7-b8bf-0d371431ad4d",
+            "panelRefName": "panel_1",
+            "title": "Applications Running",
+            "version": "7.4.0"
+          },
+          {
+            "embeddableConfig": {
+              "title": "SQL Server User Connections"
+            },
+            "gridData": {
+              "h": 12,
+              "i": "6a5abca9-1cfd-45ef-aa88-9b4a72ce2dca",
+              "w": 24,
+              "x": 24,
+              "y": 0
+            },
+            "panelIndex": "6a5abca9-1cfd-45ef-aa88-9b4a72ce2dca",
+            "panelRefName": "panel_2",
+            "title": "SQL Server User Connections",
+            "version": "7.4.0"
+          },
+          {
+            "embeddableConfig": {
+              "title": "Application Requests"
+            },
+            "gridData": {
+              "h": 12,
+              "i": "5c0158cc-c884-4665-8bbf-7fc34d885d55",
+              "w": 12,
+              "x": 0,
+              "y": 12
+            },
+            "panelIndex": "5c0158cc-c884-4665-8bbf-7fc34d885d55",
+            "panelRefName": "panel_3",
+            "title": "Application Requests",
+            "version": "7.4.0"
+          },
+          {
+            "embeddableConfig": {
+              "title": "Application Error Rates"
+            },
+            "gridData": {
+              "h": 12,
+              "i": "03c9cff0-b2ec-4dd1-9a2f-db7f441e5e71",
+              "w": 12,
+              "x": 12,
+              "y": 12
+            },
+            "panelIndex": "03c9cff0-b2ec-4dd1-9a2f-db7f441e5e71",
+            "panelRefName": "panel_4",
+            "title": "Application Error Rates",
+            "version": "7.4.0"
+          },
+          {
+            "embeddableConfig": {
+              "title": "SQL Server Total Server Memory"
+            },
+            "gridData": {
+              "h": 12,
+              "i": "aaa96404-80de-44dc-990c-76bf40d3827b",
+              "w": 24,
+              "x": 24,
+              "y": 12
+            },
+            "panelIndex": "aaa96404-80de-44dc-990c-76bf40d3827b",
+            "panelRefName": "panel_5",
+            "title": "SQL Server Total Server Memory",
+            "version": "7.4.0"
+          },
+          {
+            "embeddableConfig": {
+              "title": "Application Sessions"
+            },
+            "gridData": {
+              "h": 12,
+              "i": "b89c7551-e0e1-4642-ac18-01322ea72db8",
+              "w": 24,
+              "x": 0,
+              "y": 24
+            },
+            "panelIndex": "b89c7551-e0e1-4642-ac18-01322ea72db8",
+            "panelRefName": "panel_6",
+            "title": "Application Sessions",
+            "version": "7.4.0"
+          },
+          {
+            "embeddableConfig": {
+              "title": "SQL Server Page Reads/Writes"
+            },
+            "gridData": {
+              "h": 12,
+              "i": "43effd82-fc6a-4d11-bd1e-d3b12a34cbce",
+              "w": 24,
+              "x": 24,
+              "y": 24
+            },
+            "panelIndex": "43effd82-fc6a-4d11-bd1e-d3b12a34cbce",
+            "panelRefName": "panel_7",
+            "title": "SQL Server Page Reads/Writes",
+            "version": "7.4.0"
+          }
+        ],
+        "timeRestore": false,
+        "title": "[Metricbeat Azure] VM Guest Metrics Overview",
+        "version": 1
+      },
+      "id": "a6f5d430-eaa6-11e9-90ec-112a988266d5",
+      "migrationVersion": {
+        "dashboard": "7.3.0"
+      },
+      "references": [
+        {
+          "id": "5031b220-eb61-11e9-90ec-112a988266d5",
+          "name": "panel_0",
+          "type": "visualization"
+        },
+        {
+          "id": "1f5c1cd0-eaa3-11e9-90ec-112a988266d5",
+          "name": "panel_1",
+          "type": "visualization"
+        },
+        {
+          "id": "0aacc190-eaa8-11e9-90ec-112a988266d5",
+          "name": "panel_2",
+          "type": "visualization"
+        },
+        {
+          "id": "097bc300-eaa5-11e9-90ec-112a988266d5",
+          "name": "panel_3",
+          "type": "visualization"
+        },
+        {
+          "id": "6d52a660-eaa4-11e9-90ec-112a988266d5",
+          "name": "panel_4",
+          "type": "visualization"
+        },
+        {
+          "id": "d7ea4290-eaa8-11e9-90ec-112a988266d5",
+          "name": "panel_5",
+          "type": "visualization"
+        },
+        {
+          "id": "b9aa9b20-eaa5-11e9-90ec-112a988266d5",
+          "name": "panel_6",
+          "type": "visualization"
+        },
+        {
+          "id": "787a0a20-eaa8-11e9-90ec-112a988266d5",
+          "name": "panel_7",
+          "type": "visualization"
+        }
+      ],
+      "type": "dashboard",
+      "updated_at": "2019-10-15T11:58:39.685Z",
+      "version": "WzMyMjQsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "VM Filters [Metricbeat Azure]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "controls": [
+              {
+                "fieldName": "cloud.region",
+                "id": "1549397251041",
+                "indexPatternRefName": "control_0_index_pattern",
+                "label": "Region",
+                "options": {
+                  "dynamicOptions": true,
+                  "multiselect": true,
+                  "order": "desc",
+                  "size": 5,
+                  "type": "terms"
+                },
+                "parent": "",
+                "type": "list"
+              },
+              {
+                "fieldName": "azure.resource.group",
+                "id": "1549512142947",
+                "indexPatternRefName": "control_1_index_pattern",
+                "label": "Resource Group",
+                "options": {
+                  "dynamicOptions": true,
+                  "multiselect": true,
+                  "order": "desc",
+                  "size": 5,
+                  "type": "terms"
+                },
+                "parent": "",
+                "type": "list"
+              },
+              {
+                "fieldName": "azure.resource.name",
+                "id": "1570774891724",
+                "indexPatternRefName": "control_2_index_pattern",
+                "label": "VM Name",
+                "options": {
+                  "dynamicOptions": true,
+                  "multiselect": true,
+                  "order": "desc",
+                  "size": 5,
+                  "type": "terms"
+                },
+                "parent": "",
+                "type": "list"
+              }
+            ],
+            "pinFilters": false,
+            "updateFiltersOnChange": true,
+            "useTimeFilter": false
+          },
+          "title": "VM Filters [Metricbeat Azure]",
+          "type": "input_control_vis"
+        }
+      },
+      "id": "5031b220-eb61-11e9-90ec-112a988266d5",
+      "migrationVersion": {
+        "visualization": "7.3.1"
+      },
+      "references": [
+        {
+          "id": "metricbeat-*",
+          "name": "control_0_index_pattern",
+          "type": "index-pattern"
+        },
+        {
+          "id": "metricbeat-*",
+          "name": "control_1_index_pattern",
+          "type": "index-pattern"
+        },
+        {
+          "id": "metricbeat-*",
+          "name": "control_2_index_pattern",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-10-11T06:35:45.645Z",
+      "version": "WzE0ODMsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "ASP.NET Applications Running [Metricbeat Azure]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_min": 0,
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "background_color_rules": [
+              {
+                "id": "04bf3740-eaa3-11e9-8742-b533e334ee9a"
+              }
+            ],
+            "bar_color_rules": [
+              {
+                "id": "03eec7e0-eaa3-11e9-8742-b533e334ee9a"
+              }
+            ],
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "kuery",
+              "query": "azure.resource.type : \"Microsoft.Compute/virtualMachines\" "
+            },
+            "gauge_color_rules": [
+              {
+                "id": "07485320-eaa3-11e9-8742-b533e334ee9a"
+              }
+            ],
+            "gauge_inner_width": 10,
+            "gauge_style": "half",
+            "gauge_width": 10,
+            "id": "d1acb8f0-eaa2-11e9-a229-c9171499dcc6",
+            "index_pattern": "metricbeat-*",
+            "interval": "\u003e=5m",
+            "isModelInvalid": false,
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#3185FC",
+                "fill": "0.2",
+                "formatter": "number",
+                "id": "d1acb8f1-eaa2-11e9-a229-c9171499dcc6",
+                "label": "applications running",
+                "line_width": "1",
+                "metrics": [
+                  {
+                    "field": "azure.compute_vm.asp.net_applications_running.avg",
+                    "id": "d1acb8f2-eaa2-11e9-a229-c9171499dcc6",
+                    "type": "max"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "type": "timeseries",
+                "value_template": "{{value}}"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "ASP.NET Applications Running [Metricbeat Azure]",
+          "type": "metrics"
+        }
+      },
+      "id": "1f5c1cd0-eaa3-11e9-90ec-112a988266d5",
+      "migrationVersion": {
+        "visualization": "7.3.1"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-10-15T11:56:33.857Z",
+      "version": "WzMyMTEsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "SQL Server User Connections [Metricbeat Azure]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_min": 0,
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "kuery",
+              "query": "azure.resource.type :\"Microsoft.Compute/virtualMachines\" "
+            },
+            "id": "da495db0-eaa7-11e9-a88b-4b683ca3087b",
+            "index_pattern": "metricbeat-*",
+            "interval": "\u003e=5m",
+            "isModelInvalid": false,
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#3185FC",
+                "fill": 0,
+                "formatter": "number",
+                "id": "da495db1-eaa7-11e9-a88b-4b683ca3087b",
+                "label": "connections",
+                "line_width": 2,
+                "metrics": [
+                  {
+                    "field": "azure.compute_vm.sqlserver.general_statistics_user_connections.avg",
+                    "id": "da495db2-eaa7-11e9-a88b-4b683ca3087b",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "SQL Server User Connections [Metricbeat Azure]",
+          "type": "metrics"
+        }
+      },
+      "id": "0aacc190-eaa8-11e9-90ec-112a988266d5",
+      "migrationVersion": {
+        "visualization": "7.3.1"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-10-15T11:56:54.774Z",
+      "version": "WzMyMTMsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "ASP.NET Application Requests [Metricbeat Azure]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_min": 0,
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "kuery",
+              "query": "azure.resource.type : \"Microsoft.Compute/virtualMachines\" "
+            },
+            "id": "be74e9e0-eaa4-11e9-8923-850d87d8e766",
+            "index_pattern": "metricbeat-*",
+            "interval": "\u003e=5m",
+            "isModelInvalid": false,
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(254,146,0,1)",
+                "fill": 0,
+                "formatter": "number",
+                "id": "be74e9e1-eaa4-11e9-8923-850d87d8e766",
+                "label": "timed out",
+                "line_width": 2,
+                "metrics": [
+                  {
+                    "field": "azure.compute_vm.asp.net_applications_requests_timed_out.avg",
+                    "id": "be74e9e2-eaa4-11e9-8923-850d87d8e766",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#DB1374",
+                "fill": 0,
+                "formatter": "number",
+                "id": "be74e9e3-eaa4-11e9-8923-850d87d8e766",
+                "label": "failed",
+                "line_width": 2,
+                "metrics": [
+                  {
+                    "field": "azure.compute_vm.asp.net_applications_requests_failed.avg",
+                    "id": "be74e9e4-eaa4-11e9-8923-850d87d8e766",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#00B3A4",
+                "fill": 0,
+                "formatter": "number",
+                "id": "be7510f0-eaa4-11e9-8923-850d87d8e766",
+                "label": "succeeded",
+                "line_width": 2,
+                "metrics": [
+                  {
+                    "field": "azure.compute_vm.asp.net_applications_requests_succeeded.avg",
+                    "id": "be7510f1-eaa4-11e9-8923-850d87d8e766",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#490092",
+                "fill": 0,
+                "formatter": "number",
+                "id": "be7510f2-eaa4-11e9-8923-850d87d8e766",
+                "label": "total",
+                "line_width": 2,
+                "metrics": [
+                  {
+                    "field": "azure.compute_vm.asp.net_applications_requests_total.avg",
+                    "id": "be7510f3-eaa4-11e9-8923-850d87d8e766",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "ASP.NET Application Requests [Metricbeat Azure]",
+          "type": "metrics"
+        }
+      },
+      "id": "097bc300-eaa5-11e9-90ec-112a988266d5",
+      "migrationVersion": {
+        "visualization": "7.3.1"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-10-15T11:57:11.237Z",
+      "version": "WzMyMTUsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "ASP.NET Application Error Rates [Metricbeat Azure]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_min": 0,
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "kuery",
+              "query": "azure.resource.type : \"Microsoft.Compute/virtualMachines\" "
+            },
+            "id": "29576400-eaa4-11e9-a2d3-e7a00bbd3c18",
+            "index_pattern": "metricbeat-*",
+            "interval": "\u003e=5m",
+            "isModelInvalid": false,
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(244,78,59,1)",
+                "fill": "0.2",
+                "filter": {
+                  "language": "kuery",
+                  "query": ""
+                },
+                "formatter": "number",
+                "id": "29578b10-eaa4-11e9-a2d3-e7a00bbd3c18",
+                "label": "errors",
+                "line_width": "1",
+                "metrics": [
+                  {
+                    "field": "azure.compute_vm.asp.net_applications_errors_total.avg",
+                    "id": "29578b11-eaa4-11e9-a2d3-e7a00bbd3c18",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "ASP.NET Application Error Rates [Metricbeat Azure]",
+          "type": "metrics"
+        }
+      },
+      "id": "6d52a660-eaa4-11e9-90ec-112a988266d5",
+      "migrationVersion": {
+        "visualization": "7.3.1"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-10-15T11:57:29.302Z",
+      "version": "WzMyMTcsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "SQL Server Total Server Memory [Metricbeat Azure]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_min": 0,
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "kuery",
+              "query": "azure.resource.type:\"Microsoft.Compute/virtualMachines\" "
+            },
+            "id": "94af6a00-eaa8-11e9-9269-d92e2d3f77fd",
+            "index_pattern": "metricbeat-*",
+            "interval": "\u003e=5m",
+            "isModelInvalid": false,
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#3185FC",
+                "fill": 0,
+                "formatter": "bytes",
+                "id": "94af6a01-eaa8-11e9-9269-d92e2d3f77fd",
+                "label": "memory",
+                "line_width": 2,
+                "metrics": [
+                  {
+                    "field": "azure.compute_vm.sqlserver.memory_manager_total_server_memory.avg",
+                    "id": "94af6a02-eaa8-11e9-9269-d92e2d3f77fd",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "SQL Server Total Server Memory [Metricbeat Azure]",
+          "type": "metrics"
+        }
+      },
+      "id": "d7ea4290-eaa8-11e9-90ec-112a988266d5",
+      "migrationVersion": {
+        "visualization": "7.3.1"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-10-15T11:57:45.878Z",
+      "version": "WzMyMTksMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "ASP.NET Application Sessions [Metricbeat Azure]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_min": 0,
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "kuery",
+              "query": "azure.resource.type : \"Microsoft.Compute/virtualMachines\" "
+            },
+            "id": "6d6575a0-eaa5-11e9-84ad-5919a47b8f34",
+            "index_pattern": "metricbeat-*",
+            "interval": "\u003e=5m",
+            "isModelInvalid": false,
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#3185FC",
+                "fill": 0,
+                "formatter": "number",
+                "id": "6d6575a1-eaa5-11e9-84ad-5919a47b8f34",
+                "label": "active",
+                "line_width": 2,
+                "metrics": [
+                  {
+                    "field": "azure.compute_vm.asp.net_applications_sessions_active.avg",
+                    "id": "6d6575a2-eaa5-11e9-84ad-5919a47b8f34",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#DB1374",
+                "fill": 0,
+                "formatter": "number",
+                "id": "6d6575a3-eaa5-11e9-84ad-5919a47b8f34",
+                "label": "timed out",
+                "line_width": 2,
+                "metrics": [
+                  {
+                    "field": "azure.compute_vm.asp.net_applications_sessions_timed_out.avg",
+                    "id": "6d6575a4-eaa5-11e9-84ad-5919a47b8f34",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#00B3A4",
+                "fill": 0,
+                "formatter": "number",
+                "id": "6d6575a5-eaa5-11e9-84ad-5919a47b8f34",
+                "label": "abandoned",
+                "line_width": 2,
+                "metrics": [
+                  {
+                    "field": "azure.compute_vm.asp.net_applications_sessions_abandoned.avg",
+                    "id": "6d6575a6-eaa5-11e9-84ad-5919a47b8f34",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#490092",
+                "fill": 0,
+                "formatter": "number",
+                "id": "6d6575a7-eaa5-11e9-84ad-5919a47b8f34",
+                "label": "total",
+                "line_width": 2,
+                "metrics": [
+                  {
+                    "field": "azure.compute_vm.asp.net_applications_sessions_total.avg",
+                    "id": "6d6575a8-eaa5-11e9-84ad-5919a47b8f34",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "ASP.NET Application Sessions [Metricbeat Azure]",
+          "type": "metrics"
+        }
+      },
+      "id": "b9aa9b20-eaa5-11e9-90ec-112a988266d5",
+      "migrationVersion": {
+        "visualization": "7.3.1"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-10-15T11:58:04.891Z",
+      "version": "WzMyMjEsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "SQL Server Page Reads/Writes [Metricbeat Azure]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_min": 0,
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "kuery",
+              "query": "azure.resource.type : \"Microsoft.Compute/virtualMachines\" "
+            },
+            "id": "35459a30-eaa8-11e9-a379-c33a712c0373",
+            "index_pattern": "metricbeat-*",
+            "interval": "\u003e=5m",
+            "isModelInvalid": false,
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(252,196,0,1)",
+                "fill": 0,
+                "formatter": "number",
+                "id": "35459a31-eaa8-11e9-a379-c33a712c0373",
+                "label": "Page Reads/s",
+                "line_width": 2,
+                "metrics": [
+                  {
+                    "field": "azure.compute_vm.sqlserver.buffer_manager_page_reads_per_sec.avg",
+                    "id": "35459a32-eaa8-11e9-a379-c33a712c0373",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(176,188,0,1)",
+                "fill": 0,
+                "formatter": "number",
+                "id": "35459a33-eaa8-11e9-a379-c33a712c0373",
+                "label": "Page Writes/s",
+                "line_width": 2,
+                "metrics": [
+                  {
+                    "field": "azure.compute_vm.sqlserver.buffer_manager_page_writes_per_sec.avg",
+                    "id": "35459a34-eaa8-11e9-a379-c33a712c0373",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "SQL Server Page Reads/Writes [Metricbeat Azure]",
+          "type": "metrics"
+        }
+      },
+      "id": "787a0a20-eaa8-11e9-90ec-112a988266d5",
+      "migrationVersion": {
+        "visualization": "7.3.1"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-10-15T11:58:24.951Z",
+      "version": "WzMyMjMsMV0="
+    }
+  ],
+  "version": "7.4.0"
+}

--- a/dev/package-beats/azure-1.0.0/kibana/dashboard/Metricbeat-azure-vm-overview.json
+++ b/dev/package-beats/azure-1.0.0/kibana/dashboard/Metricbeat-azure-vm-overview.json
@@ -1,0 +1,929 @@
+{
+  "objects": [
+    {
+      "attributes": {
+        "description": "This dashboard visualized relevant metrics for VMs running on Azure cloud.",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "optionsJSON": {
+          "hidePanelTitles": false,
+          "useMargins": true
+        },
+        "panelsJSON": [
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 12,
+              "i": "aa881f9d-28d3-4722-822e-3e670021cf52",
+              "w": 6,
+              "x": 0,
+              "y": 0
+            },
+            "panelIndex": "aa881f9d-28d3-4722-822e-3e670021cf52",
+            "panelRefName": "panel_0",
+            "version": "7.4.0"
+          },
+          {
+            "embeddableConfig": {
+              "title": "VM CPU Utilization"
+            },
+            "gridData": {
+              "h": 12,
+              "i": "e673f70c-f811-4290-9087-578c7dd13675",
+              "w": 20,
+              "x": 6,
+              "y": 0
+            },
+            "panelIndex": "e673f70c-f811-4290-9087-578c7dd13675",
+            "panelRefName": "panel_1",
+            "title": "VM CPU Utilization",
+            "version": "7.4.0"
+          },
+          {
+            "embeddableConfig": {
+              "title": "VM Available Memory"
+            },
+            "gridData": {
+              "h": 12,
+              "i": "2473ef72-c56c-4783-a36a-f4b8efd66ab7",
+              "w": 22,
+              "x": 26,
+              "y": 0
+            },
+            "panelIndex": "2473ef72-c56c-4783-a36a-f4b8efd66ab7",
+            "panelRefName": "panel_2",
+            "title": "VM Available Memory",
+            "version": "7.4.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 12,
+              "i": "14e225ef-6417-4377-b2cb-6b46b6693b78",
+              "w": 12,
+              "x": 36,
+              "y": 12
+            },
+            "panelIndex": "14e225ef-6417-4377-b2cb-6b46b6693b78",
+            "panelRefName": "panel_3",
+            "version": "7.4.0"
+          },
+          {
+            "embeddableConfig": {
+              "title": "VM Network In Total"
+            },
+            "gridData": {
+              "h": 12,
+              "i": "535d70b3-3f3c-4a84-85ba-ab671b6d144f",
+              "w": 12,
+              "x": 0,
+              "y": 12
+            },
+            "panelIndex": "535d70b3-3f3c-4a84-85ba-ab671b6d144f",
+            "panelRefName": "panel_4",
+            "title": "VM Network In Total",
+            "version": "7.4.0"
+          },
+          {
+            "embeddableConfig": {
+              "title": "VM Network Out Total"
+            },
+            "gridData": {
+              "h": 12,
+              "i": "6903a45e-bf11-4db2-9497-fd9692e83448",
+              "w": 12,
+              "x": 12,
+              "y": 12
+            },
+            "panelIndex": "6903a45e-bf11-4db2-9497-fd9692e83448",
+            "panelRefName": "panel_5",
+            "title": "VM Network Out Total",
+            "version": "7.4.0"
+          },
+          {
+            "embeddableConfig": {
+              "title": "VM Disk Writes"
+            },
+            "gridData": {
+              "h": 12,
+              "i": "aa57fa8f-f6ea-45e3-9b2c-ba948d625813",
+              "w": 12,
+              "x": 24,
+              "y": 12
+            },
+            "panelIndex": "aa57fa8f-f6ea-45e3-9b2c-ba948d625813",
+            "panelRefName": "panel_6",
+            "title": "VM Disk Writes",
+            "version": "7.4.0"
+          },
+          {
+            "embeddableConfig": {
+              "title": "VM Disk Read Operations/s"
+            },
+            "gridData": {
+              "h": 13,
+              "i": "8879143b-ed83-45ec-8c58-b10dc1597c22",
+              "w": 24,
+              "x": 0,
+              "y": 24
+            },
+            "panelIndex": "8879143b-ed83-45ec-8c58-b10dc1597c22",
+            "panelRefName": "panel_7",
+            "title": "VM Disk Read Operations/s",
+            "version": "7.4.0"
+          },
+          {
+            "embeddableConfig": {
+              "title": "VM Disk Write Operations/s"
+            },
+            "gridData": {
+              "h": 13,
+              "i": "4071f2bf-1794-45ff-b76d-58864226d8b7",
+              "w": 24,
+              "x": 24,
+              "y": 24
+            },
+            "panelIndex": "4071f2bf-1794-45ff-b76d-58864226d8b7",
+            "panelRefName": "panel_8",
+            "title": "VM Disk Write Operations/s",
+            "version": "7.4.0"
+          }
+        ],
+        "timeRestore": false,
+        "title": "[Metricbeat Azure] Compute VMs Overview",
+        "version": 1
+      },
+      "id": "eb3f05f0-ea9a-11e9-90ec-112a988266d5",
+      "migrationVersion": {
+        "dashboard": "7.3.0"
+      },
+      "references": [
+        {
+          "id": "5031b220-eb61-11e9-90ec-112a988266d5",
+          "name": "panel_0",
+          "type": "visualization"
+        },
+        {
+          "id": "db9a3490-ea8f-11e9-90ec-112a988266d5",
+          "name": "panel_1",
+          "type": "visualization"
+        },
+        {
+          "id": "7205a4f0-ea95-11e9-90ec-112a988266d5",
+          "name": "panel_2",
+          "type": "visualization"
+        },
+        {
+          "id": "e8ca65c0-eb45-11e9-90ec-112a988266d5",
+          "name": "panel_3",
+          "type": "visualization"
+        },
+        {
+          "id": "8b6b9450-ea99-11e9-90ec-112a988266d5",
+          "name": "panel_4",
+          "type": "visualization"
+        },
+        {
+          "id": "abd32c30-ea99-11e9-90ec-112a988266d5",
+          "name": "panel_5",
+          "type": "visualization"
+        },
+        {
+          "id": "5c016810-ea9a-11e9-90ec-112a988266d5",
+          "name": "panel_6",
+          "type": "visualization"
+        },
+        {
+          "id": "3a50e950-eb46-11e9-90ec-112a988266d5",
+          "name": "panel_7",
+          "type": "visualization"
+        },
+        {
+          "id": "0892eaa0-ea9a-11e9-90ec-112a988266d5",
+          "name": "panel_8",
+          "type": "visualization"
+        }
+      ],
+      "type": "dashboard",
+      "updated_at": "2019-10-15T11:53:03.300Z",
+      "version": "WzMxOTAsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "VM Filters [Metricbeat Azure]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "controls": [
+              {
+                "fieldName": "cloud.region",
+                "id": "1549397251041",
+                "indexPatternRefName": "control_0_index_pattern",
+                "label": "Region",
+                "options": {
+                  "dynamicOptions": true,
+                  "multiselect": true,
+                  "order": "desc",
+                  "size": 5,
+                  "type": "terms"
+                },
+                "parent": "",
+                "type": "list"
+              },
+              {
+                "fieldName": "azure.resource.group",
+                "id": "1549512142947",
+                "indexPatternRefName": "control_1_index_pattern",
+                "label": "Resource Group",
+                "options": {
+                  "dynamicOptions": true,
+                  "multiselect": true,
+                  "order": "desc",
+                  "size": 5,
+                  "type": "terms"
+                },
+                "parent": "",
+                "type": "list"
+              },
+              {
+                "fieldName": "azure.resource.name",
+                "id": "1570774891724",
+                "indexPatternRefName": "control_2_index_pattern",
+                "label": "VM Name",
+                "options": {
+                  "dynamicOptions": true,
+                  "multiselect": true,
+                  "order": "desc",
+                  "size": 5,
+                  "type": "terms"
+                },
+                "parent": "",
+                "type": "list"
+              }
+            ],
+            "pinFilters": false,
+            "updateFiltersOnChange": true,
+            "useTimeFilter": false
+          },
+          "title": "VM Filters [Metricbeat Azure]",
+          "type": "input_control_vis"
+        }
+      },
+      "id": "5031b220-eb61-11e9-90ec-112a988266d5",
+      "migrationVersion": {
+        "visualization": "7.3.1"
+      },
+      "references": [
+        {
+          "id": "metricbeat-*",
+          "name": "control_0_index_pattern",
+          "type": "index-pattern"
+        },
+        {
+          "id": "metricbeat-*",
+          "name": "control_1_index_pattern",
+          "type": "index-pattern"
+        },
+        {
+          "id": "metricbeat-*",
+          "name": "control_2_index_pattern",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-10-11T06:35:45.645Z",
+      "version": "WzE0ODMsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "VM CPU Utilization [Metricbeat Azure]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_min": 0,
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "kuery",
+              "query": "azure.resource.type : \"Microsoft.Compute/virtualMachines\" "
+            },
+            "id": "4f6c1610-ea8e-11e9-8c73-71740bcf3d8b",
+            "index_pattern": "metricbeat-*",
+            "interval": "\u003e=5m",
+            "isModelInvalid": false,
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(252,196,0,1)",
+                "fill": 0,
+                "filter": {
+                  "language": "kuery",
+                  "query": ""
+                },
+                "formatter": "number",
+                "id": "4f6c1611-ea8e-11e9-8c73-71740bcf3d8b",
+                "label": "Azure VM CPU Utilization",
+                "line_width": 2,
+                "metrics": [
+                  {
+                    "field": "azure.compute_vm.percentage_cpu.avg",
+                    "id": "4f6c1612-ea8e-11e9-8c73-71740bcf3d8b",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_color_mode": "rainbow",
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "azure.resource.name",
+                "value_template": "{{value}}%"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "VM CPU Utilization [Metricbeat Azure]",
+          "type": "metrics"
+        }
+      },
+      "id": "db9a3490-ea8f-11e9-90ec-112a988266d5",
+      "migrationVersion": {
+        "visualization": "7.3.1"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-10-15T11:52:01.637Z",
+      "version": "WzMxODQsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "VM Available Memory [Metricbeat Azure]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_min": 0,
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "kuery",
+              "query": "azure.resource.type : \"Microsoft.Compute/virtualMachines\" "
+            },
+            "id": "c7e12030-ea94-11e9-bf06-bfc27258c9ad",
+            "index_pattern": "metricbeat-*",
+            "interval": "\u003e=5m",
+            "isModelInvalid": false,
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(176,188,0,1)",
+                "fill": 0,
+                "formatter": "bytes",
+                "id": "c7e12031-ea94-11e9-bf06-bfc27258c9ad",
+                "label": "VM Available Memory",
+                "line_width": 2,
+                "metrics": [
+                  {
+                    "field": "azure.compute_vm.memory_available_bytes.avg",
+                    "id": "c7e12032-ea94-11e9-bf06-bfc27258c9ad",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "azure.resource.name",
+                "value_template": "{{value}}"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "VM Available Memory [Metricbeat Azure]",
+          "type": "metrics"
+        }
+      },
+      "id": "7205a4f0-ea95-11e9-90ec-112a988266d5",
+      "migrationVersion": {
+        "visualization": "7.3.1"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-10-15T11:52:22.085Z",
+      "version": "WzMxODYsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "VM Disk Reads [Metricbeat Azure]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_min": 0,
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "kuery",
+              "query": "azure.resource.type :\"Microsoft.Compute/virtualMachines\" "
+            },
+            "id": "39b6adc0-ea99-11e9-8328-799c817fb96b",
+            "index_pattern": "metricbeat-*",
+            "interval": "\u003e=5m",
+            "isModelInvalid": false,
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(252,196,0,1)",
+                "fill": 0,
+                "formatter": "bytes",
+                "id": "39b6adc1-ea99-11e9-8328-799c817fb96b",
+                "label": "VM Disk Read bytes",
+                "line_width": 2,
+                "metrics": [
+                  {
+                    "field": "azure.compute_vm.disk_read_bytes.total",
+                    "id": "39b6adc2-ea99-11e9-8328-799c817fb96b",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "azure.resource.name",
+                "type": "timeseries",
+                "value_template": "{{value}}"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "VM Disk Reads [Metricbeat Azure]",
+          "type": "metrics"
+        }
+      },
+      "id": "e8ca65c0-eb45-11e9-90ec-112a988266d5",
+      "migrationVersion": {
+        "visualization": "7.3.1"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-10-15T11:50:30.820Z",
+      "version": "WzMxNzgsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "VM Network In Total [Metricbeat Azure]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_min": 0,
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "kuery",
+              "query": "azure.resource.type : \"Microsoft.Compute/virtualMachines\" "
+            },
+            "id": "39b6adc0-ea99-11e9-8328-799c817fb96b",
+            "index_pattern": "metricbeat-*",
+            "interval": "\u003e=5m",
+            "isModelInvalid": false,
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(104,204,202,1)",
+                "fill": 0,
+                "formatter": "bytes",
+                "id": "39b6adc1-ea99-11e9-8328-799c817fb96b",
+                "label": "Azure VM Network In Total",
+                "line_width": 2,
+                "metrics": [
+                  {
+                    "field": "azure.compute_vm.network_in_total.total",
+                    "id": "39b6adc2-ea99-11e9-8328-799c817fb96b",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "azure.resource.name",
+                "value_template": "{{value}}"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "VM Network In Total [Metricbeat Azure]",
+          "type": "metrics"
+        }
+      },
+      "id": "8b6b9450-ea99-11e9-90ec-112a988266d5",
+      "migrationVersion": {
+        "visualization": "7.3.1"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-10-15T11:52:40.578Z",
+      "version": "WzMxODgsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "VM Network Out Total [Metricbeat Azure]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_min": 0,
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "kuery",
+              "query": "azure.resource.type : \"Microsoft.Compute/virtualMachines\" "
+            },
+            "id": "39b6adc0-ea99-11e9-8328-799c817fb96b",
+            "index_pattern": "metricbeat-*",
+            "interval": "\u003e=5m",
+            "isModelInvalid": false,
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(115,216,255,1)",
+                "fill": 0,
+                "formatter": "bytes",
+                "id": "39b6adc1-ea99-11e9-8328-799c817fb96b",
+                "label": "Azure VM Network Out Total",
+                "line_width": 2,
+                "metrics": [
+                  {
+                    "field": "azure.compute_vm.network_out_total.total",
+                    "id": "39b6adc2-ea99-11e9-8328-799c817fb96b",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "azure.resource.name",
+                "type": "timeseries",
+                "value_template": "{{value}}"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "VM Network Out Total [Metricbeat Azure]",
+          "type": "metrics"
+        }
+      },
+      "id": "abd32c30-ea99-11e9-90ec-112a988266d5",
+      "migrationVersion": {
+        "visualization": "7.3.1"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-10-15T11:49:45.582Z",
+      "version": "WzMxNzQsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "VM Disk Writes [Metricbeat Azure]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_min": 0,
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "kuery",
+              "query": "azure.resource.type :\"Microsoft.Compute/virtualMachines\" "
+            },
+            "id": "39b6adc0-ea99-11e9-8328-799c817fb96b",
+            "index_pattern": "metricbeat-*",
+            "interval": "\u003e=5m",
+            "isModelInvalid": false,
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(176,188,0,1)",
+                "fill": 0,
+                "formatter": "bytes",
+                "id": "39b6adc1-ea99-11e9-8328-799c817fb96b",
+                "label": "VM Disk Writes bytes",
+                "line_width": 2,
+                "metrics": [
+                  {
+                    "field": "azure.compute_vm.disk_write_bytes.total",
+                    "id": "39b6adc2-ea99-11e9-8328-799c817fb96b",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "azure.resource.name",
+                "type": "timeseries",
+                "value_template": "{{value}}"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "VM Disk Writes [Metricbeat Azure]",
+          "type": "metrics"
+        }
+      },
+      "id": "5c016810-ea9a-11e9-90ec-112a988266d5",
+      "migrationVersion": {
+        "visualization": "7.3.1"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-10-15T11:50:07.876Z",
+      "version": "WzMxNzYsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "VM Disk Read Operations/s [Metricbeat Azure]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_min": 0,
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "kuery",
+              "query": "azure.resource.type : \"Microsoft.Compute/virtualMachines\" "
+            },
+            "id": "39b6adc0-ea99-11e9-8328-799c817fb96b",
+            "index_pattern": "metricbeat-*",
+            "interval": "\u003e=5m",
+            "isModelInvalid": false,
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(252,196,0,1)",
+                "fill": 0,
+                "formatter": "number",
+                "id": "39b6adc1-ea99-11e9-8328-799c817fb96b",
+                "label": "VM Disk Read Operations/s",
+                "line_width": 2,
+                "metrics": [
+                  {
+                    "field": "azure.compute_vm.disk_read_operations_per_sec.avg",
+                    "id": "39b6adc2-ea99-11e9-8328-799c817fb96b",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "azure.resource.name",
+                "type": "timeseries",
+                "value_template": "{{value}}"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "VM Disk Read Operations/s [Metricbeat Azure]",
+          "type": "metrics"
+        }
+      },
+      "id": "3a50e950-eb46-11e9-90ec-112a988266d5",
+      "migrationVersion": {
+        "visualization": "7.3.1"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-10-15T11:50:55.337Z",
+      "version": "WzMxODAsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "VM Disk Write Operations/s [Metricbeat Azure]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_min": 0,
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "kuery",
+              "query": "azure.resource.type : \"Microsoft.Compute/virtualMachines\" "
+            },
+            "id": "39b6adc0-ea99-11e9-8328-799c817fb96b",
+            "index_pattern": "metricbeat-*",
+            "interval": "\u003e=5m",
+            "isModelInvalid": false,
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(252,196,0,1)",
+                "fill": 0,
+                "formatter": "number",
+                "id": "39b6adc1-ea99-11e9-8328-799c817fb96b",
+                "label": "VM Disk Write Operations/s",
+                "line_width": 2,
+                "metrics": [
+                  {
+                    "field": "azure.compute_vm.disk_write_operations_per_sec.avg",
+                    "id": "39b6adc2-ea99-11e9-8328-799c817fb96b",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "azure.resource.name",
+                "type": "timeseries",
+                "value_template": "{{value}}"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "VM Disk Write Operations/s [Metricbeat Azure]",
+          "type": "metrics"
+        }
+      },
+      "id": "0892eaa0-ea9a-11e9-90ec-112a988266d5",
+      "migrationVersion": {
+        "visualization": "7.3.1"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-10-15T11:51:33.545Z",
+      "version": "WzMxODIsMV0="
+    }
+  ],
+  "version": "7.4.0"
+}

--- a/dev/package-beats/azure-1.0.0/kibana/dashboard/Metricbeat-azure-vmss-overview.json
+++ b/dev/package-beats/azure-1.0.0/kibana/dashboard/Metricbeat-azure-vmss-overview.json
@@ -1,0 +1,932 @@
+{
+  "objects": [
+    {
+      "attributes": {
+        "description": "This dashboard visualized relevant metrics for VMs running on Azure cloud.",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "optionsJSON": {
+          "hidePanelTitles": false,
+          "useMargins": true
+        },
+        "panelsJSON": [
+          {
+            "embeddableConfig": {
+              "title": "Filters"
+            },
+            "gridData": {
+              "h": 12,
+              "i": "d84767cd-3fc9-438c-a969-f15c4d5fc9c5",
+              "w": 6,
+              "x": 0,
+              "y": 0
+            },
+            "panelIndex": "d84767cd-3fc9-438c-a969-f15c4d5fc9c5",
+            "panelRefName": "panel_0",
+            "title": "Filters",
+            "version": "7.4.0"
+          },
+          {
+            "embeddableConfig": {
+              "title": "Percentage CPU"
+            },
+            "gridData": {
+              "h": 12,
+              "i": "127eff01-d34c-4bda-8f19-4cf06982989f",
+              "w": 20,
+              "x": 6,
+              "y": 0
+            },
+            "panelIndex": "127eff01-d34c-4bda-8f19-4cf06982989f",
+            "panelRefName": "panel_1",
+            "title": "Percentage CPU",
+            "version": "7.4.0"
+          },
+          {
+            "embeddableConfig": {
+              "title": "Available Memory"
+            },
+            "gridData": {
+              "h": 12,
+              "i": "2f85c4f1-a575-49a1-99d3-fbed8a2806ec",
+              "w": 22,
+              "x": 26,
+              "y": 0
+            },
+            "panelIndex": "2f85c4f1-a575-49a1-99d3-fbed8a2806ec",
+            "panelRefName": "panel_2",
+            "title": "Available Memory",
+            "version": "7.4.0"
+          },
+          {
+            "embeddableConfig": {
+              "title": "Disk Reads"
+            },
+            "gridData": {
+              "h": 11,
+              "i": "6cbc30b4-658e-4f7a-a888-221775fd0af3",
+              "w": 12,
+              "x": 36,
+              "y": 12
+            },
+            "panelIndex": "6cbc30b4-658e-4f7a-a888-221775fd0af3",
+            "panelRefName": "panel_3",
+            "title": "Disk Reads",
+            "version": "7.4.0"
+          },
+          {
+            "embeddableConfig": {
+              "title": "Network In Total"
+            },
+            "gridData": {
+              "h": 11,
+              "i": "e195e7ba-c736-4bf7-9f23-c96f4acd9b6b",
+              "w": 12,
+              "x": 0,
+              "y": 12
+            },
+            "panelIndex": "e195e7ba-c736-4bf7-9f23-c96f4acd9b6b",
+            "panelRefName": "panel_4",
+            "title": "Network In Total",
+            "version": "7.4.0"
+          },
+          {
+            "embeddableConfig": {
+              "title": "Network Out Total"
+            },
+            "gridData": {
+              "h": 11,
+              "i": "64fc0214-97f7-4d52-a9bd-a91449293f1c",
+              "w": 12,
+              "x": 12,
+              "y": 12
+            },
+            "panelIndex": "64fc0214-97f7-4d52-a9bd-a91449293f1c",
+            "panelRefName": "panel_5",
+            "title": "Network Out Total",
+            "version": "7.4.0"
+          },
+          {
+            "embeddableConfig": {
+              "title": "Disk Writes"
+            },
+            "gridData": {
+              "h": 11,
+              "i": "12c9c185-81ed-4313-b274-b3384de2d396",
+              "w": 12,
+              "x": 24,
+              "y": 12
+            },
+            "panelIndex": "12c9c185-81ed-4313-b274-b3384de2d396",
+            "panelRefName": "panel_6",
+            "title": "Disk Writes",
+            "version": "7.4.0"
+          },
+          {
+            "embeddableConfig": {
+              "title": "Disk Read Operations/s"
+            },
+            "gridData": {
+              "h": 15,
+              "i": "200ae92b-4184-4aed-9868-6ce5e16e7a8d",
+              "w": 24,
+              "x": 0,
+              "y": 23
+            },
+            "panelIndex": "200ae92b-4184-4aed-9868-6ce5e16e7a8d",
+            "panelRefName": "panel_7",
+            "title": "Disk Read Operations/s",
+            "version": "7.4.0"
+          },
+          {
+            "embeddableConfig": {
+              "title": "Disk Write Operations/s"
+            },
+            "gridData": {
+              "h": 15,
+              "i": "36c46a84-3e6b-4a7e-9246-357ae9d10d1e",
+              "w": 24,
+              "x": 24,
+              "y": 23
+            },
+            "panelIndex": "36c46a84-3e6b-4a7e-9246-357ae9d10d1e",
+            "panelRefName": "panel_8",
+            "title": "Disk Write Operations/s",
+            "version": "7.4.0"
+          }
+        ],
+        "timeRestore": false,
+        "title": "[Metricbeat Azure] VM Scale Sets Overview ",
+        "version": 1
+      },
+      "id": "91afcc50-eaad-11e9-90ec-112a988266d5",
+      "migrationVersion": {
+        "dashboard": "7.3.0"
+      },
+      "references": [
+        {
+          "id": "686bc990-ea92-11e9-90ec-112a988266d5",
+          "name": "panel_0",
+          "type": "visualization"
+        },
+        {
+          "id": "33500790-eaaf-11e9-90ec-112a988266d5",
+          "name": "panel_1",
+          "type": "visualization"
+        },
+        {
+          "id": "cecd6680-eb41-11e9-90ec-112a988266d5",
+          "name": "panel_2",
+          "type": "visualization"
+        },
+        {
+          "id": "42cc28d0-ea9a-11e9-90ec-112a988266d5",
+          "name": "panel_3",
+          "type": "visualization"
+        },
+        {
+          "id": "64266ec0-eb42-11e9-90ec-112a988266d5",
+          "name": "panel_4",
+          "type": "visualization"
+        },
+        {
+          "id": "b45fd8e0-eb42-11e9-90ec-112a988266d5",
+          "name": "panel_5",
+          "type": "visualization"
+        },
+        {
+          "id": "0d03a670-eb43-11e9-90ec-112a988266d5",
+          "name": "panel_6",
+          "type": "visualization"
+        },
+        {
+          "id": "9c1a1910-ea9a-11e9-90ec-112a988266d5",
+          "name": "panel_7",
+          "type": "visualization"
+        },
+        {
+          "id": "cfaedaf0-eb43-11e9-90ec-112a988266d5",
+          "name": "panel_8",
+          "type": "visualization"
+        }
+      ],
+      "type": "dashboard",
+      "updated_at": "2019-10-15T11:55:55.792Z",
+      "version": "WzMyMDksMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "VMSS Filters [Metricbeat Azure]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "controls": [
+              {
+                "fieldName": "cloud.region",
+                "id": "1549397251041",
+                "indexPatternRefName": "control_0_index_pattern",
+                "label": "Region",
+                "options": {
+                  "dynamicOptions": true,
+                  "multiselect": true,
+                  "order": "desc",
+                  "size": 5,
+                  "type": "terms"
+                },
+                "parent": "",
+                "type": "list"
+              },
+              {
+                "fieldName": "azure.resource.group",
+                "id": "1549512142947",
+                "indexPatternRefName": "control_1_index_pattern",
+                "label": "Resource Group",
+                "options": {
+                  "dynamicOptions": true,
+                  "multiselect": true,
+                  "order": "desc",
+                  "size": 5,
+                  "type": "terms"
+                },
+                "parent": "",
+                "type": "list"
+              },
+              {
+                "fieldName": "azure.dimensions.vmname",
+                "id": "1570711989416",
+                "indexPatternRefName": "control_2_index_pattern",
+                "label": "VM Name (dimension)",
+                "options": {
+                  "dynamicOptions": true,
+                  "multiselect": true,
+                  "order": "desc",
+                  "size": 5,
+                  "type": "terms"
+                },
+                "parent": "",
+                "type": "list"
+              }
+            ],
+            "pinFilters": false,
+            "updateFiltersOnChange": true,
+            "useTimeFilter": false
+          },
+          "title": "VMSS Filters [Metricbeat Azure]",
+          "type": "input_control_vis"
+        }
+      },
+      "id": "686bc990-ea92-11e9-90ec-112a988266d5",
+      "migrationVersion": {
+        "visualization": "7.3.1"
+      },
+      "references": [
+        {
+          "id": "metricbeat-*",
+          "name": "control_0_index_pattern",
+          "type": "index-pattern"
+        },
+        {
+          "id": "metricbeat-*",
+          "name": "control_1_index_pattern",
+          "type": "index-pattern"
+        },
+        {
+          "id": "metricbeat-*",
+          "name": "control_2_index_pattern",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-10-10T13:24:24.225Z",
+      "version": "WzE0MTMsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "VMSS CPU Utilization [Metricbeat Azure]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_min": 0,
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "kuery",
+              "query": "azure.resource.type :\"Microsoft.Compute/virtualMachineScaleSets\" "
+            },
+            "id": "7666abc0-eaae-11e9-a083-57ad7f0b1ec1",
+            "index_pattern": "metricbeat-*",
+            "interval": "\u003e=5m",
+            "isModelInvalid": false,
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#3185FC",
+                "fill": 0,
+                "formatter": "number",
+                "id": "7666abc1-eaae-11e9-a083-57ad7f0b1ec1",
+                "label": "avg(azure.compute_vm_scaleset.percentage_cpu.avg)",
+                "line_width": 2,
+                "metrics": [
+                  {
+                    "field": "azure.compute_vm_scaleset.percentage_cpu.avg",
+                    "id": "7666abc2-eaae-11e9-a083-57ad7f0b1ec1",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_color_mode": "rainbow",
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "azure.resource.name",
+                "value_template": "{{value}}"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "VMSS CPU Utilization [Metricbeat Azure]",
+          "type": "metrics"
+        }
+      },
+      "id": "33500790-eaaf-11e9-90ec-112a988266d5",
+      "migrationVersion": {
+        "visualization": "7.3.1"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-10-15T11:53:31.250Z",
+      "version": "WzMxOTMsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "VMSS Available Memory [Metricbeat Azure]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_min": 0,
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "kuery",
+              "query": "azure.resource.type :\"Microsoft.Compute/virtualMachineScaleSets\" "
+            },
+            "id": "e25fa710-eb3e-11e9-8bf6-ff656bce9010",
+            "index_pattern": "metricbeat-*",
+            "interval": "\u003e=5m",
+            "isModelInvalid": false,
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(22,165,165,1)",
+                "fill": 0,
+                "formatter": "bytes",
+                "id": "e25fa711-eb3e-11e9-8bf6-ff656bce9010",
+                "label": "avg(azure.compute_vm_scaleset.memory_available_bytes.avg)",
+                "line_width": 2,
+                "metrics": [
+                  {
+                    "field": "azure.compute_vm_scaleset.memory_available_bytes.avg",
+                    "id": "e25fa712-eb3e-11e9-8bf6-ff656bce9010",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "azure.resource.name",
+                "value_template": "{{value}}"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "VMSS Available Memory [Metricbeat Azure]",
+          "type": "metrics"
+        }
+      },
+      "id": "cecd6680-eb41-11e9-90ec-112a988266d5",
+      "migrationVersion": {
+        "visualization": "7.3.1"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-10-15T11:53:55.061Z",
+      "version": "WzMxOTUsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "VMSS Disk Reads [Metricbeat Azure]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_min": 0,
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "kuery",
+              "query": "azure.resource.type :\"Microsoft.Compute/virtualMachineScaleSets\" "
+            },
+            "id": "39b6adc0-ea99-11e9-8328-799c817fb96b",
+            "index_pattern": "metricbeat-*",
+            "interval": "\u003e=5m",
+            "isModelInvalid": false,
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(252,196,0,1)",
+                "fill": 0,
+                "formatter": "bytes",
+                "id": "39b6adc1-ea99-11e9-8328-799c817fb96b",
+                "label": "VM Disk Read bytes",
+                "line_width": 2,
+                "metrics": [
+                  {
+                    "field": "azure.compute_vm_scaleset.disk_read_bytes.total",
+                    "id": "39b6adc2-ea99-11e9-8328-799c817fb96b",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "azure.resource.name",
+                "type": "timeseries",
+                "value_template": "{{value}}"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "VMSS Disk Reads [Metricbeat Azure]",
+          "type": "metrics"
+        }
+      },
+      "id": "42cc28d0-ea9a-11e9-90ec-112a988266d5",
+      "migrationVersion": {
+        "visualization": "7.3.1"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-10-15T11:55:06.753Z",
+      "version": "WzMyMDMsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "VMSS Network In Total [Metricbeat Azure]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_min": 0,
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "kuery",
+              "query": "azure.resource.type : \"Microsoft.Compute/virtualMachineScaleSets\" "
+            },
+            "id": "39b6adc0-ea99-11e9-8328-799c817fb96b",
+            "index_pattern": "metricbeat-*",
+            "interval": "\u003e=5m",
+            "isModelInvalid": false,
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(104,204,202,1)",
+                "fill": 0,
+                "formatter": "bytes",
+                "id": "39b6adc1-ea99-11e9-8328-799c817fb96b",
+                "label": "Azure VMSS Network In Total",
+                "line_width": 2,
+                "metrics": [
+                  {
+                    "field": "azure.compute_vm_scaleset.network_in_total.total",
+                    "id": "39b6adc2-ea99-11e9-8328-799c817fb96b",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "azure.resource.name",
+                "type": "timeseries",
+                "value_template": "{{value}}"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "VMSS Network In Total [Metricbeat Azure]",
+          "type": "metrics"
+        }
+      },
+      "id": "64266ec0-eb42-11e9-90ec-112a988266d5",
+      "migrationVersion": {
+        "visualization": "7.3.1"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-10-15T11:54:14.745Z",
+      "version": "WzMxOTcsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "VMSS Network Out Total [Metricbeat Azure]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_min": 0,
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "kuery",
+              "query": "azure.resource.type : \"Microsoft.Compute/virtualMachineScaleSets\" "
+            },
+            "id": "39b6adc0-ea99-11e9-8328-799c817fb96b",
+            "index_pattern": "metricbeat-*",
+            "interval": "\u003e=5m",
+            "isModelInvalid": false,
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(104,188,0,1)",
+                "fill": 0,
+                "formatter": "bytes",
+                "id": "39b6adc1-ea99-11e9-8328-799c817fb96b",
+                "label": "Azure VM Network Out Total",
+                "line_width": 2,
+                "metrics": [
+                  {
+                    "field": "azure.compute_vm_scaleset.network_out_total.total",
+                    "id": "39b6adc2-ea99-11e9-8328-799c817fb96b",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "azure.resource.name",
+                "type": "timeseries",
+                "value_template": "{{value}}"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "VMSS Network Out Total [Metricbeat Azure]",
+          "type": "metrics"
+        }
+      },
+      "id": "b45fd8e0-eb42-11e9-90ec-112a988266d5",
+      "migrationVersion": {
+        "visualization": "7.3.1"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-10-15T11:54:30.361Z",
+      "version": "WzMxOTksMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "VMSS Disk Writes [Metricbeat Azure]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_min": 0,
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "kuery",
+              "query": "azure.resource.type :\"Microsoft.Compute/virtualMachineScaleSets\" "
+            },
+            "id": "39b6adc0-ea99-11e9-8328-799c817fb96b",
+            "index_pattern": "metricbeat-*",
+            "interval": "\u003e=5m",
+            "isModelInvalid": false,
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(0,180,251,1)",
+                "fill": 0,
+                "formatter": "bytes",
+                "id": "39b6adc1-ea99-11e9-8328-799c817fb96b",
+                "label": "VM Disk Writes bytes",
+                "line_width": 2,
+                "metrics": [
+                  {
+                    "field": "azure.compute_vm_scaleset.disk_write_bytes.total",
+                    "id": "39b6adc2-ea99-11e9-8328-799c817fb96b",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "azure.resource.name",
+                "type": "timeseries",
+                "value_template": "{{value}}"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "VMSS Disk Writes [Metricbeat Azure]",
+          "type": "metrics"
+        }
+      },
+      "id": "0d03a670-eb43-11e9-90ec-112a988266d5",
+      "migrationVersion": {
+        "visualization": "7.3.1"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-10-15T11:54:48.472Z",
+      "version": "WzMyMDEsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "VMSS Disk Read Operations [Metricbeat Azure]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_min": 0,
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "kuery",
+              "query": "azure.resource.type : \"Microsoft.Compute/virtualMachineScaleSets\" "
+            },
+            "id": "39b6adc0-ea99-11e9-8328-799c817fb96b",
+            "index_pattern": "metricbeat-*",
+            "interval": "\u003e=5m",
+            "isModelInvalid": false,
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(252,196,0,1)",
+                "fill": 0,
+                "formatter": "number",
+                "id": "39b6adc1-ea99-11e9-8328-799c817fb96b",
+                "label": "VM Disk Read Operations/s",
+                "line_width": 2,
+                "metrics": [
+                  {
+                    "field": "azure.compute_vm_scaleset.disk_read_operations_per_sec.avg",
+                    "id": "39b6adc2-ea99-11e9-8328-799c817fb96b",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "azure.resource.name",
+                "type": "timeseries",
+                "value_template": "{{value}}"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "VMSS Disk Read Operations [Metricbeat Azure]",
+          "type": "metrics"
+        }
+      },
+      "id": "9c1a1910-ea9a-11e9-90ec-112a988266d5",
+      "migrationVersion": {
+        "visualization": "7.3.1"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-10-15T11:55:26.389Z",
+      "version": "WzMyMDUsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "VMSS Disk Write Operations [Metricbeat Azure]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_min": 0,
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "kuery",
+              "query": "azure.resource.type : \"Microsoft.Compute/virtualMachineScaleSets\" "
+            },
+            "id": "39b6adc0-ea99-11e9-8328-799c817fb96b",
+            "index_pattern": "metricbeat-*",
+            "interval": "\u003e=5m",
+            "isModelInvalid": false,
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(104,204,202,1)",
+                "fill": 0,
+                "formatter": "number",
+                "id": "39b6adc1-ea99-11e9-8328-799c817fb96b",
+                "label": "VM Disk Write Operations/s",
+                "line_width": 2,
+                "metrics": [
+                  {
+                    "field": "azure.compute_vm_scaleset.disk_write_operations_per_sec.avg",
+                    "id": "39b6adc2-ea99-11e9-8328-799c817fb96b",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "azure.resource.name",
+                "type": "timeseries",
+                "value_template": "{{value}}"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "VMSS Disk Write Operations [Metricbeat Azure]",
+          "type": "metrics"
+        }
+      },
+      "id": "cfaedaf0-eb43-11e9-90ec-112a988266d5",
+      "migrationVersion": {
+        "visualization": "7.3.1"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-10-15T11:55:48.348Z",
+      "version": "WzMyMDcsMV0="
+    }
+  ],
+  "version": "7.4.0"
+}

--- a/dev/package-beats/azure-1.0.0/manifest.yml
+++ b/dev/package-beats/azure-1.0.0/manifest.yml
@@ -1,0 +1,14 @@
+name: azure
+title: azure
+version: 1.0.0
+description: |
+  Azure Module
+type: ""
+categories:
+- metrics
+- logs
+requirement:
+  kibana:
+    version:
+      min: 6.7.0
+      max: 7.6.0

--- a/dev/package-beats/beat-1.0.0/manifest.yml
+++ b/dev/package-beats/beat-1.0.0/manifest.yml
@@ -1,0 +1,13 @@
+name: beat
+title: Beat
+version: 1.0.0
+description: |
+  Beat module
+type: ""
+categories:
+- metrics
+requirement:
+  kibana:
+    version:
+      min: 6.7.0
+      max: 7.6.0

--- a/dev/package-beats/cef-module-1.0.0/manifest.yml
+++ b/dev/package-beats/cef-module-1.0.0/manifest.yml
@@ -1,0 +1,13 @@
+name: cef-module
+title: CEF
+version: 1.0.0
+description: |
+  Module for receiving CEF logs over Syslog. The module does not add fields beyond what the decode_cef processor provides.
+type: ""
+categories:
+- logs
+requirement:
+  kibana:
+    version:
+      min: 6.7.0
+      max: 7.6.0

--- a/dev/package-beats/ceph-1.0.0/kibana/dashboard/Metricbeat-ceph-overview.json
+++ b/dev/package-beats/ceph-1.0.0/kibana/dashboard/Metricbeat-ceph-overview.json
@@ -1,0 +1,723 @@
+{
+  "objects": [
+    {
+      "attributes": {
+        "description": "This Ceph dashboard that shows the most important cluster metrics.",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "optionsJSON": {
+          "hidePanelTitles": false,
+          "useMargins": true
+        },
+        "panelsJSON": [
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 12,
+              "i": "1",
+              "w": 18,
+              "x": 30,
+              "y": 0
+            },
+            "panelIndex": "1",
+            "panelRefName": "panel_0",
+            "title": "Cluster Disk Stats",
+            "version": "7.3.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 13,
+              "i": "2",
+              "w": 24,
+              "x": 24,
+              "y": 12
+            },
+            "panelIndex": "2",
+            "panelRefName": "panel_1",
+            "title": "Throughput",
+            "version": "7.3.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 13,
+              "i": "3",
+              "w": 24,
+              "x": 0,
+              "y": 12
+            },
+            "panelIndex": "3",
+            "panelRefName": "panel_2",
+            "title": "IOPS",
+            "version": "7.3.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 12,
+              "i": "4",
+              "w": 6,
+              "x": 24,
+              "y": 0
+            },
+            "panelIndex": "4",
+            "panelRefName": "panel_3",
+            "title": "OSD Disk Usage",
+            "version": "7.3.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 12,
+              "i": "5",
+              "w": 5,
+              "x": 0,
+              "y": 0
+            },
+            "panelIndex": "5",
+            "panelRefName": "panel_4",
+            "title": "Pools",
+            "version": "7.3.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 12,
+              "i": "6",
+              "w": 19,
+              "x": 5,
+              "y": 0
+            },
+            "panelIndex": "6",
+            "panelRefName": "panel_5",
+            "title": "Pool Objects",
+            "version": "7.3.0"
+          }
+        ],
+        "timeRestore": false,
+        "title": "[Metricbeat Ceph] Cluster Overview",
+        "version": 1
+      },
+      "id": "c93f2c30-b473-11e9-a579-f5c0a5d81340",
+      "migrationVersion": {
+        "dashboard": "7.3.0"
+      },
+      "references": [
+        {
+          "id": "054a0900-b467-11e9-a579-f5c0a5d81340",
+          "name": "panel_0",
+          "type": "visualization"
+        },
+        {
+          "id": "88d48440-b46b-11e9-a579-f5c0a5d81340",
+          "name": "panel_1",
+          "type": "visualization"
+        },
+        {
+          "id": "346d00d0-b46b-11e9-a579-f5c0a5d81340",
+          "name": "panel_2",
+          "type": "visualization"
+        },
+        {
+          "id": "13efa190-b46c-11e9-a579-f5c0a5d81340",
+          "name": "panel_3",
+          "type": "visualization"
+        },
+        {
+          "id": "393df790-b470-11e9-a579-f5c0a5d81340",
+          "name": "panel_4",
+          "type": "visualization"
+        },
+        {
+          "id": "aa9c2f10-b470-11e9-a579-f5c0a5d81340",
+          "name": "panel_5",
+          "type": "visualization"
+        }
+      ],
+      "type": "dashboard",
+      "updated_at": "2019-08-19T15:00:55.571Z",
+      "version": "WzE1NzEsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Cluster Disk Stats [Metricbeat Ceph] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "bar_color_rules": [
+              {
+                "id": "bd70f9c0-b472-11e9-ba7f-f52449624592"
+              }
+            ],
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "kuery",
+              "query": ""
+            },
+            "id": "7b71f300-b466-11e9-841e-0ddf9a697c96",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(159,5,0,1)",
+                "fill": "0",
+                "formatter": "bytes",
+                "hide_in_legend": 0,
+                "id": "7b71f301-b466-11e9-841e-0ddf9a697c96",
+                "label": "total",
+                "line_width": "1",
+                "metrics": [
+                  {
+                    "field": "ceph.cluster_disk.total.bytes",
+                    "id": "7b71f302-b466-11e9-841e-0ddf9a697c96",
+                    "type": "max"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(104,188,0,1)",
+                "fill": "0.2",
+                "formatter": "bytes",
+                "id": "7b71f303-b466-11e9-841e-0ddf9a697c96",
+                "label": "available",
+                "line_width": "1",
+                "metrics": [
+                  {
+                    "field": "ceph.cluster_disk.available.bytes",
+                    "id": "7b71f304-b466-11e9-841e-0ddf9a697c96",
+                    "type": "max"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(252,196,0,1)",
+                "fill": 0.5,
+                "formatter": "bytes",
+                "id": "64f99360-b472-11e9-ba7f-f52449624592",
+                "label": "used",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "ceph.cluster_disk.used.bytes",
+                    "id": "64f99361-b472-11e9-ba7f-f52449624592",
+                    "type": "max"
+                  }
+                ],
+                "point_size": "0",
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Cluster Disk Stats [Metricbeat Ceph] ECS",
+          "type": "metrics"
+        }
+      },
+      "id": "054a0900-b467-11e9-a579-f5c0a5d81340",
+      "migrationVersion": {
+        "visualization": "7.3.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-08-02T10:56:16.795Z",
+      "version": "WzYwMCwxXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Throughput [Metricbeat Ceph] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "kuery",
+              "query": ""
+            },
+            "id": "57f0f3e0-b46b-11e9-88d3-b1e3cace09ae",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(104,204,202,1)",
+                "fill": 0,
+                "formatter": "number",
+                "id": "57f11af0-b46b-11e9-88d3-b1e3cace09ae",
+                "label": "read",
+                "line_width": 2,
+                "metrics": [
+                  {
+                    "field": "ceph.cluster_status.traffic.read_bytes",
+                    "id": "57f11af1-b46b-11e9-88d3-b1e3cace09ae",
+                    "type": "max"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(176,188,0,1)",
+                "fill": 0,
+                "formatter": "number",
+                "id": "57f11af2-b46b-11e9-88d3-b1e3cace09ae",
+                "label": "write",
+                "line_width": 2,
+                "metrics": [
+                  {
+                    "field": "ceph.cluster_status.traffic.write_bytes",
+                    "id": "57f11af3-b46b-11e9-88d3-b1e3cace09ae",
+                    "type": "max"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Throughput [Metricbeat Ceph] ECS",
+          "type": "metrics"
+        }
+      },
+      "id": "88d48440-b46b-11e9-a579-f5c0a5d81340",
+      "migrationVersion": {
+        "visualization": "7.3.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-08-02T10:54:20.715Z",
+      "version": "WzU5NiwxXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "IOPS [Metricbeat Ceph] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "kuery",
+              "query": ""
+            },
+            "id": "0fc1f2e0-b46b-11e9-9488-8bde5ab143f4",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#3185FC",
+                "fill": 0,
+                "formatter": "number",
+                "id": "0fc1f2e1-b46b-11e9-9488-8bde5ab143f4",
+                "label": "read",
+                "line_width": 2,
+                "metrics": [
+                  {
+                    "field": "ceph.cluster_status.traffic.read_op_per_sec",
+                    "id": "0fc1f2e2-b46b-11e9-9488-8bde5ab143f4",
+                    "type": "max"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#DB1374",
+                "fill": 0,
+                "formatter": "number",
+                "id": "0fc1f2e3-b46b-11e9-9488-8bde5ab143f4",
+                "label": "write",
+                "line_width": 2,
+                "metrics": [
+                  {
+                    "field": "ceph.cluster_status.traffic.write_op_per_sec",
+                    "id": "0fc1f2e4-b46b-11e9-9488-8bde5ab143f4",
+                    "type": "max"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "IOPS [Metricbeat Ceph] ECS",
+          "type": "metrics"
+        }
+      },
+      "id": "346d00d0-b46b-11e9-a579-f5c0a5d81340",
+      "migrationVersion": {
+        "visualization": "7.3.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-08-02T10:54:00.152Z",
+      "version": "WzU5MiwxXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "OSD Disk Usage [Metricbeat Ceph] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "kuery",
+              "query": ""
+            },
+            "gauge_color_rules": [
+              {
+                "gauge": "rgba(226,115,0,1)",
+                "id": "e681d700-b46b-11e9-9bdc-15c69a730d82",
+                "operator": "gte",
+                "value": 70
+              },
+              {
+                "gauge": "rgba(247,58,26,1)",
+                "id": "61b552b0-b513-11e9-81ce-0379c4621e40",
+                "value": 90
+              }
+            ],
+            "gauge_inner_width": 10,
+            "gauge_max": "",
+            "gauge_style": "half",
+            "gauge_width": 10,
+            "id": "e17a9bc0-b46b-11e9-9a02-5de45d117640",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(164,221,0,1)",
+                "fill": 0,
+                "formatter": "percent",
+                "id": "e17a9bc1-b46b-11e9-9a02-5de45d117640",
+                "label": "OSD disk usage",
+                "line_width": 2,
+                "metrics": [
+                  {
+                    "field": "ceph.osd_df.used.pct",
+                    "id": "e17a9bc2-b46b-11e9-9a02-5de45d117640",
+                    "type": "max"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "gauge"
+          },
+          "title": "OSD Disk Usage [Metricbeat Ceph] ECS",
+          "type": "metrics"
+        }
+      },
+      "id": "13efa190-b46c-11e9-a579-f5c0a5d81340",
+      "migrationVersion": {
+        "visualization": "7.3.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-08-02T10:52:20.880Z",
+      "version": "WzU3NCwxXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Pools [Metricbeat Ceph] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "background_color_rules": [
+              {
+                "id": "e96942b0-b46f-11e9-aefa-c791377b99c3"
+              }
+            ],
+            "bar_color_rules": [
+              {
+                "id": "21aaa880-b470-11e9-aefa-c791377b99c3"
+              }
+            ],
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "kuery",
+              "query": ""
+            },
+            "gauge_color_rules": [
+              {
+                "id": "20eadaf0-b470-11e9-aefa-c791377b99c3"
+              }
+            ],
+            "gauge_inner_width": 10,
+            "gauge_style": "half",
+            "gauge_width": 10,
+            "id": "b859c050-b46f-11e9-9f8f-97f5e69abdab",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#3185FC",
+                "fill": 0,
+                "formatter": "number",
+                "id": "b859e760-b46f-11e9-9f8f-97f5e69abdab",
+                "label": "Pools",
+                "line_width": 2,
+                "metrics": [
+                  {
+                    "field": "ceph.pool_disk.id",
+                    "id": "b859e761-b46f-11e9-9f8f-97f5e69abdab",
+                    "type": "max"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "metric"
+          },
+          "title": "Pools [Metricbeat Ceph] ECS",
+          "type": "metrics"
+        }
+      },
+      "id": "393df790-b470-11e9-a579-f5c0a5d81340",
+      "migrationVersion": {
+        "visualization": "7.3.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-08-02T10:53:11.179Z",
+      "version": "WzU4MSwxXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Pool Objects [Metricbeat Ceph] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "background_color_rules": [
+              {
+                "id": "6ac91290-b470-11e9-a4bb-473d6710f872"
+              }
+            ],
+            "bar_color_rules": [
+              {
+                "id": "6b864810-b470-11e9-a4bb-473d6710f872"
+              }
+            ],
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "kuery",
+              "query": ""
+            },
+            "id": "4ce78950-b470-11e9-87e8-53bd102d292b",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(104,188,0,1)",
+                "fill": 0,
+                "formatter": "number",
+                "id": "4ce78951-b470-11e9-87e8-53bd102d292b",
+                "label": "Objects",
+                "line_width": 2,
+                "metrics": [
+                  {
+                    "field": "ceph.pool_disk.stats.objects",
+                    "id": "4ce78952-b470-11e9-87e8-53bd102d292b",
+                    "type": "max"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "ceph.pool_disk.name",
+                "value_template": "{{value}}"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Pool Objects [Metricbeat Ceph] ECS",
+          "type": "metrics"
+        }
+      },
+      "id": "aa9c2f10-b470-11e9-a579-f5c0a5d81340",
+      "migrationVersion": {
+        "visualization": "7.3.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-08-02T10:53:35.220Z",
+      "version": "WzU4NiwxXQ=="
+    }
+  ],
+  "version": "7.3.0"
+}

--- a/dev/package-beats/ceph-1.0.0/manifest.yml
+++ b/dev/package-beats/ceph-1.0.0/manifest.yml
@@ -1,0 +1,13 @@
+name: ceph
+title: Ceph
+version: 1.0.0
+description: |
+  Ceph module
+type: ""
+categories:
+- metrics
+requirement:
+  kibana:
+    version:
+      min: 6.7.0
+      max: 7.6.0

--- a/dev/package-beats/cisco-1.0.0/kibana/dashboard/Filebeat-Cisco-ASA.json
+++ b/dev/package-beats/cisco-1.0.0/kibana/dashboard/Filebeat-Cisco-ASA.json
@@ -1,0 +1,1045 @@
+{
+  "objects": [
+    {
+      "attributes": {
+        "description": "Sample dashboard for Cisco ASA Firewall devices",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "optionsJSON": {
+          "hidePanelTitles": false,
+          "useMargins": true
+        },
+        "panelsJSON": [
+          {
+            "embeddableConfig": {
+              "vis": {
+                "legendOpen": false
+              }
+            },
+            "gridData": {
+              "h": 15,
+              "i": "1",
+              "w": 12,
+              "x": 12,
+              "y": 15
+            },
+            "panelIndex": "1",
+            "panelRefName": "panel_0",
+            "title": "Destination Port and Transport",
+            "version": "7.0.0-SNAPSHOT"
+          },
+          {
+            "embeddableConfig": {
+              "vis": {
+                "legendOpen": false
+              }
+            },
+            "gridData": {
+              "h": 15,
+              "i": "2",
+              "w": 12,
+              "x": 0,
+              "y": 15
+            },
+            "panelIndex": "2",
+            "panelRefName": "panel_1",
+            "title": "Source Port and Transport",
+            "version": "7.0.0-SNAPSHOT"
+          },
+          {
+            "embeddableConfig": {
+              "vis": {
+                "legendOpen": false
+              }
+            },
+            "gridData": {
+              "h": 15,
+              "i": "3",
+              "w": 24,
+              "x": 0,
+              "y": 0
+            },
+            "panelIndex": "3",
+            "panelRefName": "panel_2",
+            "title": "ASA Firewall Events Over Time",
+            "version": "7.0.0-SNAPSHOT"
+          },
+          {
+            "embeddableConfig": {
+              "vis": {
+                "legendOpen": false
+              }
+            },
+            "gridData": {
+              "h": 15,
+              "i": "4",
+              "w": 24,
+              "x": 24,
+              "y": 0
+            },
+            "panelIndex": "4",
+            "panelRefName": "panel_3",
+            "title": "ASA Flows by Network Bytes",
+            "version": "7.0.0-SNAPSHOT"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 15,
+              "i": "5",
+              "w": 12,
+              "x": 24,
+              "y": 15
+            },
+            "panelIndex": "5",
+            "panelRefName": "panel_4",
+            "title": "Blocked by Source",
+            "version": "7.0.0-SNAPSHOT"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 15,
+              "i": "8",
+              "w": 12,
+              "x": 36,
+              "y": 15
+            },
+            "panelIndex": "8",
+            "panelRefName": "panel_5",
+            "title": "Top ACL by Blocked",
+            "version": "7.0.0-SNAPSHOT"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 12,
+              "i": "9",
+              "w": 48,
+              "x": 0,
+              "y": 30
+            },
+            "panelIndex": "9",
+            "panelRefName": "panel_6",
+            "version": "7.0.0-SNAPSHOT"
+          }
+        ],
+        "timeRestore": false,
+        "title": "[Filebeat Cisco] ASA Firewall",
+        "version": 1
+      },
+      "id": "a555b160-4987-11e9-b8ce-ed898b5ef295",
+      "migrationVersion": {
+        "dashboard": "7.0.0"
+      },
+      "references": [
+        {
+          "id": "118da960-4987-11e9-b8ce-ed898b5ef295",
+          "name": "panel_0",
+          "type": "visualization"
+        },
+        {
+          "id": "5d0322d0-4987-11e9-b8ce-ed898b5ef295",
+          "name": "panel_1",
+          "type": "visualization"
+        },
+        {
+          "id": "a3b5ab10-4989-11e9-b8ce-ed898b5ef295",
+          "name": "panel_2",
+          "type": "visualization"
+        },
+        {
+          "id": "80d0c1b0-498a-11e9-b8ce-ed898b5ef295",
+          "name": "panel_3",
+          "type": "visualization"
+        },
+        {
+          "id": "d05cdf60-498b-11e9-b8ce-ed898b5ef295",
+          "name": "panel_4",
+          "type": "visualization"
+        },
+        {
+          "id": "08ef4d90-499b-11e9-b8ce-ed898b5ef295",
+          "name": "panel_5",
+          "type": "visualization"
+        },
+        {
+          "id": "fd89b1e0-49a2-11e9-b8ce-ed898b5ef295",
+          "name": "panel_6",
+          "type": "visualization"
+        }
+      ],
+      "type": "dashboard",
+      "updated_at": "2019-03-18T18:39:06.844Z",
+      "version": "WzI2MiwxXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "savedSearchRefName": "search_0",
+        "title": "Destination Port and Transport [Filebeat Cisco]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "field": "network.transport",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 5
+              },
+              "schema": "segment",
+              "type": "terms"
+            },
+            {
+              "enabled": true,
+              "id": "3",
+              "params": {
+                "field": "destination.port",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 5
+              },
+              "schema": "segment",
+              "type": "terms"
+            }
+          ],
+          "params": {
+            "addLegend": true,
+            "addTooltip": true,
+            "isDonut": true,
+            "labels": {
+              "last_level": true,
+              "show": false,
+              "truncate": 100,
+              "values": true
+            },
+            "legendPosition": "right",
+            "type": "pie"
+          },
+          "title": "Destination Port and Transport [Filebeat Cisco]",
+          "type": "pie"
+        }
+      },
+      "id": "118da960-4987-11e9-b8ce-ed898b5ef295",
+      "migrationVersion": {
+        "visualization": "7.0.0"
+      },
+      "references": [
+        {
+          "id": "753406e0-4986-11e9-b8ce-ed898b5ef295",
+          "name": "search_0",
+          "type": "search"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-03-18T14:07:22.932Z",
+      "version": "WzI0NiwxXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "savedSearchRefName": "search_0",
+        "title": "Source Port and Transport [Filebeat Cisco]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "field": "network.transport",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 5
+              },
+              "schema": "segment",
+              "type": "terms"
+            },
+            {
+              "enabled": true,
+              "id": "3",
+              "params": {
+                "field": "source.port",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 5
+              },
+              "schema": "segment",
+              "type": "terms"
+            }
+          ],
+          "params": {
+            "addLegend": true,
+            "addTooltip": true,
+            "isDonut": true,
+            "labels": {
+              "last_level": true,
+              "show": false,
+              "truncate": 100,
+              "values": true
+            },
+            "legendPosition": "right",
+            "type": "pie"
+          },
+          "title": "Source Port and Transport [Filebeat Cisco]",
+          "type": "pie"
+        }
+      },
+      "id": "5d0322d0-4987-11e9-b8ce-ed898b5ef295",
+      "migrationVersion": {
+        "visualization": "7.0.0"
+      },
+      "references": [
+        {
+          "id": "753406e0-4986-11e9-b8ce-ed898b5ef295",
+          "name": "search_0",
+          "type": "search"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-03-18T14:08:54.141Z",
+      "version": "WzI0NywxXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "savedSearchRefName": "search_0",
+        "title": "ASA Events Over Time [Filebeat Cisco]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "field": "event.outcome",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 5
+              },
+              "schema": "group",
+              "type": "terms"
+            },
+            {
+              "enabled": true,
+              "id": "3",
+              "params": {
+                "customInterval": "2h",
+                "drop_partials": false,
+                "extended_bounds": {},
+                "field": "@timestamp",
+                "interval": "auto",
+                "min_doc_count": 1,
+                "timeRange": {
+                  "from": "now-15y",
+                  "to": "now+1y"
+                },
+                "time_zone": "Europe/Madrid",
+                "useNormalizedEsInterval": true
+              },
+              "schema": "segment",
+              "type": "date_histogram"
+            }
+          ],
+          "params": {
+            "addLegend": true,
+            "addTimeMarker": false,
+            "addTooltip": true,
+            "categoryAxes": [
+              {
+                "id": "CategoryAxis-1",
+                "labels": {
+                  "show": true,
+                  "truncate": 100
+                },
+                "position": "bottom",
+                "scale": {
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {},
+                "type": "category"
+              }
+            ],
+            "grid": {
+              "categoryLines": false
+            },
+            "legendPosition": "right",
+            "seriesParams": [
+              {
+                "data": {
+                  "id": "1",
+                  "label": "Count"
+                },
+                "drawLinesBetweenPoints": true,
+                "mode": "stacked",
+                "show": "true",
+                "showCircles": true,
+                "type": "histogram",
+                "valueAxis": "ValueAxis-1"
+              }
+            ],
+            "times": [],
+            "type": "histogram",
+            "valueAxes": [
+              {
+                "id": "ValueAxis-1",
+                "labels": {
+                  "filter": false,
+                  "rotate": 0,
+                  "show": true,
+                  "truncate": 100
+                },
+                "name": "LeftAxis-1",
+                "position": "left",
+                "scale": {
+                  "mode": "normal",
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {
+                  "text": "Count"
+                },
+                "type": "value"
+              }
+            ]
+          },
+          "title": "ASA Events Over Time [Filebeat Cisco]",
+          "type": "histogram"
+        }
+      },
+      "id": "a3b5ab10-4989-11e9-b8ce-ed898b5ef295",
+      "migrationVersion": {
+        "visualization": "7.0.0"
+      },
+      "references": [
+        {
+          "id": "96c6ff60-4986-11e9-b8ce-ed898b5ef295",
+          "name": "search_0",
+          "type": "search"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-03-18T14:27:16.950Z",
+      "version": "WzI1MSwxXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "savedSearchRefName": "search_0",
+        "title": "ASA Flows by Network Bytes [Filebeat Cisco]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customInterval": "2h",
+                "drop_partials": false,
+                "extended_bounds": {},
+                "field": "@timestamp",
+                "interval": "auto",
+                "min_doc_count": 1,
+                "timeRange": {
+                  "from": "now-15y",
+                  "to": "now+1y"
+                },
+                "time_zone": "Europe/Madrid",
+                "useNormalizedEsInterval": true
+              },
+              "schema": "segment",
+              "type": "date_histogram"
+            },
+            {
+              "enabled": true,
+              "id": "3",
+              "params": {
+                "customLabel": "Total bytes",
+                "field": "network.bytes"
+              },
+              "schema": "metric",
+              "type": "sum"
+            }
+          ],
+          "params": {
+            "addLegend": true,
+            "addTimeMarker": false,
+            "addTooltip": true,
+            "categoryAxes": [
+              {
+                "id": "CategoryAxis-1",
+                "labels": {
+                  "show": true,
+                  "truncate": 100
+                },
+                "position": "bottom",
+                "scale": {
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {},
+                "type": "category"
+              }
+            ],
+            "grid": {
+              "categoryLines": false
+            },
+            "legendPosition": "right",
+            "seriesParams": [
+              {
+                "data": {
+                  "id": "3",
+                  "label": "Total bytes"
+                },
+                "drawLinesBetweenPoints": true,
+                "mode": "stacked",
+                "show": true,
+                "showCircles": true,
+                "type": "histogram",
+                "valueAxis": "ValueAxis-1"
+              }
+            ],
+            "times": [],
+            "type": "histogram",
+            "valueAxes": [
+              {
+                "id": "ValueAxis-1",
+                "labels": {
+                  "filter": false,
+                  "rotate": 0,
+                  "show": true,
+                  "truncate": 100
+                },
+                "name": "LeftAxis-1",
+                "position": "left",
+                "scale": {
+                  "mode": "normal",
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {
+                  "text": "Total bytes"
+                },
+                "type": "value"
+              }
+            ]
+          },
+          "title": "ASA Flows by Network Bytes [Filebeat Cisco]",
+          "type": "histogram"
+        }
+      },
+      "id": "80d0c1b0-498a-11e9-b8ce-ed898b5ef295",
+      "migrationVersion": {
+        "visualization": "7.0.0"
+      },
+      "references": [
+        {
+          "id": "753406e0-4986-11e9-b8ce-ed898b5ef295",
+          "name": "search_0",
+          "type": "search"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-03-18T14:31:22.699Z",
+      "version": "WzI1MiwxXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "savedSearchRefName": "search_0",
+        "title": "ASA Firewall Blocked by Source [Filebeat Cisco]",
+        "uiStateJSON": {
+          "vis": {
+            "params": {
+              "sort": {
+                "columnIndex": null,
+                "direction": null
+              }
+            }
+          }
+        },
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": ""
+              },
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "field": "source.ip",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 5
+              },
+              "schema": "bucket",
+              "type": "terms"
+            }
+          ],
+          "params": {
+            "perPage": 10,
+            "showMetricsAtAllLevels": false,
+            "showPartialRows": false,
+            "showTotal": false,
+            "sort": {
+              "columnIndex": null,
+              "direction": null
+            },
+            "totalFunc": "sum"
+          },
+          "title": "ASA Firewall Blocked by Source [Filebeat Cisco]",
+          "type": "table"
+        }
+      },
+      "id": "d05cdf60-498b-11e9-b8ce-ed898b5ef295",
+      "migrationVersion": {
+        "visualization": "7.0.0"
+      },
+      "references": [
+        {
+          "id": "96c6ff60-4986-11e9-b8ce-ed898b5ef295",
+          "name": "search_0",
+          "type": "search"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-03-18T14:42:05.159Z",
+      "version": "WzI1NCwxXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": "event.outcome:\"deny\""
+            }
+          }
+        },
+        "savedSearchRefName": "search_0",
+        "title": "ASA Top ACL by Blocked [Filebeat Cisco]",
+        "uiStateJSON": {
+          "vis": {
+            "params": {
+              "sort": {
+                "columnIndex": null,
+                "direction": null
+              }
+            }
+          }
+        },
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": ""
+              },
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customLabel": "ACL ID",
+                "field": "cisco.asa.list_id",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 5
+              },
+              "schema": "bucket",
+              "type": "terms"
+            }
+          ],
+          "params": {
+            "perPage": 10,
+            "showMetricsAtAllLevels": false,
+            "showPartialRows": false,
+            "showTotal": false,
+            "sort": {
+              "columnIndex": null,
+              "direction": null
+            },
+            "totalFunc": "sum"
+          },
+          "title": "ASA Top ACL by Blocked [Filebeat Cisco]",
+          "type": "table"
+        }
+      },
+      "id": "08ef4d90-499b-11e9-b8ce-ed898b5ef295",
+      "migrationVersion": {
+        "visualization": "7.0.0"
+      },
+      "references": [
+        {
+          "id": "96c6ff60-4986-11e9-b8ce-ed898b5ef295",
+          "name": "search_0",
+          "type": "search"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-03-18T16:29:43.017Z",
+      "version": "WzI1NywxXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "savedSearchRefName": "search_0",
+        "title": "Top ASA Messages [Filebeat Cisco]",
+        "uiStateJSON": {
+          "vis": {
+            "params": {
+              "sort": {
+                "columnIndex": 1,
+                "direction": "desc"
+              }
+            }
+          }
+        },
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customLabel": "ID",
+                "field": "cisco.asa.message_id",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "_key",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 15
+              },
+              "schema": "bucket",
+              "type": "terms"
+            },
+            {
+              "enabled": true,
+              "id": "3",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "4",
+              "params": {
+                "aggregate": "concat",
+                "customLabel": "Severity",
+                "field": "log.level",
+                "size": 1,
+                "sortField": "@timestamp",
+                "sortOrder": "desc"
+              },
+              "schema": "metric",
+              "type": "top_hits"
+            },
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "aggregate": "concat",
+                "customLabel": "Sample message",
+                "field": "log.original",
+                "size": 1,
+                "sortField": "@timestamp",
+                "sortOrder": "desc"
+              },
+              "schema": "metric",
+              "type": "top_hits"
+            }
+          ],
+          "params": {
+            "perPage": 10,
+            "showMetricsAtAllLevels": false,
+            "showPartialRows": false,
+            "showTotal": true,
+            "sort": {
+              "columnIndex": null,
+              "direction": null
+            },
+            "totalFunc": "sum"
+          },
+          "title": "Top ASA Messages [Filebeat Cisco]",
+          "type": "table"
+        }
+      },
+      "id": "fd89b1e0-49a2-11e9-b8ce-ed898b5ef295",
+      "migrationVersion": {
+        "visualization": "7.0.0"
+      },
+      "references": [
+        {
+          "id": "14fce5e0-498f-11e9-b8ce-ed898b5ef295",
+          "name": "search_0",
+          "type": "search"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-03-18T17:26:39.870Z",
+      "version": "WzI1OSwxXQ=="
+    },
+    {
+      "attributes": {
+        "columns": [
+          "_source"
+        ],
+        "description": "",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "highlightAll": true,
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "language": "kuery",
+              "query": "cisco.asa.message_id:* and event.action:\"flow-expiration\""
+            },
+            "version": true
+          }
+        },
+        "sort": [
+          "@timestamp",
+          "desc"
+        ],
+        "title": "ASA Firewall flows [Filebeat Cisco]",
+        "version": 1
+      },
+      "id": "753406e0-4986-11e9-b8ce-ed898b5ef295",
+      "migrationVersion": {
+        "search": "7.0.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "search",
+      "updated_at": "2019-03-18T14:02:44.176Z",
+      "version": "WzI0MywxXQ=="
+    },
+    {
+      "attributes": {
+        "columns": [
+          "_source"
+        ],
+        "description": "",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "highlightAll": true,
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "language": "kuery",
+              "query": "cisco.asa.message_id:* and event.action:\"firewall-rule\""
+            },
+            "version": true
+          }
+        },
+        "sort": [
+          "@timestamp",
+          "desc"
+        ],
+        "title": "ASA Firewall Events [Filebeat Cisco]",
+        "version": 1
+      },
+      "id": "96c6ff60-4986-11e9-b8ce-ed898b5ef295",
+      "migrationVersion": {
+        "search": "7.0.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "search",
+      "updated_at": "2019-03-18T14:03:21.558Z",
+      "version": "WzI0NCwxXQ=="
+    },
+    {
+      "attributes": {
+        "columns": [
+          "_source"
+        ],
+        "description": "",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "highlightAll": true,
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "language": "kuery",
+              "query": "cisco.asa.message_id :*"
+            },
+            "version": true
+          }
+        },
+        "sort": [
+          "@timestamp",
+          "desc"
+        ],
+        "title": "All ASA Logs [Filebeat Cisco]",
+        "version": 1
+      },
+      "id": "14fce5e0-498f-11e9-b8ce-ed898b5ef295",
+      "migrationVersion": {
+        "search": "7.0.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "search",
+      "updated_at": "2019-03-18T15:04:09.277Z",
+      "version": "WzI1NiwxXQ=="
+    }
+  ],
+  "version": "7.0.0-SNAPSHOT"
+}

--- a/dev/package-beats/cisco-1.0.0/manifest.yml
+++ b/dev/package-beats/cisco-1.0.0/manifest.yml
@@ -1,0 +1,13 @@
+name: cisco
+title: Cisco
+version: 1.0.0
+description: |
+  Module for handling Cisco network device logs.
+type: ""
+categories:
+- logs
+requirement:
+  kibana:
+    version:
+      min: 6.7.0
+      max: 7.6.0

--- a/dev/package-beats/cockroachdb-1.0.0/kibana/dashboard/Metricbeat-cockroachdb-overview.json
+++ b/dev/package-beats/cockroachdb-1.0.0/kibana/dashboard/Metricbeat-cockroachdb-overview.json
@@ -1,0 +1,913 @@
+{
+  "objects": [
+    {
+      "attributes": {
+        "description": "Overview of the CockroachDB server status",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "optionsJSON": {
+          "hidePanelTitles": false,
+          "useMargins": true
+        },
+        "panelsJSON": [
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 11,
+              "i": "1",
+              "w": 24,
+              "x": 0,
+              "y": 0
+            },
+            "panelIndex": "1",
+            "panelRefName": "panel_0",
+            "title": "Number of SQL connections",
+            "version": "7.1.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 11,
+              "i": "2",
+              "w": 24,
+              "x": 24,
+              "y": 0
+            },
+            "panelIndex": "2",
+            "panelRefName": "panel_1",
+            "title": "SQL queries",
+            "version": "7.1.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 9,
+              "i": "3",
+              "w": 16,
+              "x": 16,
+              "y": 11
+            },
+            "panelIndex": "3",
+            "panelRefName": "panel_2",
+            "title": "Replicas per Store",
+            "version": "7.1.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 9,
+              "i": "4",
+              "w": 16,
+              "x": 32,
+              "y": 11
+            },
+            "panelIndex": "4",
+            "panelRefName": "panel_3",
+            "title": "Replica leaseholders",
+            "version": "7.1.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 9,
+              "i": "5",
+              "w": 16,
+              "x": 0,
+              "y": 11
+            },
+            "panelIndex": "5",
+            "panelRefName": "panel_4",
+            "title": "Ranges",
+            "version": "7.1.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 10,
+              "i": "6",
+              "w": 24,
+              "x": 0,
+              "y": 20
+            },
+            "panelIndex": "6",
+            "panelRefName": "panel_5",
+            "title": "Average log commit latency",
+            "version": "7.1.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 10,
+              "i": "7",
+              "w": 24,
+              "x": 24,
+              "y": 20
+            },
+            "panelIndex": "7",
+            "panelRefName": "panel_6",
+            "title": "Average command commit latency",
+            "version": "7.1.0"
+          }
+        ],
+        "timeRestore": false,
+        "title": "[Metricbeat CockroachDB] Overview",
+        "version": 1
+      },
+      "id": "e3ba0c30-9766-11e9-9eea-6f554992ec1f",
+      "migrationVersion": {
+        "dashboard": "7.0.0"
+      },
+      "references": [
+        {
+          "id": "79691920-9766-11e9-9eea-6f554992ec1f",
+          "name": "panel_0",
+          "type": "visualization"
+        },
+        {
+          "id": "5073ed20-9760-11e9-9eea-6f554992ec1f",
+          "name": "panel_1",
+          "type": "visualization"
+        },
+        {
+          "id": "bad285b0-9769-11e9-9eea-6f554992ec1f",
+          "name": "panel_2",
+          "type": "visualization"
+        },
+        {
+          "id": "8add0960-976a-11e9-9eea-6f554992ec1f",
+          "name": "panel_3",
+          "type": "visualization"
+        },
+        {
+          "id": "2af19b90-976c-11e9-9eea-6f554992ec1f",
+          "name": "panel_4",
+          "type": "visualization"
+        },
+        {
+          "id": "74cf44b0-9771-11e9-9eea-6f554992ec1f",
+          "name": "panel_5",
+          "type": "visualization"
+        },
+        {
+          "id": "b5ab45b0-9771-11e9-9eea-6f554992ec1f",
+          "name": "panel_6",
+          "type": "visualization"
+        }
+      ],
+      "type": "dashboard",
+      "updated_at": "2019-06-25T19:17:43.667Z",
+      "version": "WzU0LDFd"
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Number of SQL connections [Metricbeat CockroachDB]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "number",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Number of connections",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "prometheus.metrics.sql_conns",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "max"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_color_mode": "rainbow",
+                "split_mode": "terms",
+                "stacked": "stacked",
+                "terms_direction": "desc",
+                "terms_field": "service.address",
+                "terms_order_by": "_count"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Number of SQL connections [Metricbeat CockroachDB]",
+          "type": "metrics"
+        }
+      },
+      "id": "79691920-9766-11e9-9eea-6f554992ec1f",
+      "migrationVersion": {
+        "visualization": "7.0.1"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-06-25T19:10:30.316Z",
+      "version": "WzUxLDFd"
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "SQL queries [Metricbeat CockroachDB]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "annotations": [],
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "number",
+                "id": "88d6bda0-9760-11e9-b3d5-07b0ab7d6354",
+                "label": "Selects",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "prometheus.metrics.sql_select_count",
+                    "id": "88d70bc0-9760-11e9-b3d5-07b0ab7d6354",
+                    "type": "sum"
+                  },
+                  {
+                    "field": "88d70bc0-9760-11e9-b3d5-07b0ab7d6354",
+                    "id": "658d2990-9762-11e9-b3d5-07b0ab7d6354",
+                    "type": "derivative",
+                    "unit": ""
+                  },
+                  {
+                    "field": "658d2990-9762-11e9-b3d5-07b0ab7d6354",
+                    "function": "sum",
+                    "id": "ec698bc0-9762-11e9-b3d5-07b0ab7d6354",
+                    "sigma": "",
+                    "type": "positive_only"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "stacked",
+                "terms_field": "service.address",
+                "terms_order_by": "88d70bc0-9760-11e9-b3d5-07b0ab7d6354"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(244,78,59,1)",
+                "fill": 0.5,
+                "formatter": "number",
+                "hidden": false,
+                "id": "02d89100-9761-11e9-b3d5-07b0ab7d6354",
+                "label": "Inserts",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "prometheus.metrics.sql_insert_count",
+                    "id": "02d89101-9761-11e9-b3d5-07b0ab7d6354",
+                    "type": "sum"
+                  },
+                  {
+                    "field": "02d89101-9761-11e9-b3d5-07b0ab7d6354",
+                    "id": "74eba420-9762-11e9-b3d5-07b0ab7d6354",
+                    "type": "derivative",
+                    "unit": ""
+                  },
+                  {
+                    "field": "74eba420-9762-11e9-b3d5-07b0ab7d6354",
+                    "id": "54cb8aa0-9764-11e9-b3d5-07b0ab7d6354",
+                    "type": "positive_only",
+                    "unit": ""
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "stacked"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(252,220,0,1)",
+                "fill": 0.5,
+                "formatter": "number",
+                "hidden": false,
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Updates",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "prometheus.metrics.sql_update_count",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "sum"
+                  },
+                  {
+                    "field": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "id": "9aa7ace0-9762-11e9-b3d5-07b0ab7d6354",
+                    "type": "derivative",
+                    "unit": ""
+                  },
+                  {
+                    "field": "9aa7ace0-9762-11e9-b3d5-07b0ab7d6354",
+                    "id": "939af2c0-9764-11e9-b3d5-07b0ab7d6354",
+                    "type": "positive_only",
+                    "unit": ""
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "stacked",
+                "terms_field": "service.address"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(115,216,255,1)",
+                "fill": 0.5,
+                "formatter": "number",
+                "hidden": false,
+                "id": "03f6d240-9761-11e9-b3d5-07b0ab7d6354",
+                "label": "Deletes",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "prometheus.metrics.sql_delete_count",
+                    "id": "03f6d241-9761-11e9-b3d5-07b0ab7d6354",
+                    "type": "sum"
+                  },
+                  {
+                    "field": "03f6d241-9761-11e9-b3d5-07b0ab7d6354",
+                    "id": "a3ed7c30-9762-11e9-b3d5-07b0ab7d6354",
+                    "type": "derivative",
+                    "unit": ""
+                  },
+                  {
+                    "field": "a3ed7c30-9762-11e9-b3d5-07b0ab7d6354",
+                    "id": "a13994e0-9764-11e9-b3d5-07b0ab7d6354",
+                    "type": "positive_only",
+                    "unit": ""
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "stacked"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "SQL queries [Metricbeat CockroachDB]",
+          "type": "metrics"
+        }
+      },
+      "id": "5073ed20-9760-11e9-9eea-6f554992ec1f",
+      "migrationVersion": {
+        "visualization": "7.0.1"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-06-25T18:41:34.934Z",
+      "version": "WzQ0LDFd"
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Replicas per Store [Metricbeat CockroachDB]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "number",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Replicas per store",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "prometheus.metrics.replicas",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "max"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_color_mode": "rainbow",
+                "split_mode": "terms",
+                "stacked": "stacked",
+                "terms_direction": "desc",
+                "terms_field": "service.address",
+                "terms_order_by": "_count"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Replicas per Store [Metricbeat CockroachDB]",
+          "type": "metrics"
+        }
+      },
+      "id": "bad285b0-9769-11e9-9eea-6f554992ec1f",
+      "migrationVersion": {
+        "visualization": "7.0.1"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-06-25T19:06:30.737Z",
+      "version": "WzQ4LDFd"
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Replica leaseholders [Metricbeat CockroachDB]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "number",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Replica leaseholders per store",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "prometheus.metrics.replicas_leaseholders",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "max"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_color_mode": "rainbow",
+                "split_mode": "terms",
+                "stacked": "stacked",
+                "terms_field": "service.address"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Replica leaseholders [Metricbeat CockroachDB]",
+          "type": "metrics"
+        }
+      },
+      "id": "8add0960-976a-11e9-9eea-6f554992ec1f",
+      "migrationVersion": {
+        "visualization": "7.0.1"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-06-25T18:34:03.281Z",
+      "version": "WzQwLDFd"
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Ranges [Metricbeat CockroachDB]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(254,146,0,1)",
+                "fill": "0",
+                "formatter": "number",
+                "id": "e4489e50-976b-11e9-b3d5-07b0ab7d6354",
+                "label": "Underreplicated",
+                "line_width": "2",
+                "metrics": [
+                  {
+                    "field": "prometheus.metrics.ranges_underreplicated",
+                    "id": "e4489e51-976b-11e9-b3d5-07b0ab7d6354",
+                    "type": "max"
+                  }
+                ],
+                "point_size": "2",
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "terms_field": null
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(252,220,0,1)",
+                "fill": "0",
+                "formatter": "number",
+                "id": "c938f9c0-976b-11e9-b3d5-07b0ab7d6354",
+                "label": "Overreplicated",
+                "line_width": "2",
+                "metrics": [
+                  {
+                    "field": "prometheus.metrics.ranges_overreplicated",
+                    "id": "c938f9c1-976b-11e9-b3d5-07b0ab7d6354",
+                    "type": "max"
+                  }
+                ],
+                "point_size": "2",
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "terms_field": null
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(244,78,59,1)",
+                "fill": "0",
+                "formatter": "number",
+                "id": "0ed1bf80-976c-11e9-b3d5-07b0ab7d6354",
+                "label": "Unavailable",
+                "line_width": "2",
+                "metrics": [
+                  {
+                    "field": "prometheus.metrics.ranges_unavailable",
+                    "id": "0ed1bf81-976c-11e9-b3d5-07b0ab7d6354",
+                    "type": "max"
+                  }
+                ],
+                "point_size": "2",
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "terms_field": null
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(204,204,204,1)",
+                "fill": 0.5,
+                "formatter": "number",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Total",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "prometheus.metrics.ranges",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "max"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "terms_field": null
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Ranges [Metricbeat CockroachDB]",
+          "type": "metrics"
+        }
+      },
+      "id": "2af19b90-976c-11e9-9eea-6f554992ec1f",
+      "migrationVersion": {
+        "visualization": "7.0.1"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-06-25T18:38:28.645Z",
+      "version": "WzQyLDFd"
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Log commit latency [Metricbeat CockroachDB]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(104,188,0,1)",
+                "fill": 0.5,
+                "filter": "",
+                "formatter": "ns,ms,2",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Average log commit latency",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "agg_with": "avg",
+                    "field": "prometheus.metrics.raft_process_logcommit_latency_count",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "order": "desc",
+                    "size": 1,
+                    "type": "max"
+                  },
+                  {
+                    "field": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "id": "4346d3b0-976f-11e9-b3d5-07b0ab7d6354",
+                    "type": "derivative",
+                    "unit": ""
+                  },
+                  {
+                    "field": "prometheus.metrics.raft_process_logcommit_latency_sum",
+                    "id": "4a430120-976f-11e9-b3d5-07b0ab7d6354",
+                    "type": "max",
+                    "unit": ""
+                  },
+                  {
+                    "field": "4a430120-976f-11e9-b3d5-07b0ab7d6354",
+                    "id": "581519e0-9770-11e9-b3d5-07b0ab7d6354",
+                    "type": "derivative",
+                    "unit": ""
+                  },
+                  {
+                    "id": "6574b730-9770-11e9-b3d5-07b0ab7d6354",
+                    "script": "params.sum / params.count",
+                    "type": "calculation",
+                    "variables": [
+                      {
+                        "field": "581519e0-9770-11e9-b3d5-07b0ab7d6354",
+                        "id": "6fbb54b0-9770-11e9-b3d5-07b0ab7d6354",
+                        "name": "sum"
+                      },
+                      {
+                        "field": "4346d3b0-976f-11e9-b3d5-07b0ab7d6354",
+                        "id": "76cc90c0-9770-11e9-b3d5-07b0ab7d6354",
+                        "name": "count"
+                      }
+                    ]
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_color_mode": "rainbow",
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "service.address",
+                "value_template": "{{value}}ms"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Log commit latency [Metricbeat CockroachDB]",
+          "type": "metrics"
+        }
+      },
+      "id": "74cf44b0-9771-11e9-9eea-6f554992ec1f",
+      "migrationVersion": {
+        "visualization": "7.0.1"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-06-25T19:08:05.279Z",
+      "version": "WzQ5LDFd"
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Command commit latency [Metricbeat CockroachDB]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(104,188,0,1)",
+                "fill": 0.5,
+                "filter": "",
+                "formatter": "ns,ms,2",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Average command commit latency",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "agg_with": "avg",
+                    "field": "prometheus.metrics.raft_process_commandcommit_latency_count",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "order": "desc",
+                    "size": 1,
+                    "type": "max"
+                  },
+                  {
+                    "field": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "id": "4346d3b0-976f-11e9-b3d5-07b0ab7d6354",
+                    "type": "derivative",
+                    "unit": ""
+                  },
+                  {
+                    "field": "prometheus.metrics.raft_process_commandcommit_latency_sum",
+                    "id": "4a430120-976f-11e9-b3d5-07b0ab7d6354",
+                    "type": "max",
+                    "unit": ""
+                  },
+                  {
+                    "field": "4a430120-976f-11e9-b3d5-07b0ab7d6354",
+                    "id": "581519e0-9770-11e9-b3d5-07b0ab7d6354",
+                    "type": "derivative",
+                    "unit": ""
+                  },
+                  {
+                    "id": "6574b730-9770-11e9-b3d5-07b0ab7d6354",
+                    "script": "params.sum / params.count",
+                    "type": "calculation",
+                    "variables": [
+                      {
+                        "field": "581519e0-9770-11e9-b3d5-07b0ab7d6354",
+                        "id": "6fbb54b0-9770-11e9-b3d5-07b0ab7d6354",
+                        "name": "sum"
+                      },
+                      {
+                        "field": "4346d3b0-976f-11e9-b3d5-07b0ab7d6354",
+                        "id": "76cc90c0-9770-11e9-b3d5-07b0ab7d6354",
+                        "name": "count"
+                      }
+                    ]
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_color_mode": "rainbow",
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "service.address",
+                "value_template": "{{value}}ms"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Command commit latency [Metricbeat CockroachDB]",
+          "type": "metrics"
+        }
+      },
+      "id": "b5ab45b0-9771-11e9-9eea-6f554992ec1f",
+      "migrationVersion": {
+        "visualization": "7.0.1"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-06-25T19:08:47.407Z",
+      "version": "WzUwLDFd"
+    }
+  ],
+  "version": "7.1.0"
+}

--- a/dev/package-beats/cockroachdb-1.0.0/manifest.yml
+++ b/dev/package-beats/cockroachdb-1.0.0/manifest.yml
@@ -1,0 +1,13 @@
+name: cockroachdb
+title: CockroachDB
+version: 1.0.0
+description: |
+  CockroachDB module
+type: ""
+categories:
+- metrics
+requirement:
+  kibana:
+    version:
+      min: 6.7.0
+      max: 7.6.0

--- a/dev/package-beats/consul-1.0.0/kibana/dashboard/Metricbeat-consul-overview.json
+++ b/dev/package-beats/consul-1.0.0/kibana/dashboard/Metricbeat-consul-overview.json
@@ -1,0 +1,760 @@
+{
+  "objects": [
+    {
+      "attributes": {
+        "description": "Overview of Consul",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "lucene",
+              "query": ""
+            }
+          }
+        },
+        "optionsJSON": {
+          "hidePanelTitles": false,
+          "useMargins": true
+        },
+        "panelsJSON": [
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 15,
+              "i": "1",
+              "w": 24,
+              "x": 0,
+              "y": 0
+            },
+            "panelIndex": "1",
+            "panelRefName": "panel_0",
+            "title": "Garbage Collector stats",
+            "version": "7.0.0-SNAPSHOT"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 15,
+              "i": "2",
+              "w": 16,
+              "x": 15,
+              "y": 15
+            },
+            "panelIndex": "2",
+            "panelRefName": "panel_1",
+            "title": "Goroutines",
+            "version": "7.0.0-SNAPSHOT"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 15,
+              "i": "3",
+              "w": 24,
+              "x": 24,
+              "y": 0
+            },
+            "panelIndex": "3",
+            "panelRefName": "panel_2",
+            "title": "Bytes Allocated",
+            "version": "7.0.0-SNAPSHOT"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 15,
+              "i": "4",
+              "w": 17,
+              "x": 31,
+              "y": 15
+            },
+            "panelIndex": "4",
+            "panelRefName": "panel_3",
+            "title": "Heap Objects",
+            "version": "7.0.0-SNAPSHOT"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 15,
+              "i": "5",
+              "w": 15,
+              "x": 0,
+              "y": 15
+            },
+            "panelIndex": "5",
+            "panelRefName": "panel_4",
+            "title": "Bytes of memory obtained from the OS",
+            "version": "7.0.0-SNAPSHOT"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 15,
+              "i": "6",
+              "w": 16,
+              "x": 31,
+              "y": 30
+            },
+            "panelIndex": "6",
+            "panelRefName": "panel_5",
+            "title": "Malloc count",
+            "version": "7.0.0-SNAPSHOT"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 15,
+              "i": "7",
+              "w": 14,
+              "x": 0,
+              "y": 30
+            },
+            "panelIndex": "7",
+            "panelRefName": "panel_6",
+            "title": "Garbage Collector pause ms",
+            "version": "7.0.0-SNAPSHOT"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 15,
+              "i": "8",
+              "w": 17,
+              "x": 14,
+              "y": 30
+            },
+            "panelIndex": "8",
+            "panelRefName": "panel_7",
+            "title": "Garbage Collector Runs",
+            "version": "7.0.0-SNAPSHOT"
+          }
+        ],
+        "timeRestore": false,
+        "title": "[Metricbeat Consul] Overview",
+        "version": 1
+      },
+      "id": "6d0cf140-2deb-11e9-bf7e-f35bf5d2e71b",
+      "migrationVersion": {
+        "dashboard": "7.0.0"
+      },
+      "references": [
+        {
+          "id": "dda0c950-2dea-11e9-bf7e-f35bf5d2e71b",
+          "name": "panel_0",
+          "type": "visualization"
+        },
+        {
+          "id": "ea842730-2de9-11e9-bf7e-f35bf5d2e71b",
+          "name": "panel_1",
+          "type": "visualization"
+        },
+        {
+          "id": "6c39d4b0-2de9-11e9-bf7e-f35bf5d2e71b",
+          "name": "panel_2",
+          "type": "visualization"
+        },
+        {
+          "id": "37c75bc0-2dea-11e9-bf7e-f35bf5d2e71b",
+          "name": "panel_3",
+          "type": "visualization"
+        },
+        {
+          "id": "69b29820-2dea-11e9-bf7e-f35bf5d2e71b",
+          "name": "panel_4",
+          "type": "visualization"
+        },
+        {
+          "id": "8ab67000-2dea-11e9-bf7e-f35bf5d2e71b",
+          "name": "panel_5",
+          "type": "visualization"
+        },
+        {
+          "id": "d275dbc0-2de9-11e9-bf7e-f35bf5d2e71b",
+          "name": "panel_6",
+          "type": "visualization"
+        },
+        {
+          "id": "1e97c1d0-2dea-11e9-bf7e-f35bf5d2e71b",
+          "name": "panel_7",
+          "type": "visualization"
+        }
+      ],
+      "type": "dashboard",
+      "updated_at": "2019-02-11T10:55:39.323Z",
+      "version": "WzU5NywzXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "lucene",
+              "query": ""
+            }
+          }
+        },
+        "title": "Garbage Collector stats [Metricbeat Consul]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": "0",
+                "formatter": "ns,ms,2",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Pause time",
+                "line_width": "1",
+                "metrics": [
+                  {
+                    "field": "consul.agent.runtime.garbage_collector.pause.current.ns",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}} ms"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "bar",
+                "color": "rgba(115,216,255,1)",
+                "fill": "0.5",
+                "formatter": "number",
+                "id": "9728a010-2dea-11e9-83ed-b7c793d35de5",
+                "label": "Runs",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "consul.agent.runtime.garbage_collector.runs",
+                    "id": "9728a011-2dea-11e9-83ed-b7c793d35de5",
+                    "type": "sum"
+                  },
+                  {
+                    "field": "9728a011-2dea-11e9-83ed-b7c793d35de5",
+                    "id": "9ed22480-2dea-11e9-83ed-b7c793d35de5",
+                    "type": "derivative",
+                    "unit": ""
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 1,
+                "split_mode": "everything",
+                "stacked": "none",
+                "steps": 1
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Garbage Collector stats [Metricbeat Consul]",
+          "type": "metrics"
+        }
+      },
+      "id": "dda0c950-2dea-11e9-bf7e-f35bf5d2e71b",
+      "migrationVersion": {
+        "visualization": "7.0.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-02-11T10:55:03.187Z",
+      "version": "WzU5NSwzXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "lucene",
+              "query": ""
+            }
+          }
+        },
+        "title": "Goroutines [Metricbeat Consul]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_min": "0",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "number",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Goroutines",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "consul.agent.runtime.goroutines",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Goroutines [Metricbeat Consul]",
+          "type": "metrics"
+        }
+      },
+      "id": "ea842730-2de9-11e9-bf7e-f35bf5d2e71b",
+      "migrationVersion": {
+        "visualization": "7.0.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-02-11T10:43:49.667Z",
+      "version": "WzU4NywzXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "lucene",
+              "query": ""
+            }
+          }
+        },
+        "title": "Bytes Allocated [Metricbeat Consul]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_min": "0",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "bytes",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Bytes allocated",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "consul.agent.runtime.alloc.bytes",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Bytes Allocated [Metricbeat Consul]",
+          "type": "metrics"
+        }
+      },
+      "id": "6c39d4b0-2de9-11e9-bf7e-f35bf5d2e71b",
+      "migrationVersion": {
+        "visualization": "7.0.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-02-11T10:40:41.790Z",
+      "version": "WzU4NSwzXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "lucene",
+              "query": ""
+            }
+          }
+        },
+        "title": "Heap Objects [Metricbeat Consul]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_min": "0",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "number",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Heap Objects",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "consul.agent.runtime.heap_objects",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Heap Objects [Metricbeat Consul]",
+          "type": "metrics"
+        }
+      },
+      "id": "37c75bc0-2dea-11e9-bf7e-f35bf5d2e71b",
+      "migrationVersion": {
+        "visualization": "7.0.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-02-11T10:45:59.292Z",
+      "version": "WzU4OSwzXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "lucene",
+              "query": ""
+            }
+          }
+        },
+        "title": "Bytes of memory obtained from the OS [Metricbeat Consul]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_min": "0",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "bytes",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Bytes of memory obtained from the OS",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "consul.agent.runtime.sys.bytes",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Bytes of memory obtained from the OS [Metricbeat Consul]",
+          "type": "metrics"
+        }
+      },
+      "id": "69b29820-2dea-11e9-bf7e-f35bf5d2e71b",
+      "migrationVersion": {
+        "visualization": "7.0.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-02-11T10:47:23.042Z",
+      "version": "WzU5MCwzXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "lucene",
+              "query": ""
+            }
+          }
+        },
+        "title": "Malloc count [Metricbeat Consul]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_min": "0",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "number",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Malloc Count",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "consul.agent.runtime.malloc_count",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "sum"
+                  },
+                  {
+                    "field": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "id": "7a6e0aa0-2dea-11e9-83ed-b7c793d35de5",
+                    "type": "derivative",
+                    "unit": ""
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Malloc count [Metricbeat Consul]",
+          "type": "metrics"
+        }
+      },
+      "id": "8ab67000-2dea-11e9-bf7e-f35bf5d2e71b",
+      "migrationVersion": {
+        "visualization": "7.0.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-02-11T10:48:18.432Z",
+      "version": "WzU5MSwzXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "lucene",
+              "query": ""
+            }
+          }
+        },
+        "title": "Garbage Collector pause ms [Metricbeat Consul]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_min": "0",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "ns,ms,4",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Garbage Collector pause",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "consul.agent.runtime.garbage_collector.pause.current.ns",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}} ms"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Garbage Collector pause ms [Metricbeat Consul]",
+          "type": "metrics"
+        }
+      },
+      "id": "d275dbc0-2de9-11e9-bf7e-f35bf5d2e71b",
+      "migrationVersion": {
+        "visualization": "7.0.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-02-11T10:43:09.308Z",
+      "version": "WzU4NiwzXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "lucene",
+              "query": ""
+            }
+          }
+        },
+        "title": "Garbage Collector Runs [Metricbeat Consul]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_min": "0",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "number",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Garbage Collector Runs",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "consul.agent.runtime.garbage_collector.runs",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "sum"
+                  },
+                  {
+                    "field": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "id": "ffaa1fc0-2de9-11e9-83ed-b7c793d35de5",
+                    "type": "derivative",
+                    "unit": ""
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "steps": 1
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Garbage Collector Runs [Metricbeat Consul]",
+          "type": "metrics"
+        }
+      },
+      "id": "1e97c1d0-2dea-11e9-bf7e-f35bf5d2e71b",
+      "migrationVersion": {
+        "visualization": "7.0.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-02-11T10:51:44.187Z",
+      "version": "WzU5MywzXQ=="
+    }
+  ],
+  "version": "7.0.0-SNAPSHOT"
+}

--- a/dev/package-beats/consul-1.0.0/manifest.yml
+++ b/dev/package-beats/consul-1.0.0/manifest.yml
@@ -1,0 +1,13 @@
+name: consul
+title: consul
+version: 1.0.0
+description: |
+  Consul module
+type: ""
+categories:
+- metrics
+requirement:
+  kibana:
+    version:
+      min: 6.7.0
+      max: 7.6.0

--- a/dev/package-beats/coredns-1.0.0/kibana/dashboard/Coredns-Overview-Dashboard.json
+++ b/dev/package-beats/coredns-1.0.0/kibana/dashboard/Coredns-Overview-Dashboard.json
@@ -1,0 +1,464 @@
+{
+  "objects": [
+    {
+      "attributes": {
+        "description": "Overview of CoreDNS",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "optionsJSON": {
+          "hidePanelTitles": false,
+          "useMargins": true
+        },
+        "panelsJSON": [
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 14,
+              "i": "1",
+              "w": 41,
+              "x": 4,
+              "y": 7
+            },
+            "panelIndex": "1",
+            "panelRefName": "panel_0",
+            "version": "8.0.0-SNAPSHOT"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 7,
+              "i": "2",
+              "w": 20,
+              "x": 4,
+              "y": 0
+            },
+            "panelIndex": "2",
+            "panelRefName": "panel_1",
+            "version": "8.0.0-SNAPSHOT"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 7,
+              "i": "3",
+              "w": 21,
+              "x": 24,
+              "y": 0
+            },
+            "panelIndex": "3",
+            "panelRefName": "panel_2",
+            "version": "8.0.0-SNAPSHOT"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 6,
+              "i": "4",
+              "w": 41,
+              "x": 4,
+              "y": 21
+            },
+            "panelIndex": "4",
+            "panelRefName": "panel_3",
+            "version": "8.0.0-SNAPSHOT"
+          }
+        ],
+        "timeRestore": false,
+        "title": "[Filebeat CoreDNS] Overview",
+        "version": 1
+      },
+      "id": "53aa1f70-443e-11e9-8548-ab7fbe04f038",
+      "migrationVersion": {
+        "dashboard": "7.0.0"
+      },
+      "references": [
+        {
+          "id": "3ad75810-4429-11e9-8548-ab7fbe04f038",
+          "name": "panel_0",
+          "type": "visualization"
+        },
+        {
+          "id": "9dc640e0-4432-11e9-8548-ab7fbe04f038",
+          "name": "panel_1",
+          "type": "visualization"
+        },
+        {
+          "id": "75743f70-443c-11e9-8548-ab7fbe04f038",
+          "name": "panel_2",
+          "type": "visualization"
+        },
+        {
+          "id": "cfde7fb0-443d-11e9-8548-ab7fbe04f038",
+          "name": "panel_3",
+          "type": "visualization"
+        }
+      ],
+      "type": "dashboard",
+      "updated_at": "2019-03-11T20:43:54.420Z",
+      "version": "WzE0ODgsM10="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Top Domains [Filebeat CoreDNS]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "field": "coredns.query.name",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 10
+              },
+              "schema": "segment",
+              "type": "terms"
+            }
+          ],
+          "params": {
+            "maxFontSize": 72,
+            "metric": {
+              "accessor": 0,
+              "aggType": "count",
+              "format": {
+                "id": "number"
+              },
+              "params": {}
+            },
+            "minFontSize": 18,
+            "orientation": "single",
+            "scale": "linear",
+            "showLabel": true
+          },
+          "title": "Top Domains [Filebeat CoreDNS]",
+          "type": "tagcloud"
+        }
+      },
+      "id": "3ad75810-4429-11e9-8548-ab7fbe04f038",
+      "migrationVersion": {
+        "visualization": "7.0.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-03-11T18:12:28.303Z",
+      "version": "WzE0ODMsM10="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Total DNS Queries [Filebeat CoreDNS]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            }
+          ],
+          "params": {
+            "addLegend": false,
+            "addTooltip": true,
+            "metric": {
+              "colorSchema": "Green to Red",
+              "colorsRange": [
+                {
+                  "from": 0,
+                  "to": 10000
+                }
+              ],
+              "invertColors": false,
+              "labels": {
+                "show": true
+              },
+              "metricColorMode": "None",
+              "percentageMode": false,
+              "style": {
+                "bgColor": false,
+                "bgFill": "#000",
+                "fontSize": 60,
+                "labelColor": false,
+                "subText": ""
+              },
+              "useRanges": false
+            },
+            "type": "metric"
+          },
+          "title": "Total DNS Queries [Filebeat CoreDNS]",
+          "type": "metric"
+        }
+      },
+      "id": "9dc640e0-4432-11e9-8548-ab7fbe04f038",
+      "migrationVersion": {
+        "visualization": "7.0.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-03-11T19:19:39.757Z",
+      "version": "WzE0ODQsM10="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Unique Domains [Filebeat CoreDNS]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "Unique Domains",
+                "field": "coredns.query.name"
+              },
+              "schema": "metric",
+              "type": "cardinality"
+            }
+          ],
+          "params": {
+            "addLegend": false,
+            "addTooltip": true,
+            "metric": {
+              "bucket": {
+                "accessor": 0,
+                "aggType": "terms",
+                "format": {
+                  "id": "terms",
+                  "params": {
+                    "id": "string",
+                    "missingBucketLabel": "Missing",
+                    "otherBucketLabel": "Other"
+                  }
+                },
+                "params": {}
+              },
+              "colorSchema": "Green to Red",
+              "colorsRange": [
+                {
+                  "from": 0,
+                  "to": 10000
+                }
+              ],
+              "invertColors": false,
+              "labels": {
+                "show": true
+              },
+              "metricColorMode": "None",
+              "metrics": [
+                {
+                  "accessor": 0,
+                  "aggType": "cardinality",
+                  "format": {
+                    "id": "number"
+                  },
+                  "params": {}
+                }
+              ],
+              "percentageMode": false,
+              "style": {
+                "bgColor": false,
+                "bgFill": "#000",
+                "fontSize": 60,
+                "labelColor": false,
+                "subText": ""
+              },
+              "useRanges": false
+            },
+            "type": "metric"
+          },
+          "title": "Unique Domains [Filebeat CoreDNS]",
+          "type": "metric"
+        }
+      },
+      "id": "75743f70-443c-11e9-8548-ab7fbe04f038",
+      "migrationVersion": {
+        "visualization": "7.0.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-03-12T01:26:19.218Z",
+      "version": "WzE0OTMsM10="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": "tags:\"coredns\""
+            }
+          }
+        },
+        "title": "Time Series Visualizer [Filebeat CoreDNS]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "background_color_rules": [
+              {
+                "id": "65ad37b0-443f-11e9-94ba-69b05a5f82b8"
+              }
+            ],
+            "bar_color_rules": [
+              {
+                "id": "e1f6cda0-443e-11e9-94ba-69b05a5f82b8"
+              }
+            ],
+            "default_index_pattern": "filebeat-*",
+            "gauge_color_rules": [
+              {
+                "id": "6996a6e0-443f-11e9-94ba-69b05a5f82b8"
+              }
+            ],
+            "gauge_inner_width": 10,
+            "gauge_style": "half",
+            "gauge_width": 10,
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "filter": "fileset.name:kubernetes",
+                "formatter": "number",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "CoreDNS Kubernetes",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "count"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "filter",
+                "stacked": "none",
+                "terms_field": "fileset.name"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "filter": "fileset.name:log",
+                "formatter": "number",
+                "id": "3c8999f0-443f-11e9-94ba-69b05a5f82b8",
+                "label": "CoreDNS Native",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "id": "3c8999f1-443f-11e9-94ba-69b05a5f82b8",
+                    "type": "count"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "filter",
+                "stacked": "none"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Time Series Visualizer [Filebeat CoreDNS]",
+          "type": "metrics"
+        }
+      },
+      "id": "cfde7fb0-443d-11e9-8548-ab7fbe04f038",
+      "migrationVersion": {
+        "visualization": "7.0.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-03-11T20:51:52.103Z",
+      "version": "WzE0ODksM10="
+    }
+  ],
+  "version": "8.0.0-SNAPSHOT"
+}

--- a/dev/package-beats/coredns-1.0.0/kibana/dashboard/Metricbeat-coredns-overview.json
+++ b/dev/package-beats/coredns-1.0.0/kibana/dashboard/Metricbeat-coredns-overview.json
@@ -1,0 +1,1371 @@
+{
+  "objects": [
+    {
+      "attributes": {
+        "description": "Overview of CoreDNS server metrics.",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "lucene",
+              "query": ""
+            }
+          }
+        },
+        "optionsJSON": {
+          "darkTheme": false,
+          "hidePanelTitles": false,
+          "useMargins": true
+        },
+        "panelsJSON": [
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 10,
+              "i": "1",
+              "w": 10,
+              "x": 0,
+              "y": 0
+            },
+            "panelIndex": "1",
+            "panelRefName": "panel_0",
+            "version": "6.7.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 10,
+              "i": "2",
+              "w": 14,
+              "x": 10,
+              "y": 0
+            },
+            "panelIndex": "2",
+            "panelRefName": "panel_1",
+            "version": "6.7.0"
+          },
+          {
+            "embeddableConfig": {
+              "vis": {
+                "colors": {
+                  "NXDOMAIN": "#99440A"
+                }
+              }
+            },
+            "gridData": {
+              "h": 15,
+              "i": "3",
+              "w": 19,
+              "x": 24,
+              "y": 25
+            },
+            "panelIndex": "3",
+            "panelRefName": "panel_2",
+            "version": "6.7.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 14,
+              "i": "10",
+              "w": 24,
+              "x": 0,
+              "y": 40
+            },
+            "panelIndex": "10",
+            "panelRefName": "panel_3",
+            "version": "6.7.0"
+          },
+          {
+            "embeddableConfig": {
+              "vis": {
+                "colors": {
+                  "tcp - 1": "#B7DBAB",
+                  "udp - 1": "#5195CE"
+                },
+                "legendOpen": true
+              }
+            },
+            "gridData": {
+              "h": 10,
+              "i": "11",
+              "w": 19,
+              "x": 24,
+              "y": 0
+            },
+            "panelIndex": "11",
+            "panelRefName": "panel_4",
+            "version": "7.0.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 15,
+              "i": "12",
+              "w": 19,
+              "x": 24,
+              "y": 10
+            },
+            "panelIndex": "12",
+            "panelRefName": "panel_5",
+            "version": "7.0.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 15,
+              "i": "15",
+              "w": 24,
+              "x": 0,
+              "y": 10
+            },
+            "panelIndex": "15",
+            "panelRefName": "panel_6",
+            "version": "7.0.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 15,
+              "i": "16",
+              "w": 24,
+              "x": 0,
+              "y": 25
+            },
+            "panelIndex": "16",
+            "panelRefName": "panel_7",
+            "version": "7.0.0"
+          }
+        ],
+        "timeRestore": false,
+        "title": "[Metricbeat CoreDNS] Overview ECS",
+        "version": 1
+      },
+      "id": "Metricbeat-CoreDNS-Dashboard-ecs",
+      "migrationVersion": {
+        "dashboard": "7.0.0"
+      },
+      "references": [
+        {
+          "id": "36e08510-53c4-11e9-b466-9be470bbd327-ecs",
+          "name": "panel_0",
+          "type": "visualization"
+        },
+        {
+          "id": "a19df590-53c4-11e9-b466-9be470bbd327-ecs",
+          "name": "panel_1",
+          "type": "visualization"
+        },
+        {
+          "id": "27da53f0-53d5-11e9-b466-9be470bbd327-ecs",
+          "name": "panel_2",
+          "type": "visualization"
+        },
+        {
+          "id": "277fc650-67a9-11e9-a534-715561d0bf42",
+          "name": "panel_3",
+          "type": "visualization"
+        },
+        {
+          "id": "86177430-728d-11e9-b0d0-414c3011ddbb",
+          "name": "panel_4",
+          "type": "visualization"
+        },
+        {
+          "id": "a58345f0-7298-11e9-b0d0-414c3011ddbb",
+          "name": "panel_5",
+          "type": "visualization"
+        },
+        {
+          "id": "57c74300-7308-11e9-b0d0-414c3011ddbb",
+          "name": "panel_6",
+          "type": "visualization"
+        },
+        {
+          "id": "4804eaa0-7315-11e9-b0d0-414c3011ddbb",
+          "name": "panel_7",
+          "type": "visualization"
+        }
+      ],
+      "type": "dashboard",
+      "updated_at": "2019-05-10T11:25:44.629Z",
+      "version": "WzE3MzcsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [
+              {
+                "$state": {
+                  "store": "appState"
+                },
+                "exists": {
+                  "field": "coredns.stats.panic.count"
+                },
+                "meta": {
+                  "alias": null,
+                  "disabled": false,
+                  "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                  "key": "coredns.stats.panic.count",
+                  "negate": false,
+                  "type": "exists",
+                  "value": "exists"
+                }
+              }
+            ],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "language": "lucene",
+              "query": ""
+            }
+          }
+        },
+        "title": "Panic Count [Metricbeat CoreDNS] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "field": "coredns.stats.panic.count",
+                "percents": [
+                  100
+                ]
+              },
+              "schema": "metric",
+              "type": "percentiles"
+            }
+          ],
+          "params": {
+            "addLegend": false,
+            "addTooltip": true,
+            "metric": {
+              "colorSchema": "Green to Red",
+              "colorsRange": [
+                {
+                  "from": 0,
+                  "to": 10000
+                }
+              ],
+              "invertColors": false,
+              "labels": {
+                "show": false
+              },
+              "metricColorMode": "None",
+              "percentageMode": false,
+              "style": {
+                "bgColor": false,
+                "bgFill": "#000",
+                "fontSize": 60,
+                "labelColor": false,
+                "subText": ""
+              },
+              "useRanges": false
+            },
+            "type": "metric"
+          },
+          "title": "Panic Count [Metricbeat CoreDNS] ECS",
+          "type": "metric"
+        }
+      },
+      "id": "36e08510-53c4-11e9-b466-9be470bbd327-ecs",
+      "migrationVersion": {
+        "visualization": "7.0.0"
+      },
+      "references": [
+        {
+          "id": "metricbeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        },
+        {
+          "id": "metricbeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-05-10T07:46:22.258Z",
+      "version": "WzE1MjcsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [
+              {
+                "$state": {
+                  "store": "appState"
+                },
+                "exists": {
+                  "field": "coredns.stats.dns.request.do.count"
+                },
+                "meta": {
+                  "alias": null,
+                  "disabled": false,
+                  "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                  "key": "coredns.stats.dns.request.do.count",
+                  "negate": false,
+                  "type": "exists",
+                  "value": "exists"
+                }
+              }
+            ],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "language": "lucene",
+              "query": ""
+            }
+          }
+        },
+        "title": "DO Count [Metricbeat CoreDNS] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "DO Count",
+                "field": "coredns.stats.dns.request.do.count",
+                "percents": [
+                  100
+                ]
+              },
+              "schema": "metric",
+              "type": "percentiles"
+            }
+          ],
+          "params": {
+            "addLegend": false,
+            "addTooltip": true,
+            "metric": {
+              "colorSchema": "Green to Red",
+              "colorsRange": [
+                {
+                  "from": 0,
+                  "to": 10000
+                }
+              ],
+              "invertColors": false,
+              "labels": {
+                "show": false
+              },
+              "metricColorMode": "None",
+              "percentageMode": false,
+              "style": {
+                "bgColor": false,
+                "bgFill": "#000",
+                "fontSize": 60,
+                "labelColor": false,
+                "subText": ""
+              },
+              "useRanges": false
+            },
+            "type": "metric"
+          },
+          "title": "DO Count [Metricbeat CoreDNS] ECS",
+          "type": "metric"
+        }
+      },
+      "id": "a19df590-53c4-11e9-b466-9be470bbd327-ecs",
+      "migrationVersion": {
+        "visualization": "7.0.0"
+      },
+      "references": [
+        {
+          "id": "metricbeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        },
+        {
+          "id": "metricbeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-05-10T07:46:22.258Z",
+      "version": "WzE1MjgsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "language": "lucene",
+              "query": ""
+            }
+          }
+        },
+        "title": "Responses by Rcode [Metricbeat CoreDNS] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "Response per rcode",
+                "field": "coredns.stats.dns.response.rcode.count"
+              },
+              "schema": "metric",
+              "type": "avg"
+            },
+            {
+              "enabled": true,
+              "id": "5",
+              "params": {
+                "customLabel": "server",
+                "field": "coredns.stats.server",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "row": true,
+                "size": 5
+              },
+              "schema": "split",
+              "type": "terms"
+            },
+            {
+              "enabled": true,
+              "id": "3",
+              "params": {
+                "customInterval": "2h",
+                "drop_partials": false,
+                "extended_bounds": {},
+                "field": "@timestamp",
+                "interval": "auto",
+                "min_doc_count": 1,
+                "timeRange": {
+                  "from": "now-15m",
+                  "to": "now"
+                },
+                "useNormalizedEsInterval": true
+              },
+              "schema": "segment",
+              "type": "date_histogram"
+            },
+            {
+              "enabled": true,
+              "id": "4",
+              "params": {
+                "field": "coredns.stats.rcode",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 5
+              },
+              "schema": "group",
+              "type": "terms"
+            },
+            {
+              "enabled": true,
+              "id": "6",
+              "params": {
+                "field": "coredns.stats.zone",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 5
+              },
+              "schema": "group",
+              "type": "terms"
+            }
+          ],
+          "params": {
+            "addLegend": true,
+            "addTimeMarker": false,
+            "addTooltip": true,
+            "categoryAxes": [
+              {
+                "id": "CategoryAxis-1",
+                "labels": {
+                  "show": true,
+                  "truncate": 100
+                },
+                "position": "bottom",
+                "scale": {
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {},
+                "type": "category"
+              }
+            ],
+            "grid": {
+              "categoryLines": false,
+              "style": {
+                "color": "#eee"
+              }
+            },
+            "legendPosition": "right",
+            "seriesParams": [
+              {
+                "data": {
+                  "id": "1",
+                  "label": "Response per rcode"
+                },
+                "drawLinesBetweenPoints": true,
+                "interpolate": "linear",
+                "lineWidth": 1,
+                "mode": "normal",
+                "show": "true",
+                "showCircles": true,
+                "type": "line",
+                "valueAxis": "ValueAxis-1"
+              }
+            ],
+            "times": [],
+            "type": "line",
+            "valueAxes": [
+              {
+                "id": "ValueAxis-1",
+                "labels": {
+                  "filter": false,
+                  "rotate": 0,
+                  "show": true,
+                  "truncate": 100
+                },
+                "name": "LeftAxis-1",
+                "position": "left",
+                "scale": {
+                  "mode": "normal",
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {
+                  "text": "Response per rcode"
+                },
+                "type": "value"
+              }
+            ]
+          },
+          "title": "Responses by Rcode [Metricbeat CoreDNS] ECS",
+          "type": "line"
+        }
+      },
+      "id": "27da53f0-53d5-11e9-b466-9be470bbd327-ecs",
+      "migrationVersion": {
+        "visualization": "7.0.0"
+      },
+      "references": [
+        {
+          "id": "metricbeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-05-10T07:46:22.258Z",
+      "version": "WzE1MjksMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "language": "lucene",
+              "query": ""
+            }
+          }
+        },
+        "title": " Cache Hits, Misses [Metricbeat CoreDNS] ECS",
+        "uiStateJSON": {
+          "vis": {
+            "colors": {
+              "Average coredns.stats.dns.cache.misses.count": "#E24D42",
+              "Hits": "#9AC48A",
+              "Misses": "#EA6460"
+            }
+          }
+        },
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "Hits",
+                "field": "coredns.stats.dns.cache.hits.count"
+              },
+              "schema": "metric",
+              "type": "max"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customInterval": "2h",
+                "drop_partials": false,
+                "extended_bounds": {},
+                "field": "@timestamp",
+                "interval": "auto",
+                "min_doc_count": 0,
+                "timeRange": {
+                  "from": "now-30m",
+                  "to": "now"
+                },
+                "useNormalizedEsInterval": true
+              },
+              "schema": "segment",
+              "type": "date_histogram"
+            },
+            {
+              "enabled": true,
+              "id": "3",
+              "params": {
+                "customLabel": "Misses",
+                "field": "coredns.stats.dns.cache.misses.count"
+              },
+              "schema": "metric",
+              "type": "max"
+            },
+            {
+              "enabled": true,
+              "id": "4",
+              "params": {
+                "customLabel": "server",
+                "field": "coredns.stats.server",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "row": true,
+                "size": 5
+              },
+              "schema": "split",
+              "type": "terms"
+            }
+          ],
+          "params": {
+            "addLegend": true,
+            "addTimeMarker": false,
+            "addTooltip": true,
+            "categoryAxes": [
+              {
+                "id": "CategoryAxis-1",
+                "labels": {
+                  "show": true,
+                  "truncate": 100
+                },
+                "position": "bottom",
+                "scale": {
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {},
+                "type": "category"
+              }
+            ],
+            "grid": {
+              "categoryLines": false,
+              "style": {
+                "color": "#eee"
+              }
+            },
+            "legendPosition": "right",
+            "seriesParams": [
+              {
+                "data": {
+                  "id": "1",
+                  "label": "Hits"
+                },
+                "drawLinesBetweenPoints": true,
+                "mode": "normal",
+                "show": "true",
+                "showCircles": true,
+                "type": "line",
+                "valueAxis": "ValueAxis-1"
+              },
+              {
+                "data": {
+                  "id": "3",
+                  "label": "Misses"
+                },
+                "drawLinesBetweenPoints": true,
+                "mode": "normal",
+                "show": true,
+                "showCircles": true,
+                "type": "line",
+                "valueAxis": "ValueAxis-2"
+              }
+            ],
+            "times": [],
+            "type": "line",
+            "valueAxes": [
+              {
+                "id": "ValueAxis-1",
+                "labels": {
+                  "filter": false,
+                  "rotate": 0,
+                  "show": true,
+                  "truncate": 100
+                },
+                "name": "LeftAxis-1",
+                "position": "left",
+                "scale": {
+                  "defaultYExtents": false,
+                  "mode": "normal",
+                  "setYExtents": false,
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {
+                  "text": "Hits"
+                },
+                "type": "value"
+              },
+              {
+                "id": "ValueAxis-2",
+                "labels": {
+                  "filter": false,
+                  "rotate": 0,
+                  "show": true,
+                  "truncate": 100
+                },
+                "name": "RightAxis-1",
+                "position": "right",
+                "scale": {
+                  "mode": "normal",
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {
+                  "text": "Misses"
+                },
+                "type": "value"
+              }
+            ]
+          },
+          "title": " Cache Hits, Misses [Metricbeat CoreDNS] ECS",
+          "type": "line"
+        }
+      },
+      "id": "277fc650-67a9-11e9-a534-715561d0bf42",
+      "migrationVersion": {
+        "visualization": "7.0.0"
+      },
+      "references": [
+        {
+          "id": "metricbeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-05-10T07:46:22.258Z",
+      "version": "WzE1MzAsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Requests by Zone [Metricbeat CoreDNS] ECS",
+        "uiStateJSON": {
+          "vis": {
+            "legendOpen": true
+          }
+        },
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "aggregate": "max",
+                "customLabel": "Request count",
+                "field": "coredns.stats.dns.request.count",
+                "size": 1,
+                "sortField": "@timestamp",
+                "sortOrder": "desc"
+              },
+              "schema": "metric",
+              "type": "top_hits"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customLabel": "server",
+                "field": "coredns.stats.server",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "_key",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "row": true,
+                "size": 5
+              },
+              "schema": "split",
+              "type": "terms"
+            },
+            {
+              "enabled": true,
+              "id": "4",
+              "params": {
+                "customLabel": "zone",
+                "field": "coredns.stats.zone",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "_key",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 5
+              },
+              "schema": "segment",
+              "type": "terms"
+            },
+            {
+              "enabled": true,
+              "id": "5",
+              "params": {
+                "customLabel": "protocol",
+                "field": "coredns.stats.proto",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "_key",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 5
+              },
+              "schema": "group",
+              "type": "terms"
+            },
+            {
+              "enabled": true,
+              "id": "6",
+              "params": {
+                "customLabel": "family",
+                "field": "coredns.stats.family",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "_key",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 5
+              },
+              "schema": "group",
+              "type": "terms"
+            }
+          ],
+          "params": {
+            "addLegend": true,
+            "addTimeMarker": false,
+            "addTooltip": true,
+            "categoryAxes": [
+              {
+                "id": "CategoryAxis-1",
+                "labels": {
+                  "filter": true,
+                  "rotate": 0,
+                  "show": true,
+                  "truncate": 200
+                },
+                "position": "left",
+                "scale": {
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {},
+                "type": "category"
+              }
+            ],
+            "grid": {
+              "categoryLines": false
+            },
+            "legendPosition": "right",
+            "orderBucketsBySum": false,
+            "seriesParams": [
+              {
+                "data": {
+                  "id": "1",
+                  "label": "Request count"
+                },
+                "drawLinesBetweenPoints": true,
+                "mode": "stacked",
+                "show": true,
+                "showCircles": true,
+                "type": "histogram",
+                "valueAxis": "ValueAxis-1"
+              }
+            ],
+            "times": [],
+            "type": "histogram",
+            "valueAxes": [
+              {
+                "id": "ValueAxis-1",
+                "labels": {
+                  "filter": true,
+                  "rotate": 75,
+                  "show": true,
+                  "truncate": 100
+                },
+                "name": "BottomAxis-1",
+                "position": "bottom",
+                "scale": {
+                  "mode": "normal",
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {
+                  "text": "Request count"
+                },
+                "type": "value"
+              }
+            ]
+          },
+          "title": "Requests by Zone [Metricbeat CoreDNS] ECS",
+          "type": "horizontal_bar"
+        }
+      },
+      "id": "86177430-728d-11e9-b0d0-414c3011ddbb",
+      "migrationVersion": {
+        "visualization": "7.0.0"
+      },
+      "references": [
+        {
+          "id": "metricbeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-05-10T07:46:22.258Z",
+      "version": "WzE1MzEsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Requests by Type [Metricbeat CoreDNS] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "aggregate": "max",
+                "customLabel": "Requests",
+                "field": "coredns.stats.dns.request.type.count",
+                "size": 1,
+                "sortField": "@timestamp",
+                "sortOrder": "desc"
+              },
+              "schema": "metric",
+              "type": "top_hits"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customLabel": "server",
+                "field": "coredns.stats.server",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "_key",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "row": true,
+                "size": 5
+              },
+              "schema": "split",
+              "type": "terms"
+            },
+            {
+              "enabled": true,
+              "id": "3",
+              "params": {
+                "customInterval": "2h",
+                "drop_partials": false,
+                "extended_bounds": {},
+                "field": "@timestamp",
+                "interval": "auto",
+                "min_doc_count": 1,
+                "timeRange": {
+                  "from": "now-15m",
+                  "to": "now"
+                },
+                "useNormalizedEsInterval": true
+              },
+              "schema": "segment",
+              "type": "date_histogram"
+            },
+            {
+              "enabled": true,
+              "id": "4",
+              "params": {
+                "field": "coredns.stats.zone",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "_key",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 5
+              },
+              "schema": "group",
+              "type": "terms"
+            },
+            {
+              "enabled": true,
+              "id": "5",
+              "params": {
+                "field": "coredns.stats.type",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "_key",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 5
+              },
+              "schema": "group",
+              "type": "terms"
+            }
+          ],
+          "params": {
+            "addLegend": true,
+            "addTimeMarker": false,
+            "addTooltip": true,
+            "categoryAxes": [
+              {
+                "id": "CategoryAxis-1",
+                "labels": {
+                  "show": true,
+                  "truncate": 100
+                },
+                "position": "bottom",
+                "scale": {
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {},
+                "type": "category"
+              }
+            ],
+            "grid": {
+              "categoryLines": false
+            },
+            "legendPosition": "right",
+            "seriesParams": [
+              {
+                "data": {
+                  "id": "1",
+                  "label": "Requests"
+                },
+                "drawLinesBetweenPoints": true,
+                "mode": "normal",
+                "show": "true",
+                "showCircles": true,
+                "type": "line",
+                "valueAxis": "ValueAxis-1"
+              }
+            ],
+            "times": [],
+            "type": "line",
+            "valueAxes": [
+              {
+                "id": "ValueAxis-1",
+                "labels": {
+                  "filter": false,
+                  "rotate": 0,
+                  "show": true,
+                  "truncate": 100
+                },
+                "name": "LeftAxis-1",
+                "position": "left",
+                "scale": {
+                  "mode": "normal",
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {
+                  "text": "Requests"
+                },
+                "type": "value"
+              }
+            ]
+          },
+          "title": "Requests by Type [Metricbeat CoreDNS] ECS",
+          "type": "line"
+        }
+      },
+      "id": "a58345f0-7298-11e9-b0d0-414c3011ddbb",
+      "migrationVersion": {
+        "visualization": "7.0.0"
+      },
+      "references": [
+        {
+          "id": "metricbeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-05-10T07:46:22.258Z",
+      "version": "WzE1MzIsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Avg Request Duration (cumulative) [Metricbeat CoreDNS] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": "0.1",
+                "filter": "",
+                "formatter": "number",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Avg Request Duration (ms)",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "agg_with": "max",
+                    "field": "coredns.stats.dns.request.duration.ns.sum",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "order": "desc",
+                    "order_by": "@timestamp",
+                    "size": 1,
+                    "type": "sum"
+                  },
+                  {
+                    "agg_with": "max",
+                    "field": "coredns.stats.dns.request.duration.ns.count",
+                    "id": "f6c82d30-7307-11e9-aba0-4f43d70788c6",
+                    "order": "desc",
+                    "order_by": "@timestamp",
+                    "size": 1,
+                    "type": "sum"
+                  },
+                  {
+                    "id": "1d9de350-7308-11e9-aba0-4f43d70788c6",
+                    "script": "params.sum / params.count / 1e6",
+                    "type": "calculation",
+                    "variables": [
+                      {
+                        "field": "61ca57f2-469d-11e7-af02-69e470af7417",
+                        "id": "20eee310-7308-11e9-aba0-4f43d70788c6",
+                        "name": "sum"
+                      },
+                      {
+                        "field": "f6c82d30-7307-11e9-aba0-4f43d70788c6",
+                        "id": "2e4139f0-7308-11e9-aba0-4f43d70788c6",
+                        "name": "count"
+                      }
+                    ]
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_filters": [
+                  {
+                    "color": "#68BC00",
+                    "filter": "",
+                    "id": "505e0670-7309-11e9-aba0-4f43d70788c6",
+                    "label": ""
+                  }
+                ],
+                "split_mode": "terms",
+                "stacked": "none",
+                "steps": 0,
+                "terms_field": "coredns.stats.zone",
+                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417",
+                "value_template": "{{value}} ms"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Avg Request Duration (cumulative) [Metricbeat CoreDNS] ECS",
+          "type": "metrics"
+        }
+      },
+      "id": "57c74300-7308-11e9-b0d0-414c3011ddbb",
+      "migrationVersion": {
+        "visualization": "7.0.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-05-10T11:07:14.131Z",
+      "version": "WzE3MzQsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Avg Request Size (cumulative) [Metricbeat CoreDNS] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(228,155,238,1)",
+                "fill": "0.1",
+                "formatter": "number",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Avg Request Size (bytes)",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "coredns.stats.dns.request.size.bytes.sum",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "sum"
+                  },
+                  {
+                    "field": "coredns.stats.dns.request.size.bytes.count",
+                    "id": "98fe65e0-7314-11e9-8e06-d9a616f1e6f2",
+                    "type": "sum"
+                  },
+                  {
+                    "id": "ab81ee30-7314-11e9-8e06-d9a616f1e6f2",
+                    "script": "params.sum / params.count",
+                    "type": "calculation",
+                    "variables": [
+                      {
+                        "field": "61ca57f2-469d-11e7-af02-69e470af7417",
+                        "id": "aeed53c0-7314-11e9-8e06-d9a616f1e6f2",
+                        "name": "sum"
+                      },
+                      {
+                        "field": "98fe65e0-7314-11e9-8e06-d9a616f1e6f2",
+                        "id": "b84dd700-7314-11e9-8e06-d9a616f1e6f2",
+                        "name": "count"
+                      }
+                    ]
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "coredns.stats.zone",
+                "value_template": "{{value}} bytes"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Avg Request Size (cumulative) [Metricbeat CoreDNS] ECS",
+          "type": "metrics"
+        }
+      },
+      "id": "4804eaa0-7315-11e9-b0d0-414c3011ddbb",
+      "migrationVersion": {
+        "visualization": "7.0.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-05-10T11:18:05.129Z",
+      "version": "WzE3MzUsMV0="
+    }
+  ],
+  "version": "7.0.0"
+}

--- a/dev/package-beats/coredns-1.0.0/manifest.yml
+++ b/dev/package-beats/coredns-1.0.0/manifest.yml
@@ -1,0 +1,14 @@
+name: coredns
+title: coredns
+version: 1.0.0
+description: |
+  Module for handling logs produced by coredns
+type: ""
+categories:
+- metrics
+- logs
+requirement:
+  kibana:
+    version:
+      min: 6.7.0
+      max: 7.6.0

--- a/dev/package-beats/couchbase-1.0.0/kibana/dashboard/Metricbeat-couchbase-overview.json
+++ b/dev/package-beats/couchbase-1.0.0/kibana/dashboard/Metricbeat-couchbase-overview.json
@@ -1,0 +1,1179 @@
+{
+  "objects": [
+    {
+      "attributes": {
+        "description": "This Couchbase dashboard visualizes the most relevant metrics for cluster, nodes and buckets. ",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "optionsJSON": {
+          "hidePanelTitles": false,
+          "useMargins": true
+        },
+        "panelsJSON": [
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 11,
+              "i": "1",
+              "w": 12,
+              "x": 0,
+              "y": 11
+            },
+            "panelIndex": "1",
+            "panelRefName": "panel_0",
+            "title": "Buckets RAM Used",
+            "version": "7.3.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 11,
+              "i": "2",
+              "w": 12,
+              "x": 12,
+              "y": 11
+            },
+            "panelIndex": "2",
+            "panelRefName": "panel_1",
+            "title": "Buckets Disk Used",
+            "version": "7.3.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 11,
+              "i": "3",
+              "w": 24,
+              "x": 24,
+              "y": 11
+            },
+            "panelIndex": "3",
+            "panelRefName": "panel_2",
+            "title": "Node CPU Utilization",
+            "version": "7.3.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 11,
+              "i": "4",
+              "w": 12,
+              "x": 0,
+              "y": 22
+            },
+            "panelIndex": "4",
+            "panelRefName": "panel_3",
+            "title": "Buckets Operations Per Second",
+            "version": "7.3.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 11,
+              "i": "5",
+              "w": 24,
+              "x": 24,
+              "y": 0
+            },
+            "panelIndex": "5",
+            "panelRefName": "panel_4",
+            "title": "Operations per Node",
+            "version": "7.3.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 11,
+              "i": "6",
+              "w": 12,
+              "x": 0,
+              "y": 0
+            },
+            "panelIndex": "6",
+            "panelRefName": "panel_5",
+            "title": "Cluster HDD Usage",
+            "version": "7.3.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 11,
+              "i": "7",
+              "w": 12,
+              "x": 12,
+              "y": 0
+            },
+            "panelIndex": "7",
+            "panelRefName": "panel_6",
+            "title": "Cluster RAM",
+            "version": "7.3.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 11,
+              "i": "8",
+              "w": 12,
+              "x": 12,
+              "y": 22
+            },
+            "panelIndex": "8",
+            "panelRefName": "panel_7",
+            "title": "Bucket Item Count",
+            "version": "7.3.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 11,
+              "i": "9",
+              "w": 24,
+              "x": 24,
+              "y": 33
+            },
+            "panelIndex": "9",
+            "panelRefName": "panel_8",
+            "title": "Document Replicas",
+            "version": "7.3.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 11,
+              "i": "10",
+              "w": 24,
+              "x": 24,
+              "y": 22
+            },
+            "panelIndex": "10",
+            "panelRefName": "panel_9",
+            "title": "Disk space used by docs",
+            "version": "7.3.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 11,
+              "i": "11",
+              "w": 24,
+              "x": 0,
+              "y": 33
+            },
+            "panelIndex": "11",
+            "panelRefName": "panel_10",
+            "title": "Disk Fetches",
+            "version": "7.3.0"
+          }
+        ],
+        "timeRestore": false,
+        "title": "[Metricbeat Couchbase] Cluster Overview",
+        "version": 1
+      },
+      "id": "46d21220-b9f1-11e9-a579-f5c0a5d81340",
+      "migrationVersion": {
+        "dashboard": "7.3.0"
+      },
+      "references": [
+        {
+          "id": "e781add0-b9dc-11e9-a579-f5c0a5d81340",
+          "name": "panel_0",
+          "type": "visualization"
+        },
+        {
+          "id": "c4c81a30-b9dd-11e9-a579-f5c0a5d81340",
+          "name": "panel_1",
+          "type": "visualization"
+        },
+        {
+          "id": "467c99c0-b9de-11e9-a579-f5c0a5d81340",
+          "name": "panel_2",
+          "type": "visualization"
+        },
+        {
+          "id": "e23a9fe0-b9db-11e9-a579-f5c0a5d81340",
+          "name": "panel_3",
+          "type": "visualization"
+        },
+        {
+          "id": "17a01210-b9e0-11e9-a579-f5c0a5d81340",
+          "name": "panel_4",
+          "type": "visualization"
+        },
+        {
+          "id": "f515f2e0-b9e0-11e9-a579-f5c0a5d81340",
+          "name": "panel_5",
+          "type": "visualization"
+        },
+        {
+          "id": "7cc8def0-b9e1-11e9-a579-f5c0a5d81340",
+          "name": "panel_6",
+          "type": "visualization"
+        },
+        {
+          "id": "97ee1ea0-b9f2-11e9-a579-f5c0a5d81340",
+          "name": "panel_7",
+          "type": "visualization"
+        },
+        {
+          "id": "63efced0-b9f4-11e9-a579-f5c0a5d81340",
+          "name": "panel_8",
+          "type": "visualization"
+        },
+        {
+          "id": "99980c90-ba8b-11e9-a579-f5c0a5d81340",
+          "name": "panel_9",
+          "type": "visualization"
+        },
+        {
+          "id": "19eed0e0-ba8c-11e9-a579-f5c0a5d81340",
+          "name": "panel_10",
+          "type": "visualization"
+        }
+      ],
+      "type": "dashboard",
+      "updated_at": "2019-08-19T14:28:56.796Z",
+      "version": "WzE1NDYsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Buckets RAM Used [Metricbeat Couchbase] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "kuery",
+              "query": ""
+            },
+            "id": "1ad80860-b9dc-11e9-a74b-270ba78f4926",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(164,221,0,1)",
+                "fill": "0.1",
+                "filter": {
+                  "language": "kuery",
+                  "query": ""
+                },
+                "formatter": "bytes",
+                "id": "1ad80861-b9dc-11e9-a74b-270ba78f4926",
+                "label": " RAM used",
+                "line_width": "1",
+                "metrics": [
+                  {
+                    "field": "couchbase.bucket.memory.used.bytes",
+                    "id": "1ad80862-b9dc-11e9-a74b-270ba78f4926",
+                    "type": "max"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_color_mode": "rainbow",
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "couchbase.bucket.name",
+                "terms_order_by": "1ad80862-b9dc-11e9-a74b-270ba78f4926",
+                "value_template": "{{value}}"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Buckets RAM Used [Metricbeat Couchbase] ECS",
+          "type": "metrics"
+        }
+      },
+      "id": "e781add0-b9dc-11e9-a579-f5c0a5d81340",
+      "migrationVersion": {
+        "visualization": "7.3.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-08-19T14:26:15.240Z",
+      "version": "WzE0NzgsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Buckets Disk Used [Metricbeat Couchbase] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "background_color_rules": [
+              {
+                "id": "a126b410-b9dd-11e9-aa9d-55aa18f46863"
+              }
+            ],
+            "bar_color_rules": [
+              {
+                "id": "9bcf0ee0-b9dd-11e9-aa9d-55aa18f46863"
+              }
+            ],
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "kuery",
+              "query": ""
+            },
+            "gauge_color_rules": [
+              {
+                "id": "97d88050-b9dd-11e9-aa9d-55aa18f46863"
+              }
+            ],
+            "gauge_inner_width": 10,
+            "gauge_style": "half",
+            "gauge_width": 10,
+            "id": "04f7a400-b9dd-11e9-b988-d77f6106a7f0",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(0,98,177,1)",
+                "fill": "0.1",
+                "formatter": "bytes",
+                "id": "04f7a401-b9dd-11e9-b988-d77f6106a7f0",
+                "label": "Disk Used",
+                "line_width": "1",
+                "metrics": [
+                  {
+                    "field": "couchbase.bucket.disk.used.bytes",
+                    "id": "04f7a402-b9dd-11e9-b988-d77f6106a7f0",
+                    "type": "max"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "couchbase.bucket.name",
+                "value_template": "{{value}}"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Buckets Disk Used [Metricbeat Couchbase] ECS",
+          "type": "metrics"
+        }
+      },
+      "id": "c4c81a30-b9dd-11e9-a579-f5c0a5d81340",
+      "migrationVersion": {
+        "visualization": "7.3.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-08-09T09:59:37.672Z",
+      "version": "Wzk5NiwxXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Node CPU Utilization [Metricbeat Couchbase] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "kuery",
+              "query": ""
+            },
+            "id": "f6ae4d80-b9dd-11e9-a864-6f6fa2fda75a",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#3185FC",
+                "fill": 0,
+                "formatter": "'0.'",
+                "id": "f6ae7490-b9dd-11e9-a864-6f6fa2fda75a",
+                "label": "CPU Utilization",
+                "line_width": 2,
+                "metrics": [
+                  {
+                    "field": "couchbase.node.cpu_utilization_rate.pct",
+                    "id": "f6ae7491-b9dd-11e9-a864-6f6fa2fda75a",
+                    "type": "max"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_color_mode": "rainbow",
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "couchbase.node.hostname",
+                "value_template": "{{value}}%"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Node CPU Utilization [Metricbeat Couchbase] ECS",
+          "type": "metrics"
+        }
+      },
+      "id": "467c99c0-b9de-11e9-a579-f5c0a5d81340",
+      "migrationVersion": {
+        "visualization": "7.3.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-08-09T10:01:08.255Z",
+      "version": "WzEwMzEsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Buckets Operations Per Second [Metricbeat Couchbase] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "kuery",
+              "query": ""
+            },
+            "id": "b8a49140-b9db-11e9-bc93-69919d73c9bb",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#3185FC",
+                "fill": 0,
+                "formatter": "number",
+                "id": "b8a49141-b9db-11e9-bc93-69919d73c9bb",
+                "label": "ops_per_sec",
+                "line_width": 2,
+                "metrics": [
+                  {
+                    "field": "couchbase.bucket.ops_per_sec",
+                    "id": "b8a49142-b9db-11e9-bc93-69919d73c9bb",
+                    "type": "max"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "couchbase.bucket.name",
+                "value_template": "{{value}}"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Buckets Operations Per Second [Metricbeat Couchbase] ECS",
+          "type": "metrics"
+        }
+      },
+      "id": "e23a9fe0-b9db-11e9-a579-f5c0a5d81340",
+      "migrationVersion": {
+        "visualization": "7.3.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-08-09T09:58:23.524Z",
+      "version": "Wzk3MiwxXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Operations per Node [Metricbeat Couchbase] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "kuery",
+              "query": ""
+            },
+            "id": "ec9c42a0-b9df-11e9-8634-0fd532c4482a",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(84,141,162,1)",
+                "fill": "0.1",
+                "formatter": "number",
+                "id": "ec9c42a1-b9df-11e9-8634-0fd532c4482a",
+                "label": "max(couchbase.node.ops)",
+                "line_width": "1",
+                "metrics": [
+                  {
+                    "field": "couchbase.node.ops",
+                    "id": "ec9c42a2-b9df-11e9-8634-0fd532c4482a",
+                    "type": "max"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "couchbase.node.hostname",
+                "value_template": "{{value}}"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Operations per Node [Metricbeat Couchbase] ECS",
+          "type": "metrics"
+        }
+      },
+      "id": "17a01210-b9e0-11e9-a579-f5c0a5d81340",
+      "migrationVersion": {
+        "visualization": "7.3.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-08-09T10:00:47.340Z",
+      "version": "WzEwMjQsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Cluster HDD Usage [Metricbeat Couchbase] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "background_color_rules": [
+              {
+                "id": "c7abd1d0-b9e0-11e9-8604-efdef550e653"
+              }
+            ],
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "kuery",
+              "query": ""
+            },
+            "gauge_color_rules": [
+              {
+                "id": "c82f80c0-b9e0-11e9-8604-efdef550e653"
+              }
+            ],
+            "gauge_inner_width": 10,
+            "gauge_style": "half",
+            "gauge_width": 10,
+            "id": "c34f7c90-b9e0-11e9-ab08-bf43409c5a0d",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(67,191,147,1)",
+                "fill": "0.2",
+                "formatter": "bytes",
+                "id": "c34f7c91-b9e0-11e9-ab08-bf43409c5a0d",
+                "label": "Free",
+                "line_width": "1",
+                "metrics": [
+                  {
+                    "field": "couchbase.cluster.hdd.free.bytes",
+                    "id": "c34f7c92-b9e0-11e9-ab08-bf43409c5a0d",
+                    "type": "max"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_color_mode": "gradient",
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "bytes",
+                "id": "8949ecc0-ba89-11e9-8d4d-f510918c2882",
+                "label": "Data",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "couchbase.cluster.hdd.used.by_data.bytes",
+                    "id": "8949ecc1-ba89-11e9-8d4d-f510918c2882",
+                    "type": "max"
+                  }
+                ],
+                "point_size": "0",
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(0,156,224,1)",
+                "fill": 0.5,
+                "formatter": "bytes",
+                "id": "ce3d98e0-ba89-11e9-8d4d-f510918c2882",
+                "label": "Cluster",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "couchbase.cluster.hdd.used.value.bytes",
+                    "id": "ce3d98e1-ba89-11e9-8d4d-f510918c2882",
+                    "type": "max"
+                  }
+                ],
+                "point_size": "0",
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(159,5,0,1)",
+                "fill": "0",
+                "formatter": "bytes",
+                "id": "2f4dbb20-ba89-11e9-8d4d-f510918c2882",
+                "label": "Total",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "couchbase.cluster.hdd.total.bytes",
+                    "id": "2f4dbb21-ba89-11e9-8d4d-f510918c2882",
+                    "type": "max"
+                  }
+                ],
+                "point_size": "0",
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Cluster HDD Usage [Metricbeat Couchbase] ECS",
+          "type": "metrics"
+        }
+      },
+      "id": "f515f2e0-b9e0-11e9-a579-f5c0a5d81340",
+      "migrationVersion": {
+        "visualization": "7.3.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-08-09T10:00:12.389Z",
+      "version": "WzEwMTUsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Cluster RAM [Metricbeat Couchbase] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "bar_color_rules": [
+              {
+                "id": "3afe8650-b9e1-11e9-861c-7f7211bffe38"
+              }
+            ],
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "kuery",
+              "query": ""
+            },
+            "id": "24242700-b9e1-11e9-ab98-51a45917a19d",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(159,5,0,1)",
+                "fill": 0,
+                "formatter": "bytes",
+                "id": "24242701-b9e1-11e9-ab98-51a45917a19d",
+                "label": "Total",
+                "line_width": 2,
+                "metrics": [
+                  {
+                    "field": "couchbase.cluster.ram.total.bytes",
+                    "id": "24242702-b9e1-11e9-ab98-51a45917a19d",
+                    "type": "max"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(226,115,0,1)",
+                "fill": "0.2",
+                "formatter": "bytes",
+                "id": "24242703-b9e1-11e9-ab98-51a45917a19d",
+                "label": "Used",
+                "line_width": "1",
+                "metrics": [
+                  {
+                    "field": "couchbase.cluster.ram.used.value.bytes",
+                    "id": "24242704-b9e1-11e9-ab98-51a45917a19d",
+                    "type": "max"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Cluster RAM [Metricbeat Couchbase] ECS",
+          "type": "metrics"
+        }
+      },
+      "id": "7cc8def0-b9e1-11e9-a579-f5c0a5d81340",
+      "migrationVersion": {
+        "visualization": "7.3.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-08-09T09:59:56.912Z",
+      "version": "WzEwMDUsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Bucket Item Count [Metricbeat Couchbase] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "kuery",
+              "query": ""
+            },
+            "id": "5b94e6a0-b9f2-11e9-9c08-535482acfc9e",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(252,196,0,1)",
+                "fill": "0.1",
+                "formatter": "number",
+                "id": "5b94e6a1-b9f2-11e9-9c08-535482acfc9e",
+                "label": "items",
+                "line_width": "1",
+                "metrics": [
+                  {
+                    "field": "couchbase.bucket.item_count",
+                    "id": "5b94e6a2-b9f2-11e9-9c08-535482acfc9e",
+                    "type": "max"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "couchbase.bucket.name",
+                "terms_order_by": "5b94e6a2-b9f2-11e9-9c08-535482acfc9e",
+                "value_template": "{{value}}"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Bucket Item Count [Metricbeat Couchbase] ECS",
+          "type": "metrics"
+        }
+      },
+      "id": "97ee1ea0-b9f2-11e9-a579-f5c0a5d81340",
+      "migrationVersion": {
+        "visualization": "7.3.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-08-09T09:58:47.462Z",
+      "version": "Wzk4MCwxXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Document Replicas [Metricbeat Couchbase] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "kuery",
+              "query": ""
+            },
+            "id": "2658bfa0-b9f4-11e9-ac89-cd269ee83e5f",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#3185FC",
+                "fill": "0.2",
+                "formatter": "number",
+                "id": "2658bfa1-b9f4-11e9-ac89-cd269ee83e5f",
+                "label": "replicas",
+                "line_width": "1",
+                "metrics": [
+                  {
+                    "field": "couchbase.node.vb_replica_curr_items",
+                    "id": "2658bfa2-b9f4-11e9-ac89-cd269ee83e5f",
+                    "type": "max"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "couchbase.node.hostname",
+                "value_template": "{{value}}"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Document Replicas [Metricbeat Couchbase] ECS",
+          "type": "metrics"
+        }
+      },
+      "id": "63efced0-b9f4-11e9-a579-f5c0a5d81340",
+      "migrationVersion": {
+        "visualization": "7.3.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-08-09T10:01:57.445Z",
+      "version": "WzEwNDgsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Disk space used by docs [Metricbeat Couchbase] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "kuery",
+              "query": ""
+            },
+            "id": "46d25240-ba8b-11e9-a06c-c5fca4bfd53b",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(83,167,131,1)",
+                "fill": "0.1",
+                "formatter": "bytes",
+                "id": "46d25241-ba8b-11e9-a06c-c5fca4bfd53b",
+                "label": "Docs ",
+                "line_width": "1",
+                "metrics": [
+                  {
+                    "field": "couchbase.node.couch.docs.disk_size.bytes",
+                    "id": "46d25242-ba8b-11e9-a06c-c5fca4bfd53b",
+                    "type": "max"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_color_mode": "gradient",
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "couchbase.node.hostname",
+                "value_template": "{{value}}"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Disk space used by docs [Metricbeat Couchbase] ECS",
+          "type": "metrics"
+        }
+      },
+      "id": "99980c90-ba8b-11e9-a579-f5c0a5d81340",
+      "migrationVersion": {
+        "visualization": "7.3.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-08-09T10:15:08.388Z",
+      "version": "WzEwNzMsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Disk Fetches [Metricbeat Couchbase] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "kuery",
+              "query": ""
+            },
+            "id": "ead970d0-ba8b-11e9-8d1e-992a5619d7be",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(176,188,0,1)",
+                "fill": 0,
+                "formatter": "number",
+                "id": "ead970d1-ba8b-11e9-8d1e-992a5619d7be",
+                "label": "Disk Fetches",
+                "line_width": 2,
+                "metrics": [
+                  {
+                    "field": "couchbase.bucket.disk.fetches",
+                    "id": "ead970d2-ba8b-11e9-8d1e-992a5619d7be",
+                    "type": "max"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "couchbase.bucket.name",
+                "value_template": "{{value}}"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Disk Fetches [Metricbeat Couchbase] ECS",
+          "type": "metrics"
+        }
+      },
+      "id": "19eed0e0-ba8c-11e9-a579-f5c0a5d81340",
+      "migrationVersion": {
+        "visualization": "7.3.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-08-09T09:57:30.478Z",
+      "version": "Wzk2NSwxXQ=="
+    }
+  ],
+  "version": "7.3.0"
+}

--- a/dev/package-beats/couchbase-1.0.0/manifest.yml
+++ b/dev/package-beats/couchbase-1.0.0/manifest.yml
@@ -1,0 +1,13 @@
+name: couchbase
+title: Couchbase
+version: 1.0.0
+description: |
+  Metrics collected from Couchbase servers.
+type: ""
+categories:
+- metrics
+requirement:
+  kibana:
+    version:
+      min: 6.7.0
+      max: 7.6.0

--- a/dev/package-beats/couchdb-1.0.0/kibana/dashboard/Metricbeat-couchdb-overview.json
+++ b/dev/package-beats/couchdb-1.0.0/kibana/dashboard/Metricbeat-couchdb-overview.json
@@ -1,0 +1,1347 @@
+{
+  "objects": [
+    {
+      "attributes": {
+        "description": "This CouchDB dashboard visualizes the most important CouchDB server metrics.\n\n",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "optionsJSON": {
+          "hidePanelTitles": false,
+          "useMargins": true
+        },
+        "panelsJSON": [
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 15,
+              "i": "1",
+              "w": 24,
+              "x": 0,
+              "y": 10
+            },
+            "panelIndex": "1",
+            "panelRefName": "panel_0",
+            "title": "HTTP Status Codes",
+            "version": "7.3.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 15,
+              "i": "2",
+              "w": 24,
+              "x": 24,
+              "y": 10
+            },
+            "panelIndex": "2",
+            "panelRefName": "panel_1",
+            "title": "HTTP Request Methods",
+            "version": "7.3.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 10,
+              "i": "3",
+              "w": 10,
+              "x": 0,
+              "y": 0
+            },
+            "panelIndex": "3",
+            "panelRefName": "panel_2",
+            "title": "Open Databases",
+            "version": "7.3.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 10,
+              "i": "4",
+              "w": 24,
+              "x": 24,
+              "y": 0
+            },
+            "panelIndex": "4",
+            "panelRefName": "panel_3",
+            "title": "Database Read/Writes",
+            "version": "7.3.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 10,
+              "i": "5",
+              "w": 24,
+              "x": 24,
+              "y": 25
+            },
+            "panelIndex": "5",
+            "panelRefName": "panel_4",
+            "title": "Auth Cache Hit/Miss",
+            "version": "7.3.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 10,
+              "i": "6",
+              "w": 14,
+              "x": 10,
+              "y": 0
+            },
+            "panelIndex": "6",
+            "panelRefName": "panel_5",
+            "title": "Number of HTTP Requests",
+            "version": "7.3.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 10,
+              "i": "7",
+              "w": 24,
+              "x": 0,
+              "y": 25
+            },
+            "panelIndex": "7",
+            "panelRefName": "panel_6",
+            "title": "Number of View Reads",
+            "version": "7.3.0"
+          }
+        ],
+        "timeRestore": false,
+        "title": "[Metricbeat CouchDB] Database Overview",
+        "version": 1
+      },
+      "id": "a3ab9a60-b952-11e9-a579-f5c0a5d81340",
+      "migrationVersion": {
+        "dashboard": "7.3.0"
+      },
+      "references": [
+        {
+          "id": "8e15ece0-b94e-11e9-a579-f5c0a5d81340",
+          "name": "panel_0",
+          "type": "visualization"
+        },
+        {
+          "id": "1b60bb70-b94f-11e9-a579-f5c0a5d81340",
+          "name": "panel_1",
+          "type": "visualization"
+        },
+        {
+          "id": "f8c29f10-b94f-11e9-a579-f5c0a5d81340",
+          "name": "panel_2",
+          "type": "visualization"
+        },
+        {
+          "id": "702584a0-b950-11e9-a579-f5c0a5d81340",
+          "name": "panel_3",
+          "type": "visualization"
+        },
+        {
+          "id": "abfaf130-b951-11e9-a579-f5c0a5d81340",
+          "name": "panel_4",
+          "type": "visualization"
+        },
+        {
+          "id": "06018310-b952-11e9-a579-f5c0a5d81340",
+          "name": "panel_5",
+          "type": "visualization"
+        },
+        {
+          "id": "496910f0-b952-11e9-a579-f5c0a5d81340",
+          "name": "panel_6",
+          "type": "visualization"
+        }
+      ],
+      "type": "dashboard",
+      "updated_at": "2019-08-19T15:05:11.218Z",
+      "version": "WzE1NzksMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "HTTP Status Codes [Metricbeat CouchDB] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "kuery",
+              "query": ""
+            },
+            "id": "c8c0f520-b94d-11e9-8899-f736e404b0e7",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#3185FC",
+                "fill": "0.2",
+                "formatter": "number",
+                "id": "c8c0f521-b94d-11e9-8899-f736e404b0e7",
+                "label": "200 OK",
+                "line_width": "1",
+                "metrics": [
+                  {
+                    "field": "couchdb.server.httpd_status_codes.200",
+                    "id": "c8c0f522-b94d-11e9-8899-f736e404b0e7",
+                    "type": "max"
+                  },
+                  {
+                    "field": "c8c0f522-b94d-11e9-8899-f736e404b0e7",
+                    "id": "c8c0f524-b94d-11e9-8899-f736e404b0e7",
+                    "type": "derivative",
+                    "unit": "1s"
+                  },
+                  {
+                    "field": "c8c0f524-b94d-11e9-8899-f736e404b0e7",
+                    "id": "c8c0f523-b94d-11e9-8899-f736e404b0e7",
+                    "type": "positive_only"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#00B3A4",
+                "fill": "0.2",
+                "formatter": "number",
+                "id": "c8c0f529-b94d-11e9-8899-f736e404b0e7",
+                "label": "400 Bad Request",
+                "line_width": "1",
+                "metrics": [
+                  {
+                    "field": "couchdb.server.httpd_status_codes.400",
+                    "id": "c8c0f52a-b94d-11e9-8899-f736e404b0e7",
+                    "type": "max"
+                  },
+                  {
+                    "field": "c8c0f52a-b94d-11e9-8899-f736e404b0e7",
+                    "id": "c8c0f52c-b94d-11e9-8899-f736e404b0e7",
+                    "type": "derivative",
+                    "unit": "1s"
+                  },
+                  {
+                    "field": "c8c0f52c-b94d-11e9-8899-f736e404b0e7",
+                    "id": "c8c0f52b-b94d-11e9-8899-f736e404b0e7",
+                    "type": "positive_only"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#490092",
+                "fill": "0.2",
+                "formatter": "number",
+                "id": "c8c0f52d-b94d-11e9-8899-f736e404b0e7",
+                "label": "401 Unauthorized",
+                "line_width": "1",
+                "metrics": [
+                  {
+                    "field": "couchdb.server.httpd_status_codes.401",
+                    "id": "c8c0f52e-b94d-11e9-8899-f736e404b0e7",
+                    "type": "max"
+                  },
+                  {
+                    "field": "c8c0f52e-b94d-11e9-8899-f736e404b0e7",
+                    "id": "c8c0f530-b94d-11e9-8899-f736e404b0e7",
+                    "type": "derivative",
+                    "unit": "1s"
+                  },
+                  {
+                    "field": "c8c0f530-b94d-11e9-8899-f736e404b0e7",
+                    "id": "c8c0f52f-b94d-11e9-8899-f736e404b0e7",
+                    "type": "positive_only"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#461A0A",
+                "fill": "0.2",
+                "formatter": "number",
+                "id": "c8c0f541-b94d-11e9-8899-f736e404b0e7",
+                "label": "500  Internal Server Error",
+                "line_width": "1",
+                "metrics": [
+                  {
+                    "field": "couchdb.server.httpd_status_codes.500",
+                    "id": "c8c0f542-b94d-11e9-8899-f736e404b0e7",
+                    "type": "max"
+                  },
+                  {
+                    "field": "c8c0f542-b94d-11e9-8899-f736e404b0e7",
+                    "id": "c8c0f544-b94d-11e9-8899-f736e404b0e7",
+                    "type": "derivative",
+                    "unit": "1s"
+                  },
+                  {
+                    "field": "c8c0f544-b94d-11e9-8899-f736e404b0e7",
+                    "id": "c8c0f543-b94d-11e9-8899-f736e404b0e7",
+                    "type": "positive_only"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#FEB6DB",
+                "fill": "0.2",
+                "formatter": "number",
+                "id": "c8c0f531-b94d-11e9-8899-f736e404b0e7",
+                "label": "403 Forbidden",
+                "line_width": "1",
+                "metrics": [
+                  {
+                    "field": "couchdb.server.httpd_status_codes.403",
+                    "id": "c8c0f532-b94d-11e9-8899-f736e404b0e7",
+                    "type": "max"
+                  },
+                  {
+                    "field": "c8c0f532-b94d-11e9-8899-f736e404b0e7",
+                    "id": "c8c0f534-b94d-11e9-8899-f736e404b0e7",
+                    "type": "derivative",
+                    "unit": "1s"
+                  },
+                  {
+                    "field": "c8c0f534-b94d-11e9-8899-f736e404b0e7",
+                    "id": "c8c0f533-b94d-11e9-8899-f736e404b0e7",
+                    "type": "positive_only"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#E6C220",
+                "fill": "0.2",
+                "formatter": "number",
+                "id": "c8c0f535-b94d-11e9-8899-f736e404b0e7",
+                "label": "404 Not Found",
+                "line_width": "1",
+                "metrics": [
+                  {
+                    "field": "couchdb.server.httpd_status_codes.404",
+                    "id": "c8c0f536-b94d-11e9-8899-f736e404b0e7",
+                    "type": "max"
+                  },
+                  {
+                    "field": "c8c0f536-b94d-11e9-8899-f736e404b0e7",
+                    "id": "c8c0f538-b94d-11e9-8899-f736e404b0e7",
+                    "type": "derivative",
+                    "unit": "1s"
+                  },
+                  {
+                    "field": "c8c0f538-b94d-11e9-8899-f736e404b0e7",
+                    "id": "c8c0f537-b94d-11e9-8899-f736e404b0e7",
+                    "type": "positive_only"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#DB1374",
+                "fill": "0.2",
+                "formatter": "number",
+                "id": "c8c0f525-b94d-11e9-8899-f736e404b0e7",
+                "label": "202 Accepted",
+                "line_width": "1",
+                "metrics": [
+                  {
+                    "field": "couchdb.server.httpd_status_codes.202",
+                    "id": "c8c0f526-b94d-11e9-8899-f736e404b0e7",
+                    "type": "max"
+                  },
+                  {
+                    "field": "c8c0f526-b94d-11e9-8899-f736e404b0e7",
+                    "id": "c8c0f528-b94d-11e9-8899-f736e404b0e7",
+                    "type": "derivative",
+                    "unit": "1s"
+                  },
+                  {
+                    "field": "c8c0f528-b94d-11e9-8899-f736e404b0e7",
+                    "id": "c8c0f527-b94d-11e9-8899-f736e404b0e7",
+                    "type": "positive_only"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#BFA180",
+                "fill": "0.2",
+                "formatter": "number",
+                "id": "c8c0f539-b94d-11e9-8899-f736e404b0e7",
+                "label": "405 Method Not Allowed",
+                "line_width": "1",
+                "metrics": [
+                  {
+                    "field": "couchdb.server.httpd_status_codes.405",
+                    "id": "c8c0f53a-b94d-11e9-8899-f736e404b0e7",
+                    "type": "max"
+                  },
+                  {
+                    "field": "c8c0f53a-b94d-11e9-8899-f736e404b0e7",
+                    "id": "c8c0f53c-b94d-11e9-8899-f736e404b0e7",
+                    "type": "derivative",
+                    "unit": "1s"
+                  },
+                  {
+                    "field": "c8c0f53c-b94d-11e9-8899-f736e404b0e7",
+                    "id": "c8c0f53b-b94d-11e9-8899-f736e404b0e7",
+                    "type": "positive_only"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#F98510",
+                "fill": "0.2",
+                "formatter": "number",
+                "id": "c8c0f53d-b94d-11e9-8899-f736e404b0e7",
+                "label": "409 Conflict",
+                "line_width": "1",
+                "metrics": [
+                  {
+                    "field": "couchdb.server.httpd_status_codes.409",
+                    "id": "c8c0f53e-b94d-11e9-8899-f736e404b0e7",
+                    "type": "max"
+                  },
+                  {
+                    "field": "c8c0f53e-b94d-11e9-8899-f736e404b0e7",
+                    "id": "c8c0f540-b94d-11e9-8899-f736e404b0e7",
+                    "type": "derivative",
+                    "unit": "1s"
+                  },
+                  {
+                    "field": "c8c0f540-b94d-11e9-8899-f736e404b0e7",
+                    "id": "c8c0f53f-b94d-11e9-8899-f736e404b0e7",
+                    "type": "positive_only"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#920000",
+                "fill": "0.2",
+                "formatter": "number",
+                "id": "c8c0f545-b94d-11e9-8899-f736e404b0e7",
+                "label": "201 Created",
+                "line_width": "1",
+                "metrics": [
+                  {
+                    "field": "couchdb.server.httpd_status_codes.201",
+                    "id": "c8c0f546-b94d-11e9-8899-f736e404b0e7",
+                    "type": "max"
+                  },
+                  {
+                    "field": "c8c0f546-b94d-11e9-8899-f736e404b0e7",
+                    "id": "c8c0f548-b94d-11e9-8899-f736e404b0e7",
+                    "type": "derivative",
+                    "unit": "1s"
+                  },
+                  {
+                    "field": "c8c0f548-b94d-11e9-8899-f736e404b0e7",
+                    "id": "c8c0f547-b94d-11e9-8899-f736e404b0e7",
+                    "type": "positive_only"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "HTTP Status Codes [Metricbeat CouchDB] ECS",
+          "type": "metrics"
+        }
+      },
+      "id": "8e15ece0-b94e-11e9-a579-f5c0a5d81340",
+      "migrationVersion": {
+        "visualization": "7.3.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-08-09T10:30:56.854Z",
+      "version": "WzExMTksMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "HTTP Request Methods [Metricbeat CouchDB] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "kuery",
+              "query": ""
+            },
+            "id": "bb936ee0-b94e-11e9-86ee-f5b628c75be4",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(164,221,0,1)",
+                "fill": "0.2",
+                "formatter": "number",
+                "id": "bb936ee1-b94e-11e9-86ee-f5b628c75be4",
+                "label": "GET",
+                "line_width": "1",
+                "metrics": [
+                  {
+                    "field": "couchdb.server.httpd_request_methods.GET",
+                    "id": "bb936ee2-b94e-11e9-86ee-f5b628c75be4",
+                    "type": "max"
+                  },
+                  {
+                    "field": "bb936ee2-b94e-11e9-86ee-f5b628c75be4",
+                    "id": "bb936ee4-b94e-11e9-86ee-f5b628c75be4",
+                    "type": "derivative",
+                    "unit": "1s"
+                  },
+                  {
+                    "field": "bb936ee4-b94e-11e9-86ee-f5b628c75be4",
+                    "id": "bb936ee3-b94e-11e9-86ee-f5b628c75be4",
+                    "type": "positive_only"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#DB1374",
+                "fill": "0.2",
+                "formatter": "number",
+                "id": "bb936ee5-b94e-11e9-86ee-f5b628c75be4",
+                "label": "POST",
+                "line_width": "1",
+                "metrics": [
+                  {
+                    "field": "couchdb.server.httpd_request_methods.POST",
+                    "id": "bb936ee6-b94e-11e9-86ee-f5b628c75be4",
+                    "type": "max"
+                  },
+                  {
+                    "field": "bb936ee6-b94e-11e9-86ee-f5b628c75be4",
+                    "id": "bb936ee8-b94e-11e9-86ee-f5b628c75be4",
+                    "type": "derivative",
+                    "unit": "1s"
+                  },
+                  {
+                    "field": "bb936ee8-b94e-11e9-86ee-f5b628c75be4",
+                    "id": "bb936ee7-b94e-11e9-86ee-f5b628c75be4",
+                    "type": "positive_only"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#00B3A4",
+                "fill": "0.2",
+                "formatter": "number",
+                "id": "bb936ee9-b94e-11e9-86ee-f5b628c75be4",
+                "label": "PUT",
+                "line_width": "1",
+                "metrics": [
+                  {
+                    "field": "couchdb.server.httpd_request_methods.PUT",
+                    "id": "bb936eea-b94e-11e9-86ee-f5b628c75be4",
+                    "type": "max"
+                  },
+                  {
+                    "field": "bb936eea-b94e-11e9-86ee-f5b628c75be4",
+                    "id": "bb936eec-b94e-11e9-86ee-f5b628c75be4",
+                    "type": "derivative",
+                    "unit": "1s"
+                  },
+                  {
+                    "field": "bb936eec-b94e-11e9-86ee-f5b628c75be4",
+                    "id": "bb936eeb-b94e-11e9-86ee-f5b628c75be4",
+                    "type": "positive_only"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#490092",
+                "fill": "0.2",
+                "formatter": "number",
+                "id": "bb936eed-b94e-11e9-86ee-f5b628c75be4",
+                "label": "DELETE",
+                "line_width": "1",
+                "metrics": [
+                  {
+                    "field": "couchdb.server.httpd_request_methods.DELETE",
+                    "id": "bb936eee-b94e-11e9-86ee-f5b628c75be4",
+                    "type": "max"
+                  },
+                  {
+                    "field": "bb936eee-b94e-11e9-86ee-f5b628c75be4",
+                    "id": "bb936ef0-b94e-11e9-86ee-f5b628c75be4",
+                    "type": "derivative",
+                    "unit": "1s"
+                  },
+                  {
+                    "field": "bb936ef0-b94e-11e9-86ee-f5b628c75be4",
+                    "id": "bb936eef-b94e-11e9-86ee-f5b628c75be4",
+                    "type": "positive_only"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#FEB6DB",
+                "fill": "0.2",
+                "formatter": "number",
+                "id": "bb936ef1-b94e-11e9-86ee-f5b628c75be4",
+                "label": "HEAD",
+                "line_width": "1",
+                "metrics": [
+                  {
+                    "field": "couchdb.server.httpd_request_methods.HEAD",
+                    "id": "bb936ef2-b94e-11e9-86ee-f5b628c75be4",
+                    "type": "max"
+                  },
+                  {
+                    "field": "bb936ef2-b94e-11e9-86ee-f5b628c75be4",
+                    "id": "bb936ef4-b94e-11e9-86ee-f5b628c75be4",
+                    "type": "derivative",
+                    "unit": "1s"
+                  },
+                  {
+                    "field": "bb936ef4-b94e-11e9-86ee-f5b628c75be4",
+                    "id": "bb936ef3-b94e-11e9-86ee-f5b628c75be4",
+                    "type": "positive_only"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#E6C220",
+                "fill": "0.2",
+                "formatter": "number",
+                "id": "bb936ef5-b94e-11e9-86ee-f5b628c75be4",
+                "label": "COPY",
+                "line_width": "1",
+                "metrics": [
+                  {
+                    "field": "couchdb.server.httpd_request_methods.COPY",
+                    "id": "bb936ef6-b94e-11e9-86ee-f5b628c75be4",
+                    "type": "max"
+                  },
+                  {
+                    "field": "bb936ef6-b94e-11e9-86ee-f5b628c75be4",
+                    "id": "bb936ef8-b94e-11e9-86ee-f5b628c75be4",
+                    "type": "derivative",
+                    "unit": "1s"
+                  },
+                  {
+                    "field": "bb936ef8-b94e-11e9-86ee-f5b628c75be4",
+                    "id": "bb936ef7-b94e-11e9-86ee-f5b628c75be4",
+                    "type": "positive_only"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "HTTP Request Methods [Metricbeat CouchDB] ECS",
+          "type": "metrics"
+        }
+      },
+      "id": "1b60bb70-b94f-11e9-a579-f5c0a5d81340",
+      "migrationVersion": {
+        "visualization": "7.3.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-08-09T10:31:20.866Z",
+      "version": "WzExMjQsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Open Databases [Metricbeat CouchDB] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "background_color": null,
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "kuery",
+              "query": "couchdb"
+            },
+            "gauge_color_rules": [
+              {
+                "id": "ef4c9800-b94f-11e9-bce6-47447dde021d"
+              }
+            ],
+            "gauge_inner_color": null,
+            "gauge_inner_width": 10,
+            "gauge_style": "half",
+            "gauge_width": 10,
+            "id": "71dd6340-b94f-11e9-9f6f-832b64f4a79f",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "legend_position": "right",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(12,121,125,1)",
+                "fill": "0.1",
+                "formatter": "number",
+                "id": "71dd8a50-b94f-11e9-9f6f-832b64f4a79f",
+                "label": "Open Databases",
+                "line_width": 2,
+                "metrics": [
+                  {
+                    "field": "couchdb.server.couchdb.open_databases",
+                    "id": "71dd8a51-b94f-11e9-9f6f-832b64f4a79f",
+                    "type": "max"
+                  }
+                ],
+                "point_size": "0",
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Open Databases [Metricbeat CouchDB] ECS",
+          "type": "metrics"
+        }
+      },
+      "id": "f8c29f10-b94f-11e9-a579-f5c0a5d81340",
+      "migrationVersion": {
+        "visualization": "7.3.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-08-09T10:26:58.696Z",
+      "version": "WzExMDUsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Database Read/Writes [Metricbeat CouchDB] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "kuery",
+              "query": "couchdb"
+            },
+            "id": "48918790-b950-11e9-84ff-97e538653deb",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(226,115,0,1)",
+                "fill": "0.2",
+                "formatter": "number",
+                "id": "48918791-b950-11e9-84ff-97e538653deb",
+                "label": "database_writes",
+                "line_width": "1",
+                "metrics": [
+                  {
+                    "field": "couchdb.server.couchdb.database_writes",
+                    "id": "48918792-b950-11e9-84ff-97e538653deb",
+                    "type": "max"
+                  },
+                  {
+                    "field": "48918792-b950-11e9-84ff-97e538653deb",
+                    "id": "48918794-b950-11e9-84ff-97e538653deb",
+                    "type": "derivative",
+                    "unit": "1s"
+                  },
+                  {
+                    "field": "48918794-b950-11e9-84ff-97e538653deb",
+                    "id": "48918793-b950-11e9-84ff-97e538653deb",
+                    "type": "positive_only"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(160,203,38,1)",
+                "fill": "0.2",
+                "formatter": "number",
+                "id": "7c71dd30-b950-11e9-bd31-d98b40ea3379",
+                "label": "database_reads",
+                "line_width": "1",
+                "metrics": [
+                  {
+                    "field": "couchdb.server.couchdb.database_reads",
+                    "id": "7c71dd31-b950-11e9-bd31-d98b40ea3379",
+                    "type": "max"
+                  },
+                  {
+                    "field": "7c71dd31-b950-11e9-bd31-d98b40ea3379",
+                    "id": "7c71dd32-b950-11e9-bd31-d98b40ea3379",
+                    "type": "derivative",
+                    "unit": "1s"
+                  },
+                  {
+                    "field": "7c71dd32-b950-11e9-bd31-d98b40ea3379",
+                    "id": "7c71dd33-b950-11e9-bd31-d98b40ea3379",
+                    "type": "positive_only",
+                    "unit": ""
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Database Read/Writes [Metricbeat CouchDB] ECS",
+          "type": "metrics"
+        }
+      },
+      "id": "702584a0-b950-11e9-a579-f5c0a5d81340",
+      "migrationVersion": {
+        "visualization": "7.3.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-08-09T10:30:34.762Z",
+      "version": "WzExMTUsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Auth Cache Hit/Miss [Metricbeat CouchDB] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "kuery",
+              "query": "couchdb"
+            },
+            "id": "7ccd9c50-b951-11e9-8e1d-17d2519ede48",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(179,101,87,1)",
+                "fill": 0,
+                "formatter": "number",
+                "id": "7ccd9c51-b951-11e9-8e1d-17d2519ede48",
+                "label": "auth_cache_misses",
+                "line_width": 2,
+                "metrics": [
+                  {
+                    "field": "couchdb.server.couchdb.auth_cache_misses",
+                    "id": "7ccd9c52-b951-11e9-8e1d-17d2519ede48",
+                    "type": "max"
+                  },
+                  {
+                    "field": "7ccd9c52-b951-11e9-8e1d-17d2519ede48",
+                    "id": "7ccd9c54-b951-11e9-8e1d-17d2519ede48",
+                    "type": "derivative",
+                    "unit": "1s"
+                  },
+                  {
+                    "field": "7ccd9c54-b951-11e9-8e1d-17d2519ede48",
+                    "id": "7ccd9c53-b951-11e9-8e1d-17d2519ede48",
+                    "type": "positive_only"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(129,169,80,1)",
+                "fill": 0,
+                "formatter": "number",
+                "id": "7ccd9c55-b951-11e9-8e1d-17d2519ede48",
+                "label": "auth_cache_hits",
+                "line_width": 2,
+                "metrics": [
+                  {
+                    "field": "couchdb.server.couchdb.auth_cache_hits",
+                    "id": "7ccd9c56-b951-11e9-8e1d-17d2519ede48",
+                    "type": "max"
+                  },
+                  {
+                    "field": "7ccd9c56-b951-11e9-8e1d-17d2519ede48",
+                    "id": "7ccd9c58-b951-11e9-8e1d-17d2519ede48",
+                    "type": "derivative",
+                    "unit": "1s"
+                  },
+                  {
+                    "field": "7ccd9c58-b951-11e9-8e1d-17d2519ede48",
+                    "id": "7ccd9c57-b951-11e9-8e1d-17d2519ede48",
+                    "type": "positive_only"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Auth Cache Hit/Miss [Metricbeat CouchDB] ECS",
+          "type": "metrics"
+        }
+      },
+      "id": "abfaf130-b951-11e9-a579-f5c0a5d81340",
+      "migrationVersion": {
+        "visualization": "7.3.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-08-09T10:32:05.471Z",
+      "version": "WzExMzYsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Number of HTTP Requests [Metricbeat CouchDB] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "kuery",
+              "query": "couchdb"
+            },
+            "id": "caae9780-b951-11e9-8945-b5f393c4775d",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(82,174,177,1)",
+                "fill": "0.2",
+                "formatter": "number",
+                "id": "caae9781-b951-11e9-8945-b5f393c4775d",
+                "label": "requests",
+                "line_width": "1",
+                "metrics": [
+                  {
+                    "field": "couchdb.server.httpd.requests",
+                    "id": "caae9782-b951-11e9-8945-b5f393c4775d",
+                    "type": "max"
+                  },
+                  {
+                    "field": "caae9782-b951-11e9-8945-b5f393c4775d",
+                    "id": "caae9784-b951-11e9-8945-b5f393c4775d",
+                    "type": "derivative",
+                    "unit": "1s"
+                  },
+                  {
+                    "field": "caae9784-b951-11e9-8945-b5f393c4775d",
+                    "id": "caae9783-b951-11e9-8945-b5f393c4775d",
+                    "type": "positive_only"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(237,193,119,1)",
+                "fill": "0.2",
+                "formatter": "number",
+                "id": "caae9785-b951-11e9-8945-b5f393c4775d",
+                "label": "bulk_requests",
+                "line_width": "1",
+                "metrics": [
+                  {
+                    "field": "couchdb.server.httpd.bulk_requests",
+                    "id": "caae9786-b951-11e9-8945-b5f393c4775d",
+                    "type": "max"
+                  },
+                  {
+                    "field": "caae9786-b951-11e9-8945-b5f393c4775d",
+                    "id": "caae9788-b951-11e9-8945-b5f393c4775d",
+                    "type": "derivative",
+                    "unit": "1s"
+                  },
+                  {
+                    "field": "caae9788-b951-11e9-8945-b5f393c4775d",
+                    "id": "caae9787-b951-11e9-8945-b5f393c4775d",
+                    "type": "positive_only"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Number of HTTP Requests [Metricbeat CouchDB] ECS",
+          "type": "metrics"
+        }
+      },
+      "id": "06018310-b952-11e9-a579-f5c0a5d81340",
+      "migrationVersion": {
+        "visualization": "7.3.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-08-09T10:30:13.765Z",
+      "version": "WzExMTAsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Number of View Reads [Metricbeat CouchDB] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "kuery",
+              "query": "couchdb"
+            },
+            "id": "1d4e0520-b952-11e9-b9f3-4d741a808166",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(0,156,224,1)",
+                "fill": 0,
+                "formatter": "number",
+                "id": "1d4e0521-b952-11e9-b9f3-4d741a808166",
+                "label": "view_reads",
+                "line_width": 2,
+                "metrics": [
+                  {
+                    "field": "couchdb.server.httpd.view_reads",
+                    "id": "1d4e0522-b952-11e9-b9f3-4d741a808166",
+                    "type": "max"
+                  },
+                  {
+                    "field": "1d4e0522-b952-11e9-b9f3-4d741a808166",
+                    "id": "1d4e0524-b952-11e9-b9f3-4d741a808166",
+                    "type": "derivative",
+                    "unit": "1s"
+                  },
+                  {
+                    "field": "1d4e0524-b952-11e9-b9f3-4d741a808166",
+                    "id": "1d4e0523-b952-11e9-b9f3-4d741a808166",
+                    "type": "positive_only"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(247,61,231,1)",
+                "fill": 0,
+                "formatter": "number",
+                "id": "1d4e0525-b952-11e9-b9f3-4d741a808166",
+                "label": "temporary_view_reads",
+                "line_width": 2,
+                "metrics": [
+                  {
+                    "field": "couchdb.server.httpd.temporary_view_reads",
+                    "id": "1d4e0526-b952-11e9-b9f3-4d741a808166",
+                    "type": "max"
+                  },
+                  {
+                    "field": "1d4e0526-b952-11e9-b9f3-4d741a808166",
+                    "id": "1d4e0528-b952-11e9-b9f3-4d741a808166",
+                    "type": "derivative",
+                    "unit": "1s"
+                  },
+                  {
+                    "field": "1d4e0528-b952-11e9-b9f3-4d741a808166",
+                    "id": "1d4e0527-b952-11e9-b9f3-4d741a808166",
+                    "type": "positive_only"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Number of View Reads [Metricbeat CouchDB] ECS",
+          "type": "metrics"
+        }
+      },
+      "id": "496910f0-b952-11e9-a579-f5c0a5d81340",
+      "migrationVersion": {
+        "visualization": "7.3.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-08-09T10:31:41.262Z",
+      "version": "WzExMzEsMV0="
+    }
+  ],
+  "version": "7.3.0"
+}

--- a/dev/package-beats/couchdb-1.0.0/manifest.yml
+++ b/dev/package-beats/couchdb-1.0.0/manifest.yml
@@ -1,0 +1,13 @@
+name: couchdb
+title: couchdb
+version: 1.0.0
+description: |
+  couchdb module
+type: ""
+categories:
+- metrics
+requirement:
+  kibana:
+    version:
+      min: 6.7.0
+      max: 7.6.0

--- a/dev/package-beats/docker-1.0.0/kibana/dashboard/Metricbeat-docker-overview.json
+++ b/dev/package-beats/docker-1.0.0/kibana/dashboard/Metricbeat-docker-overview.json
@@ -1,0 +1,1004 @@
+{
+    "objects": [
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "Metricbeat-Docker-ecs", 
+                "title": "Docker containers [Metricbeat Docker] ECS", 
+                "uiStateJSON": {
+                    "vis": {
+                        "params": {
+                            "sort": {
+                                "columnIndex": 1, 
+                                "direction": "asc"
+                            }
+                        }
+                    }
+                }, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customLabel": "Name", 
+                                "field": "container.name", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "bucket", 
+                            "type": "terms"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "customLabel": "CPU usage (%)", 
+                                "field": "docker.cpu.total.pct"
+                            }, 
+                            "schema": "metric", 
+                            "type": "max"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "4", 
+                            "params": {
+                                "customLabel": "DiskIO", 
+                                "field": "docker.diskio.total"
+                            }, 
+                            "schema": "metric", 
+                            "type": "max"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "5", 
+                            "params": {
+                                "customLabel": "Mem (%)", 
+                                "field": "docker.memory.usage.pct"
+                            }, 
+                            "schema": "metric", 
+                            "type": "max"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "6", 
+                            "params": {
+                                "customLabel": "Mem RSS", 
+                                "field": "docker.memory.rss.total"
+                            }, 
+                            "schema": "metric", 
+                            "type": "max"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "Number of Containers", 
+                                "field": "container.id"
+                            }, 
+                            "schema": "metric", 
+                            "type": "cardinality"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "perPage": 8, 
+                        "showMeticsAtAllLevels": false, 
+                        "showPartialRows": false, 
+                        "showTotal": true, 
+                        "sort": {
+                            "columnIndex": null, 
+                            "direction": null
+                        }, 
+                        "totalFunc": "sum"
+                    }, 
+                    "title": "Docker containers [Metricbeat Docker] ECS", 
+                    "type": "table"
+                }
+            }, 
+            "col": 1, 
+            "id": "Docker-containers-ecs", 
+            "panelIndex": 1, 
+            "row": 1, 
+            "size_x": 7, 
+            "size_y": 5, 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "Metricbeat-Docker-ecs", 
+                "title": "Number of Containers [Metricbeat Docker] ECS", 
+                "uiStateJSON": {
+                    "vis": {
+                        "defaultColors": {
+                            "0 - 100": "rgb(0,104,55)"
+                        }
+                    }
+                }, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customLabel": "Running", 
+                                "field": "docker.info.containers.running"
+                            }, 
+                            "schema": "metric", 
+                            "type": "max"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "customLabel": "Paused", 
+                                "field": "docker.info.containers.paused"
+                            }, 
+                            "schema": "metric", 
+                            "type": "max"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "4", 
+                            "params": {
+                                "customLabel": "Stopped", 
+                                "field": "docker.info.containers.stopped"
+                            }, 
+                            "schema": "metric", 
+                            "type": "max"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": false, 
+                        "addTooltip": true, 
+                        "fontSize": "36", 
+                        "gauge": {
+                            "autoExtend": false, 
+                            "backStyle": "Full", 
+                            "colorSchema": "Green to Red", 
+                            "colorsRange": [
+                                {
+                                    "from": 0, 
+                                    "to": 100
+                                }
+                            ], 
+                            "gaugeColorMode": "None", 
+                            "gaugeStyle": "Full", 
+                            "gaugeType": "Metric", 
+                            "invertColors": false, 
+                            "labels": {
+                                "color": "black", 
+                                "show": true
+                            }, 
+                            "orientation": "vertical", 
+                            "percentageMode": false, 
+                            "scale": {
+                                "color": "#333", 
+                                "labels": false, 
+                                "show": false, 
+                                "width": 2
+                            }, 
+                            "style": {
+                                "bgColor": false, 
+                                "fontSize": 60, 
+                                "labelColor": false, 
+                                "subText": ""
+                            }, 
+                            "type": "simple", 
+                            "useRange": false, 
+                            "verticalSplit": false
+                        }, 
+                        "handleNoResults": true, 
+                        "type": "gauge"
+                    }, 
+                    "title": "Number of Containers [Metricbeat Docker] ECS", 
+                    "type": "metric"
+                }
+            }, 
+            "col": 8, 
+            "id": "Docker-Number-of-Containers-ecs", 
+            "panelIndex": 2, 
+            "row": 1, 
+            "size_x": 5, 
+            "size_y": 2, 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "Metricbeat-Docker-ecs", 
+                "title": "Docker containers per host [Metricbeat Docker] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "Number of containers", 
+                                "field": "container.id"
+                            }, 
+                            "schema": "metric", 
+                            "type": "cardinality"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customLabel": "Hosts", 
+                                "field": "agent.hostname", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "segment", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTooltip": true, 
+                        "isDonut": true, 
+                        "legendPosition": "bottom", 
+                        "shareYAxis": true
+                    }, 
+                    "title": "Docker containers per host [Metricbeat Docker] ECS", 
+                    "type": "pie"
+                }
+            }, 
+            "col": 8, 
+            "id": "Docker-containers-per-host-ecs", 
+            "panelIndex": 3, 
+            "row": 3, 
+            "size_x": 2, 
+            "size_y": 3, 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "Metricbeat-Docker-ecs", 
+                "title": "Docker images and names [Metricbeat Docker] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "field": "container.image.name", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "segment", 
+                            "type": "terms"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "field": "container.name", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "segment", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTooltip": true, 
+                        "isDonut": true, 
+                        "legendPosition": "bottom", 
+                        "shareYAxis": true
+                    }, 
+                    "title": "Docker images and names [Metricbeat Docker] ECS", 
+                    "type": "pie"
+                }
+            }, 
+            "col": 10, 
+            "id": "Docker-images-and-names-ecs", 
+            "panelIndex": 7, 
+            "row": 3, 
+            "size_x": 3, 
+            "size_y": 3, 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlight": {
+                            "fields": {
+                                "*": {}
+                            }, 
+                            "fragment_size": 2147483647, 
+                            "post_tags": [
+                                "@/kibana-highlighted-field@"
+                            ], 
+                            "pre_tags": [
+                                "@kibana-highlighted-field@"
+                            ], 
+                            "require_field_match": false
+                        }, 
+                        "index": "metricbeat-*", 
+                        "query": {
+                            "language": "kuery",
+                                "query": "event.module:docker AND metricset.name:cpu"
+                            }
+                    }
+                }, 
+                "title": "CPU usage [Metricbeat Docker] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "Total CPU time", 
+                                "field": "docker.cpu.total.pct", 
+                                "percents": [
+                                    75
+                                ]
+                            }, 
+                            "schema": "metric", 
+                            "type": "percentiles"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "customLabel": "Container name", 
+                                "field": "container.name", 
+                                "order": "desc", 
+                                "orderBy": "1.75", 
+                                "size": 5
+                            }, 
+                            "schema": "group", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "categoryAxes": [
+                            {
+                                "id": "CategoryAxis-1", 
+                                "labels": {
+                                    "show": true, 
+                                    "truncate": 100
+                                }, 
+                                "position": "bottom", 
+                                "scale": {
+                                    "type": "linear"
+                                }, 
+                                "show": true, 
+                                "style": {}, 
+                                "title": {}, 
+                                "type": "category"
+                            }
+                        ], 
+                        "defaultYExtents": false, 
+                        "grid": {
+                            "categoryLines": false, 
+                            "style": {
+                                "color": "#eee"
+                            }
+                        }, 
+                        "interpolate": "linear", 
+                        "legendPosition": "top", 
+                        "mode": "stacked", 
+                        "scale": "linear", 
+                        "seriesParams": [
+                            {
+                                "data": {
+                                    "id": "1", 
+                                    "label": "Count"
+                                }, 
+                                "drawLinesBetweenPoints": true, 
+                                "interpolate": "linear", 
+                                "mode": "stacked", 
+                                "show": "true", 
+                                "showCircles": true, 
+                                "type": "area", 
+                                "valueAxis": "ValueAxis-1"
+                            }
+                        ], 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "smoothLines": true, 
+                        "times": [], 
+                        "valueAxes": [
+                            {
+                                "id": "ValueAxis-1", 
+                                "labels": {
+                                    "filter": false, 
+                                    "rotate": 0, 
+                                    "show": true, 
+                                    "truncate": 100
+                                }, 
+                                "name": "LeftAxis-1", 
+                                "position": "left", 
+                                "scale": {
+                                    "mode": "normal", 
+                                    "type": "linear"
+                                }, 
+                                "show": true, 
+                                "style": {}, 
+                                "title": {
+                                    "text": "Count"
+                                }, 
+                                "type": "value"
+                            }
+                        ], 
+                        "yAxis": {}
+                    }, 
+                    "title": "CPU usage [Metricbeat Docker] ECS", 
+                    "type": "area"
+                }
+            }, 
+            "col": 1, 
+            "id": "Docker-CPU-usage-ecs", 
+            "panelIndex": 4, 
+            "row": 6, 
+            "size_x": 6, 
+            "size_y": 3, 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlight": {
+                            "fields": {
+                                "*": {}
+                            }, 
+                            "fragment_size": 2147483647, 
+                            "post_tags": [
+                                "@/kibana-highlighted-field@"
+                            ], 
+                            "pre_tags": [
+                                "@kibana-highlighted-field@"
+                            ], 
+                            "require_field_match": false
+                        }, 
+                        "index": "metricbeat-*", 
+                        "query": {
+                            "language": "kuery",
+                                "query": "event.module:docker AND metricset.name:memory"
+                            }
+                    }
+                }, 
+                "title": "Memory usage [Metricbeat Docker] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "Memory", 
+                                "field": "docker.memory.usage.total"
+                            }, 
+                            "schema": "metric", 
+                            "type": "max"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "customLabel": "Container name", 
+                                "field": "container.name", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "group", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "categoryAxes": [
+                            {
+                                "id": "CategoryAxis-1", 
+                                "labels": {
+                                    "show": true, 
+                                    "truncate": 100
+                                }, 
+                                "position": "bottom", 
+                                "scale": {
+                                    "type": "linear"
+                                }, 
+                                "show": true, 
+                                "style": {}, 
+                                "title": {}, 
+                                "type": "category"
+                            }
+                        ], 
+                        "defaultYExtents": false, 
+                        "grid": {
+                            "categoryLines": false, 
+                            "style": {
+                                "color": "#eee"
+                            }
+                        }, 
+                        "interpolate": "linear", 
+                        "legendPosition": "top", 
+                        "mode": "stacked", 
+                        "scale": "linear", 
+                        "seriesParams": [
+                            {
+                                "data": {
+                                    "id": "1", 
+                                    "label": "Count"
+                                }, 
+                                "drawLinesBetweenPoints": true, 
+                                "interpolate": "linear", 
+                                "mode": "stacked", 
+                                "show": "true", 
+                                "showCircles": true, 
+                                "type": "area", 
+                                "valueAxis": "ValueAxis-1"
+                            }
+                        ], 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "smoothLines": false, 
+                        "times": [], 
+                        "valueAxes": [
+                            {
+                                "id": "ValueAxis-1", 
+                                "labels": {
+                                    "filter": false, 
+                                    "rotate": 0, 
+                                    "show": true, 
+                                    "truncate": 100
+                                }, 
+                                "name": "LeftAxis-1", 
+                                "position": "left", 
+                                "scale": {
+                                    "mode": "normal", 
+                                    "type": "linear"
+                                }, 
+                                "show": true, 
+                                "style": {}, 
+                                "title": {
+                                    "text": "Count"
+                                }, 
+                                "type": "value"
+                            }
+                        ], 
+                        "yAxis": {}
+                    }, 
+                    "title": "Memory usage [Metricbeat Docker] ECS", 
+                    "type": "area"
+                }
+            }, 
+            "col": 7, 
+            "id": "Docker-memory-usage-ecs", 
+            "panelIndex": 5, 
+            "row": 6, 
+            "size_x": 6, 
+            "size_y": 3, 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlight": {
+                            "fields": {
+                                "*": {}
+                            }, 
+                            "fragment_size": 2147483647, 
+                            "post_tags": [
+                                "@/kibana-highlighted-field@"
+                            ], 
+                            "pre_tags": [
+                                "@kibana-highlighted-field@"
+                            ], 
+                            "require_field_match": false
+                        }, 
+                        "index": "metricbeat-*", 
+                        "query": {
+                            "language": "kuery",
+                                "query": "event.module:docker AND metricset.name:network"
+                            }
+                    }
+                }, 
+                "title": "Network IO [Metricbeat Docker] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "IN bytes", 
+                                "field": "docker.network.in.bytes"
+                            }, 
+                            "schema": "metric", 
+                            "type": "max"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "customLabel": "Container name", 
+                                "field": "container.name", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "group", 
+                            "type": "terms"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "4", 
+                            "params": {
+                                "customLabel": "OUT bytes", 
+                                "field": "docker.network.out.bytes"
+                            }, 
+                            "schema": "metric", 
+                            "type": "max"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "categoryAxes": [
+                            {
+                                "id": "CategoryAxis-1", 
+                                "labels": {
+                                    "show": true, 
+                                    "truncate": 100
+                                }, 
+                                "position": "bottom", 
+                                "scale": {
+                                    "type": "linear"
+                                }, 
+                                "show": true, 
+                                "style": {}, 
+                                "title": {}, 
+                                "type": "category"
+                            }
+                        ], 
+                        "defaultYExtents": false, 
+                        "grid": {
+                            "categoryLines": false, 
+                            "style": {
+                                "color": "#eee"
+                            }
+                        }, 
+                        "interpolate": "linear", 
+                        "legendPosition": "top", 
+                        "mode": "stacked", 
+                        "scale": "linear", 
+                        "seriesParams": [
+                            {
+                                "data": {
+                                    "id": "1", 
+                                    "label": "Count"
+                                }, 
+                                "drawLinesBetweenPoints": true, 
+                                "interpolate": "linear", 
+                                "mode": "stacked", 
+                                "show": "true", 
+                                "showCircles": true, 
+                                "type": "area", 
+                                "valueAxis": "ValueAxis-1"
+                            }
+                        ], 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "smoothLines": true, 
+                        "times": [], 
+                        "valueAxes": [
+                            {
+                                "id": "ValueAxis-1", 
+                                "labels": {
+                                    "filter": false, 
+                                    "rotate": 0, 
+                                    "show": true, 
+                                    "truncate": 100
+                                }, 
+                                "name": "LeftAxis-1", 
+                                "position": "left", 
+                                "scale": {
+                                    "mode": "normal", 
+                                    "type": "linear"
+                                }, 
+                                "show": true, 
+                                "style": {}, 
+                                "title": {
+                                    "text": "Count"
+                                }, 
+                                "type": "value"
+                            }
+                        ], 
+                        "yAxis": {}
+                    }, 
+                    "title": "Network IO [Metricbeat Docker] ECS", 
+                    "type": "area"
+                }
+            }, 
+            "col": 1, 
+            "id": "Docker-Network-IO-ecs", 
+            "panelIndex": 6, 
+            "row": 9, 
+            "size_x": 12, 
+            "size_y": 3, 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "columns": [
+                    "_source"
+                ], 
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlight": {
+                            "fields": {
+                                "*": {}
+                            }, 
+                            "fragment_size": 2147483647, 
+                            "post_tags": [
+                                "@/kibana-highlighted-field@"
+                            ], 
+                            "pre_tags": [
+                                "@kibana-highlighted-field@"
+                            ], 
+                            "require_field_match": false
+                        }, 
+                        "index": "metricbeat-*", 
+                        "query": {
+                            "language": "kuery",
+                                "query": "event.module:docker"
+                            }
+                    }
+                }, 
+                "sort": [
+                    "@timestamp", 
+                    "desc"
+                ], 
+                "title": "Metricbeat Docker ECS", 
+                "version": 1
+            }, 
+            "id": "Metricbeat-Docker-ecs", 
+            "type": "search", 
+            "version": 4
+        }, 
+        {
+            "attributes": {
+                "description": "Overview of docker containers",
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                                "query": {
+                            "language": "kuery",
+                            "query": ""
+                        },
+                        "highlightAll": true, 
+                        "version": true
+                    }
+                }, 
+                "optionsJSON": {
+                    "darkTheme": false
+                }, 
+                "panelsJSON": [
+                    {
+                        "col": 1, 
+                        "id": "Docker-containers-ecs", 
+                        "panelIndex": 1, 
+                        "row": 1, 
+                        "size_x": 7, 
+                        "size_y": 5, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 8, 
+                        "id": "Docker-Number-of-Containers-ecs", 
+                        "panelIndex": 2, 
+                        "row": 1, 
+                        "size_x": 5, 
+                        "size_y": 2, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 8, 
+                        "id": "Docker-containers-per-host-ecs", 
+                        "panelIndex": 3, 
+                        "row": 3, 
+                        "size_x": 2, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 10, 
+                        "id": "Docker-images-and-names-ecs", 
+                        "panelIndex": 7, 
+                        "row": 3, 
+                        "size_x": 3, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "Docker-CPU-usage-ecs", 
+                        "panelIndex": 4, 
+                        "row": 6, 
+                        "size_x": 6, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 7, 
+                        "id": "Docker-memory-usage-ecs", 
+                        "panelIndex": 5, 
+                        "row": 6, 
+                        "size_x": 6, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "Docker-Network-IO-ecs", 
+                        "panelIndex": 6, 
+                        "row": 9, 
+                        "size_x": 12, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }
+                ], 
+                "timeRestore": false, 
+                "title": "[Metricbeat Docker] Overview ECS", 
+                "uiStateJSON": {
+                    "P-1": {
+                        "vis": {
+                            "params": {
+                                "sort": {
+                                    "columnIndex": 1, 
+                                    "direction": "asc"
+                                }
+                            }
+                        }
+                    }, 
+                    "P-2": {
+                        "vis": {
+                            "defaultColors": {
+                                "0 - 100": "rgb(0,104,55)"
+                            }
+                        }
+                    }, 
+                    "P-3": {
+                        "vis": {
+                            "legendOpen": true
+                        }
+                    }, 
+                    "P-5": {
+                        "vis": {
+                            "legendOpen": true
+                        }
+                    }, 
+                    "P-7": {
+                        "vis": {
+                            "legendOpen": true
+                        }
+                    }
+                }, 
+                "version": 1
+            }, 
+            "id": "AV4REOpp5NkDleZmzKkE-ecs", 
+            "type": "dashboard", 
+            "version": 3
+        }
+    ], 
+    "version": "5.6.0-SNAPSHOT"
+}

--- a/dev/package-beats/docker-1.0.0/manifest.yml
+++ b/dev/package-beats/docker-1.0.0/manifest.yml
@@ -1,0 +1,13 @@
+name: docker
+title: Docker
+version: 1.0.0
+description: |
+  Docker stats collected from Docker.
+type: ""
+categories:
+- metrics
+requirement:
+  kibana:
+    version:
+      min: 6.7.0
+      max: 7.6.0

--- a/dev/package-beats/dropwizard-1.0.0/manifest.yml
+++ b/dev/package-beats/dropwizard-1.0.0/manifest.yml
@@ -1,0 +1,13 @@
+name: dropwizard
+title: Dropwizard
+version: 1.0.0
+description: |
+  Stats collected from Dropwizard.
+type: ""
+categories:
+- metrics
+requirement:
+  kibana:
+    version:
+      min: 6.7.0
+      max: 7.6.0

--- a/dev/package-beats/elasticsearch-1.0.0/manifest.yml
+++ b/dev/package-beats/elasticsearch-1.0.0/manifest.yml
@@ -1,0 +1,14 @@
+name: elasticsearch
+title: elasticsearch
+version: 1.0.0
+description: |
+  Elasticsearch module
+type: ""
+categories:
+- logs
+- metrics
+requirement:
+  kibana:
+    version:
+      min: 6.7.0
+      max: 7.6.0

--- a/dev/package-beats/envoyproxy-1.0.0/kibana/dashboard/Filebeat-Envoyproxy-Overview.json
+++ b/dev/package-beats/envoyproxy-1.0.0/kibana/dashboard/Filebeat-Envoyproxy-Overview.json
@@ -1,0 +1,910 @@
+{
+  "objects": [
+    {
+      "attributes": {
+        "description": "Filebeat Envoyproxy Overview Dashboard",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "optionsJSON": {
+          "hidePanelTitles": false,
+          "useMargins": true
+        },
+        "panelsJSON": [
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 7,
+              "i": "1",
+              "w": 22,
+              "x": 22,
+              "y": 0
+            },
+            "panelIndex": "1",
+            "panelRefName": "panel_0",
+            "version": "8.0.0-SNAPSHOT"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 10,
+              "i": "2",
+              "w": 22,
+              "x": 22,
+              "y": 7
+            },
+            "panelIndex": "2",
+            "panelRefName": "panel_1",
+            "version": "8.0.0-SNAPSHOT"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 10,
+              "i": "3",
+              "w": 22,
+              "x": 0,
+              "y": 7
+            },
+            "panelIndex": "3",
+            "panelRefName": "panel_2",
+            "version": "8.0.0-SNAPSHOT"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 7,
+              "i": "4",
+              "w": 22,
+              "x": 0,
+              "y": 0
+            },
+            "panelIndex": "4",
+            "panelRefName": "panel_3",
+            "version": "8.0.0-SNAPSHOT"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 10,
+              "i": "5",
+              "w": 22,
+              "x": 0,
+              "y": 17
+            },
+            "panelIndex": "5",
+            "panelRefName": "panel_4",
+            "version": "8.0.0-SNAPSHOT"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 10,
+              "i": "6",
+              "w": 22,
+              "x": 22,
+              "y": 17
+            },
+            "panelIndex": "6",
+            "panelRefName": "panel_5",
+            "version": "8.0.0-SNAPSHOT"
+          }
+        ],
+        "timeRestore": false,
+        "title": "[Filebeat Envoyproxy] Overview",
+        "version": 1
+      },
+      "id": "0c610510-5cbd-11e9-8477-077ec9664dbd",
+      "migrationVersion": {
+        "dashboard": "7.0.0"
+      },
+      "references": [
+        {
+          "id": "36f872a0-5c03-11e9-85b4-19d0072eb4f2",
+          "name": "panel_0",
+          "type": "visualization"
+        },
+        {
+          "id": "80844540-5c97-11e9-8477-077ec9664dbd",
+          "name": "panel_1",
+          "type": "visualization"
+        },
+        {
+          "id": "38f96190-5c99-11e9-8477-077ec9664dbd",
+          "name": "panel_2",
+          "type": "visualization"
+        },
+        {
+          "id": "7e4084e0-5c99-11e9-8477-077ec9664dbd",
+          "name": "panel_3",
+          "type": "visualization"
+        },
+        {
+          "id": "0a994af0-5c9d-11e9-8477-077ec9664dbd",
+          "name": "panel_4",
+          "type": "visualization"
+        },
+        {
+          "id": "ab48c3f0-5ca6-11e9-8477-077ec9664dbd",
+          "name": "panel_5",
+          "type": "visualization"
+        }
+      ],
+      "type": "dashboard",
+      "updated_at": "2019-04-12T01:00:18.033Z",
+      "version": "WzExNjU4LDld"
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [
+              {
+                "$state": {
+                  "store": "appState"
+                },
+                "meta": {
+                  "alias": null,
+                  "disabled": false,
+                  "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                  "key": "event.dataset",
+                  "negate": false,
+                  "params": {
+                    "query": "envoyproxy.log"
+                  },
+                  "type": "phrase",
+                  "value": "envoyproxy.log"
+                },
+                "query": {
+                  "match": {
+                    "event.dataset": {
+                      "query": "envoyproxy.log",
+                      "type": "phrase"
+                    }
+                  }
+                }
+              }
+            ],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Top HTTP Response Codes [Filebeat Envoyproxy]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "field": "http.response.status_code",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 5
+              },
+              "schema": "segment",
+              "type": "terms"
+            }
+          ],
+          "params": {
+            "bucket": {
+              "accessor": 0,
+              "aggType": "terms",
+              "format": {
+                "id": "terms",
+                "params": {
+                  "id": "number",
+                  "missingBucketLabel": "Missing",
+                  "otherBucketLabel": "Other"
+                }
+              },
+              "params": {}
+            },
+            "maxFontSize": 72,
+            "metric": {
+              "accessor": 1,
+              "aggType": "count",
+              "format": {
+                "id": "number"
+              },
+              "params": {}
+            },
+            "minFontSize": 18,
+            "orientation": "single",
+            "scale": "linear",
+            "showLabel": false
+          },
+          "title": "Top HTTP Response Codes [Filebeat Envoyproxy]",
+          "type": "tagcloud"
+        }
+      },
+      "id": "36f872a0-5c03-11e9-85b4-19d0072eb4f2",
+      "migrationVersion": {
+        "visualization": "7.0.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        },
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-04-12T00:58:13.110Z",
+      "version": "WzExNjUzLDld"
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [
+              {
+                "$state": {
+                  "store": "appState"
+                },
+                "meta": {
+                  "alias": null,
+                  "disabled": false,
+                  "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                  "key": "event.dataset",
+                  "negate": false,
+                  "params": {
+                    "query": "envoyproxy.log"
+                  },
+                  "type": "phrase",
+                  "value": "envoyproxy.log"
+                },
+                "query": {
+                  "match": {
+                    "event.dataset": {
+                      "query": "envoyproxy.log",
+                      "type": "phrase"
+                    }
+                  }
+                }
+              }
+            ],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Top Domains [Filebeat Envoyproxy]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "field": "url.domain",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 5
+              },
+              "schema": "segment",
+              "type": "terms"
+            }
+          ],
+          "params": {
+            "addLegend": true,
+            "addTooltip": true,
+            "dimensions": {
+              "metric": {
+                "accessor": 0,
+                "aggType": "count",
+                "format": {
+                  "id": "number"
+                },
+                "params": {}
+              }
+            },
+            "isDonut": true,
+            "labels": {
+              "last_level": true,
+              "show": false,
+              "truncate": 100,
+              "values": true
+            },
+            "legendPosition": "right",
+            "type": "pie"
+          },
+          "title": "Top Domains [Filebeat Envoyproxy]",
+          "type": "pie"
+        }
+      },
+      "id": "80844540-5c97-11e9-8477-077ec9664dbd",
+      "migrationVersion": {
+        "visualization": "7.0.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        },
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-04-12T00:58:53.299Z",
+      "version": "WzExNjU1LDld"
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [
+              {
+                "$state": {
+                  "store": "appState"
+                },
+                "meta": {
+                  "alias": null,
+                  "disabled": false,
+                  "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                  "key": "event.dataset",
+                  "negate": false,
+                  "params": {
+                    "query": "envoyproxy.log"
+                  },
+                  "type": "phrase",
+                  "value": "envoyproxy.log"
+                },
+                "query": {
+                  "match": {
+                    "event.dataset": {
+                      "query": "envoyproxy.log",
+                      "type": "phrase"
+                    }
+                  }
+                }
+              }
+            ],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Requests per Source [Filebeat Envoyproxy]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "field": "source.address",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 5
+              },
+              "schema": "segment",
+              "type": "terms"
+            }
+          ],
+          "params": {
+            "addLegend": true,
+            "addTimeMarker": false,
+            "addTooltip": true,
+            "categoryAxes": [
+              {
+                "id": "CategoryAxis-1",
+                "labels": {
+                  "show": true,
+                  "truncate": 100
+                },
+                "position": "bottom",
+                "scale": {
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {},
+                "type": "category"
+              }
+            ],
+            "dimensions": {
+              "x": null,
+              "y": [
+                {
+                  "accessor": 0,
+                  "aggType": "count",
+                  "format": {
+                    "id": "number"
+                  },
+                  "params": {}
+                }
+              ]
+            },
+            "grid": {
+              "categoryLines": false
+            },
+            "legendPosition": "right",
+            "seriesParams": [
+              {
+                "data": {
+                  "id": "1",
+                  "label": "Count"
+                },
+                "drawLinesBetweenPoints": true,
+                "mode": "stacked",
+                "show": "true",
+                "showCircles": true,
+                "type": "histogram",
+                "valueAxis": "ValueAxis-1"
+              }
+            ],
+            "times": [],
+            "type": "histogram",
+            "valueAxes": [
+              {
+                "id": "ValueAxis-1",
+                "labels": {
+                  "filter": false,
+                  "rotate": 0,
+                  "show": true,
+                  "truncate": 100
+                },
+                "name": "LeftAxis-1",
+                "position": "left",
+                "scale": {
+                  "mode": "normal",
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {
+                  "text": "Count"
+                },
+                "type": "value"
+              }
+            ]
+          },
+          "title": "Requests per Source [Filebeat Envoyproxy]",
+          "type": "histogram"
+        }
+      },
+      "id": "38f96190-5c99-11e9-8477-077ec9664dbd",
+      "migrationVersion": {
+        "visualization": "7.0.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        },
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-04-12T00:58:36.398Z",
+      "version": "WzExNjU0LDld"
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [
+              {
+                "$state": {
+                  "store": "appState"
+                },
+                "meta": {
+                  "alias": null,
+                  "disabled": false,
+                  "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                  "key": "event.dataset",
+                  "negate": false,
+                  "params": {
+                    "query": "envoyproxy.log"
+                  },
+                  "type": "phrase",
+                  "value": "envoyproxy.log"
+                },
+                "query": {
+                  "match": {
+                    "event.dataset": {
+                      "query": "envoyproxy.log",
+                      "type": "phrase"
+                    }
+                  }
+                }
+              }
+            ],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Unique Domains [Filebeat Envoyproxy]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "field": "url.domain"
+              },
+              "schema": "metric",
+              "type": "cardinality"
+            }
+          ],
+          "params": {
+            "addLegend": false,
+            "addTooltip": true,
+            "metric": {
+              "bucket": {
+                "accessor": 0,
+                "aggType": "terms",
+                "format": {
+                  "id": "terms",
+                  "params": {
+                    "id": "string",
+                    "missingBucketLabel": "Missing",
+                    "otherBucketLabel": "Other"
+                  }
+                },
+                "params": {}
+              },
+              "colorSchema": "Green to Red",
+              "colorsRange": [
+                {
+                  "from": 0,
+                  "to": 10000
+                }
+              ],
+              "invertColors": false,
+              "labels": {
+                "show": false
+              },
+              "metricColorMode": "None",
+              "metrics": [
+                {
+                  "accessor": 0,
+                  "aggType": "cardinality",
+                  "format": {
+                    "id": "number"
+                  },
+                  "params": {}
+                }
+              ],
+              "percentageMode": false,
+              "style": {
+                "bgColor": false,
+                "bgFill": "#000",
+                "fontSize": 60,
+                "labelColor": false,
+                "subText": ""
+              },
+              "useRanges": false
+            },
+            "type": "metric"
+          },
+          "title": "Unique Domains [Filebeat Envoyproxy]",
+          "type": "metric"
+        }
+      },
+      "id": "7e4084e0-5c99-11e9-8477-077ec9664dbd",
+      "migrationVersion": {
+        "visualization": "7.0.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        },
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-04-12T00:57:42.389Z",
+      "version": "WzExNjUyLDld"
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [
+              {
+                "$state": {
+                  "store": "appState"
+                },
+                "meta": {
+                  "alias": null,
+                  "disabled": false,
+                  "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                  "key": "event.dataset",
+                  "negate": false,
+                  "params": {
+                    "query": "envoyproxy.log"
+                  },
+                  "type": "phrase",
+                  "value": "envoyproxy.log"
+                },
+                "query": {
+                  "match": {
+                    "event.dataset": {
+                      "query": "envoyproxy.log",
+                      "type": "phrase"
+                    }
+                  }
+                }
+              }
+            ],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "language": "lucene",
+              "query": ""
+            }
+          }
+        },
+        "title": "Top User Agents [Filebeat Envoyproxy]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "field": "user_agent.name",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 5
+              },
+              "schema": "segment",
+              "type": "terms"
+            }
+          ],
+          "params": {
+            "addLegend": true,
+            "addTooltip": true,
+            "dimensions": {
+              "metric": {
+                "accessor": 0,
+                "aggType": "count",
+                "format": {
+                  "id": "number"
+                },
+                "params": {}
+              }
+            },
+            "isDonut": true,
+            "labels": {
+              "last_level": true,
+              "show": false,
+              "truncate": 100,
+              "values": true
+            },
+            "legendPosition": "right",
+            "type": "pie"
+          },
+          "title": "Top User Agents [Filebeat Envoyproxy]",
+          "type": "pie"
+        }
+      },
+      "id": "0a994af0-5c9d-11e9-8477-077ec9664dbd",
+      "migrationVersion": {
+        "visualization": "7.0.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        },
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-04-12T00:59:11.691Z",
+      "version": "WzExNjU2LDld"
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [
+              {
+                "$state": {
+                  "store": "appState"
+                },
+                "meta": {
+                  "alias": null,
+                  "disabled": false,
+                  "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                  "key": "event.dataset",
+                  "negate": false,
+                  "params": {
+                    "query": "envoyproxy.log"
+                  },
+                  "type": "phrase",
+                  "value": "envoyproxy.log"
+                },
+                "query": {
+                  "match": {
+                    "event.dataset": {
+                      "query": "envoyproxy.log",
+                      "type": "phrase"
+                    }
+                  }
+                }
+              }
+            ],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "language": "kuery",
+              "query": "event.dataset:envoyproxy.log"
+            }
+          }
+        },
+        "title": "Proxy Request Distribution [Filebeat Envoyproxy]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "field": "envoyproxy.proxy_type",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 5
+              },
+              "schema": "segment",
+              "type": "terms"
+            }
+          ],
+          "params": {
+            "addLegend": true,
+            "addTooltip": true,
+            "dimensions": {
+              "metric": {
+                "accessor": 0,
+                "aggType": "count",
+                "format": {
+                  "id": "number"
+                },
+                "params": {}
+              }
+            },
+            "isDonut": true,
+            "labels": {
+              "last_level": true,
+              "show": false,
+              "truncate": 100,
+              "values": true
+            },
+            "legendPosition": "right",
+            "type": "pie"
+          },
+          "title": "Proxy Request Distribution [Filebeat Envoyproxy] ",
+          "type": "pie"
+        }
+      },
+      "id": "ab48c3f0-5ca6-11e9-8477-077ec9664dbd",
+      "migrationVersion": {
+        "visualization": "7.0.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        },
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-04-11T22:10:51.951Z",
+      "version": "WzExNjQ5LDld"
+    }
+  ],
+  "version": "8.0.0-SNAPSHOT"
+}

--- a/dev/package-beats/envoyproxy-1.0.0/manifest.yml
+++ b/dev/package-beats/envoyproxy-1.0.0/manifest.yml
@@ -1,0 +1,14 @@
+name: envoyproxy
+title: Envoyproxy
+version: 1.0.0
+description: |
+  envoyproxy module
+type: ""
+categories:
+- logs
+- metrics
+requirement:
+  kibana:
+    version:
+      min: 6.7.0
+      max: 7.6.0

--- a/dev/package-beats/etcd-1.0.0/manifest.yml
+++ b/dev/package-beats/etcd-1.0.0/manifest.yml
@@ -1,0 +1,13 @@
+name: etcd
+title: Etcd
+version: 1.0.0
+description: |
+  etcd Module
+type: ""
+categories:
+- metrics
+requirement:
+  kibana:
+    version:
+      min: 6.7.0
+      max: 7.6.0

--- a/dev/package-beats/golang-1.0.0/kibana/dashboard/Metricbeat-golang-overview.json
+++ b/dev/package-beats/golang-1.0.0/kibana/dashboard/Metricbeat-golang-overview.json
@@ -1,0 +1,262 @@
+{
+    "objects": [
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                }, 
+                "title": "Heap Summary [Metricbeat Golang] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "expression": ".es(index=\"metricbeat*\",metric=\"avg:golang.heap.system.total\").label(\"System Total Memory\").yaxis(label=\"Bytes\",units=bytes),.es(index=\"metricbeat*\",metric=\"min:golang.heap.allocations.allocated\").label(\"Bytes Allocated(min)\").movingaverage(30),.es(index=\"metricbeat*\",metric=\"max:golang.heap.allocations.allocated\").label(\"Bytes Allocated(max)\").movingaverage(30),.es(index=\"metricbeat*\",metric=\"avg:golang.heap.gc.next_gc_limit\").label(\"GC Limit\"),.es(index=\"metricbeat*\",metric=\"avg:golang.heap.gc.pause.count\").condition(lt,1, null).points().label(\"GC Cycles(count)\").yaxis(2,label=\"Count\")", 
+                        "interval": "10s"
+                    }, 
+                    "title": "Heap Summary [Metricbeat Golang] ECS", 
+                    "type": "timelion"
+                }
+            }, 
+            "id": "58000780-f529-11e6-844d-b170e2f0a07e-ecs", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                }, 
+                "title": "Heap [Metricbeat Golang] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "expression": ".es(index=\"metricbeat*\",metric=\"avg:golang.heap.allocations.total\").label(\"Heap Total\").derivative().movingaverage(30).yaxis(label=\"Bytes\",units=bytes),.es(index=\"metricbeat*\",metric=\"avg:golang.heap.allocations.active\").label(\"Heap Inuse\").movingaverage(30),.es(index=\"metricbeat*\",metric=\"avg:golang.heap.allocations.allocated\").label(\"Heap Allocated\").movingaverage(30),.es(index=\"metricbeat*\",metric=\"avg:golang.heap.allocations.idle\").label(\"Heap Idle\").movingaverage(30)", 
+                        "interval": "10s"
+                    }, 
+                    "title": "Heap [Metricbeat Golang] ECS", 
+                    "type": "timelion"
+                }
+            }, 
+            "id": "95388680-f52a-11e6-969c-518c48c913e4-ecs", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                }, 
+                "title": "Objects [Metricbeat Golang] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "expression": ".es(index=\"metricbeat*\",metric=\"max:golang.heap.allocations.objects\").label(\"Object Count(avg)\").yaxis(1,label=\"Count\").movingaverage(30),.es(index=\"metricbeat*\",metric=\"max:golang.heap.allocations.total\").derivative().label(\"Allocation Rate\").yaxis(2,label=\"Rate\").movingaverage(30)", 
+                        "interval": "10s"
+                    }, 
+                    "title": "Objects [Metricbeat Golang] ECS", 
+                    "type": "timelion"
+                }
+            }, 
+            "id": "b59a5200-f52a-11e6-969c-518c48c913e4-ecs", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                }, 
+                "title": "System [Metricbeat Golang] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "expression": ".es(index=\"metricbeat*\",metric=\"avg:golang.heap.system.total\").label(\"System Total\").yaxis(label=\"Bytes\",units=bytes),.es(index=\"metricbeat*\",metric=\"avg:golang.heap.system.obtained\").label(\"System Obtained\"),.es(index=\"metricbeat*\",metric=\"avg:golang.heap.system.stack\").label(\"System Stack\"),.es(index=\"metricbeat*\",metric=\"avg:golang.heap.system.released\").label(\"System Released\")", 
+                        "interval": "10s"
+                    }, 
+                    "title": "System  [Metricbeat Golang] ECS", 
+                    "type": "timelion"
+                }
+            }, 
+            "id": "9a9a8bf0-f52a-11e6-969c-518c48c913e4-ecs", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                }, 
+                "title": "GC count [Metricbeat Golang] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "expression": ".es(index=\"metricbeat*\",metric=\"max:golang.heap.gc.pause.count\").label(\"GC Count\").bars().yaxis(label=\"Count\"),.es(index=\"metricbeat*\",metric=\"max:golang.heap.gc.total_count\").label(\"GC Rate\").derivative().movingaverage(30),.es(index=\"metricbeat*\",metric=\"max:golang.heap.gc.cpu_fraction\").label(\"CPU Fraction\").yaxis(2,label=\"Fraction\")", 
+                        "interval": "10s"
+                    }, 
+                    "title": "GC count [Metricbeat Golang] ECS", 
+                    "type": "timelion"
+                }
+            }, 
+            "id": "b046cb80-f52a-11e6-969c-518c48c913e4-ecs", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                }, 
+                "title": "GC durations [Metricbeat Golang] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "expression": ".es(index=\"metricbeat*\",metric=\"max:golang.heap.gc.pause.sum.ns\").bars().label(\"sum of GC Pause durations(ns)\").yaxis(label=\"Durations(ns)\"),.es(index=\"metricbeat*\",metric=\"max:golang.heap.gc.total_pause.ns\").derivative().movingaverage(30).label(\"Total GC Pause(ns) Rate\"),.es(index=\"metricbeat*\",metric=\"max:golang.heap.gc.pause.max.ns\").label(\"Max GC Pause(ns)\").movingaverage(30),.es(index=\"metricbeat*\",metric=\"avg:golang.heap.gc.pause.avg.ns\").label(\"Avg GC Pause(ns)\").movingaverage(30),.es(index=\"metricbeat*\",metric=\"max:golang.heap.gc.pause.count\").condition(lt,1, null).label(\"GC Pause count\").points().yaxis(2,label=\"Count\")", 
+                        "interval": "10s"
+                    }, 
+                    "title": "GC durations [Metricbeat Golang] ECS", 
+                    "type": "timelion"
+                }
+            }, 
+            "id": "ab226b50-f52a-11e6-969c-518c48c913e4-ecs", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "Overview of Go profiling information",
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlightAll": true, 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "optionsJSON": {
+                    "darkTheme": false
+                }, 
+                "panelsJSON": [
+                    {
+                        "col": 1, 
+                        "id": "58000780-f529-11e6-844d-b170e2f0a07e-ecs", 
+                        "panelIndex": 8, 
+                        "row": 1, 
+                        "size_x": 12, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "95388680-f52a-11e6-969c-518c48c913e4-ecs", 
+                        "panelIndex": 9, 
+                        "row": 4, 
+                        "size_x": 4, 
+                        "size_y": 4, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 9, 
+                        "id": "b59a5200-f52a-11e6-969c-518c48c913e4-ecs", 
+                        "panelIndex": 10, 
+                        "row": 4, 
+                        "size_x": 4, 
+                        "size_y": 4, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 5, 
+                        "id": "9a9a8bf0-f52a-11e6-969c-518c48c913e4-ecs", 
+                        "panelIndex": 11, 
+                        "row": 4, 
+                        "size_x": 4, 
+                        "size_y": 4, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 7, 
+                        "id": "b046cb80-f52a-11e6-969c-518c48c913e4-ecs", 
+                        "panelIndex": 12, 
+                        "row": 8, 
+                        "size_x": 6, 
+                        "size_y": 4, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "ab226b50-f52a-11e6-969c-518c48c913e4-ecs", 
+                        "panelIndex": 13, 
+                        "row": 8, 
+                        "size_x": 6, 
+                        "size_y": 4, 
+                        "type": "visualization"
+                    }
+                ], 
+                "timeRestore": false, 
+                "title": "[Metricbeat Golang] Overview ECS", 
+                "uiStateJSON": {}, 
+                "version": 1
+            }, 
+            "id": "f2dc7320-f519-11e6-a3c9-9d1f7c42b045-ecs", 
+            "type": "dashboard", 
+            "version": 3
+        }
+    ], 
+    "version": "6.0.0-beta1-SNAPSHOT"
+}

--- a/dev/package-beats/golang-1.0.0/manifest.yml
+++ b/dev/package-beats/golang-1.0.0/manifest.yml
@@ -1,0 +1,13 @@
+name: golang
+title: Golang
+version: 1.0.0
+description: |
+  Golang module
+type: ""
+categories:
+- metrics
+requirement:
+  kibana:
+    version:
+      min: 6.7.0
+      max: 7.6.0

--- a/dev/package-beats/googlecloud-1.0.0/manifest.yml
+++ b/dev/package-beats/googlecloud-1.0.0/manifest.yml
@@ -1,0 +1,13 @@
+name: googlecloud
+title: Google Cloud
+version: 1.0.0
+description: |
+  Module for handling logs from Google Cloud.
+type: ""
+categories:
+- logs
+requirement:
+  kibana:
+    version:
+      min: 6.7.0
+      max: 7.6.0

--- a/dev/package-beats/graphite-1.0.0/manifest.yml
+++ b/dev/package-beats/graphite-1.0.0/manifest.yml
@@ -1,0 +1,13 @@
+name: graphite
+title: Graphite
+version: 1.0.0
+description: |
+  graphite Module
+type: ""
+categories:
+- metrics
+requirement:
+  kibana:
+    version:
+      min: 6.7.0
+      max: 7.6.0

--- a/dev/package-beats/haproxy-1.0.0/kibana/dashboard/Filebeat-haproxy-overview.json
+++ b/dev/package-beats/haproxy-1.0.0/kibana/dashboard/Filebeat-haproxy-overview.json
@@ -1,0 +1,443 @@
+{
+  "objects": [
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "index": "filebeat-*",
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Backend breakdown [Filebeat HAProxy] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "field": "haproxy.backend_name",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 5
+              },
+              "schema": "segment",
+              "type": "terms"
+            }
+          ],
+          "params": {
+            "addLegend": true,
+            "addTooltip": true,
+            "isDonut": true,
+            "labels": {
+              "last_level": true,
+              "show": false,
+              "truncate": 100,
+              "values": true
+            },
+            "legendPosition": "right",
+            "type": "pie"
+          },
+          "title": "Backend breakdown [Filebeat HAProxy] ECS",
+          "type": "pie"
+        }
+      },
+      "id": "55251360-aa32-11e8-9c06-877f0445e3e0-ecs",
+      "type": "visualization",
+      "updated_at": "2018-12-06T11:35:36.721Z",
+      "version": 2
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "index": "filebeat-*",
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Frontend breakdown [Filebeat HAProxy] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "field": "haproxy.frontend_name",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 5
+              },
+              "schema": "segment",
+              "type": "terms"
+            }
+          ],
+          "params": {
+            "addLegend": true,
+            "addTooltip": true,
+            "isDonut": true,
+            "labels": {
+              "last_level": true,
+              "show": false,
+              "truncate": 100,
+              "values": true
+            },
+            "legendPosition": "right",
+            "type": "pie"
+          },
+          "title": "Frontend breakdown [Filebeat HAProxy] ECS",
+          "type": "pie"
+        }
+      },
+      "id": "7fb671f0-aa32-11e8-9c06-877f0445e3e0-ecs",
+      "type": "visualization",
+      "updated_at": "2018-12-06T11:35:36.721Z",
+      "version": 2
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "index": "filebeat-*",
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "IP Geohashes [Filebeat HAProxy] ECS",
+        "uiStateJSON": {
+          "mapCenter": [
+            14.944784875088372,
+            5.09765625
+          ]
+        },
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "field": "source.address"
+              },
+              "schema": "metric",
+              "type": "cardinality"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "autoPrecision": true,
+                "field": "source.geo.location",
+                "isFilteredByCollar": true,
+                "precision": 2,
+                "useGeocentroid": true
+              },
+              "schema": "segment",
+              "type": "geohash_grid"
+            }
+          ],
+          "params": {
+            "addTooltip": true,
+            "heatBlur": 15,
+            "heatMaxZoom": 16,
+            "heatMinOpacity": 0.1,
+            "heatNormalizeData": true,
+            "heatRadius": 25,
+            "isDesaturated": true,
+            "legendPosition": "bottomright",
+            "mapCenter": [
+              15,
+              5
+            ],
+            "mapType": "Scaled Circle Markers",
+            "mapZoom": 2,
+            "wms": {
+              "enabled": false,
+              "options": {
+                "attribution": "Maps provided by USGS",
+                "format": "image/png",
+                "layers": "0",
+                "styles": "",
+                "transparent": true,
+                "version": "1.3.0"
+              },
+              "url": "https://basemap.nationalmap.gov/arcgis/services/USGSTopo/MapServer/WMSServer"
+            }
+          },
+          "title": "IP Geohashes [Filebeat HAProxy] ECS",
+          "type": "tile_map"
+        }
+      },
+      "id": "11f8b9c0-aa32-11e8-9c06-877f0445e3e0-ecs",
+      "type": "visualization",
+      "updated_at": "2018-12-06T11:35:36.721Z",
+      "version": 2
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "index": "filebeat-*",
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Response codes over time [Filebeat HAProxy] ECS",
+        "uiStateJSON": {
+          "vis": {
+            "colors": {
+              "200": "#508642",
+              "204": "#629E51",
+              "302": "#6ED0E0",
+              "404": "#EAB839",
+              "503": "#705DA0"
+            }
+          }
+        },
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customInterval": "2h",
+                "extended_bounds": {},
+                "field": "@timestamp",
+                "interval": "auto",
+                "min_doc_count": 1
+              },
+              "schema": "segment",
+              "type": "date_histogram"
+            },
+            {
+              "enabled": true,
+              "id": "3",
+              "params": {
+                "field": "http.response.status_code",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "_term",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 5
+              },
+              "schema": "group",
+              "type": "terms"
+            }
+          ],
+          "params": {
+            "addLegend": true,
+            "addTimeMarker": false,
+            "addTooltip": true,
+            "categoryAxes": [
+              {
+                "id": "CategoryAxis-1",
+                "labels": {
+                  "show": true,
+                  "truncate": 100
+                },
+                "position": "bottom",
+                "scale": {
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {},
+                "type": "category"
+              }
+            ],
+            "grid": {
+              "categoryLines": false,
+              "style": {
+                "color": "#eee"
+              }
+            },
+            "legendPosition": "right",
+            "seriesParams": [
+              {
+                "data": {
+                  "id": "1",
+                  "label": "Count"
+                },
+                "drawLinesBetweenPoints": true,
+                "mode": "stacked",
+                "show": "true",
+                "showCircles": true,
+                "type": "histogram",
+                "valueAxis": "ValueAxis-1"
+              }
+            ],
+            "times": [],
+            "type": "histogram",
+            "valueAxes": [
+              {
+                "id": "ValueAxis-1",
+                "labels": {
+                  "filter": false,
+                  "rotate": 0,
+                  "show": true,
+                  "truncate": 100
+                },
+                "name": "LeftAxis-1",
+                "position": "left",
+                "scale": {
+                  "mode": "normal",
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {
+                  "text": "Count"
+                },
+                "type": "value"
+              }
+            ]
+          },
+          "title": "Response codes over time [Filebeat HAProxy] ECS",
+          "type": "histogram"
+        }
+      },
+      "id": "68af8ef0-aa33-11e8-9c06-877f0445e3e0-ecs",
+      "type": "visualization",
+      "updated_at": "2018-12-06T11:35:36.721Z",
+      "version": 2
+    },
+    {
+      "attributes": {
+        "description": "Filebeat HAProxy module dashboard",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "optionsJSON": {
+          "darkTheme": false,
+          "hidePanelTitles": false,
+          "useMargins": true
+        },
+        "panelsJSON": [
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 15,
+              "i": "1",
+              "w": 24,
+              "x": 0,
+              "y": 0
+            },
+            "id": "55251360-aa32-11e8-9c06-877f0445e3e0-ecs",
+            "panelIndex": "1",
+            "type": "visualization",
+            "version": "6.5.2"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 15,
+              "i": "2",
+              "w": 24,
+              "x": 24,
+              "y": 0
+            },
+            "id": "7fb671f0-aa32-11e8-9c06-877f0445e3e0-ecs",
+            "panelIndex": "2",
+            "type": "visualization",
+            "version": "6.5.2"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 15,
+              "i": "3",
+              "w": 24,
+              "x": 0,
+              "y": 15
+            },
+            "id": "11f8b9c0-aa32-11e8-9c06-877f0445e3e0-ecs",
+            "panelIndex": "3",
+            "type": "visualization",
+            "version": "6.5.2"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 15,
+              "i": "4",
+              "w": 24,
+              "x": 24,
+              "y": 15
+            },
+            "id": "68af8ef0-aa33-11e8-9c06-877f0445e3e0-ecs",
+            "panelIndex": "4",
+            "type": "visualization",
+            "version": "6.5.2"
+          }
+        ],
+        "timeRestore": false,
+        "title": "[Filebeat HAProxy] Overview ECS",
+        "version": 1
+      },
+      "id": "3560d580-aa34-11e8-9c06-877f0445e3e0-ecs",
+      "type": "dashboard",
+      "updated_at": "2018-12-06T11:40:40.204Z",
+      "version": 6
+    }
+  ],
+  "version": "6.5.2"
+}

--- a/dev/package-beats/haproxy-1.0.0/kibana/dashboard/Metricbeat-haproxy-backend.json
+++ b/dev/package-beats/haproxy-1.0.0/kibana/dashboard/Metricbeat-haproxy-backend.json
@@ -1,0 +1,114 @@
+{
+    "objects": [
+        {
+            "attributes": {
+                "description": "HAProxy backend metrics",
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlightAll": true, 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "optionsJSON": {
+                    "darkTheme": false, 
+                    "hidePanelTitles": false, 
+                    "useMargins": true
+                }, 
+                "panelsJSON": [
+                    {
+                        "gridData": {
+                            "h": 2, 
+                            "i": "1", 
+                            "w": 6, 
+                            "x": 0, 
+                            "y": 0
+                        }, 
+                        "id": "a64b4fd0-471c-11e8-bc13-1397384faad3-ecs", 
+                        "panelIndex": "1", 
+                        "type": "visualization", 
+                        "version": "6.2.2"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 2, 
+                            "i": "2", 
+                            "w": 3, 
+                            "x": 6, 
+                            "y": 0
+                        }, 
+                        "id": "794b6cd0-471d-11e8-bc13-1397384faad3-ecs", 
+                        "panelIndex": "2", 
+                        "type": "visualization", 
+                        "version": "6.2.2"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 4, 
+                            "i": "3", 
+                            "w": 6, 
+                            "x": 6, 
+                            "y": 2
+                        }, 
+                        "id": "bb0ab500-4735-11e8-bc13-1397384faad3-ecs", 
+                        "panelIndex": "3", 
+                        "type": "visualization", 
+                        "version": "6.2.2"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 2, 
+                            "i": "4", 
+                            "w": 3, 
+                            "x": 9, 
+                            "y": 0
+                        }, 
+                        "id": "40bed190-473b-11e8-bc13-1397384faad3-ecs", 
+                        "panelIndex": "4", 
+                        "type": "visualization", 
+                        "version": "6.2.2"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 2, 
+                            "i": "5", 
+                            "w": 6, 
+                            "x": 0, 
+                            "y": 2
+                        }, 
+                        "id": "0751ed00-479c-11e8-bc13-1397384faad3-ecs", 
+                        "panelIndex": "5", 
+                        "type": "visualization", 
+                        "version": "6.2.2"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 2, 
+                            "i": "6", 
+                            "w": 6, 
+                            "x": 0, 
+                            "y": 4
+                        }, 
+                        "id": "b3463670-47a1-11e8-bc13-1397384faad3-ecs", 
+                        "panelIndex": "6", 
+                        "type": "visualization", 
+                        "version": "6.2.2"
+                    }
+                ], 
+                "timeRestore": false, 
+                "title": "[Metricbeat HAProxy] Backend ECS", 
+                "version": 1
+            }, 
+            "id": "9151c900-471d-11e8-bc13-1397384faad3-ecs", 
+            "type": "dashboard", 
+            "updated_at": "2018-04-24T18:31:25.838Z", 
+            "version": 15
+        }
+    ], 
+    "version": "6.2.2"
+}

--- a/dev/package-beats/haproxy-1.0.0/kibana/dashboard/Metricbeat-haproxy-frontend.json
+++ b/dev/package-beats/haproxy-1.0.0/kibana/dashboard/Metricbeat-haproxy-frontend.json
@@ -1,0 +1,62 @@
+{
+    "objects": [
+        {
+            "attributes": {
+                "description": "HAProxy frontend metrics",
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlightAll": true, 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "optionsJSON": {
+                    "darkTheme": false, 
+                    "hidePanelTitles": false, 
+                    "useMargins": true
+                }, 
+                "panelsJSON": [
+                    {
+                        "gridData": {
+                            "h": 3, 
+                            "i": "2", 
+                            "w": 6, 
+                            "x": 0, 
+                            "y": 0
+                        }, 
+                        "id": "a64b4fd0-471c-11e8-bc13-1397384faad3-ecs", 
+                        "panelIndex": "2", 
+                        "type": "visualization", 
+                        "version": "6.2.2"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 3, 
+                            "i": "3", 
+                            "w": 6, 
+                            "x": 6, 
+                            "y": 0
+                        }, 
+                        "id": "86159190-47c5-11e8-bc13-1397384faad3-ecs", 
+                        "panelIndex": "3", 
+                        "type": "visualization", 
+                        "version": "6.2.2"
+                    }
+                ], 
+                "timeRestore": false, 
+                "title": "[Metricbeat HAProxy] Frontend ECS", 
+                "version": 1
+            }, 
+            "id": "d5878d00-47c5-11e8-bc13-1397384faad3-ecs", 
+            "type": "dashboard", 
+            "updated_at": "2018-04-24T18:32:51.945Z", 
+            "version": 5
+        }
+    ], 
+    "version": "6.2.2"
+}

--- a/dev/package-beats/haproxy-1.0.0/kibana/dashboard/Metricbeat-haproxy-http-backend.json
+++ b/dev/package-beats/haproxy-1.0.0/kibana/dashboard/Metricbeat-haproxy-http-backend.json
@@ -1,0 +1,140 @@
+{
+    "objects": [
+        {
+            "attributes": {
+                "description": "HAProxy HTTP backend metrics",
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlightAll": true, 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "optionsJSON": {
+                    "darkTheme": false, 
+                    "hidePanelTitles": false, 
+                    "useMargins": true
+                }, 
+                "panelsJSON": [
+                    {
+                        "gridData": {
+                            "h": 2, 
+                            "i": "1", 
+                            "w": 4, 
+                            "x": 0, 
+                            "y": 5
+                        }, 
+                        "id": "a64b4fd0-471c-11e8-bc13-1397384faad3-ecs", 
+                        "panelIndex": "1", 
+                        "type": "visualization", 
+                        "version": "6.2.2"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 2, 
+                            "i": "2", 
+                            "w": 3, 
+                            "x": 9, 
+                            "y": 0
+                        }, 
+                        "id": "794b6cd0-471d-11e8-bc13-1397384faad3-ecs", 
+                        "panelIndex": "2", 
+                        "type": "visualization", 
+                        "version": "6.2.2"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 3, 
+                            "i": "3", 
+                            "w": 6, 
+                            "x": 6, 
+                            "y": 2
+                        }, 
+                        "id": "bb0ab500-4735-11e8-bc13-1397384faad3-ecs", 
+                        "panelIndex": "3", 
+                        "type": "visualization", 
+                        "version": "6.2.2"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 2, 
+                            "i": "4", 
+                            "w": 3, 
+                            "x": 6, 
+                            "y": 0
+                        }, 
+                        "id": "40bed190-473b-11e8-bc13-1397384faad3-ecs", 
+                        "panelIndex": "4", 
+                        "type": "visualization", 
+                        "version": "6.2.2"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 2, 
+                            "i": "5", 
+                            "w": 4, 
+                            "x": 4, 
+                            "y": 5
+                        }, 
+                        "id": "0751ed00-479c-11e8-bc13-1397384faad3-ecs", 
+                        "panelIndex": "5", 
+                        "type": "visualization", 
+                        "version": "6.2.2"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 2, 
+                            "i": "6", 
+                            "w": 4, 
+                            "x": 8, 
+                            "y": 5
+                        }, 
+                        "id": "b3463670-47a1-11e8-bc13-1397384faad3-ecs", 
+                        "panelIndex": "6", 
+                        "type": "visualization", 
+                        "version": "6.2.2"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 3, 
+                            "i": "7", 
+                            "w": 6, 
+                            "x": 0, 
+                            "y": 0
+                        }, 
+                        "id": "fcbdfa60-47bd-11e8-bc13-1397384faad3-ecs", 
+                        "panelIndex": "7", 
+                        "type": "visualization", 
+                        "version": "6.2.2"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 2, 
+                            "i": "8", 
+                            "w": 6, 
+                            "x": 0, 
+                            "y": 3
+                        }, 
+                        "id": "981d1040-47be-11e8-bc13-1397384faad3-ecs", 
+                        "panelIndex": "8", 
+                        "type": "visualization", 
+                        "version": "6.2.2"
+                    }
+                ], 
+                "timeRestore": false, 
+                "title": "[Metricbeat HAProxy] HTTP backend ECS", 
+                "version": 1
+            }, 
+            "id": "0836a4b0-47bd-11e8-bc13-1397384faad3-ecs", 
+            "type": "dashboard", 
+            "updated_at": "2018-04-24T18:33:28.791Z", 
+            "version": 6
+        }
+    ], 
+    "version": "6.2.2"
+}

--- a/dev/package-beats/haproxy-1.0.0/kibana/dashboard/Metricbeat-haproxy-http-frontend.json
+++ b/dev/package-beats/haproxy-1.0.0/kibana/dashboard/Metricbeat-haproxy-http-frontend.json
@@ -1,0 +1,75 @@
+{
+    "objects": [
+        {
+            "attributes": {
+                "description": "HAProxy frontend metrics",
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlightAll": true, 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "optionsJSON": {
+                    "darkTheme": false, 
+                    "hidePanelTitles": false, 
+                    "useMargins": true
+                }, 
+                "panelsJSON": [
+                    {
+                        "gridData": {
+                            "h": 3, 
+                            "i": "3", 
+                            "w": 6, 
+                            "x": 6, 
+                            "y": 3
+                        }, 
+                        "id": "86159190-47c5-11e8-bc13-1397384faad3-ecs", 
+                        "panelIndex": "3", 
+                        "type": "visualization", 
+                        "version": "6.2.2"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 3, 
+                            "i": "4", 
+                            "w": 12, 
+                            "x": 0, 
+                            "y": 0
+                        }, 
+                        "id": "fcbdfa60-47bd-11e8-bc13-1397384faad3-ecs", 
+                        "panelIndex": "4", 
+                        "type": "visualization", 
+                        "version": "6.2.2"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 3, 
+                            "i": "5", 
+                            "w": 6, 
+                            "x": 0, 
+                            "y": 3
+                        }, 
+                        "id": "30956d00-47d7-11e8-bc13-1397384faad3-ecs", 
+                        "panelIndex": "5", 
+                        "type": "visualization", 
+                        "version": "6.2.2"
+                    }
+                ], 
+                "timeRestore": false, 
+                "title": "[Metricbeat HAProxy] HTTP frontend ECS", 
+                "version": 1
+            }, 
+            "id": "e9057ae0-47c5-11e8-bc13-1397384faad3-ecs", 
+            "type": "dashboard", 
+            "updated_at": "2018-04-24T18:34:15.954Z", 
+            "version": 5
+        }
+    ], 
+    "version": "6.2.2"
+}

--- a/dev/package-beats/haproxy-1.0.0/kibana/dashboard/Metricbeat-haproxy-http-server.json
+++ b/dev/package-beats/haproxy-1.0.0/kibana/dashboard/Metricbeat-haproxy-http-server.json
@@ -1,0 +1,114 @@
+{
+    "objects": [
+        {
+            "attributes": {
+                "description": "HAProxy metrics for HTTP mode",
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlightAll": true, 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "optionsJSON": {
+                    "darkTheme": false, 
+                    "hidePanelTitles": false, 
+                    "useMargins": true
+                }, 
+                "panelsJSON": [
+                    {
+                        "gridData": {
+                            "h": 2, 
+                            "i": "5", 
+                            "w": 6, 
+                            "x": 0, 
+                            "y": 5
+                        }, 
+                        "id": "0751ed00-479c-11e8-bc13-1397384faad3-ecs", 
+                        "panelIndex": "5", 
+                        "type": "visualization", 
+                        "version": "6.2.2"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 2, 
+                            "i": "6", 
+                            "w": 6, 
+                            "x": 6, 
+                            "y": 3
+                        }, 
+                        "id": "b3463670-47a1-11e8-bc13-1397384faad3-ecs", 
+                        "panelIndex": "6", 
+                        "type": "visualization", 
+                        "version": "6.2.2"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 3, 
+                            "i": "7", 
+                            "w": 6, 
+                            "x": 0, 
+                            "y": 0
+                        }, 
+                        "id": "fcbdfa60-47bd-11e8-bc13-1397384faad3-ecs", 
+                        "panelIndex": "7", 
+                        "type": "visualization", 
+                        "version": "6.2.2"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 2, 
+                            "i": "8", 
+                            "w": 6, 
+                            "x": 0, 
+                            "y": 3
+                        }, 
+                        "id": "981d1040-47be-11e8-bc13-1397384faad3-ecs", 
+                        "panelIndex": "8", 
+                        "type": "visualization", 
+                        "version": "6.2.2"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 3, 
+                            "i": "10", 
+                            "w": 6, 
+                            "x": 6, 
+                            "y": 0
+                        }, 
+                        "id": "72e84b00-47e1-11e8-bc13-1397384faad3-ecs", 
+                        "panelIndex": "10", 
+                        "type": "visualization", 
+                        "version": "6.2.2"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 2, 
+                            "i": "11", 
+                            "w": 6, 
+                            "x": 6, 
+                            "y": 5
+                        }, 
+                        "id": "976b0910-47e4-11e8-bc13-1397384faad3-ecs", 
+                        "panelIndex": "11", 
+                        "type": "visualization", 
+                        "version": "6.2.2"
+                    }
+                ], 
+                "timeRestore": false, 
+                "title": "[Metricbeat HAProxy] HTTP server ECS", 
+                "version": 1
+            }, 
+            "id": "8cc50a50-47e0-11e8-bc13-1397384faad3-ecs", 
+            "type": "dashboard", 
+            "updated_at": "2018-04-24T18:34:50.803Z", 
+            "version": 9
+        }
+    ], 
+    "version": "6.2.2"
+}

--- a/dev/package-beats/haproxy-1.0.0/kibana/dashboard/Metricbeat-haproxy-overview.json
+++ b/dev/package-beats/haproxy-1.0.0/kibana/dashboard/Metricbeat-haproxy-overview.json
@@ -1,0 +1,91 @@
+{
+    "objects": [
+        {
+            "attributes": {
+                "description": "HAProxy overview",
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlightAll": true, 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "optionsJSON": {
+                    "darkTheme": false, 
+                    "hidePanelTitles": false, 
+                    "useMargins": true
+                }, 
+                "panelsJSON": [
+                    {
+                        "gridData": {
+                            "h": 6, 
+                            "i": "2", 
+                            "w": 4, 
+                            "x": 8, 
+                            "y": 2
+                        }, 
+                        "id": "79350d50-47db-11e8-bc13-1397384faad3-ecs", 
+                        "panelIndex": "2", 
+                        "title": "Servers", 
+                        "type": "visualization", 
+                        "version": "6.2.2"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 6, 
+                            "i": "3", 
+                            "w": 4, 
+                            "x": 4, 
+                            "y": 2
+                        }, 
+                        "id": "8c8f0300-47dc-11e8-bc13-1397384faad3-ecs", 
+                        "panelIndex": "3", 
+                        "title": "Backends", 
+                        "type": "visualization", 
+                        "version": "6.2.2"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 6, 
+                            "i": "4", 
+                            "w": 4, 
+                            "x": 0, 
+                            "y": 2
+                        }, 
+                        "id": "f1e27ed0-47dc-11e8-bc13-1397384faad3-ecs", 
+                        "panelIndex": "4", 
+                        "title": "Frontends", 
+                        "type": "visualization", 
+                        "version": "6.2.2"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 2, 
+                            "i": "5", 
+                            "w": 12, 
+                            "x": 0, 
+                            "y": 0
+                        }, 
+                        "id": "a64b4fd0-471c-11e8-bc13-1397384faad3-ecs", 
+                        "panelIndex": "5", 
+                        "type": "visualization", 
+                        "version": "6.2.2"
+                    }
+                ], 
+                "timeRestore": false, 
+                "title": "[Metricbeat HAProxy] Overview ECS", 
+                "version": 1
+            }, 
+            "id": "4b555c30-47dd-11e8-bc13-1397384faad3-ecs", 
+            "type": "dashboard", 
+            "updated_at": "2018-04-24T18:31:56.356Z", 
+            "version": 3
+        }
+    ], 
+    "version": "6.2.2"
+}

--- a/dev/package-beats/haproxy-1.0.0/kibana/dashboard/Metricbeat-haproxy-visualizations.json
+++ b/dev/package-beats/haproxy-1.0.0/kibana/dashboard/Metricbeat-haproxy-visualizations.json
@@ -1,0 +1,1341 @@
+{
+    "objects": [
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "Connections [Metricbeat HAProxy] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "background_color_rules": [
+                            {
+                                "id": "4e35d500-471b-11e8-a520-3f46123ab5eb"
+                            }
+                        ], 
+                        "bar_color_rules": [
+                            {
+                                "id": "69899960-4719-11e8-a520-3f46123ab5eb"
+                            }
+                        ], 
+                        "filter": "haproxy.stat.component_type:(0 OR 1)", 
+                        "gauge_color_rules": [
+                            {
+                                "id": "6f171ba0-4719-11e8-a520-3f46123ab5eb"
+                            }
+                        ], 
+                        "gauge_inner_width": 10, 
+                        "gauge_style": "half", 
+                        "gauge_width": 10, 
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": 0.5, 
+                                "filter": "", 
+                                "formatter": "number", 
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417", 
+                                "label": "Number of connections", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "haproxy.stat.connection.total", 
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "type": "sum"
+                                    }, 
+                                    {
+                                        "field": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "id": "41ff3940-4719-11e8-a520-3f46123ab5eb", 
+                                        "type": "derivative", 
+                                        "unit": ""
+                                    }, 
+                                    {
+                                        "field": "41ff3940-4719-11e8-a520-3f46123ab5eb", 
+                                        "id": "456a5fa0-4738-11e8-8633-8f8b3acf1566", 
+                                        "type": "positive_only", 
+                                        "unit": ""
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "series_drop_last_bucket": 1, 
+                                "split_color_mode": "rainbow", 
+                                "split_filters": [
+                                    {
+                                        "color": "#68BC00", 
+                                        "id": "0ceb7740-471a-11e8-a520-3f46123ab5eb"
+                                    }
+                                ], 
+                                "split_mode": "terms", 
+                                "stacked": "none", 
+                                "terms_field": "haproxy.stat.proxy.name"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "timeseries"
+                    }, 
+                    "title": "HAProxy connections ECS", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "a64b4fd0-471c-11e8-bc13-1397384faad3-ecs", 
+            "type": "visualization", 
+            "updated_at": "2018-04-23T20:54:01.082Z", 
+            "version": 3
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "Active servers in backend [Metricbeat HAProxy] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "background_color_rules": [
+                            {
+                                "color": "rgba(255,0,6,1)", 
+                                "id": "1ec0dde0-471d-11e8-9876-09cc6c85f5f2", 
+                                "operator": "lte", 
+                                "value": 0
+                            }
+                        ], 
+                        "bar_color_rules": [
+                            {
+                                "id": "297160c0-471d-11e8-9876-09cc6c85f5f2"
+                            }
+                        ], 
+                        "filter": "haproxy.stat.component_type:(2 OR 3)", 
+                        "gauge_color_rules": [
+                            {
+                                "gauge": "rgba(255,0,5,1)", 
+                                "id": "4ce156a0-471d-11e8-9876-09cc6c85f5f2", 
+                                "operator": "lte", 
+                                "text": null, 
+                                "value": 0
+                            }, 
+                            {
+                                "gauge": "rgba(255,196,0,1)", 
+                                "id": "f8458a80-4721-11e8-b854-2f6d2b452362", 
+                                "operator": "lte", 
+                                "value": 0.5
+                            }
+                        ], 
+                        "gauge_inner_width": 10, 
+                        "gauge_max": "1", 
+                        "gauge_style": "half", 
+                        "gauge_width": 10, 
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": 0.5, 
+                                "filter": "haproxy.stat.status:UP", 
+                                "formatter": "number", 
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417", 
+                                "label": "Active servers", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "denominator": "*", 
+                                        "field": "haproxy.stat.server.id", 
+                                        "id": "b754d060-471e-11e8-9876-09cc6c85f5f2", 
+                                        "metric_agg": "count", 
+                                        "numerator": "*", 
+                                        "script": "params.up / (params.down + params.up)", 
+                                        "type": "cardinality", 
+                                        "variables": [
+                                            {
+                                                "field": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                                "id": "cfd51780-471e-11e8-9d35-6baabcdce3dc", 
+                                                "name": "down"
+                                            }, 
+                                            {
+                                                "field": "a049c420-471e-11e8-9876-09cc6c85f5f2", 
+                                                "id": "45e6ec00-471f-11e8-9d35-6baabcdce3dc", 
+                                                "name": "up"
+                                            }
+                                        ]
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none", 
+                                "terms_field": "haproxy.stat.proxy.name"
+                            }, 
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": 0.5, 
+                                "formatter": "number", 
+                                "id": "2cba9420-4724-11e8-b854-2f6d2b452362", 
+                                "label": "Total servers", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "haproxy.stat.server.id", 
+                                        "id": "2cba9421-4724-11e8-b854-2f6d2b452362", 
+                                        "type": "cardinality"
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "metric"
+                    }, 
+                    "title": "HAProxy active servers in backend ECS", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "794b6cd0-471d-11e8-bc13-1397384faad3-ecs", 
+            "type": "visualization", 
+            "updated_at": "2018-04-23T21:36:57.634Z", 
+            "version": 8
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "Connections per server [Metricbeat HAProxy] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "bar_color_rules": [
+                            {
+                                "id": "978f2660-4735-11e8-b619-8f82b8185e96"
+                            }
+                        ], 
+                        "drilldown_url": "../app/kibana#/dashboard/8cc50a50-47e0-11e8-bc13-1397384faad3-ecs?_a=(query:(language:kuery,query:'haproxy.stat.service_name:\"{{ key }}\"'))",
+                        "filter": "haproxy.stat.component_type:(2 OR 3)", 
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": 0.5, 
+                                "formatter": "number", 
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417", 
+                                "label": "Connections per server", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "haproxy.stat.connection.total", 
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "type": "avg"
+                                    }, 
+                                    {
+                                        "field": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "id": "3ea29000-4735-11e8-b619-8f82b8185e96", 
+                                        "type": "derivative", 
+                                        "unit": ""
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "terms", 
+                                "stacked": "none", 
+                                "terms_field": "haproxy.stat.service_name"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "top_n"
+                    }, 
+                    "title": "HAProxy connections per server ECS", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "bb0ab500-4735-11e8-bc13-1397384faad3-ecs", 
+            "type": "visualization", 
+            "updated_at": "2018-04-24T17:12:35.298Z", 
+            "version": 3
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "Downtime seconds [Metricbeat HAProxy] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "background_color_rules": [
+                            {
+                                "id": "c86b8e00-4739-11e8-8953-55bbe33e1362"
+                            }
+                        ], 
+                        "filter": "haproxy.stat.component_type:1", 
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "rgba(255,0,0,1)", 
+                                "fill": 0.5, 
+                                "formatter": "number", 
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417", 
+                                "label": "Downtime", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "haproxy.stat.downtime", 
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "type": "avg"
+                                    }, 
+                                    {
+                                        "field": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "id": "91aa6a20-473a-11e8-8953-55bbe33e1362", 
+                                        "type": "derivative", 
+                                        "unit": ""
+                                    }, 
+                                    {
+                                        "field": "91aa6a20-473a-11e8-8953-55bbe33e1362", 
+                                        "id": "a8ce7ca0-473a-11e8-8953-55bbe33e1362", 
+                                        "sigma": "", 
+                                        "type": "sum_bucket"
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "terms", 
+                                "stacked": "none", 
+                                "terms_field": "haproxy.stat.proxy.name", 
+                                "value_template": "{{value}}s"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "metric"
+                    }, 
+                    "title": "HAProxy downtime seconds ECS", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "40bed190-473b-11e8-bc13-1397384faad3-ecs", 
+            "type": "visualization", 
+            "updated_at": "2018-04-23T21:29:04.708Z", 
+            "version": 3
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "Average time in queue [Metricbeat HAProxy] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": 0.5, 
+                                "formatter": "number", 
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417", 
+                                "label": "Average time in queue", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "haproxy.stat.queue.time.avg", 
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "type": "avg"
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "timeseries"
+                    }, 
+                    "title": "HAProxy average time in queue ECS", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "b3463670-47a1-11e8-bc13-1397384faad3-ecs", 
+            "type": "visualization", 
+            "updated_at": "2018-04-24T09:27:25.783Z", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "Traffic volume [Metricbeat HAProxy] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "rgba(164,221,0,1)", 
+                                "fill": "0.5", 
+                                "formatter": "bytes", 
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417", 
+                                "label": "Incoming", 
+                                "line_width": "1", 
+                                "metrics": [
+                                    {
+                                        "field": "haproxy.stat.in.bytes", 
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "type": "sum"
+                                    }, 
+                                    {
+                                        "field": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "id": "9814c420-47c4-11e8-994c-81d2daeb7c86", 
+                                        "type": "derivative", 
+                                        "unit": ""
+                                    }
+                                ], 
+                                "point_size": "1", 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }, 
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "rgba(25,77,51,1)", 
+                                "fill": "0.5", 
+                                "formatter": "bytes", 
+                                "id": "c89d1520-47c4-11e8-994c-81d2daeb7c86", 
+                                "label": "Outgoing", 
+                                "line_width": "1", 
+                                "metrics": [
+                                    {
+                                        "field": "haproxy.stat.out.bytes", 
+                                        "id": "c89d6340-47c4-11e8-994c-81d2daeb7c86", 
+                                        "type": "sum"
+                                    }, 
+                                    {
+                                        "field": "c89d6340-47c4-11e8-994c-81d2daeb7c86", 
+                                        "id": "c89d6341-47c4-11e8-994c-81d2daeb7c86", 
+                                        "type": "derivative", 
+                                        "unit": ""
+                                    }
+                                ], 
+                                "override_index_pattern": 0, 
+                                "point_size": "1", 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "timeseries"
+                    }, 
+                    "title": "HAProxy traffic volume ECS", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "86159190-47c5-11e8-bc13-1397384faad3-ecs", 
+            "type": "visualization", 
+            "updated_at": "2018-04-24T14:43:27.616Z", 
+            "version": 3
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "HTTP response codes [Metricbeat HAProxy] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": 0.5, 
+                                "formatter": "number", 
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417", 
+                                "label": "200s", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "haproxy.stat.response.http.2xx", 
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "type": "sum"
+                                    }, 
+                                    {
+                                        "field": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "id": "973a6de0-47bd-11e8-b7ab-dff70b15977c", 
+                                        "type": "derivative", 
+                                        "unit": ""
+                                    }, 
+                                    {
+                                        "field": "973a6de0-47bd-11e8-b7ab-dff70b15977c", 
+                                        "id": "4971d580-47e5-11e8-b45e-f10c3845381c", 
+                                        "type": "positive_only", 
+                                        "unit": ""
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }, 
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "rgba(64,240,0,1)", 
+                                "fill": 0.5, 
+                                "formatter": "number", 
+                                "id": "aafd05e0-47bd-11e8-b7ab-dff70b15977c", 
+                                "label": "300s", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "haproxy.stat.response.http.3xx", 
+                                        "id": "aafd05e1-47bd-11e8-b7ab-dff70b15977c", 
+                                        "type": "sum"
+                                    }, 
+                                    {
+                                        "field": "aafd05e1-47bd-11e8-b7ab-dff70b15977c", 
+                                        "id": "aafd05e2-47bd-11e8-b7ab-dff70b15977c", 
+                                        "type": "derivative", 
+                                        "unit": ""
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }, 
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "rgba(255,246,0,1)", 
+                                "fill": 0.5, 
+                                "formatter": "number", 
+                                "id": "c77191a0-47bd-11e8-b7ab-dff70b15977c", 
+                                "label": "400s", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "haproxy.stat.response.http.4xx", 
+                                        "id": "c77191a1-47bd-11e8-b7ab-dff70b15977c", 
+                                        "type": "sum"
+                                    }, 
+                                    {
+                                        "field": "c77191a1-47bd-11e8-b7ab-dff70b15977c", 
+                                        "id": "c77191a2-47bd-11e8-b7ab-dff70b15977c", 
+                                        "type": "derivative", 
+                                        "unit": ""
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }, 
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "rgba(255,0,4,1)", 
+                                "fill": 0.5, 
+                                "formatter": "number", 
+                                "id": "d574e900-47bd-11e8-b7ab-dff70b15977c", 
+                                "label": "500s", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "haproxy.stat.response.http.5xx", 
+                                        "id": "d574e901-47bd-11e8-b7ab-dff70b15977c", 
+                                        "type": "sum"
+                                    }, 
+                                    {
+                                        "field": "d574e901-47bd-11e8-b7ab-dff70b15977c", 
+                                        "id": "d5753720-47bd-11e8-b7ab-dff70b15977c", 
+                                        "type": "derivative", 
+                                        "unit": ""
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }, 
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "rgba(0,251,255,1)", 
+                                "fill": 0.5, 
+                                "formatter": "number", 
+                                "id": "e3b8a4c0-47bd-11e8-b7ab-dff70b15977c", 
+                                "label": "Other", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "haproxy.stat.response.http.other", 
+                                        "id": "e3b8a4c1-47bd-11e8-b7ab-dff70b15977c", 
+                                        "type": "sum"
+                                    }, 
+                                    {
+                                        "field": "e3b8a4c1-47bd-11e8-b7ab-dff70b15977c", 
+                                        "id": "e3b8a4c2-47bd-11e8-b7ab-dff70b15977c", 
+                                        "type": "derivative", 
+                                        "unit": ""
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }, 
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "rgba(15,20,25,1)", 
+                                "fill": 0.5, 
+                                "formatter": "number", 
+                                "id": "f9217d40-47be-11e8-b7ab-dff70b15977c", 
+                                "label": "Response errors", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "haproxy.stat.response.errors", 
+                                        "id": "f9217d41-47be-11e8-b7ab-dff70b15977c", 
+                                        "type": "sum"
+                                    }, 
+                                    {
+                                        "field": "f9217d41-47be-11e8-b7ab-dff70b15977c", 
+                                        "id": "1b7d4400-47bf-11e8-b7ab-dff70b15977c", 
+                                        "type": "derivative", 
+                                        "unit": ""
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "timeseries"
+                    }, 
+                    "title": "HAProxy HTTP response codes ECS", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "fcbdfa60-47bd-11e8-bc13-1397384faad3-ecs", 
+            "type": "visualization", 
+            "updated_at": "2018-04-24T17:31:30.169Z", 
+            "version": 4
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "Average response time [Metricbeat HAProxy] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": 0.5, 
+                                "formatter": "ms,ms,0", 
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417", 
+                                "label": "Average response time", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "haproxy.stat.response.time.avg", 
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "type": "avg"
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none", 
+                                "value_template": "{{value}}ms"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "timeseries"
+                    }, 
+                    "title": "HAProxy average response time ECS", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "981d1040-47be-11e8-bc13-1397384faad3-ecs", 
+            "type": "visualization", 
+            "updated_at": "2018-04-24T13:01:49.811Z", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "Requests [Metricbeat HAProxy] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": 0.5, 
+                                "formatter": "number", 
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417", 
+                                "label": "Requests", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "haproxy.stat.request.total", 
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "type": "max"
+                                    }, 
+                                    {
+                                        "field": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "id": "ad38e2c0-47d6-11e8-994c-81d2daeb7c86", 
+                                        "type": "derivative", 
+                                        "unit": ""
+                                    }, 
+                                    {
+                                        "field": "ad38e2c0-47d6-11e8-994c-81d2daeb7c86", 
+                                        "id": "b1ca03a0-47d6-11e8-994c-81d2daeb7c86", 
+                                        "type": "positive_only", 
+                                        "unit": ""
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }, 
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "rgba(255,0,0,1)", 
+                                "fill": 0.5, 
+                                "formatter": "number", 
+                                "id": "c2f30500-47d6-11e8-994c-81d2daeb7c86", 
+                                "label": "Request errors", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "haproxy.stat.request.errors", 
+                                        "id": "c2f30501-47d6-11e8-994c-81d2daeb7c86", 
+                                        "type": "max"
+                                    }, 
+                                    {
+                                        "field": "c2f30501-47d6-11e8-994c-81d2daeb7c86", 
+                                        "id": "c2f30502-47d6-11e8-994c-81d2daeb7c86", 
+                                        "type": "derivative", 
+                                        "unit": ""
+                                    }, 
+                                    {
+                                        "field": "c2f30502-47d6-11e8-994c-81d2daeb7c86", 
+                                        "id": "c2f30503-47d6-11e8-994c-81d2daeb7c86", 
+                                        "type": "positive_only", 
+                                        "unit": ""
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }, 
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "rgba(0,0,0,1)", 
+                                "fill": 0.5, 
+                                "formatter": "number", 
+                                "id": "11968ce0-47d7-11e8-994c-81d2daeb7c86", 
+                                "label": "Denied requests", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "haproxy.stat.request.denied", 
+                                        "id": "11968ce1-47d7-11e8-994c-81d2daeb7c86", 
+                                        "type": "max"
+                                    }, 
+                                    {
+                                        "field": "11968ce1-47d7-11e8-994c-81d2daeb7c86", 
+                                        "id": "11968ce2-47d7-11e8-994c-81d2daeb7c86", 
+                                        "type": "derivative", 
+                                        "unit": ""
+                                    }, 
+                                    {
+                                        "field": "11968ce2-47d7-11e8-994c-81d2daeb7c86", 
+                                        "id": "11968ce3-47d7-11e8-994c-81d2daeb7c86", 
+                                        "type": "positive_only", 
+                                        "unit": ""
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "timeseries"
+                    }, 
+                    "title": "HAProxy requests ECS", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "30956d00-47d7-11e8-bc13-1397384faad3-ecs", 
+            "type": "visualization", 
+            "updated_at": "2018-04-24T15:50:19.344Z", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "Average connection time [Metricbeat HAProxy] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": "0.1", 
+                                "formatter": "number", 
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417", 
+                                "label": "Percentile", 
+                                "line_width": "1", 
+                                "metrics": [
+                                    {
+                                        "field": "haproxy.stat.connection.time.avg", 
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "percentiles": [
+                                            {
+                                                "id": "9fa517e0-479b-11e8-9590-e34c5ed2dd95", 
+                                                "mode": "line", 
+                                                "percentile": "", 
+                                                "shade": 0.2, 
+                                                "value": "99"
+                                            }, 
+                                            {
+                                                "id": "daafd6e0-479b-11e8-9590-e34c5ed2dd95", 
+                                                "mode": "line", 
+                                                "percentile": "", 
+                                                "shade": 0.2, 
+                                                "value": "90"
+                                            }, 
+                                            {
+                                                "id": "e006b8c0-479b-11e8-9590-e34c5ed2dd95", 
+                                                "mode": "line", 
+                                                "percentile": "", 
+                                                "shade": 0.2, 
+                                                "value": "50"
+                                            }
+                                        ], 
+                                        "type": "percentile"
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_color_mode": "gradient", 
+                                "split_mode": "everything", 
+                                "stacked": "none", 
+                                "terms_field": "haproxy.stat.service_name"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "timeseries"
+                    }, 
+                    "title": "HAProxy average connection time ECS", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "0751ed00-479c-11e8-bc13-1397384faad3-ecs", 
+            "type": "visualization", 
+            "updated_at": "2018-04-24T08:51:34.252Z", 
+            "version": 4
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "Number of server connections [Metricbeat HAProxy] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": 0.5, 
+                                "filter": "haproxy.stat.component_type:(2 OR 3)", 
+                                "formatter": "number", 
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417", 
+                                "label": "Number of connections", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "haproxy.stat.connection.total", 
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "type": "sum"
+                                    }, 
+                                    {
+                                        "field": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "id": "22668d40-47e1-11e8-96ee-d767c73d008a", 
+                                        "type": "derivative", 
+                                        "unit": ""
+                                    }, 
+                                    {
+                                        "field": "22668d40-47e1-11e8-96ee-d767c73d008a", 
+                                        "id": "2a1d0a00-47e1-11e8-96ee-d767c73d008a", 
+                                        "type": "positive_only", 
+                                        "unit": ""
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "terms", 
+                                "stacked": "none", 
+                                "terms_field": "haproxy.stat.service_name"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "timeseries"
+                    }, 
+                    "title": "HAProxy number of server connections ECS", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "72e84b00-47e1-11e8-bc13-1397384faad3-ecs", 
+            "type": "visualization", 
+            "updated_at": "2018-04-24T17:05:00.128Z", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "Healthcheck [Metricbeat HAProxy] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "rgba(255,0,4,1)", 
+                                "fill": 0.5, 
+                                "formatter": "number", 
+                                "id": "198f56e0-47e4-11e8-b45e-f10c3845381c", 
+                                "label": "Down", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "haproxy.stat.downtime", 
+                                        "id": "198f56e1-47e4-11e8-b45e-f10c3845381c", 
+                                        "type": "sum"
+                                    }, 
+                                    {
+                                        "field": "198f56e1-47e4-11e8-b45e-f10c3845381c", 
+                                        "id": "dbf38560-47e6-11e8-b45e-f10c3845381c", 
+                                        "sigma": "", 
+                                        "type": "derivative", 
+                                        "unit": ""
+                                    }, 
+                                    {
+                                        "field": "dbf38560-47e6-11e8-b45e-f10c3845381c", 
+                                        "id": "62274b80-47e7-11e8-b45e-f10c3845381c", 
+                                        "type": "positive_only", 
+                                        "unit": ""
+                                    }, 
+                                    {
+                                        "id": "7b7a7300-47e7-11e8-b45e-f10c3845381c", 
+                                        "script": "(params.down > 0) ? 1 : 0", 
+                                        "type": "calculation", 
+                                        "variables": [
+                                            {
+                                                "field": "62274b80-47e7-11e8-b45e-f10c3845381c", 
+                                                "id": "7e577b40-47e7-11e8-b45e-f10c3845381c", 
+                                                "name": "down"
+                                            }
+                                        ]
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 1, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }, 
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "rgba(255,218,0,1)", 
+                                "fill": 0.5, 
+                                "formatter": "ms,ms,0", 
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417", 
+                                "label": "Duration (ms)", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "haproxy.stat.check.duration", 
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "type": "avg"
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "timeseries"
+                    }, 
+                    "title": "HAProxy healthcheck ECS", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "976b0910-47e4-11e8-bc13-1397384faad3-ecs", 
+            "type": "visualization", 
+            "updated_at": "2018-04-24T17:49:15.393Z", 
+            "version": 5
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "Servers per connection [Metricbeat HAProxy] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "bar_color_rules": [
+                            {
+                                "id": "50830800-47d9-11e8-9db9-274c7a5e25e4"
+                            }
+                        ], 
+                        "drilldown_url": "../app/kibana#/dashboard/8cc50a50-47e0-11e8-bc13-1397384faad3-ecs?_a=(query:(language:kuery,query:'haproxy.stat.service_name:\"{{ key }}\"'))",
+                        "filter": "", 
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417", 
+                        "ignore_global_filter": 0, 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "markdown": "{{#each _all}}\n{{ label }}\n\n{{/each}}", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": 0.5, 
+                                "filter": "haproxy.stat.component_type:(2 OR 3)", 
+                                "formatter": "number", 
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417", 
+                                "label": "Servers", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "haproxy.stat.connection.total", 
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "type": "sum"
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "terms", 
+                                "stacked": "none", 
+                                "terms_field": "haproxy.stat.service_name", 
+                                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                "terms_size": "20", 
+                                "var_name": ""
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "top_n"
+                    }, 
+                    "title": "HAProxy servers per connection ECS", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "79350d50-47db-11e8-bc13-1397384faad3-ecs", 
+            "type": "visualization", 
+            "updated_at": "2018-04-24T17:11:53.619Z", 
+            "version": 7
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "Backends per connection [Metricbeat HAProxy] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "bar_color_rules": [
+                            {
+                                "id": "4aeddd40-47dc-11e8-9db9-274c7a5e25e4"
+                            }
+                        ], 
+                        "drilldown_url": "../app/kibana#/dashboard/0836a4b0-47bd-11e8-bc13-1397384faad3-ecs?_a=(query:(language:kuery,query:'haproxy.stat.proxy.name:\"{{ key }}\"'))",
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": 0.5, 
+                                "filter": "haproxy.stat.component_type:1", 
+                                "formatter": "number", 
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417", 
+                                "label": "Backends", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "haproxy.stat.connection.total", 
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "type": "sum"
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "terms", 
+                                "stacked": "none", 
+                                "terms_field": "haproxy.stat.proxy.name", 
+                                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                "terms_size": "20"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "top_n"
+                    }, 
+                    "title": "HAProxy backends per connection ECS", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "8c8f0300-47dc-11e8-bc13-1397384faad3-ecs", 
+            "type": "visualization", 
+            "updated_at": "2018-04-24T16:46:24.802Z", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "Frontends per connection [Metricbeat HAProxy] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "bar_color_rules": [
+                            {
+                                "id": "b81d8640-47dc-11e8-9a25-99b107967d82"
+                            }
+                        ], 
+                        "drilldown_url": "../app/kibana#/dashboard/e9057ae0-47c5-11e8-bc13-1397384faad3-ecs?_a=(query:(language:kuery,query:'haproxy.stat.proxy.name:\"{{ key }}\"'))",
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": 0.5, 
+                                "filter": "haproxy.stat.component_type:0", 
+                                "formatter": "number", 
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417", 
+                                "label": "Frontends", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "haproxy.stat.connection.total", 
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "type": "sum"
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "terms", 
+                                "stacked": "none", 
+                                "terms_field": "haproxy.stat.proxy.name", 
+                                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                "terms_size": "20"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "top_n"
+                    }, 
+                    "title": "HAProxy frontends per connection ECS", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "f1e27ed0-47dc-11e8-bc13-1397384faad3-ecs", 
+            "type": "visualization", 
+            "updated_at": "2018-04-24T16:54:16.639Z", 
+            "version": 3
+        }
+    ], 
+    "version": "6.2.2"
+}

--- a/dev/package-beats/haproxy-1.0.0/manifest.yml
+++ b/dev/package-beats/haproxy-1.0.0/manifest.yml
@@ -1,0 +1,14 @@
+name: haproxy
+title: haproxy
+version: 1.0.0
+description: |
+  HAProxy Module
+type: ""
+categories:
+- logs
+- metrics
+requirement:
+  kibana:
+    version:
+      min: 6.7.0
+      max: 7.6.0

--- a/dev/package-beats/http-1.0.0/manifest.yml
+++ b/dev/package-beats/http-1.0.0/manifest.yml
@@ -1,0 +1,13 @@
+name: http
+title: HTTP
+version: 1.0.0
+description: |
+  HTTP module
+type: ""
+categories:
+- metrics
+requirement:
+  kibana:
+    version:
+      min: 6.7.0
+      max: 7.6.0

--- a/dev/package-beats/ibmmq-1.0.0/kibana/dashboard/Filebeat-IBMMQ-Overview.json
+++ b/dev/package-beats/ibmmq-1.0.0/kibana/dashboard/Filebeat-IBMMQ-Overview.json
@@ -1,0 +1,931 @@
+{
+  "objects": [
+    {
+      "attributes": {
+        "description": "Overview of IBM MQ",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "optionsJSON": {
+          "hidePanelTitles": false,
+          "useMargins": true
+        },
+        "panelsJSON": [
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 9,
+              "i": "1",
+              "w": 24,
+              "x": 0,
+              "y": 7
+            },
+            "panelIndex": "1",
+            "panelRefName": "panel_0",
+            "version": "7.0.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 14,
+              "i": "6",
+              "w": 48,
+              "x": 0,
+              "y": 16
+            },
+            "panelIndex": "6",
+            "panelRefName": "panel_1",
+            "title": "Top 5 Errors [Filebeat IBM MQ]",
+            "version": "7.0.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 7,
+              "i": "8",
+              "w": 13,
+              "x": 0,
+              "y": 0
+            },
+            "panelIndex": "8",
+            "panelRefName": "panel_2",
+            "version": "7.0.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 27,
+              "i": "9",
+              "w": 48,
+              "x": 0,
+              "y": 30
+            },
+            "panelIndex": "9",
+            "panelRefName": "panel_3",
+            "version": "7.2.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 9,
+              "i": "10",
+              "w": 24,
+              "x": 24,
+              "y": 7
+            },
+            "panelIndex": "10",
+            "panelRefName": "panel_4",
+            "version": "7.2.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 7,
+              "i": "11",
+              "w": 7,
+              "x": 13,
+              "y": 0
+            },
+            "panelIndex": "11",
+            "panelRefName": "panel_5",
+            "version": "7.2.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 7,
+              "i": "12",
+              "w": 7,
+              "x": 20,
+              "y": 0
+            },
+            "panelIndex": "12",
+            "panelRefName": "panel_6",
+            "version": "7.2.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 7,
+              "i": "13",
+              "w": 21,
+              "x": 27,
+              "y": 0
+            },
+            "panelIndex": "13",
+            "panelRefName": "panel_7",
+            "version": "7.2.0"
+          }
+        ],
+        "refreshInterval": {
+          "pause": true,
+          "value": 0
+        },
+        "timeFrom": "now-2M",
+        "timeRestore": true,
+        "timeTo": "now",
+        "title": "[Filebeat IBM MQ] Overview of error log overview",
+        "version": 1
+      },
+      "id": "ba1d8830-7c7b-11e9-9645-e37efaf5baff",
+      "migrationVersion": {
+        "dashboard": "7.0.0"
+      },
+      "references": [
+        {
+          "id": "4b2794c0-d901-11e8-aa1c-3fc8e6195a8e",
+          "name": "panel_0",
+          "type": "visualization"
+        },
+        {
+          "id": "b6308f30-7c7e-11e9-9645-e37efaf5baff",
+          "name": "panel_1",
+          "type": "visualization"
+        },
+        {
+          "id": "bf8e5de0-7c7f-11e9-9645-e37efaf5baff",
+          "name": "panel_2",
+          "type": "visualization"
+        },
+        {
+          "id": "82db7ba0-adec-11e9-8358-1517661d7c84",
+          "name": "panel_3",
+          "type": "search"
+        },
+        {
+          "id": "df35c4b0-adf0-11e9-8358-1517661d7c84",
+          "name": "panel_4",
+          "type": "visualization"
+        },
+        {
+          "id": "3ff778d0-adf0-11e9-8358-1517661d7c84",
+          "name": "panel_5",
+          "type": "visualization"
+        },
+        {
+          "id": "57eae940-adf0-11e9-8358-1517661d7c84",
+          "name": "panel_6",
+          "type": "visualization"
+        },
+        {
+          "id": "845fca50-adef-11e9-8358-1517661d7c84",
+          "name": "panel_7",
+          "type": "visualization"
+        }
+      ],
+      "type": "dashboard",
+      "updated_at": "2019-07-24T09:05:03.616Z",
+      "version": "WzI4OSwxXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Errors over time by Queue Manager [Filebeat IBM MQ]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "qbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": "event.module:ibmmq",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "filebeat-*",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "number",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "count"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "terms",
+                "stacked": "stacked",
+                "terms_field": "ibmmq.errorlog.qmgr",
+                "terms_size": "50",
+                "value_template": "{{value}} Errors"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Errors over time by Queue Manager [Filebeat IBM MQ]",
+          "type": "metrics"
+        }
+      },
+      "id": "4b2794c0-d901-11e8-aa1c-3fc8e6195a8e",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-07-24T08:44:22.220Z",
+      "version": "WzI3OCwxXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [
+              {
+                "$state": {
+                  "store": "appState"
+                },
+                "meta": {
+                  "alias": null,
+                  "disabled": false,
+                  "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                  "key": "event.module",
+                  "negate": false,
+                  "params": {
+                    "query": "ibmmq"
+                  },
+                  "type": "phrase",
+                  "value": "ibmmq"
+                },
+                "query": {
+                  "match": {
+                    "event.module": {
+                      "query": "ibmmq",
+                      "type": "phrase"
+                    }
+                  }
+                }
+              }
+            ],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Top 5 Errors [Filebeat IBM MQ]",
+        "uiStateJSON": {
+          "vis": {
+            "params": {
+              "sort": {
+                "columnIndex": null,
+                "direction": null
+              }
+            }
+          }
+        },
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "Occurences"
+              },
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "3",
+              "params": {
+                "aggregate": "concat",
+                "customLabel": "Description",
+                "field": "message",
+                "size": 1,
+                "sortField": "@timestamp",
+                "sortOrder": "desc"
+              },
+              "schema": "metric",
+              "type": "top_hits"
+            },
+            {
+              "enabled": true,
+              "id": "5",
+              "params": {
+                "aggregate": "concat",
+                "customLabel": "Explanation",
+                "field": "ibmmq.errorlog.explanation",
+                "size": 1,
+                "sortField": "@timestamp",
+                "sortOrder": "desc"
+              },
+              "schema": "metric",
+              "type": "top_hits"
+            },
+            {
+              "enabled": true,
+              "id": "4",
+              "params": {
+                "aggregate": "concat",
+                "customLabel": "Recommended Action",
+                "field": "ibmmq.errorlog.action",
+                "size": 1,
+                "sortField": "@timestamp",
+                "sortOrder": "desc"
+              },
+              "schema": "metric",
+              "type": "top_hits"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customLabel": "Error Codes",
+                "field": "ibmmq.errorlog.code",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 5
+              },
+              "schema": "bucket",
+              "type": "terms"
+            }
+          ],
+          "params": {
+            "perPage": 5,
+            "showMetricsAtAllLevels": false,
+            "showPartialRows": false,
+            "showTotal": false,
+            "sort": {
+              "columnIndex": null,
+              "direction": null
+            },
+            "totalFunc": "sum"
+          },
+          "title": "Top 5 Errors [Filebeat IBM MQ]",
+          "type": "table"
+        }
+      },
+      "id": "b6308f30-7c7e-11e9-9645-e37efaf5baff",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        },
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-07-24T09:03:08.635Z",
+      "version": "WzI4OCwxXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Control [Filebeat IBM MQ]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "controls": [
+              {
+                "fieldName": "ibmmq.errorlog.qmgr",
+                "id": "1558522305526",
+                "indexPatternRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+                "label": "Queue Manager",
+                "options": {
+                  "dynamicOptions": true,
+                  "multiselect": true,
+                  "order": "desc",
+                  "size": 5,
+                  "type": "terms"
+                },
+                "parent": "",
+                "type": "list"
+              }
+            ],
+            "pinFilters": false,
+            "updateFiltersOnChange": false,
+            "useTimeFilter": false
+          },
+          "title": "Control [Filebeat IBM MQ]",
+          "type": "input_control_vis"
+        }
+      },
+      "id": "bf8e5de0-7c7f-11e9-9645-e37efaf5baff",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-07-24T08:20:32.926Z",
+      "version": "WzI2NSwxXQ=="
+    },
+    {
+      "attributes": {
+        "columns": [
+          "@timestamp",
+          "message",
+          "ibmmq.errorlog.explanation",
+          "ibmmq.errorlog.action"
+        ],
+        "description": "",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [
+              {
+                "$state": {
+                  "store": "appState"
+                },
+                "meta": {
+                  "alias": null,
+                  "disabled": false,
+                  "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                  "key": "event.module",
+                  "negate": false,
+                  "params": {
+                    "query": "ibmmq"
+                  },
+                  "type": "phrase",
+                  "value": "ibmmq"
+                },
+                "query": {
+                  "match": {
+                    "event.module": {
+                      "query": "ibmmq",
+                      "type": "phrase"
+                    }
+                  }
+                }
+              }
+            ],
+            "highlightAll": true,
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "language": "lucene",
+              "query": ""
+            },
+            "version": true
+          }
+        },
+        "sort": [
+          "@timestamp",
+          "desc"
+        ],
+        "title": "Errorlogs [Filebeat IBM MQ]",
+        "version": 1
+      },
+      "id": "82db7ba0-adec-11e9-8358-1517661d7c84",
+      "migrationVersion": {
+        "search": "7.0.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        },
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "search",
+      "updated_at": "2019-07-24T08:36:18.357Z",
+      "version": "WzI3NCwxXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "lucene",
+              "query": ""
+            }
+          }
+        },
+        "savedSearchRefName": "search_0",
+        "title": "Errors per code, queue manager and host [Filebeat IBM MQ]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customLabel": "Errorcodes",
+                "field": "ibmmq.errorlog.code",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": true,
+                "otherBucketLabel": "Other",
+                "size": 5
+              },
+              "schema": "segment",
+              "type": "terms"
+            },
+            {
+              "enabled": true,
+              "id": "3",
+              "params": {
+                "customLabel": "Queue Manager",
+                "field": "ibmmq.errorlog.qmgr",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 5
+              },
+              "schema": "segment",
+              "type": "terms"
+            },
+            {
+              "enabled": true,
+              "id": "4",
+              "params": {
+                "customLabel": "Host",
+                "field": "host.name",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 5
+              },
+              "schema": "segment",
+              "type": "terms"
+            }
+          ],
+          "params": {
+            "addLegend": true,
+            "addTooltip": true,
+            "dimensions": {
+              "metric": {
+                "accessor": 0,
+                "aggType": "count",
+                "format": {
+                  "id": "number"
+                },
+                "params": {}
+              }
+            },
+            "isDonut": true,
+            "labels": {
+              "last_level": true,
+              "show": false,
+              "truncate": 100,
+              "values": true
+            },
+            "legendPosition": "right",
+            "type": "pie"
+          },
+          "title": "Errors per code, queue manager and host [Filebeat IBM MQ]",
+          "type": "pie"
+        }
+      },
+      "id": "df35c4b0-adf0-11e9-8358-1517661d7c84",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [
+        {
+          "id": "82db7ba0-adec-11e9-8358-1517661d7c84",
+          "name": "search_0",
+          "type": "search"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-07-24T08:56:55.163Z",
+      "version": "WzI4NiwxXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "lucene",
+              "query": ""
+            }
+          }
+        },
+        "savedSearchRefName": "search_0",
+        "title": "Different error codes [Filebeat IBM MQ]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "Different error codes",
+                "field": "ibmmq.errorlog.code"
+              },
+              "schema": "metric",
+              "type": "cardinality"
+            }
+          ],
+          "params": {
+            "addLegend": false,
+            "addTooltip": true,
+            "dimensions": {
+              "metrics": [
+                {
+                  "accessor": 0,
+                  "aggType": "count",
+                  "format": {
+                    "id": "number"
+                  },
+                  "params": {}
+                }
+              ]
+            },
+            "metric": {
+              "colorSchema": "Green to Red",
+              "colorsRange": [
+                {
+                  "from": 0,
+                  "to": 10000
+                }
+              ],
+              "invertColors": false,
+              "labels": {
+                "show": true
+              },
+              "metricColorMode": "None",
+              "percentageMode": false,
+              "style": {
+                "bgColor": false,
+                "bgFill": "#000",
+                "fontSize": 60,
+                "labelColor": false,
+                "subText": ""
+              },
+              "useRanges": false
+            },
+            "type": "metric"
+          },
+          "title": "Different error codes [Filebeat IBM MQ]",
+          "type": "metric"
+        }
+      },
+      "id": "3ff778d0-adf0-11e9-8358-1517661d7c84",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [
+        {
+          "id": "82db7ba0-adec-11e9-8358-1517661d7c84",
+          "name": "search_0",
+          "type": "search"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-07-24T08:51:38.844Z",
+      "version": "WzI4MSwxXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "lucene",
+              "query": ""
+            }
+          }
+        },
+        "savedSearchRefName": "search_0",
+        "title": "Number of Queue Manager [Filebeat IBM MQ]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "Queue Manager",
+                "field": "ibmmq.errorlog.qmgr"
+              },
+              "schema": "metric",
+              "type": "cardinality"
+            }
+          ],
+          "params": {
+            "addLegend": false,
+            "addTooltip": true,
+            "dimensions": {
+              "metrics": [
+                {
+                  "accessor": 0,
+                  "aggType": "cardinality",
+                  "format": {
+                    "id": "number"
+                  },
+                  "params": {}
+                }
+              ]
+            },
+            "metric": {
+              "colorSchema": "Green to Red",
+              "colorsRange": [
+                {
+                  "from": 0,
+                  "to": 10000
+                }
+              ],
+              "invertColors": false,
+              "labels": {
+                "show": true
+              },
+              "metricColorMode": "None",
+              "percentageMode": false,
+              "style": {
+                "bgColor": false,
+                "bgFill": "#000",
+                "fontSize": 60,
+                "labelColor": false,
+                "subText": ""
+              },
+              "useRanges": false
+            },
+            "type": "metric"
+          },
+          "title": "Number of Queue Manager [Filebeat IBM MQ]",
+          "type": "metric"
+        }
+      },
+      "id": "57eae940-adf0-11e9-8358-1517661d7c84",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [
+        {
+          "id": "82db7ba0-adec-11e9-8358-1517661d7c84",
+          "name": "search_0",
+          "type": "search"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-07-24T08:52:19.027Z",
+      "version": "WzI4MiwxXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "lucene",
+              "query": ""
+            }
+          }
+        },
+        "savedSearchRefName": "search_0",
+        "title": "Last error [Filebeat IBM MQ]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "Last error",
+                "field": "@timestamp"
+              },
+              "schema": "metric",
+              "type": "max"
+            }
+          ],
+          "params": {
+            "addLegend": false,
+            "addTooltip": true,
+            "dimensions": {
+              "metrics": [
+                {
+                  "accessor": 0,
+                  "aggType": "count",
+                  "format": {
+                    "id": "number"
+                  },
+                  "params": {}
+                }
+              ]
+            },
+            "metric": {
+              "colorSchema": "Green to Red",
+              "colorsRange": [
+                {
+                  "from": 0,
+                  "to": 10000
+                }
+              ],
+              "invertColors": false,
+              "labels": {
+                "show": true
+              },
+              "metricColorMode": "None",
+              "percentageMode": false,
+              "style": {
+                "bgColor": false,
+                "bgFill": "#000",
+                "fontSize": 60,
+                "labelColor": false,
+                "subText": ""
+              },
+              "useRanges": false
+            },
+            "type": "metric"
+          },
+          "title": "Last error [Filebeat IBM MQ]",
+          "type": "metric"
+        }
+      },
+      "id": "845fca50-adef-11e9-8358-1517661d7c84",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [
+        {
+          "id": "82db7ba0-adec-11e9-8358-1517661d7c84",
+          "name": "search_0",
+          "type": "search"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-07-24T08:46:24.117Z",
+      "version": "WzI3OSwxXQ=="
+    }
+  ],
+  "version": "7.2.0"
+}

--- a/dev/package-beats/ibmmq-1.0.0/manifest.yml
+++ b/dev/package-beats/ibmmq-1.0.0/manifest.yml
@@ -1,0 +1,13 @@
+name: ibmmq
+title: ibmmq
+version: 1.0.0
+description: |
+  ibmmq Module
+type: ""
+categories:
+- logs
+requirement:
+  kibana:
+    version:
+      min: 6.7.0
+      max: 7.6.0

--- a/dev/package-beats/icinga-1.0.0/kibana/dashboard/Filebeat-icinga-debug-log.json
+++ b/dev/package-beats/icinga-1.0.0/kibana/dashboard/Filebeat-icinga-debug-log.json
@@ -1,0 +1,298 @@
+{
+    "objects": [
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "c876e6a0-2418-11e7-a83b-d5f4cebac9ff-ecs", 
+                "title": "Debuglog Facility [Filebeat Icinga] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "field": "icinga.debug.facility", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "group", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "defaultYExtents": false, 
+                        "legendPosition": "right", 
+                        "mode": "stacked", 
+                        "scale": "linear", 
+                        "setYExtents": false, 
+                        "times": []
+                    }, 
+                    "title": "Icinga Debuglog Facility ECS", 
+                    "type": "histogram"
+                }
+            }, 
+            "id": "0bc34b60-2419-11e7-a83b-d5f4cebac9ff-ecs", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "c876e6a0-2418-11e7-a83b-d5f4cebac9ff-ecs", 
+                "title": "Debuglog Severity [Filebeat Icinga] ECS", 
+                "uiStateJSON": {
+                    "vis": {
+                        "colors": {
+                            "debug": "#BA43A9", 
+                            "information": "#629E51", 
+                            "notice": "#6ED0E0", 
+                            "warning": "#E5AC0E"
+                        }
+                    }
+                }, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "field": "log.level", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "group", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "defaultYExtents": false, 
+                        "legendPosition": "right", 
+                        "mode": "stacked", 
+                        "scale": "linear", 
+                        "setYExtents": false, 
+                        "times": []
+                    }, 
+                    "title": "Icinga Debuglog Severity ECS", 
+                    "type": "histogram"
+                }
+            }, 
+            "id": "fb09d4b0-2418-11e7-a83b-d5f4cebac9ff-ecs", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "columns": [
+                    "icinga.debug.facility", 
+                    "log.level", 
+                    "message"
+                ], 
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [
+                            {
+                                "$state": {
+                                    "store": "appState"
+                                }, 
+                                "meta": {
+                                    "alias": null, 
+                                    "disabled": false, 
+                                    "index": "filebeat-*", 
+                                    "key": "event.module", 
+                                    "negate": false, 
+                                    "params": {
+                                        "query": "icinga", 
+                                        "type": "phrase"
+                                    }, 
+                                    "type": "phrase", 
+                                    "value": "icinga"
+                                }, 
+                                "query": {
+                                    "match": {
+                                        "event.module": {
+                                            "query": "icinga", 
+                                            "type": "phrase"
+                                        }
+                                    }
+                                }
+                            }, 
+                            {
+                                "$state": {
+                                    "store": "appState"
+                                }, 
+                                "meta": {
+                                    "alias": null, 
+                                    "disabled": false, 
+                                    "index": "filebeat-*", 
+                                    "key": "fileset.name", 
+                                    "negate": false, 
+                                    "params": {
+                                        "query": "debug", 
+                                        "type": "phrase"
+                                    }, 
+                                    "type": "phrase", 
+                                    "value": "debug"
+                                }, 
+                                "query": {
+                                    "match": {
+                                        "fileset.name": {
+                                            "query": "debug", 
+                                            "type": "phrase"
+                                        }
+                                    }
+                                }
+                            }
+                        ], 
+                        "highlightAll": true, 
+                        "index": "filebeat-*", 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "sort": [
+                    "@timestamp", 
+                    "desc"
+                ], 
+                "title": "Debug Log [Filebeat Icinga] ECS", 
+                "version": 1
+            }, 
+            "id": "c876e6a0-2418-11e7-a83b-d5f4cebac9ff-ecs", 
+            "type": "search", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "Filebeat Icinga module dashboard for the debug logs", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlightAll": true, 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "optionsJSON": {
+                    "darkTheme": false
+                }, 
+                "panelsJSON": [
+                    {
+                        "col": 1, 
+                        "id": "0bc34b60-2419-11e7-a83b-d5f4cebac9ff-ecs", 
+                        "panelIndex": 1, 
+                        "row": 1, 
+                        "size_x": 6, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 7, 
+                        "id": "fb09d4b0-2418-11e7-a83b-d5f4cebac9ff-ecs", 
+                        "panelIndex": 2, 
+                        "row": 1, 
+                        "size_x": 6, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "columns": [
+                            "icinga.debug.facility", 
+                            "log.level", 
+                            "message"
+                        ], 
+                        "id": "c876e6a0-2418-11e7-a83b-d5f4cebac9ff-ecs", 
+                        "panelIndex": 3, 
+                        "row": 4, 
+                        "size_x": 12, 
+                        "size_y": 29, 
+                        "sort": [
+                            "@timestamp", 
+                            "desc"
+                        ], 
+                        "type": "search"
+                    }
+                ], 
+                "timeRestore": false, 
+                "title": "[Filebeat Icinga] Debug Log ECS", 
+                "uiStateJSON": {}, 
+                "version": 1
+            }, 
+            "id": "26309570-2419-11e7-a83b-d5f4cebac9ff-ecs", 
+            "type": "dashboard", 
+            "version": 2
+        }
+    ], 
+    "version": "6.0.0-beta1-SNAPSHOT"
+}

--- a/dev/package-beats/icinga-1.0.0/kibana/dashboard/Filebeat-icinga-main-log.json
+++ b/dev/package-beats/icinga-1.0.0/kibana/dashboard/Filebeat-icinga-main-log.json
@@ -1,0 +1,296 @@
+{
+    "objects": [
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "ffaf5a30-2413-11e7-a0d9-39604d45ca7f-ecs", 
+                "title": "Mainlog Severity [Filebeat Icinga] ECS", 
+                "uiStateJSON": {
+                    "vis": {
+                        "colors": {
+                            "critical": "#BF1B00", 
+                            "warning": "#E5AC0E"
+                        }
+                    }
+                }, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "field": "log.level", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "group", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "defaultYExtents": false, 
+                        "legendPosition": "right", 
+                        "mode": "stacked", 
+                        "scale": "linear", 
+                        "setYExtents": false, 
+                        "times": []
+                    }, 
+                    "title": "Icinga Mainlog Severity ECS", 
+                    "type": "histogram"
+                }
+            }, 
+            "id": "d8e5dc40-2417-11e7-a83b-d5f4cebac9ff-ecs", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "columns": [
+                    "icinga.main.facility", 
+                    "log.level", 
+                    "message"
+                ], 
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [
+                            {
+                                "$state": {
+                                    "store": "appState"
+                                }, 
+                                "meta": {
+                                    "alias": null, 
+                                    "disabled": false, 
+                                    "index": "filebeat-*", 
+                                    "key": "event.module", 
+                                    "negate": false, 
+                                    "params": {
+                                        "query": "icinga", 
+                                        "type": "phrase"
+                                    }, 
+                                    "type": "phrase", 
+                                    "value": "icinga"
+                                }, 
+                                "query": {
+                                    "match": {
+                                        "event.module": {
+                                            "query": "icinga", 
+                                            "type": "phrase"
+                                        }
+                                    }
+                                }
+                            }, 
+                            {
+                                "$state": {
+                                    "store": "appState"
+                                }, 
+                                "meta": {
+                                    "alias": null, 
+                                    "disabled": false, 
+                                    "index": "filebeat-*", 
+                                    "key": "fileset.name", 
+                                    "negate": false, 
+                                    "params": {
+                                        "query": "main", 
+                                        "type": "phrase"
+                                    }, 
+                                    "type": "phrase", 
+                                    "value": "main"
+                                }, 
+                                "query": {
+                                    "match": {
+                                        "fileset.name": {
+                                            "query": "main", 
+                                            "type": "phrase"
+                                        }
+                                    }
+                                }
+                            }
+                        ], 
+                        "highlightAll": true, 
+                        "index": "filebeat-*", 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "sort": [
+                    "@timestamp", 
+                    "desc"
+                ], 
+                "title": "Main Log [Filebeat Icinga] ECS", 
+                "version": 1
+            }, 
+            "id": "ffaf5a30-2413-11e7-a0d9-39604d45ca7f-ecs", 
+            "type": "search", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "ffaf5a30-2413-11e7-a0d9-39604d45ca7f-ecs", 
+                "title": "Mainlog Facility [Filebeat Icinga] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "field": "icinga.main.facility", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "group", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "defaultYExtents": false, 
+                        "legendPosition": "right", 
+                        "mode": "stacked", 
+                        "scale": "linear", 
+                        "setYExtents": false, 
+                        "times": []
+                    }, 
+                    "title": "Icinga Mainlog Facility ECS", 
+                    "type": "histogram"
+                }
+            }, 
+            "id": "2cf77780-2418-11e7-a83b-d5f4cebac9ff-ecs", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "Filebeat Icinga module dashboard for the main log files", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlightAll": true, 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "optionsJSON": {
+                    "darkTheme": false
+                }, 
+                "panelsJSON": [
+                    {
+                        "col": 7, 
+                        "id": "d8e5dc40-2417-11e7-a83b-d5f4cebac9ff-ecs", 
+                        "panelIndex": 1, 
+                        "row": 1, 
+                        "size_x": 6, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "columns": [
+                            "icinga.main.facility", 
+                            "log.level", 
+                            "message"
+                        ], 
+                        "id": "ffaf5a30-2413-11e7-a0d9-39604d45ca7f-ecs", 
+                        "panelIndex": 2, 
+                        "row": 4, 
+                        "size_x": 12, 
+                        "size_y": 25, 
+                        "sort": [
+                            "@timestamp", 
+                            "desc"
+                        ], 
+                        "type": "search"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "2cf77780-2418-11e7-a83b-d5f4cebac9ff-ecs", 
+                        "panelIndex": 3, 
+                        "row": 1, 
+                        "size_x": 6, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }
+                ], 
+                "timeRestore": false, 
+                "title": "[Filebeat Icinga] Main Log ECS", 
+                "uiStateJSON": {}, 
+                "version": 1
+            }, 
+            "id": "f693d260-2417-11e7-a83b-d5f4cebac9ff-ecs", 
+            "type": "dashboard", 
+            "version": 4
+        }
+    ], 
+    "version": "6.0.0-beta1-SNAPSHOT"
+}

--- a/dev/package-beats/icinga-1.0.0/kibana/dashboard/Filebeat-icinga-startup-errors.json
+++ b/dev/package-beats/icinga-1.0.0/kibana/dashboard/Filebeat-icinga-startup-errors.json
@@ -1,0 +1,154 @@
+{
+    "objects": [
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "710043e0-2417-11e7-a83b-d5f4cebac9ff-ecs", 
+                "title": "Startup Errors [Filebeat Icinga] ECS", 
+                "uiStateJSON": {
+                    "vis": {
+                        "colors": {
+                            "Count": "#BF1B00"
+                        }
+                    }
+                }, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "defaultYExtents": false, 
+                        "legendPosition": "right", 
+                        "mode": "stacked", 
+                        "scale": "linear", 
+                        "setYExtents": false, 
+                        "times": []
+                    }, 
+                    "title": "Icinga Startup Errors ECS", 
+                    "type": "histogram"
+                }
+            }, 
+            "id": "a59b5e00-2417-11e7-a83b-d5f4cebac9ff-ecs", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "columns": [
+                    "icinga.startup.facility", 
+                    "log.level", 
+                    "message"
+                ], 
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlightAll": true, 
+                        "index": "filebeat-*", 
+                        "query": {
+                            "language": "kuery",
+                                    "query": "log.level:critical"
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "sort": [
+                    "@timestamp", 
+                    "desc"
+                ], 
+                "title": "Startup Errors [Filebeat Icinga] ECS", 
+                "version": 1
+            }, 
+            "id": "710043e0-2417-11e7-a83b-d5f4cebac9ff-ecs", 
+            "type": "search", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "Filebeat Icinga module dashboard for startup errors", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlightAll": true, 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "optionsJSON": {
+                    "darkTheme": false
+                }, 
+                "panelsJSON": [
+                    {
+                        "col": 1, 
+                        "id": "a59b5e00-2417-11e7-a83b-d5f4cebac9ff-ecs", 
+                        "panelIndex": 1, 
+                        "row": 1, 
+                        "size_x": 12, 
+                        "size_y": 2, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "columns": [
+                            "icinga.startup.facility", 
+                            "log.level", 
+                            "message"
+                        ], 
+                        "id": "710043e0-2417-11e7-a83b-d5f4cebac9ff-ecs", 
+                        "panelIndex": 2, 
+                        "row": 3, 
+                        "size_x": 12, 
+                        "size_y": 13, 
+                        "sort": [
+                            "@timestamp", 
+                            "desc"
+                        ], 
+                        "type": "search"
+                    }
+                ], 
+                "timeRestore": false, 
+                "title": "[Filebeat Icinga] Startup Errors ECS", 
+                "uiStateJSON": {}, 
+                "version": 1
+            }, 
+            "id": "b9163ea0-2417-11e7-a83b-d5f4cebac9ff-ecs", 
+            "type": "dashboard", 
+            "version": 2
+        }
+    ], 
+    "version": "6.0.0-beta1-SNAPSHOT"
+}

--- a/dev/package-beats/icinga-1.0.0/manifest.yml
+++ b/dev/package-beats/icinga-1.0.0/manifest.yml
@@ -1,0 +1,13 @@
+name: icinga
+title: Icinga
+version: 1.0.0
+description: |
+  Icinga Module
+type: ""
+categories:
+- logs
+requirement:
+  kibana:
+    version:
+      min: 6.7.0
+      max: 7.6.0

--- a/dev/package-beats/iis-1.0.0/kibana/dashboard/Filebeat-iis.json
+++ b/dev/package-beats/iis-1.0.0/kibana/dashboard/Filebeat-iis.json
@@ -1,0 +1,656 @@
+{
+    "objects": [
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "index": "filebeat-*", 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                }, 
+                "title": "Access map [Filebeat IIS] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "autoPrecision": true, 
+                                "field": "source.geo.location", 
+                                "isFilteredByCollar": true, 
+                                "precision": 2, 
+                                "useGeocentroid": true
+                            }, 
+                            "schema": "segment", 
+                            "type": "geohash_grid"
+                        }
+                    ], 
+                    "params": {
+                        "addTooltip": true, 
+                        "heatClusterSize": 1.5, 
+                        "isDesaturated": true, 
+                        "legendPosition": "bottomright", 
+                        "mapCenter": [
+                            0, 
+                            0
+                        ], 
+                        "mapType": "Scaled Circle Markers", 
+                        "mapZoom": 2, 
+                        "wms": {
+                            "enabled": false, 
+                            "options": {
+                                "format": "image/png", 
+                                "transparent": true
+                            }
+                        }
+                    }, 
+                    "title": "Access map [Filebeat IIS] ECS", 
+                    "type": "tile_map"
+                }
+            }, 
+            "id": "eb2db5b0-fe11-11e7-a3b0-d13028918f9f-ecs", 
+            "type": "visualization", 
+            "updated_at": "2018-01-20T18:44:17.162Z", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "index": "filebeat-*", 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                }, 
+                "title": "Response codes over time [Filebeat IIS] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "field": "http.response.status_code", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "group", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "categoryAxes": [
+                            {
+                                "id": "CategoryAxis-1", 
+                                "labels": {
+                                    "show": true, 
+                                    "truncate": 100
+                                }, 
+                                "position": "bottom", 
+                                "scale": {
+                                    "type": "linear"
+                                }, 
+                                "show": true, 
+                                "style": {}, 
+                                "title": {}, 
+                                "type": "category"
+                            }
+                        ], 
+                        "grid": {
+                            "categoryLines": false, 
+                            "style": {
+                                "color": "#eee"
+                            }
+                        }, 
+                        "legendPosition": "right", 
+                        "seriesParams": [
+                            {
+                                "data": {
+                                    "id": "1", 
+                                    "label": "Count"
+                                }, 
+                                "drawLinesBetweenPoints": true, 
+                                "mode": "stacked", 
+                                "show": "true", 
+                                "showCircles": true, 
+                                "type": "histogram", 
+                                "valueAxis": "ValueAxis-1"
+                            }
+                        ], 
+                        "times": [], 
+                        "type": "histogram", 
+                        "valueAxes": [
+                            {
+                                "id": "ValueAxis-1", 
+                                "labels": {
+                                    "filter": false, 
+                                    "rotate": 0, 
+                                    "show": true, 
+                                    "truncate": 100
+                                }, 
+                                "name": "LeftAxis-1", 
+                                "position": "left", 
+                                "scale": {
+                                    "mode": "normal", 
+                                    "type": "linear"
+                                }, 
+                                "show": true, 
+                                "style": {}, 
+                                "title": {
+                                    "text": "Count"
+                                }, 
+                                "type": "value"
+                            }
+                        ]
+                    }, 
+                    "title": "Response codes over time [Filebeat IIS] ECS", 
+                    "type": "histogram"
+                }
+            }, 
+            "id": "f31414b0-fe14-11e7-a3b0-d13028918f9f-ecs", 
+            "type": "visualization", 
+            "updated_at": "2018-01-20T19:05:58.905Z", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "index": "filebeat-*", 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                }, 
+                "title": "Browsers breakdown [Filebeat IIS] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "field": "user_agent.name", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "segment", 
+                            "type": "terms"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "field": "user_agent.version", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "segment", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "params": {
+                        "addLegend": true, 
+                        "addTooltip": true, 
+                        "isDonut": true, 
+                        "labels": {
+                            "last_level": true, 
+                            "show": false, 
+                            "truncate": 100, 
+                            "values": true
+                        }, 
+                        "legendPosition": "right", 
+                        "type": "pie"
+                    }, 
+                    "title": "Browsers breakdown [Filebeat IIS] ECS", 
+                    "type": "pie"
+                }
+            }, 
+            "id": "63129c80-fe12-11e7-a3b0-d13028918f9f-ecs", 
+            "type": "visualization", 
+            "updated_at": "2018-01-20T18:47:38.312Z", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "index": "filebeat-*", 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                }, 
+                "title": "Operating systems breakdown [Filebeat IIS] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "field": "user_agent.os.name", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "segment", 
+                            "type": "terms"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "field": "user_agent.os.version", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "segment", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "params": {
+                        "addLegend": true, 
+                        "addTooltip": true, 
+                        "isDonut": true, 
+                        "labels": {
+                            "last_level": true, 
+                            "show": false, 
+                            "truncate": 100, 
+                            "values": true
+                        }, 
+                        "legendPosition": "right", 
+                        "type": "pie"
+                    }, 
+                    "title": "Operating systems breakdown [Filebeat IIS] ECS", 
+                    "type": "pie"
+                }
+            }, 
+            "id": "ccd3f9c0-fe12-11e7-a3b0-d13028918f9f-ecs", 
+            "type": "visualization", 
+            "updated_at": "2018-01-20T18:51:54.619Z", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "index": "filebeat-*", 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                }, 
+                "title": "Error logs over time [Filebeat IIS] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "field": "http.response.status_code", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "group", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "categoryAxes": [
+                            {
+                                "id": "CategoryAxis-1", 
+                                "labels": {
+                                    "show": true, 
+                                    "truncate": 100
+                                }, 
+                                "position": "bottom", 
+                                "scale": {
+                                    "type": "linear"
+                                }, 
+                                "show": true, 
+                                "style": {}, 
+                                "title": {}, 
+                                "type": "category"
+                            }
+                        ], 
+                        "grid": {
+                            "categoryLines": false, 
+                            "style": {
+                                "color": "#eee"
+                            }
+                        }, 
+                        "legendPosition": "right", 
+                        "seriesParams": [
+                            {
+                                "data": {
+                                    "id": "1", 
+                                    "label": "Count"
+                                }, 
+                                "drawLinesBetweenPoints": true, 
+                                "mode": "stacked", 
+                                "show": "true", 
+                                "showCircles": true, 
+                                "type": "histogram", 
+                                "valueAxis": "ValueAxis-1"
+                            }
+                        ], 
+                        "times": [], 
+                        "type": "histogram", 
+                        "valueAxes": [
+                            {
+                                "id": "ValueAxis-1", 
+                                "labels": {
+                                    "filter": false, 
+                                    "rotate": 0, 
+                                    "show": true, 
+                                    "truncate": 100
+                                }, 
+                                "name": "LeftAxis-1", 
+                                "position": "left", 
+                                "scale": {
+                                    "mode": "normal", 
+                                    "type": "linear"
+                                }, 
+                                "show": true, 
+                                "style": {}, 
+                                "title": {
+                                    "text": "Count"
+                                }, 
+                                "type": "value"
+                            }
+                        ]
+                    }, 
+                    "title": "Error logs over time [Filebeat IIS] ECS", 
+                    "type": "histogram"
+                }
+            }, 
+            "id": "41f38230-fe17-11e7-a3b0-d13028918f9f-ecs", 
+            "type": "visualization", 
+            "updated_at": "2018-01-20T19:22:30.227Z", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "index": "filebeat-*", 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                }, 
+                "title": "Top URLs by response code [Filebeat IIS] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customLabel": "URL", 
+                                "field": "url.path", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "row": false, 
+                                "size": 5
+                            }, 
+                            "schema": "split", 
+                            "type": "terms"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "field": "http.response.status_code", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "segment", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "params": {
+                        "addLegend": true, 
+                        "addTooltip": true, 
+                        "isDonut": false, 
+                        "labels": {
+                            "last_level": true, 
+                            "show": false, 
+                            "truncate": 100, 
+                            "values": true
+                        }, 
+                        "legendPosition": "right", 
+                        "type": "pie"
+                    }, 
+                    "title": "Top URLs by response code [Filebeat IIS] ECS", 
+                    "type": "pie"
+                }
+            }, 
+            "id": "c0d02cd0-fe1b-11e7-a3b0-d13028918f9f-ecs", 
+            "type": "visualization", 
+            "updated_at": "2018-01-20T19:58:24.005Z", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "Dashboard for the Filebeat IIS module", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlightAll": true, 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "optionsJSON": {
+                    "darkTheme": false, 
+                    "hidePanelTitles": false, 
+                    "useMargins": true
+                }, 
+                "panelsJSON": [
+                    {
+                        "gridData": {
+                            "h": 3, 
+                            "i": "1", 
+                            "w": 12, 
+                            "x": 0, 
+                            "y": 0
+                        }, 
+                        "id": "eb2db5b0-fe11-11e7-a3b0-d13028918f9f-ecs", 
+                        "panelIndex": "1", 
+                        "type": "visualization", 
+                        "version": "6.1.2"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 3, 
+                            "i": "2", 
+                            "w": 7, 
+                            "x": 0, 
+                            "y": 3
+                        }, 
+                        "id": "f31414b0-fe14-11e7-a3b0-d13028918f9f-ecs", 
+                        "panelIndex": "2", 
+                        "type": "visualization", 
+                        "version": "6.1.2"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 3, 
+                            "i": "4", 
+                            "w": 6, 
+                            "x": 0, 
+                            "y": 9
+                        }, 
+                        "id": "63129c80-fe12-11e7-a3b0-d13028918f9f-ecs", 
+                        "panelIndex": "4", 
+                        "type": "visualization", 
+                        "version": "6.1.2"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 3, 
+                            "i": "5", 
+                            "w": 6, 
+                            "x": 6, 
+                            "y": 9
+                        }, 
+                        "id": "ccd3f9c0-fe12-11e7-a3b0-d13028918f9f-ecs", 
+                        "panelIndex": "5", 
+                        "type": "visualization", 
+                        "version": "6.1.2"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 3, 
+                            "i": "6", 
+                            "w": 5, 
+                            "x": 7, 
+                            "y": 3
+                        }, 
+                        "id": "41f38230-fe17-11e7-a3b0-d13028918f9f-ecs", 
+                        "panelIndex": "6", 
+                        "type": "visualization", 
+                        "version": "6.1.2"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 3, 
+                            "i": "7", 
+                            "w": 12, 
+                            "x": 0, 
+                            "y": 6
+                        }, 
+                        "id": "c0d02cd0-fe1b-11e7-a3b0-d13028918f9f-ecs", 
+                        "panelIndex": "7", 
+                        "type": "visualization", 
+                        "version": "6.1.2"
+                    }
+                ], 
+                "timeRestore": false, 
+                "title": "[Filebeat IIS] Access and error logs ECS", 
+                "uiStateJSON": {}, 
+                "version": 1
+            }, 
+            "id": "4278ad30-fe16-11e7-a3b0-d13028918f9f-ecs", 
+            "type": "dashboard", 
+            "updated_at": "2018-01-20T19:57:50.287Z", 
+            "version": 4
+        }
+    ], 
+    "version": "6.1.2"
+}

--- a/dev/package-beats/iis-1.0.0/manifest.yml
+++ b/dev/package-beats/iis-1.0.0/manifest.yml
@@ -1,0 +1,13 @@
+name: iis
+title: IIS
+version: 1.0.0
+description: |
+  Module for parsing IIS log files.
+type: ""
+categories:
+- logs
+requirement:
+  kibana:
+    version:
+      min: 6.7.0
+      max: 7.6.0

--- a/dev/package-beats/iptables-1.0.0/kibana/dashboard/Filebeat-Iptables-Overview.json
+++ b/dev/package-beats/iptables-1.0.0/kibana/dashboard/Filebeat-Iptables-Overview.json
@@ -1,0 +1,759 @@
+{
+  "objects": [
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "savedSearchId": "b3f1b010-1f26-11e9-8ec4-cf5d91a864b3-ecs",
+        "title": "Events Timeline [Filebeat Iptables] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customInterval": "2h",
+                "drop_partials": false,
+                "extended_bounds": {},
+                "field": "@timestamp",
+                "interval": "auto",
+                "min_doc_count": 1,
+                "time_zone": "Europe/Berlin",
+                "useNormalizedEsInterval": true
+              },
+              "schema": "segment",
+              "type": "date_histogram"
+            }
+          ],
+          "params": {
+            "addLegend": true,
+            "addTimeMarker": false,
+            "addTooltip": true,
+            "categoryAxes": [
+              {
+                "id": "CategoryAxis-1",
+                "labels": {
+                  "show": true,
+                  "truncate": 100
+                },
+                "position": "bottom",
+                "scale": {
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {},
+                "type": "category"
+              }
+            ],
+            "grid": {
+              "categoryLines": false,
+              "style": {
+                "color": "#eee"
+              }
+            },
+            "legendPosition": "right",
+            "seriesParams": [
+              {
+                "data": {
+                  "id": "1",
+                  "label": "Count"
+                },
+                "drawLinesBetweenPoints": true,
+                "interpolate": "linear",
+                "mode": "stacked",
+                "show": "true",
+                "showCircles": true,
+                "type": "area",
+                "valueAxis": "ValueAxis-1"
+              }
+            ],
+            "times": [],
+            "type": "area",
+            "valueAxes": [
+              {
+                "id": "ValueAxis-1",
+                "labels": {
+                  "filter": false,
+                  "rotate": 0,
+                  "show": true,
+                  "truncate": 100
+                },
+                "name": "LeftAxis-1",
+                "position": "left",
+                "scale": {
+                  "mode": "normal",
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {
+                  "text": "Count"
+                },
+                "type": "value"
+              }
+            ]
+          },
+          "title": "Events Timeline [Filebeat Iptables] ECS",
+          "type": "area"
+        }
+      },
+      "id": "4c913eb0-1f51-11e9-93ed-f7e068f4aebb-ecs",
+      "type": "visualization",
+      "updated_at": "2019-01-23T20:56:04.891Z",
+      "version": 1
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": "iptables.length:*"
+            }
+          }
+        },
+        "savedSearchId": "b3f1b010-1f26-11e9-8ec4-cf5d91a864b3-ecs",
+        "title": "Top Source Countries [Filebeat Iptables] ECS",
+        "uiStateJSON": {
+          "vis": {
+            "params": {
+              "sort": {
+                "columnIndex": null,
+                "direction": null
+              }
+            }
+          }
+        },
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customLabel": "Country",
+                "field": "source.geo.country_iso_code",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 5
+              },
+              "schema": "bucket",
+              "type": "terms"
+            }
+          ],
+          "params": {
+            "perPage": 10,
+            "showMetricsAtAllLevels": false,
+            "showPartialRows": false,
+            "showTotal": false,
+            "sort": {
+              "columnIndex": null,
+              "direction": null
+            },
+            "totalFunc": "sum"
+          },
+          "title": "Top Source Countries [Filebeat Iptables] ECS",
+          "type": "table"
+        }
+      },
+      "id": "2599f5e0-1e98-11e9-8ec4-cf5d91a864b3-ecs",
+      "type": "visualization",
+      "updated_at": "2019-01-23T20:51:02.293Z",
+      "version": 1
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": "iptables.length:*"
+            }
+          }
+        },
+        "savedSearchId": "b3f1b010-1f26-11e9-8ec4-cf5d91a864b3-ecs",
+        "title": "Source Map [Filebeat Iptables] ECS",
+        "uiStateJSON": {
+          "mapCenter": [
+            45.02695045318546,
+            -44.82421875000001
+          ],
+          "mapZoom": 3
+        },
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "autoPrecision": true,
+                "field": "source.geo.location",
+                "isFilteredByCollar": true,
+                "mapCenter": [
+                  0,
+                  0
+                ],
+                "mapZoom": 2,
+                "precision": 2,
+                "useGeocentroid": true
+              },
+              "schema": "segment",
+              "type": "geohash_grid"
+            }
+          ],
+          "params": {
+            "addTooltip": true,
+            "colorSchema": "Yellow to Red",
+            "heatClusterSize": 1.5,
+            "isDesaturated": true,
+            "legendPosition": "bottomright",
+            "mapCenter": [
+              0,
+              0
+            ],
+            "mapType": "Scaled Circle Markers",
+            "mapZoom": 2,
+            "wms": {
+              "enabled": false,
+              "options": {
+                "format": "image/png",
+                "transparent": true
+              },
+              "selectedTmsLayer": {
+                "attribution": "\u003cp\u003e\u0026#169; \u003ca href=\"http://www.openstreetmap.org/copyright\"\u003eOpenStreetMap\u003c/a\u003e contributors | \u003ca href=\"https://www.elastic.co/elastic-maps-service\"\u003eElastic Maps Service\u003c/a\u003e\u003c/p\u003e\u0026#10;",
+                "id": "road_map",
+                "maxZoom": 18,
+                "minZoom": 0,
+                "origin": "elastic_maps_service"
+              }
+            }
+          },
+          "title": "Source Map [Filebeat Iptables] ECS",
+          "type": "tile_map"
+        }
+      },
+      "id": "c4394ec0-1efd-11e9-8ec4-cf5d91a864b3-ecs",
+      "type": "visualization",
+      "updated_at": "2019-01-23T20:51:02.293Z",
+      "version": 1
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": "iptables.length:*"
+            }
+          }
+        },
+        "savedSearchId": "b3f1b010-1f26-11e9-8ec4-cf5d91a864b3-ecs",
+        "title": "Destination Map [Filebeat Iptables] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "autoPrecision": true,
+                "field": "destination.geo.location",
+                "isFilteredByCollar": true,
+                "mapCenter": [
+                  0,
+                  0
+                ],
+                "mapZoom": 2,
+                "precision": 2,
+                "useGeocentroid": true
+              },
+              "schema": "segment",
+              "type": "geohash_grid"
+            }
+          ],
+          "params": {
+            "addTooltip": true,
+            "colorSchema": "Yellow to Red",
+            "heatClusterSize": 1.5,
+            "isDesaturated": true,
+            "legendPosition": "bottomright",
+            "mapCenter": [
+              0,
+              0
+            ],
+            "mapType": "Scaled Circle Markers",
+            "mapZoom": 2,
+            "wms": {
+              "enabled": false,
+              "options": {
+                "format": "image/png",
+                "transparent": true
+              },
+              "selectedTmsLayer": {
+                "attribution": "\u003cp\u003e\u0026#169; \u003ca href=\"http://www.openstreetmap.org/copyright\"\u003eOpenStreetMap\u003c/a\u003e contributors | \u003ca href=\"https://www.elastic.co/elastic-maps-service\"\u003eElastic Maps Service\u003c/a\u003e\u003c/p\u003e\u0026#10;",
+                "id": "road_map",
+                "maxZoom": 18,
+                "minZoom": 0,
+                "origin": "elastic_maps_service"
+              }
+            }
+          },
+          "title": "Destination Map [Filebeat Iptables] ECS",
+          "type": "tile_map"
+        }
+      },
+      "id": "d8cea010-1efd-11e9-8ec4-cf5d91a864b3-ecs",
+      "type": "visualization",
+      "updated_at": "2019-01-23T20:51:02.293Z",
+      "version": 1
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": "iptables.length:*"
+            }
+          }
+        },
+        "savedSearchId": "b3f1b010-1f26-11e9-8ec4-cf5d91a864b3-ecs",
+        "title": "Network Type Breakdown [Filebeat Iptables] ECS",
+        "uiStateJSON": {
+          "vis": {
+            "legendOpen": false
+          }
+        },
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "field": "network.type",
+                "missingBucket": true,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": true,
+                "otherBucketLabel": "Other",
+                "size": 5
+              },
+              "schema": "segment",
+              "type": "terms"
+            }
+          ],
+          "params": {
+            "addLegend": true,
+            "addTooltip": true,
+            "isDonut": true,
+            "labels": {
+              "last_level": true,
+              "show": true,
+              "truncate": 100,
+              "values": true
+            },
+            "legendPosition": "right",
+            "type": "pie"
+          },
+          "title": "Network Type Breakdown [Filebeat Iptables] ECS",
+          "type": "pie"
+        }
+      },
+      "id": "b57b7370-1f1d-11e9-8ec4-cf5d91a864b3-ecs",
+      "type": "visualization",
+      "updated_at": "2019-01-23T20:51:02.293Z",
+      "version": 1
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": "iptables.length:*"
+            }
+          }
+        },
+        "savedSearchId": "b3f1b010-1f26-11e9-8ec4-cf5d91a864b3-ecs",
+        "title": "Network Transport Breakdown [Filebeat Iptables] ECS",
+        "uiStateJSON": {
+          "vis": {
+            "legendOpen": false
+          }
+        },
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "field": "network.transport",
+                "missingBucket": true,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": true,
+                "otherBucketLabel": "Other",
+                "size": 5
+              },
+              "schema": "segment",
+              "type": "terms"
+            }
+          ],
+          "params": {
+            "addLegend": true,
+            "addTooltip": true,
+            "isDonut": true,
+            "labels": {
+              "last_level": true,
+              "show": true,
+              "truncate": 100,
+              "values": true
+            },
+            "legendPosition": "right",
+            "type": "pie"
+          },
+          "title": "Network Transport Breakdown [Filebeat Iptables] ECS",
+          "type": "pie"
+        }
+      },
+      "id": "35fe0910-1f26-11e9-8ec4-cf5d91a864b3-ecs",
+      "type": "visualization",
+      "updated_at": "2019-01-23T20:51:02.293Z",
+      "version": 1
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": "iptables.length:*"
+            }
+          }
+        },
+        "savedSearchId": "b3f1b010-1f26-11e9-8ec4-cf5d91a864b3-ecs",
+        "title": "Top Destination Ports [Filebeat Iptables] ECS",
+        "uiStateJSON": {
+          "vis": {
+            "params": {
+              "sort": {
+                "columnIndex": null,
+                "direction": null
+              }
+            }
+          }
+        },
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customLabel": "Port",
+                "field": "destination.port",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 5
+              },
+              "schema": "bucket",
+              "type": "terms"
+            }
+          ],
+          "params": {
+            "perPage": 10,
+            "showMetricsAtAllLevels": false,
+            "showPartialRows": false,
+            "showTotal": false,
+            "sort": {
+              "columnIndex": null,
+              "direction": null
+            },
+            "totalFunc": "sum"
+          },
+          "title": "Top Destination Ports [Filebeat Iptables] ECS",
+          "type": "table"
+        }
+      },
+      "id": "683402b0-1f29-11e9-8ec4-cf5d91a864b3-ecs",
+      "type": "visualization",
+      "updated_at": "2019-01-23T20:51:02.293Z",
+      "version": 1
+    },
+    {
+      "attributes": {
+        "columns": [
+          "_source"
+        ],
+        "description": "",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "highlightAll": true,
+            "index": "filebeat-*",
+            "query": {
+              "language": "kuery",
+              "query": "iptables.length :*"
+            },
+            "version": true
+          }
+        },
+        "sort": [
+          "@timestamp",
+          "desc"
+        ],
+        "title": "Events Search [Filebeat Iptables] ECS",
+        "version": 1
+      },
+      "id": "b3f1b010-1f26-11e9-8ec4-cf5d91a864b3-ecs",
+      "type": "search",
+      "updated_at": "2019-01-23T20:51:02.293Z",
+      "version": 1
+    },
+    {
+      "attributes": {
+        "description": "Overview of the iptables events dashboard.",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "optionsJSON": {
+          "darkTheme": false,
+          "hidePanelTitles": false,
+          "useMargins": true
+        },
+        "panelsJSON": [
+          {
+            "embeddableConfig": {
+              "vis": {
+                "legendOpen": false
+              }
+            },
+            "gridData": {
+              "h": 15,
+              "i": "1",
+              "w": 37,
+              "x": 0,
+              "y": 0
+            },
+            "id": "4c913eb0-1f51-11e9-93ed-f7e068f4aebb-ecs",
+            "panelIndex": "1",
+            "type": "visualization",
+            "version": "6.6.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 15,
+              "i": "2",
+              "w": 11,
+              "x": 37,
+              "y": 0
+            },
+            "id": "2599f5e0-1e98-11e9-8ec4-cf5d91a864b3-ecs",
+            "panelIndex": "2",
+            "type": "visualization",
+            "version": "6.6.0"
+          },
+          {
+            "embeddableConfig": {
+              "mapCenter": [
+                47.15984001304432,
+                -47.02148437500001
+              ],
+              "mapZoom": 2
+            },
+            "gridData": {
+              "h": 15,
+              "i": "3",
+              "w": 24,
+              "x": 0,
+              "y": 15
+            },
+            "id": "c4394ec0-1efd-11e9-8ec4-cf5d91a864b3-ecs",
+            "panelIndex": "3",
+            "type": "visualization",
+            "version": "6.6.0"
+          },
+          {
+            "embeddableConfig": {
+              "mapCenter": [
+                49.15296965617042,
+                -27.949218750000004
+              ],
+              "mapZoom": 2
+            },
+            "gridData": {
+              "h": 15,
+              "i": "4",
+              "w": 24,
+              "x": 24,
+              "y": 15
+            },
+            "id": "d8cea010-1efd-11e9-8ec4-cf5d91a864b3-ecs",
+            "panelIndex": "4",
+            "type": "visualization",
+            "version": "6.6.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 15,
+              "i": "5",
+              "w": 19,
+              "x": 0,
+              "y": 30
+            },
+            "id": "b57b7370-1f1d-11e9-8ec4-cf5d91a864b3-ecs",
+            "panelIndex": "5",
+            "type": "visualization",
+            "version": "6.6.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 15,
+              "i": "6",
+              "w": 18,
+              "x": 19,
+              "y": 30
+            },
+            "id": "35fe0910-1f26-11e9-8ec4-cf5d91a864b3-ecs",
+            "panelIndex": "6",
+            "type": "visualization",
+            "version": "6.6.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 15,
+              "i": "7",
+              "w": 11,
+              "x": 37,
+              "y": 30
+            },
+            "id": "683402b0-1f29-11e9-8ec4-cf5d91a864b3-ecs",
+            "panelIndex": "7",
+            "type": "visualization",
+            "version": "6.6.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 19,
+              "i": "8",
+              "w": 48,
+              "x": 0,
+              "y": 45
+            },
+            "id": "b3f1b010-1f26-11e9-8ec4-cf5d91a864b3-ecs",
+            "panelIndex": "8",
+            "type": "search",
+            "version": "6.6.0"
+          }
+        ],
+        "timeRestore": false,
+        "title": "[Filebeat Iptables] Overview ECS",
+        "version": 1
+      },
+      "id": "ceefb9e0-1f51-11e9-93ed-f7e068f4aebb-ecs",
+      "type": "dashboard",
+      "updated_at": "2019-01-23T20:59:43.614Z",
+      "version": 1
+    }
+  ],
+  "version": "6.6.0"
+}

--- a/dev/package-beats/iptables-1.0.0/kibana/dashboard/Filebeat-Iptables-Ubiquiti-Firewall-Overview.json
+++ b/dev/package-beats/iptables-1.0.0/kibana/dashboard/Filebeat-Iptables-Ubiquiti-Firewall-Overview.json
@@ -1,0 +1,848 @@
+{
+  "objects": [
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "savedSearchId": "c4e80aa0-1fd4-11e9-ae2a-939083c6a64e-ecs",
+        "title": "Ubiquiti Firewall Event Timeline [Filebeat Iptables] ECS",
+        "uiStateJSON": {
+          "vis": {
+            "colors": {
+              "allow": "#64B0C8",
+              "deny": "#E24D42"
+            }
+          }
+        },
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customInterval": "2h",
+                "drop_partials": false,
+                "extended_bounds": {},
+                "field": "@timestamp",
+                "interval": "auto",
+                "min_doc_count": 1,
+                "timeRange": {
+                  "from": "2019-01-24T15:47:12.171Z",
+                  "mode": "absolute",
+                  "to": "2019-01-24T15:47:52.785Z"
+                },
+                "time_zone": "Europe/Berlin",
+                "useNormalizedEsInterval": true
+              },
+              "schema": "segment",
+              "type": "date_histogram"
+            },
+            {
+              "enabled": true,
+              "id": "3",
+              "params": {
+                "field": "event.outcome",
+                "missingBucket": true,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "_key",
+                "otherBucket": true,
+                "otherBucketLabel": "Other",
+                "size": 5
+              },
+              "schema": "group",
+              "type": "terms"
+            }
+          ],
+          "params": {
+            "addLegend": true,
+            "addTimeMarker": false,
+            "addTooltip": true,
+            "categoryAxes": [
+              {
+                "id": "CategoryAxis-1",
+                "labels": {
+                  "show": true,
+                  "truncate": 100
+                },
+                "position": "bottom",
+                "scale": {
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {},
+                "type": "category"
+              }
+            ],
+            "grid": {
+              "categoryLines": false,
+              "style": {
+                "color": "#eee"
+              }
+            },
+            "legendPosition": "top",
+            "seriesParams": [
+              {
+                "data": {
+                  "id": "1",
+                  "label": "Count"
+                },
+                "drawLinesBetweenPoints": true,
+                "mode": "stacked",
+                "show": "true",
+                "showCircles": true,
+                "type": "histogram",
+                "valueAxis": "ValueAxis-1"
+              }
+            ],
+            "times": [],
+            "type": "histogram",
+            "valueAxes": [
+              {
+                "id": "ValueAxis-1",
+                "labels": {
+                  "filter": false,
+                  "rotate": 0,
+                  "show": true,
+                  "truncate": 100
+                },
+                "name": "LeftAxis-1",
+                "position": "left",
+                "scale": {
+                  "mode": "normal",
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {
+                  "text": "Count"
+                },
+                "type": "value"
+              }
+            ]
+          },
+          "title": "Ubiquiti Firewall Event Timeline [Filebeat Iptables] ECS",
+          "type": "histogram"
+        }
+      },
+      "id": "758b3620-1fda-11e9-ae2a-939083c6a64e-ecs",
+      "type": "visualization",
+      "updated_at": "2019-01-24T16:37:11.788Z",
+      "version": 2
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "savedSearchId": "9f7d97c0-1fe9-11e9-ae2a-939083c6a64e-ecs",
+        "title": "Ubiquiti Firewall Top Blocked IPs [Filebeat Iptables] ECS",
+        "uiStateJSON": {
+          "vis": {
+            "params": {
+              "sort": {
+                "columnIndex": null,
+                "direction": null
+              }
+            }
+          }
+        },
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customLabel": "Source IP",
+                "field": "source.ip",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 5
+              },
+              "schema": "bucket",
+              "type": "terms"
+            }
+          ],
+          "params": {
+            "perPage": 10,
+            "showMetricsAtAllLevels": false,
+            "showPartialRows": false,
+            "showTotal": false,
+            "sort": {
+              "columnIndex": null,
+              "direction": null
+            },
+            "totalFunc": "sum"
+          },
+          "title": "Ubiquiti Firewall Top Blocked IPs [Filebeat Iptables] ECS",
+          "type": "table"
+        }
+      },
+      "id": "1ba82fd0-1ff0-11e9-ae2a-939083c6a64e-ecs",
+      "type": "visualization",
+      "updated_at": "2019-01-24T16:06:20.635Z",
+      "version": 2
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "savedSearchId": "7862cab0-1fdb-11e9-ae2a-939083c6a64e-ecs",
+        "title": "Ubiquiti Firewall Allowed Traffic Map [Filebeat Iptables] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "autoPrecision": true,
+                "field": "source.geo.location",
+                "isFilteredByCollar": true,
+                "mapCenter": [
+                  0,
+                  0
+                ],
+                "mapZoom": 2,
+                "precision": 2,
+                "useGeocentroid": true
+              },
+              "schema": "segment",
+              "type": "geohash_grid"
+            }
+          ],
+          "params": {
+            "addTooltip": true,
+            "colorSchema": "Yellow to Red",
+            "heatClusterSize": 1.5,
+            "isDesaturated": true,
+            "legendPosition": "bottomright",
+            "mapCenter": [
+              0,
+              0
+            ],
+            "mapType": "Scaled Circle Markers",
+            "mapZoom": 2,
+            "wms": {
+              "enabled": false,
+              "options": {
+                "format": "image/png",
+                "transparent": true
+              },
+              "selectedTmsLayer": {
+                "attribution": "\u003cp\u003e\u0026#169; \u003ca href=\"http://www.openstreetmap.org/copyright\"\u003eOpenStreetMap\u003c/a\u003e contributors | \u003ca href=\"https://www.elastic.co/elastic-maps-service\"\u003eElastic Maps Service\u003c/a\u003e\u003c/p\u003e\u0026#10;",
+                "id": "road_map",
+                "maxZoom": 18,
+                "minZoom": 0,
+                "origin": "elastic_maps_service"
+              }
+            }
+          },
+          "title": "Ubiquiti Firewall Allowed Traffic Map [Filebeat Iptables] ECS",
+          "type": "tile_map"
+        }
+      },
+      "id": "5bd53050-1fe9-11e9-ae2a-939083c6a64e-ecs",
+      "type": "visualization",
+      "updated_at": "2019-01-24T15:04:34.005Z",
+      "version": 1
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "savedSearchId": "9f7d97c0-1fe9-11e9-ae2a-939083c6a64e-ecs",
+        "title": "Ubiquiti Firewall Blocked Traffic Map [Filebeat Iptables] ECS",
+        "uiStateJSON": {
+          "mapCenter": [
+            19.228176737766262,
+            -22.851562500000004
+          ],
+          "mapZoom": 3
+        },
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "autoPrecision": true,
+                "field": "source.geo.location",
+                "isFilteredByCollar": true,
+                "mapCenter": [
+                  0,
+                  0
+                ],
+                "mapZoom": 2,
+                "precision": 2,
+                "useGeocentroid": true
+              },
+              "schema": "segment",
+              "type": "geohash_grid"
+            }
+          ],
+          "params": {
+            "addTooltip": true,
+            "colorSchema": "Yellow to Red",
+            "heatClusterSize": 1.5,
+            "isDesaturated": true,
+            "legendPosition": "bottomright",
+            "mapCenter": [
+              0,
+              0
+            ],
+            "mapType": "Scaled Circle Markers",
+            "mapZoom": 2,
+            "wms": {
+              "enabled": false,
+              "options": {
+                "format": "image/png",
+                "transparent": true
+              },
+              "selectedTmsLayer": {
+                "attribution": "\u003cp\u003e\u0026#169; \u003ca href=\"http://www.openstreetmap.org/copyright\"\u003eOpenStreetMap\u003c/a\u003e contributors | \u003ca href=\"https://www.elastic.co/elastic-maps-service\"\u003eElastic Maps Service\u003c/a\u003e\u003c/p\u003e\u0026#10;",
+                "id": "road_map",
+                "maxZoom": 18,
+                "minZoom": 0,
+                "origin": "elastic_maps_service"
+              }
+            }
+          },
+          "title": "Ubiquiti Firewall Blocked Traffic Map [Filebeat Iptables] ECS",
+          "type": "tile_map"
+        }
+      },
+      "id": "8853aa20-1fef-11e9-ae2a-939083c6a64e-ecs",
+      "type": "visualization",
+      "updated_at": "2019-01-24T15:50:31.689Z",
+      "version": 2
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "savedSearchId": "c4e80aa0-1fd4-11e9-ae2a-939083c6a64e-ecs",
+        "title": "Ubiquiti Firewall Traffic Breakdown [Filebeat Iptables] ECS",
+        "uiStateJSON": {
+          "vis": {
+            "colors": {
+              "deny": "#E24D42",
+              "icmp": "#F29191",
+              "ipv4": "#65C5DB",
+              "ipv6": "#D683CE",
+              "ipv6-icmp": "#EA6460",
+              "tcp": "#447EBC",
+              "udp": "#F2C96D"
+            }
+          }
+        },
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "field": "event.outcome",
+                "missingBucket": true,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": true,
+                "otherBucketLabel": "Other",
+                "size": 5
+              },
+              "schema": "segment",
+              "type": "terms"
+            },
+            {
+              "enabled": true,
+              "id": "3",
+              "params": {
+                "field": "network.type",
+                "missingBucket": true,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": true,
+                "otherBucketLabel": "Other",
+                "size": 5
+              },
+              "schema": "segment",
+              "type": "terms"
+            },
+            {
+              "enabled": true,
+              "id": "4",
+              "params": {
+                "field": "network.transport",
+                "missingBucket": true,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": true,
+                "otherBucketLabel": "Other",
+                "size": 5
+              },
+              "schema": "segment",
+              "type": "terms"
+            }
+          ],
+          "params": {
+            "addLegend": true,
+            "addTooltip": true,
+            "isDonut": true,
+            "labels": {
+              "last_level": false,
+              "show": true,
+              "truncate": 100,
+              "values": false
+            },
+            "legendPosition": "top",
+            "type": "pie"
+          },
+          "title": "Ubiquiti Firewall Traffic Breakdown [Filebeat Iptables] ECS",
+          "type": "pie"
+        }
+      },
+      "id": "fdea1ad0-1ff4-11e9-ae2a-939083c6a64e-ecs",
+      "type": "visualization",
+      "updated_at": "2019-01-24T16:27:50.397Z",
+      "version": 1
+    },
+    {
+      "attributes": {
+        "columns": [
+          "_source"
+        ],
+        "description": "",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "highlightAll": true,
+            "index": "filebeat-*",
+            "query": {
+              "language": "kuery",
+              "query": "iptables.ubiquiti.rule_set :*"
+            },
+            "version": true
+          }
+        },
+        "sort": [
+          "@timestamp",
+          "desc"
+        ],
+        "title": "Ubiquiti Firewall Events [Filebeat Iptables] ECS",
+        "version": 1
+      },
+      "id": "c4e80aa0-1fd4-11e9-ae2a-939083c6a64e-ecs",
+      "type": "search",
+      "updated_at": "2019-01-24T12:37:10.858Z",
+      "version": 1
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "savedSearchId": "c4e80aa0-1fd4-11e9-ae2a-939083c6a64e-ecs",
+        "title": "Ubiquiti Firewall Traffic by Port [Filebeat Iptables] ECS",
+        "uiStateJSON": {
+          "vis": {
+            "params": {
+              "sort": {
+                "columnIndex": null,
+                "direction": null
+              }
+            }
+          }
+        },
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customLabel": "event.outcome",
+                "field": "event.outcome",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "row": false,
+                "size": 5
+              },
+              "schema": "split",
+              "type": "terms"
+            },
+            {
+              "enabled": true,
+              "id": "3",
+              "params": {
+                "customLabel": "Destination port",
+                "field": "destination.port",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 5
+              },
+              "schema": "bucket",
+              "type": "terms"
+            }
+          ],
+          "params": {
+            "perPage": 10,
+            "showMetricsAtAllLevels": false,
+            "showPartialRows": false,
+            "showTotal": false,
+            "sort": {
+              "columnIndex": null,
+              "direction": null
+            },
+            "totalFunc": "sum"
+          },
+          "title": "Ubiquiti Firewall Traffic by Port [Filebeat Iptables] ECS",
+          "type": "table"
+        }
+      },
+      "id": "190bcb50-1ff6-11e9-ae2a-939083c6a64e-ecs",
+      "type": "visualization",
+      "updated_at": "2019-01-24T16:35:45.413Z",
+      "version": 1
+    },
+    {
+      "attributes": {
+        "columns": [
+          "_source"
+        ],
+        "description": "",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "highlightAll": true,
+            "index": "filebeat-*",
+            "query": {
+              "language": "kuery",
+              "query": "iptables.ubiquiti.rule_set :* and event.outcome : \"deny\""
+            },
+            "version": true
+          }
+        },
+        "sort": [
+          "@timestamp",
+          "desc"
+        ],
+        "title": "Ubiquiti Firewall Blocked Events [Filebeat Iptables] ECS",
+        "version": 1
+      },
+      "id": "9f7d97c0-1fe9-11e9-ae2a-939083c6a64e-ecs",
+      "type": "search",
+      "updated_at": "2019-01-24T15:35:33.942Z",
+      "version": 2
+    },
+    {
+      "attributes": {
+        "columns": [
+          "_source"
+        ],
+        "description": "",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "highlightAll": true,
+            "index": "filebeat-*",
+            "query": {
+              "language": "kuery",
+              "query": "iptables.ubiquiti.rule_set :* and event.outcome : \"allow\""
+            },
+            "version": true
+          }
+        },
+        "sort": [
+          "@timestamp",
+          "desc"
+        ],
+        "title": "Ubiquiti Firewall Allowed Events [Filebeat Iptables] ECS",
+        "version": 1
+      },
+      "id": "7862cab0-1fdb-11e9-ae2a-939083c6a64e-ecs",
+      "type": "search",
+      "updated_at": "2019-01-24T15:04:12.010Z",
+      "version": 3
+    },
+    {
+      "attributes": {
+        "description": "Overview of the Ubiquiti Firewall iptables events dashboard.",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "optionsJSON": {
+          "darkTheme": false,
+          "hidePanelTitles": false,
+          "useMargins": true
+        },
+        "panelsJSON": [
+          {
+            "embeddableConfig": {
+              "vis": {
+                "colors": {
+                  "allow": "#64B0C8",
+                  "deny": "#E24D42"
+                },
+                "legendOpen": true
+              }
+            },
+            "gridData": {
+              "h": 15,
+              "i": "1",
+              "w": 33,
+              "x": 0,
+              "y": 0
+            },
+            "id": "758b3620-1fda-11e9-ae2a-939083c6a64e-ecs",
+            "panelIndex": "1",
+            "title": "Event Timeline",
+            "type": "visualization",
+            "version": "6.6.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 15,
+              "i": "2",
+              "w": 15,
+              "x": 33,
+              "y": 0
+            },
+            "id": "1ba82fd0-1ff0-11e9-ae2a-939083c6a64e-ecs",
+            "panelIndex": "2",
+            "title": "Top Blocked by source IP",
+            "type": "visualization",
+            "version": "6.6.0"
+          },
+          {
+            "embeddableConfig": {
+              "mapCenter": [
+                39.095962936305476,
+                -22.148437500000004
+              ],
+              "mapZoom": 2
+            },
+            "gridData": {
+              "h": 15,
+              "i": "3",
+              "w": 24,
+              "x": 0,
+              "y": 15
+            },
+            "id": "5bd53050-1fe9-11e9-ae2a-939083c6a64e-ecs",
+            "panelIndex": "3",
+            "title": "Allowed Traffic Map",
+            "type": "visualization",
+            "version": "6.6.0"
+          },
+          {
+            "embeddableConfig": {
+              "mapCenter": [
+                46.31658418182218,
+                -34.10156250000001
+              ],
+              "mapZoom": 2
+            },
+            "gridData": {
+              "h": 15,
+              "i": "4",
+              "w": 24,
+              "x": 24,
+              "y": 15
+            },
+            "id": "8853aa20-1fef-11e9-ae2a-939083c6a64e-ecs",
+            "panelIndex": "4",
+            "title": "Blocked Traffic Map",
+            "type": "visualization",
+            "version": "6.6.0"
+          },
+          {
+            "embeddableConfig": {
+              "vis": {
+                "colors": {
+                  "allow": "#7EB26D",
+                  "deny": "#E24D42",
+                  "icmp": "#F29191",
+                  "ipv4": "#65C5DB",
+                  "ipv6": "#D683CE",
+                  "ipv6-icmp": "#EA6460",
+                  "tcp": "#447EBC",
+                  "udp": "#F2C96D"
+                }
+              }
+            },
+            "gridData": {
+              "h": 18,
+              "i": "5",
+              "w": 24,
+              "x": 0,
+              "y": 30
+            },
+            "id": "fdea1ad0-1ff4-11e9-ae2a-939083c6a64e-ecs",
+            "panelIndex": "5",
+            "title": "Traffic Breakdown by Protocol",
+            "type": "visualization",
+            "version": "6.6.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 27,
+              "i": "6",
+              "w": 48,
+              "x": 0,
+              "y": 48
+            },
+            "id": "c4e80aa0-1fd4-11e9-ae2a-939083c6a64e-ecs",
+            "panelIndex": "6",
+            "title": "Event View",
+            "type": "search",
+            "version": "6.6.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 18,
+              "i": "7",
+              "w": 24,
+              "x": 24,
+              "y": 30
+            },
+            "id": "190bcb50-1ff6-11e9-ae2a-939083c6a64e-ecs",
+            "panelIndex": "7",
+            "title": "Traffic Breakdown by Port",
+            "type": "visualization",
+            "version": "6.6.0"
+          }
+        ],
+        "timeRestore": false,
+        "title": "[Filebeat Iptables] Ubiquiti Firewall Overview ECS",
+        "version": 1
+      },
+      "id": "d39f0980-1ff3-11e9-ae2a-939083c6a64e-ecs",
+      "type": "dashboard",
+      "updated_at": "2019-01-24T16:38:35.174Z",
+      "version": 4
+    }
+  ],
+  "version": "6.6.0"
+}

--- a/dev/package-beats/iptables-1.0.0/manifest.yml
+++ b/dev/package-beats/iptables-1.0.0/manifest.yml
@@ -1,0 +1,13 @@
+name: iptables
+title: iptables
+version: 1.0.0
+description: |
+  Module for handling the iptables logs.
+type: ""
+categories:
+- logs
+requirement:
+  kibana:
+    version:
+      min: 6.7.0
+      max: 7.6.0

--- a/dev/package-beats/jolokia-1.0.0/manifest.yml
+++ b/dev/package-beats/jolokia-1.0.0/manifest.yml
@@ -1,0 +1,13 @@
+name: jolokia
+title: Jolokia
+version: 1.0.0
+description: |
+  Jolokia module
+type: ""
+categories:
+- metrics
+requirement:
+  kibana:
+    version:
+      min: 6.7.0
+      max: 7.6.0

--- a/dev/package-beats/kafka-1.0.0/kibana/dashboard/Filebeat-Kafka-overview.json
+++ b/dev/package-beats/kafka-1.0.0/kibana/dashboard/Filebeat-Kafka-overview.json
@@ -1,0 +1,456 @@
+{
+    "objects": [
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "Kafka stacktraces-ecs", 
+                "title": "Number of stracktraces by class [Filebeat Kafka] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "field": "kafka.log.trace.class", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 10
+                            }, 
+                            "schema": "group", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "categoryAxes": [
+                            {
+                                "id": "CategoryAxis-1", 
+                                "labels": {
+                                    "show": true, 
+                                    "truncate": 100
+                                }, 
+                                "position": "bottom", 
+                                "scale": {
+                                    "type": "linear"
+                                }, 
+                                "show": true, 
+                                "style": {}, 
+                                "title": {
+                                    "text": "@timestamp per 30 minutes"
+                                }, 
+                                "type": "category"
+                            }
+                        ], 
+                        "grid": {
+                            "categoryLines": false, 
+                            "style": {
+                                "color": "#eee"
+                            }
+                        }, 
+                        "legendPosition": "right", 
+                        "seriesParams": [
+                            {
+                                "data": {
+                                    "id": "1", 
+                                    "label": "Count"
+                                }, 
+                                "drawLinesBetweenPoints": true, 
+                                "mode": "stacked", 
+                                "show": "true", 
+                                "showCircles": true, 
+                                "type": "histogram", 
+                                "valueAxis": "ValueAxis-1"
+                            }
+                        ], 
+                        "times": [], 
+                        "type": "histogram", 
+                        "valueAxes": [
+                            {
+                                "id": "ValueAxis-1", 
+                                "labels": {
+                                    "filter": false, 
+                                    "rotate": 0, 
+                                    "show": true, 
+                                    "truncate": 100
+                                }, 
+                                "name": "LeftAxis-1", 
+                                "position": "left", 
+                                "scale": {
+                                    "mode": "normal", 
+                                    "type": "linear"
+                                }, 
+                                "show": true, 
+                                "style": {}, 
+                                "title": {
+                                    "text": "Count"
+                                }, 
+                                "type": "value"
+                            }
+                        ]
+                    }, 
+                    "title": "Number of Kafka stracktraces by class [Filebeat Kafka] ECS",
+                    "type": "histogram"
+                }
+            }, 
+            "id": "number-of-kafka-stracktraces-by-class-ecs",
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "columns": [
+                    "kafka.log.class", 
+                    "kafka.log.trace.class", 
+                    "kafka.log.trace.full"
+                ], 
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlightAll": true, 
+                        "index": "filebeat-*", 
+                        "query": {
+                            "language": "kuery",
+                            "query": "kafka.log.trace.class:*"
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "sort": [
+                    "@timestamp", 
+                    "desc"
+                ], 
+                "title": "Stacktraces [Filebeat Kafka] ECS", 
+                "version": 1
+            }, 
+            "id": "Kafka stacktraces-ecs", 
+            "type": "search", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "columns": [
+                    "log.level", 
+                    "kafka.log.component", 
+                    "message"
+                ], 
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [
+                            {
+                                "$state": {
+                                    "store": "appState"
+                                }, 
+                                "meta": {
+                                    "alias": null, 
+                                    "disabled": false, 
+                                    "index": "filebeat-*", 
+                                    "key": "event.module", 
+                                    "negate": false, 
+                                    "params": {
+                                        "query": "kafka", 
+                                        "type": "phrase"
+                                    }, 
+                                    "type": "phrase", 
+                                    "value": "kafka"
+                                }, 
+                                "query": {
+                                    "match": {
+                                        "event.module": {
+                                            "query": "kafka", 
+                                            "type": "phrase"
+                                        }
+                                    }
+                                }
+                            }, 
+                            {
+                                "$state": {
+                                    "store": "appState"
+                                }, 
+                                "meta": {
+                                    "alias": null, 
+                                    "disabled": false, 
+                                    "index": "filebeat-*", 
+                                    "key": "fileset.name", 
+                                    "negate": false, 
+                                    "params": {
+                                        "query": "log", 
+                                        "type": "phrase"
+                                    }, 
+                                    "type": "phrase", 
+                                    "value": "log"
+                                }, 
+                                "query": {
+                                    "match": {
+                                        "fileset.name": {
+                                            "query": "log", 
+                                            "type": "phrase"
+                                        }
+                                    }
+                                }
+                            }
+                        ], 
+                        "highlightAll": true, 
+                        "index": "filebeat-*", 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "sort": [
+                    "@timestamp", 
+                    "desc"
+                ], 
+                "title": "All logs [Filebeat Kafka] ECS", 
+                "version": 1
+            }, 
+            "id": "All Kafka logs-ecs", 
+            "type": "search", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "All Kafka logs-ecs", 
+                "title": "Log levels over time [Filebeat Kafka] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "customLabel": "Log Level", 
+                                "field": "log.level", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "group", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "categoryAxes": [
+                            {
+                                "id": "CategoryAxis-1", 
+                                "labels": {
+                                    "show": true, 
+                                    "truncate": 100
+                                }, 
+                                "position": "bottom", 
+                                "scale": {
+                                    "type": "linear"
+                                }, 
+                                "show": true, 
+                                "style": {}, 
+                                "title": {
+                                    "text": "@timestamp per day"
+                                }, 
+                                "type": "category"
+                            }
+                        ], 
+                        "grid": {
+                            "categoryLines": false, 
+                            "style": {
+                                "color": "#eee"
+                            }
+                        }, 
+                        "legendPosition": "right", 
+                        "seriesParams": [
+                            {
+                                "data": {
+                                    "id": "1", 
+                                    "label": "Count"
+                                }, 
+                                "drawLinesBetweenPoints": true, 
+                                "mode": "stacked", 
+                                "show": "true", 
+                                "showCircles": true, 
+                                "type": "histogram", 
+                                "valueAxis": "ValueAxis-1"
+                            }
+                        ], 
+                        "times": [], 
+                        "type": "histogram", 
+                        "valueAxes": [
+                            {
+                                "id": "ValueAxis-1", 
+                                "labels": {
+                                    "filter": false, 
+                                    "rotate": 0, 
+                                    "show": true, 
+                                    "truncate": 100
+                                }, 
+                                "name": "LeftAxis-1", 
+                                "position": "left", 
+                                "scale": {
+                                    "mode": "normal", 
+                                    "type": "linear"
+                                }, 
+                                "show": true, 
+                                "style": {}, 
+                                "title": {
+                                    "text": "Count"
+                                }, 
+                                "type": "value"
+                            }
+                        ]
+                    }, 
+                    "title": "Log levels over time [Filebeat Kafka] ECS", 
+                    "type": "histogram"
+                }
+            }, 
+            "id": "3f7c33c0-87ee-11e7-ad9c-db80de0bf8d3-ecs", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "Filebeat Kafka module dashboard", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlightAll": true, 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "optionsJSON": {
+                    "darkTheme": false
+                }, 
+                "panelsJSON": [
+                    {
+                        "col": 1, 
+                        "id": "number-of-kafka-stracktraces-by-class-ecs",
+                        "panelIndex": 1, 
+                        "row": 1, 
+                        "size_x": 6, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 7, 
+                        "columns": [
+                            "kafka.log.class", 
+                            "kafka.log.trace.class", 
+                            "kafka.log.trace.full"
+                        ], 
+                        "id": "Kafka stacktraces-ecs", 
+                        "panelIndex": 2, 
+                        "row": 1, 
+                        "size_x": 6, 
+                        "size_y": 3, 
+                        "sort": [
+                            "@timestamp", 
+                            "desc"
+                        ], 
+                        "type": "search"
+                    }, 
+                    {
+                        "col": 1, 
+                        "columns": [
+                            "log.level", 
+                            "kafka.log.component", 
+                            "message"
+                        ], 
+                        "id": "All Kafka logs-ecs", 
+                        "panelIndex": 3, 
+                        "row": 6, 
+                        "size_x": 12, 
+                        "size_y": 5, 
+                        "sort": [
+                            "@timestamp", 
+                            "desc"
+                        ], 
+                        "type": "search"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "3f7c33c0-87ee-11e7-ad9c-db80de0bf8d3-ecs", 
+                        "panelIndex": 4, 
+                        "row": 4, 
+                        "size_x": 12, 
+                        "size_y": 2, 
+                        "type": "visualization"
+                    }
+                ], 
+                "timeRestore": false, 
+                "title": "[Filebeat Kafka] Overview ECS", 
+                "uiStateJSON": {}, 
+                "version": 1
+            }, 
+            "id": "943caca0-87ee-11e7-ad9c-db80de0bf8d3-ecs", 
+            "type": "dashboard", 
+            "version": 1
+        }
+    ], 
+    "version": "6.0.0-beta1-SNAPSHOT"
+}

--- a/dev/package-beats/kafka-1.0.0/kibana/dashboard/Metricbeat-kafka-overview.json
+++ b/dev/package-beats/kafka-1.0.0/kibana/dashboard/Metricbeat-kafka-overview.json
@@ -1,0 +1,1184 @@
+{
+    "objects": [
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "Kafka Topic & Consumer Offsets [Metricbeat Kafka] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "background_color_rules": [
+                            {
+                                "id": "8b27e6a0-8e61-11e8-b741-c3e458b74a68"
+                            }
+                        ], 
+                        "filter": "NOT kafka.topic.name:__consumer_offsets", 
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "bar", 
+                                "color": "rgba(244,78,59,1)", 
+                                "fill": "0.1", 
+                                "filter": "metricset.name: partition AND kafka.partition.partition.is_leader: true", 
+                                "formatter": "number", 
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417", 
+                                "label": "Topic Offsets", 
+                                "line_width": "0.5", 
+                                "metrics": [
+                                    {
+                                        "field": "kafka.partition.offset.newest", 
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "type": "sum"
+                                    }
+                                ], 
+                                "point_size": "0", 
+                                "seperate_axis": 0, 
+                                "split_color_mode": "rainbow", 
+                                "split_mode": "terms", 
+                                "stacked": "none", 
+                                "terms_field": "kafka.topic.name", 
+                                "terms_order_by": "_term", 
+                                "value_template": "{{value}}"
+                            }, 
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "rgba(244,78,59,0.52)", 
+                                "fill": "0", 
+                                "filter": "metricset.name: consumergroup", 
+                                "formatter": "number", 
+                                "id": "d43034c0-8f1e-11e8-8784-cd0acd161a28", 
+                                "label": "Consumer Offsets", 
+                                "line_width": "1", 
+                                "metrics": [
+                                    {
+                                        "field": "kafka.consumergroup.offset", 
+                                        "id": "d43034c1-8f1e-11e8-8784-cd0acd161a28", 
+                                        "type": "sum"
+                                    }
+                                ], 
+                                "point_size": "1.5", 
+                                "seperate_axis": 0, 
+                                "split_color_mode": "rainbow", 
+                                "split_filters": [
+                                    {
+                                        "color": "#68BC00", 
+                                        "id": "dd41ada0-8f1e-11e8-8784-cd0acd161a28"
+                                    }
+                                ], 
+                                "split_mode": "terms", 
+                                "stacked": "none", 
+                                "terms_field": "kafka.consumergroup.id", 
+                                "terms_order_by": "_term", 
+                                "value_template": "{{value}}"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "timeseries"
+                    }, 
+                    "title": "Kafka Topic & Consumer Offsets [Metricbeat Kafka] ECS", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "b9d12c80-8e63-11e8-8fa2-3d5f811fbd0f-ecs", 
+            "type": "visualization", 
+            "updated_at": "2018-10-18T16:12:14.222Z", 
+            "version": 9
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "Kafka Controls [Metricbeat Kafka] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "controls": [
+                            {
+                                "fieldName": "kafka.topic.name", 
+                                "id": "1532342651170", 
+                                "indexPattern": "metricbeat-*", 
+                                "label": "Topic Name", 
+                                "options": {
+                                    "multiselect": true, 
+                                    "order": "desc", 
+                                    "size": 10, 
+                                    "type": "terms"
+                                }, 
+                                "parent": "", 
+                                "type": "list"
+                            }, 
+                            {
+                                "fieldName": "kafka.partition.id", 
+                                "id": "1539799686678", 
+                                "indexPattern": "metricbeat-*", 
+                                "label": "Partition", 
+                                "options": {
+                                    "multiselect": true, 
+                                    "order": "desc", 
+                                    "size": 5, 
+                                    "type": "terms"
+                                }, 
+                                "parent": "1532342651170", 
+                                "type": "list"
+                            }
+                        ], 
+                        "pinFilters": false, 
+                        "updateFiltersOnChange": true, 
+                        "useTimeFilter": false
+                    }, 
+                    "title": "Kafka Controls [Metricbeat Kafka] ECS", 
+                    "type": "input_control_vis"
+                }
+            }, 
+            "id": "8d2f79a0-8e65-11e8-8fa2-3d5f811fbd0f-ecs", 
+            "type": "visualization", 
+            "updated_at": "2018-10-18T16:12:14.222Z", 
+            "version": 10
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "Kafka Consumer Group Lag vs Time [Metricbeat Kafka] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "filter": "((metricset.name: partition AND kafka.partition.partition.is_leader: true) OR metricset.name: consumergroup) AND NOT kafka.topic.name:__consumer_offsets", 
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "rgba(0,156,224,1)", 
+                                "fill": "0.2", 
+                                "formatter": "number", 
+                                "id": "0dcb8020-8e6d-11e8-bfab-6f29bad3a6f2", 
+                                "label": "Consumer Groups", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "kafka.partition.offset.newest", 
+                                        "id": "0dcb8021-8e6d-11e8-bfab-6f29bad3a6f2", 
+                                        "type": "max"
+                                    }, 
+                                    {
+                                        "field": "kafka.consumergroup.offset", 
+                                        "id": "4bd11db0-8e6f-11e8-bfab-6f29bad3a6f2", 
+                                        "type": "max"
+                                    }, 
+                                    {
+                                        "id": "e0742d50-8e78-11e8-abb3-cf57ca7a810c", 
+                                        "script": "def lag = params.partition - params.consumergroup; if (lag < 0) { return 0 } return lag", 
+                                        "type": "calculation", 
+                                        "variables": [
+                                            {
+                                                "field": "0dcb8021-8e6d-11e8-bfab-6f29bad3a6f2", 
+                                                "id": "e20d6af0-8e78-11e8-abb3-cf57ca7a810c", 
+                                                "name": "partition"
+                                            }, 
+                                            {
+                                                "field": "4bd11db0-8e6f-11e8-bfab-6f29bad3a6f2", 
+                                                "id": "e6cc2b80-8e78-11e8-abb3-cf57ca7a810c", 
+                                                "name": "consumergroup"
+                                            }
+                                        ]
+                                    }
+                                ], 
+                                "point_size": "0", 
+                                "seperate_axis": 0, 
+                                "split_color_mode": "rainbow", 
+                                "split_mode": "terms", 
+                                "stacked": "none", 
+                                "terms_field": "kafka.topic.name"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "timeseries"
+                    }, 
+                    "title": "Kafka Consumer Group Lag vs Time [Metricbeat Kafka] ECS", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "944188f0-8e79-11e8-8fa2-3d5f811fbd0f-ecs", 
+            "type": "visualization", 
+            "updated_at": "2018-10-18T16:12:14.222Z", 
+            "version": 8
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [
+                            {
+                                "$state": {
+                                    "store": "appState"
+                                }, 
+                                "meta": {
+                                    "alias": "Partition Metricset", 
+                                    "disabled": false, 
+                                    "index": "metricbeat-*", 
+                                    "key": "metricset.name", 
+                                    "negate": false, 
+                                    "params": {
+                                        "query": "partition", 
+                                        "type": "phrase"
+                                    }, 
+                                    "type": "phrase", 
+                                    "value": "partition"
+                                }, 
+                                "query": {
+                                    "match": {
+                                        "metricset.name": {
+                                            "query": "partition", 
+                                            "type": "phrase"
+                                        }
+                                    }
+                                }
+                            }, 
+                            {
+                                "$state": {
+                                    "store": "appState"
+                                }, 
+                                "meta": {
+                                    "alias": null, 
+                                    "disabled": false, 
+                                    "index": "metricbeat-*", 
+                                    "key": "kafka.topic.name", 
+                                    "negate": true, 
+                                    "params": {
+                                        "query": "__consumer_offsets", 
+                                        "type": "phrase"
+                                    }, 
+                                    "type": "phrase", 
+                                    "value": "__consumer_offsets"
+                                }, 
+                                "query": {
+                                    "match": {
+                                        "kafka.topic.name": {
+                                            "query": "__consumer_offsets", 
+                                            "type": "phrase"
+                                        }
+                                    }
+                                }
+                            }
+                        ], 
+                        "index": "metricbeat-*", 
+                        "query": {
+                            "language": "kuery", 
+                            "query": ""
+                        }
+                    }
+                }, 
+                "title": "Kafka Metrics [Metricbeat Kafka] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "Topics", 
+                                "field": "kafka.topic.name"
+                            }, 
+                            "schema": "metric", 
+                            "type": "cardinality"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "customLabel": "Brokers", 
+                                "field": "kafka.partition.broker.id"
+                            }, 
+                            "schema": "metric", 
+                            "type": "cardinality"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "5", 
+                            "params": {
+                                "customLabel": "Partitions", 
+                                "field": "kafka.partition.topic_id"
+                            }, 
+                            "schema": "metric", 
+                            "type": "cardinality"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "6", 
+                            "params": {
+                                "customLabel": "Replicas", 
+                                "field": "kafka.partition.topic_broker_id"
+                            }, 
+                            "schema": "metric", 
+                            "type": "cardinality"
+                        }
+                    ], 
+                    "params": {
+                        "addLegend": false, 
+                        "addTooltip": true, 
+                        "metric": {
+                            "colorSchema": "Green to Red", 
+                            "colorsRange": [
+                                {
+                                    "from": 0, 
+                                    "to": 10000
+                                }
+                            ], 
+                            "invertColors": false, 
+                            "labels": {
+                                "show": true
+                            }, 
+                            "metricColorMode": "None", 
+                            "percentageMode": false, 
+                            "style": {
+                                "bgColor": false, 
+                                "bgFill": "#000", 
+                                "fontSize": 32, 
+                                "labelColor": false, 
+                                "subText": ""
+                            }, 
+                            "useRanges": false
+                        }, 
+                        "type": "metric"
+                    }, 
+                    "title": "Kafka Metrics [Metricbeat Kafka] ECS", 
+                    "type": "metric"
+                }
+            }, 
+            "id": "dc89f8d0-8e8e-11e8-8fa2-3d5f811fbd0f-ecs", 
+            "type": "visualization", 
+            "updated_at": "2018-10-18T16:12:14.222Z", 
+            "version": 12
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "Consumer Partition Reassignments [Metricbeat Kafka] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_max": "1", 
+                        "axis_min": "-1", 
+                        "axis_position": "right", 
+                        "filter": "NOT kafka.topic.name:__consumer_offsets", 
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": "0", 
+                                "formatter": "number", 
+                                "hide_in_legend": 0, 
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417", 
+                                "label": "Consumer -> Partition Reassignment", 
+                                "line_width": "1", 
+                                "metrics": [
+                                    {
+                                        "field": "kafka.consumergroup.partition", 
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "type": "sum"
+                                    }, 
+                                    {
+                                        "field": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "id": "6b69c760-8f20-11e8-8927-d7e991b5b6ab", 
+                                        "type": "derivative", 
+                                        "unit": ""
+                                    }, 
+                                    {
+                                        "id": "976f9d80-8f20-11e8-8927-d7e991b5b6ab", 
+                                        "script": "if (params.sum_partition < 0) { return -1 } else if (params.sum_partition > 0) { return 1 }", 
+                                        "type": "calculation", 
+                                        "variables": [
+                                            {
+                                                "field": "6b69c760-8f20-11e8-8927-d7e991b5b6ab", 
+                                                "id": "99cc2b20-8f20-11e8-8927-d7e991b5b6ab", 
+                                                "name": "sum_partition"
+                                            }
+                                        ]
+                                    }
+                                ], 
+                                "point_size": "20", 
+                                "seperate_axis": 0, 
+                                "split_color_mode": "rainbow", 
+                                "split_mode": "terms", 
+                                "stacked": "none", 
+                                "terms_field": "kafka.consumergroup.id", 
+                                "value_template": ""
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "timeseries"
+                    }, 
+                    "title": "Consumer Partition Reassignments [Metricbeat Kafka] ECS", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "587f2360-8f21-11e8-8fa2-3d5f811fbd0f-ecs", 
+            "type": "visualization", 
+            "updated_at": "2018-10-18T16:12:14.222Z", 
+            "version": 8
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [
+                            {
+                                "$state": {
+                                    "store": "appState"
+                                }, 
+                                "meta": {
+                                    "alias": null, 
+                                    "disabled": false, 
+                                    "index": "metricbeat-*", 
+                                    "key": "kafka.topic.name", 
+                                    "negate": true, 
+                                    "params": {
+                                        "query": "__consumer_offsets", 
+                                        "type": "phrase"
+                                    }, 
+                                    "type": "phrase", 
+                                    "value": "__consumer_offsets"
+                                }, 
+                                "query": {
+                                    "match": {
+                                        "kafka.topic.name": {
+                                            "query": "__consumer_offsets", 
+                                            "type": "phrase"
+                                        }
+                                    }
+                                }
+                            }
+                        ], 
+                        "index": "metricbeat-*", 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                }, 
+                "title": "Consumer Metrics [Metricbeat Kafka] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "Consumer Groups", 
+                                "field": "kafka.consumergroup.id"
+                            }, 
+                            "schema": "metric", 
+                            "type": "cardinality"
+                        }
+                    ], 
+                    "params": {
+                        "addLegend": false, 
+                        "addTooltip": true, 
+                        "metric": {
+                            "colorSchema": "Green to Red", 
+                            "colorsRange": [
+                                {
+                                    "from": 0, 
+                                    "to": 10000
+                                }
+                            ], 
+                            "invertColors": false, 
+                            "labels": {
+                                "show": true
+                            }, 
+                            "metricColorMode": "None", 
+                            "percentageMode": false, 
+                            "style": {
+                                "bgColor": false, 
+                                "bgFill": "#000", 
+                                "fontSize": 32, 
+                                "labelColor": false, 
+                                "subText": ""
+                            }, 
+                            "useRanges": false
+                        }, 
+                        "type": "metric"
+                    }, 
+                    "title": "Consumer Metrics [Metricbeat Kafka] ECS", 
+                    "type": "metric"
+                }
+            }, 
+            "id": "1681f1a0-90e7-11e8-8fa2-3d5f811fbd0f-ecs", 
+            "type": "visualization", 
+            "updated_at": "2018-10-18T16:12:14.222Z", 
+            "version": 8
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "index": "metricbeat-*", 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                }, 
+                "title": "Kafka Consumer Group Clients [Metricbeat Kafka] ECS", 
+                "uiStateJSON": {
+                    "vis": {
+                        "params": {
+                            "sort": {
+                                "columnIndex": null, 
+                                "direction": null
+                            }
+                        }
+                    }
+                }, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "Newest Offset", 
+                                "field": "kafka.consumergroup.offset"
+                            }, 
+                            "schema": "metric", 
+                            "type": "max"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customLabel": "Consumer group client", 
+                                "field": "kafka.consumergroup.client.id", 
+                                "missingBucket": false, 
+                                "missingBucketLabel": "Missing", 
+                                "order": "desc", 
+                                "orderBy": "_term", 
+                                "otherBucket": false, 
+                                "otherBucketLabel": "Other", 
+                                "size": 64
+                            }, 
+                            "schema": "bucket", 
+                            "type": "terms"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "customLabel": "Topic", 
+                                "field": "kafka.topic.name", 
+                                "missingBucket": false, 
+                                "missingBucketLabel": "Missing", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "otherBucket": false, 
+                                "otherBucketLabel": "Other", 
+                                "size": 64
+                            }, 
+                            "schema": "bucket", 
+                            "type": "terms"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "4", 
+                            "params": {
+                                "customLabel": "Partition", 
+                                "field": "kafka.partition.id", 
+                                "missingBucket": false, 
+                                "missingBucketLabel": "Missing", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "otherBucket": false, 
+                                "otherBucketLabel": "Other", 
+                                "size": 256
+                            }, 
+                            "schema": "bucket", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "params": {
+                        "perPage": 10, 
+                        "showMeticsAtAllLevels": false, 
+                        "showPartialRows": false, 
+                        "showTotal": false, 
+                        "sort": {
+                            "columnIndex": null, 
+                            "direction": null
+                        }, 
+                        "totalFunc": "sum"
+                    }, 
+                    "title": "Kafka Consumer Group Clients [Metricbeat Kafka] ECS", 
+                    "type": "table"
+                }
+            }, 
+            "id": "9a7576e0-d231-11e8-8766-dbbdc39e7ba9-ecs", 
+            "type": "visualization", 
+            "updated_at": "2018-10-18T16:12:14.222Z", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "Kafka Broker Details [Metricbeat Kafka] ECS", 
+                "uiStateJSON": {
+                    "table": {
+                        "sort": {
+                            "column": "cf09c940-d2ec-11e8-88c8-af5b2a9ee6b2", 
+                            "order": "asc"
+                        }
+                    }
+                }, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "bar_color_rules": [
+                            {
+                                "id": "7fb31e00-d2ec-11e8-88c8-af5b2a9ee6b2"
+                            }
+                        ], 
+                        "filter": "", 
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "pivot_id": "kafka.partition.partition.replica", 
+                        "pivot_label": "Broker ID", 
+                        "pivot_rows": "256", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": 0.5, 
+                                "formatter": "number", 
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417", 
+                                "label": "Topics", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "kafka.topic.name", 
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "type": "cardinality"
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "terms", 
+                                "stacked": "none", 
+                                "terms_field": "kafka.broker.id", 
+                                "terms_size": "100"
+                            }, 
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "color_rules": [
+                                    {
+                                        "id": "7e9ee780-d2ef-11e8-9dd4-c5f03280d7b0"
+                                    }
+                                ], 
+                                "fill": 0.5, 
+                                "filter": "kafka.partition.partition.is_leader: true", 
+                                "formatter": "number", 
+                                "id": "b38e91a0-d2ec-11e8-88c8-af5b2a9ee6b2", 
+                                "label": "Leader Partitions", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "kafka.partition.topic_id", 
+                                        "id": "b38eb8b0-d2ec-11e8-88c8-af5b2a9ee6b2", 
+                                        "type": "cardinality"
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }, 
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "color_rules": [
+                                    {
+                                        "id": "d4d9d2c0-d2ec-11e8-88c8-af5b2a9ee6b2"
+                                    }
+                                ], 
+                                "fill": 0.5, 
+                                "filter": "", 
+                                "formatter": "number", 
+                                "id": "cf09c940-d2ec-11e8-88c8-af5b2a9ee6b2", 
+                                "label": "Replicas", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "kafka.partition.topic_broker_id", 
+                                        "id": "cf09f050-d2ec-11e8-88c8-af5b2a9ee6b2", 
+                                        "type": "cardinality"
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "table"
+                    }, 
+                    "title": "Kafka Broker Details [Metricbeat Kafka] ECS", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "27dd5960-d2ed-11e8-8766-dbbdc39e7ba9-ecs", 
+            "type": "visualization", 
+            "updated_at": "2018-10-18T16:28:30.809Z", 
+            "version": 6
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "Kafka Topic Details [Metricbeat Kafka] ECS", 
+                "uiStateJSON": {
+                    "table": {
+                        "sort": {
+                            "column": "_default_", 
+                            "order": "asc"
+                        }
+                    }
+                }, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "bar_color_rules": [
+                            {
+                                "id": "f81e47a0-d2f3-11e8-9dd4-c5f03280d7b0"
+                            }
+                        ], 
+                        "filter": "NOT kafka.topic.name: __consumer_offsets", 
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "pivot_id": "kafka.topic.name", 
+                        "pivot_label": "Topic Name", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "color_rules": [
+                                    {
+                                        "id": "f07881d0-d2f5-11e8-95b9-eb9260148efc"
+                                    }
+                                ], 
+                                "fill": 0.5, 
+                                "filter": " metricset.name: partition", 
+                                "formatter": "number", 
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417", 
+                                "label": "Brokers", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "kafka.broker.id", 
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "type": "cardinality"
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }, 
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "color_rules": [
+                                    {
+                                        "id": "fb759e10-d2f5-11e8-95b9-eb9260148efc"
+                                    }
+                                ], 
+                                "fill": 0.5, 
+                                "filter": " metricset.name: partition", 
+                                "formatter": "number", 
+                                "id": "7d640440-d2f4-11e8-9dd4-c5f03280d7b0", 
+                                "label": "Partitions", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "kafka.partition.id", 
+                                        "id": "7d640441-d2f4-11e8-9dd4-c5f03280d7b0", 
+                                        "type": "cardinality"
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }, 
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "color_rules": [
+                                    {
+                                        "id": "fdb1ab60-d2f5-11e8-95b9-eb9260148efc"
+                                    }
+                                ], 
+                                "fill": 0.5, 
+                                "filter": " metricset.name: partition", 
+                                "formatter": "number", 
+                                "id": "ad26e260-d2f4-11e8-9dd4-c5f03280d7b0", 
+                                "label": "Replicas", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "kafka.partition.topic_broker_id", 
+                                        "id": "ad26e261-d2f4-11e8-9dd4-c5f03280d7b0", 
+                                        "type": "cardinality"
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }, 
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "color_rules": [
+                                    {
+                                        "id": "ff90f2b0-d2f5-11e8-95b9-eb9260148efc"
+                                    }
+                                ], 
+                                "fill": 0.5, 
+                                "filter": " metricset.name: consumergroup", 
+                                "formatter": "number", 
+                                "id": "26d2cd90-d2f5-11e8-9dd4-c5f03280d7b0", 
+                                "label": "Consumers", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "kafka.consumergroup.client.id", 
+                                        "id": "26d2cd91-d2f5-11e8-9dd4-c5f03280d7b0", 
+                                        "type": "cardinality"
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }, 
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "color_rules": [
+                                    {
+                                        "id": "ea4984e0-d2f4-11e8-9dd4-c5f03280d7b0"
+                                    }
+                                ], 
+                                "fill": 0.5, 
+                                "filter": " metricset.name: partition", 
+                                "formatter": "number", 
+                                "id": "dc390e20-d2f4-11e8-9dd4-c5f03280d7b0", 
+                                "label": "Newest Offset", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "kafka.partition.offset.newest", 
+                                        "id": "dc393530-d2f4-11e8-9dd4-c5f03280d7b0", 
+                                        "type": "max"
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }, 
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "color_rules": [
+                                    {
+                                        "id": "043b67f0-d2f6-11e8-95b9-eb9260148efc"
+                                    }
+                                ], 
+                                "fill": 0.5, 
+                                "filter": " metricset.name: partition", 
+                                "formatter": "number", 
+                                "id": "11366c80-d2f5-11e8-9dd4-c5f03280d7b0", 
+                                "label": "Oldest Offset", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "kafka.partition.offset.oldest", 
+                                        "id": "11366c81-d2f5-11e8-9dd4-c5f03280d7b0", 
+                                        "type": "min"
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "table"
+                    }, 
+                    "title": "Kafka Topic Details [Metricbeat Kafka] ECS", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "491fee50-d2f5-11e8-8766-dbbdc39e7ba9-ecs", 
+            "type": "visualization", 
+            "updated_at": "2018-10-18T16:51:33.352Z", 
+            "version": 3
+        }, 
+        {
+            "attributes": {
+                "description": "Kafka analysis of topics and consumer groups", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlightAll": true, 
+                        "query": {
+                            "language": "kuery", 
+                            "query": ""
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "optionsJSON": {
+                    "darkTheme": false, 
+                    "hidePanelTitles": false, 
+                    "useMargins": true
+                }, 
+                "panelsJSON": [
+                    {
+                        "gridData": {
+                            "h": 13, 
+                            "i": "1", 
+                            "w": 24, 
+                            "x": 0, 
+                            "y": 20
+                        }, 
+                        "id": "b9d12c80-8e63-11e8-8fa2-3d5f811fbd0f-ecs", 
+                        "panelIndex": "1", 
+                        "title": "Kafka Topic & Consumer Offsets", 
+                        "type": "visualization", 
+                        "version": "6.3.1"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 6, 
+                            "i": "3", 
+                            "w": 16, 
+                            "x": 0, 
+                            "y": 0
+                        }, 
+                        "id": "8d2f79a0-8e65-11e8-8fa2-3d5f811fbd0f-ecs", 
+                        "panelIndex": "3", 
+                        "title": "Kafka Controls", 
+                        "type": "visualization", 
+                        "version": "6.3.1"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 14, 
+                            "i": "6", 
+                            "w": 24, 
+                            "x": 0, 
+                            "y": 6
+                        }, 
+                        "id": "944188f0-8e79-11e8-8fa2-3d5f811fbd0f-ecs", 
+                        "panelIndex": "6", 
+                        "title": "Consumer Group Lag by Topic", 
+                        "type": "visualization", 
+                        "version": "6.3.1"
+                    }, 
+                    {
+                        "embeddableConfig": {
+                            "spy": null
+                        }, 
+                        "gridData": {
+                            "h": 6, 
+                            "i": "10", 
+                            "w": 25, 
+                            "x": 16, 
+                            "y": 0
+                        }, 
+                        "id": "dc89f8d0-8e8e-11e8-8fa2-3d5f811fbd0f-ecs", 
+                        "panelIndex": "10", 
+                        "title": "Kafka Metrics", 
+                        "type": "visualization", 
+                        "version": "6.3.1"
+                    }, 
+                    {
+                        "embeddableConfig": {}, 
+                        "gridData": {
+                            "h": 7, 
+                            "i": "12", 
+                            "w": 24, 
+                            "x": 0, 
+                            "y": 33
+                        }, 
+                        "id": "587f2360-8f21-11e8-8fa2-3d5f811fbd0f-ecs", 
+                        "panelIndex": "12", 
+                        "title": "Consumer Partition Reassignments", 
+                        "type": "visualization", 
+                        "version": "6.3.1"
+                    }, 
+                    {
+                        "embeddableConfig": {}, 
+                        "gridData": {
+                            "h": 6, 
+                            "i": "13", 
+                            "w": 7, 
+                            "x": 41, 
+                            "y": 0
+                        }, 
+                        "id": "1681f1a0-90e7-11e8-8fa2-3d5f811fbd0f-ecs", 
+                        "panelIndex": "13", 
+                        "title": "Consumer Metrics", 
+                        "type": "visualization", 
+                        "version": "6.3.1"
+                    }, 
+                    {
+                        "embeddableConfig": {
+                            "spy": null, 
+                            "vis": {
+                                "params": {
+                                    "sort": {
+                                        "columnIndex": null, 
+                                        "direction": null
+                                    }
+                                }
+                            }
+                        }, 
+                        "gridData": {
+                            "h": 13, 
+                            "i": "14", 
+                            "w": 24, 
+                            "x": 24, 
+                            "y": 27
+                        }, 
+                        "id": "9a7576e0-d231-11e8-8766-dbbdc39e7ba9-ecs", 
+                        "panelIndex": "14", 
+                        "title": "Kafka Consumer Group Clients", 
+                        "type": "visualization", 
+                        "version": "6.3.0"
+                    }, 
+                    {
+                        "embeddableConfig": {}, 
+                        "gridData": {
+                            "h": 10, 
+                            "i": "15", 
+                            "w": 24, 
+                            "x": 24, 
+                            "y": 6
+                        }, 
+                        "id": "27dd5960-d2ed-11e8-8766-dbbdc39e7ba9-ecs", 
+                        "panelIndex": "15", 
+                        "title": "Kafka Brokers", 
+                        "type": "visualization", 
+                        "version": "6.3.0"
+                    }, 
+                    {
+                        "embeddableConfig": {
+                            "table": {
+                                "sort": {
+                                    "column": "26d2cd90-d2f5-11e8-9dd4-c5f03280d7b0", 
+                                    "order": "desc"
+                                }
+                            }
+                        }, 
+                        "gridData": {
+                            "h": 11, 
+                            "i": "16", 
+                            "w": 24, 
+                            "x": 24, 
+                            "y": 16
+                        }, 
+                        "id": "491fee50-d2f5-11e8-8766-dbbdc39e7ba9-ecs", 
+                        "panelIndex": "16", 
+                        "title": "Kafka Topic Details", 
+                        "type": "visualization", 
+                        "version": "6.3.0"
+                    }
+                ], 
+                "timeRestore": false, 
+                "title": "[Metricbeat Kafka] Overview ECS", 
+                "version": 1
+            }, 
+            "id": "ea488d90-8e63-11e8-8fa2-3d5f811fbd0f-ecs", 
+            "type": "dashboard", 
+            "updated_at": "2018-10-18T17:11:35.895Z", 
+            "version": 23
+        }
+    ], 
+    "version": "6.3.0"
+}

--- a/dev/package-beats/kafka-1.0.0/manifest.yml
+++ b/dev/package-beats/kafka-1.0.0/manifest.yml
@@ -1,0 +1,14 @@
+name: kafka
+title: Kafka
+version: 1.0.0
+description: |
+  Kafka module
+type: ""
+categories:
+- logs
+- metrics
+requirement:
+  kibana:
+    version:
+      min: 6.7.0
+      max: 7.6.0

--- a/dev/package-beats/kibana-1.0.0/manifest.yml
+++ b/dev/package-beats/kibana-1.0.0/manifest.yml
@@ -1,0 +1,14 @@
+name: kibana
+title: kibana
+version: 1.0.0
+description: |
+  Kibana module
+type: ""
+categories:
+- logs
+- metrics
+requirement:
+  kibana:
+    version:
+      min: 6.7.0
+      max: 7.6.0

--- a/dev/package-beats/kubernetes-1.0.0/kibana/dashboard/Metricbeat-kubernetes-apiserver.json
+++ b/dev/package-beats/kubernetes-1.0.0/kibana/dashboard/Metricbeat-kubernetes-apiserver.json
@@ -1,0 +1,335 @@
+{
+    "objects": [
+        {
+            "attributes": {
+                "description": "Overview of Kubernetes API Server", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "API Server Top clients by number of requests [Metricbeat Kubernetes] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "bar_color_rules": [
+                            {
+                                "id": "61a13010-5794-11e8-8bd0-2180975e72dd"
+                            }
+                        ], 
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "5m", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "rgba(104,188,0,1)", 
+                                "fill": 0.5, 
+                                "filter": "", 
+                                "formatter": "number", 
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417", 
+                                "label": "Top clients by number of requests (5m)", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "kubernetes.apiserver.request.count", 
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "type": "sum"
+                                    }, 
+                                    {
+                                        "field": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "id": "0e6ff4a0-5792-11e8-8bd0-2180975e72dd", 
+                                        "type": "derivative", 
+                                        "unit": ""
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_filters": [
+                                    {
+                                        "color": "#68BC00", 
+                                        "id": "9e4b8030-5792-11e8-8bd0-2180975e72dd"
+                                    }
+                                ], 
+                                "split_mode": "terms", 
+                                "stacked": "stacked", 
+                                "terms_field": "kubernetes.apiserver.request.client", 
+                                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                "terms_size": "10"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "top_n"
+                    }, 
+                    "title": "API Server Top clients by number of requests [Metricbeat Kubernetes] ECS", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "7cbeb750-5794-11e8-afa2-e9067ea62228-ecs", 
+            "type": "visualization", 
+            "updated_at": "2018-05-14T18:23:10.501Z", 
+            "version": 5
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "API Server Requests [Metricbeat Kubernetes] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "rgba(159,5,0,1)", 
+                                "fill": "0", 
+                                "filter": "NOT (kubernetes.apiserver.request.verb: WATCH or kubernetes.apiserver.request.verb: CONNECT)", 
+                                "formatter": "us,ms,2", 
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417", 
+                                "label": "Avg response time", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "kubernetes.apiserver.request.latency.sum", 
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "type": "sum"
+                                    }, 
+                                    {
+                                        "field": "kubernetes.apiserver.request.count", 
+                                        "id": "a2185e50-57a0-11e8-af57-a1d645d2b569", 
+                                        "type": "sum"
+                                    }, 
+                                    {
+                                        "id": "b09133d0-57a0-11e8-af57-a1d645d2b569", 
+                                        "script": "params.sum / params.count", 
+                                        "type": "calculation", 
+                                        "variables": [
+                                            {
+                                                "field": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                                "id": "b27c8910-57a0-11e8-af57-a1d645d2b569", 
+                                                "name": "sum"
+                                            }, 
+                                            {
+                                                "field": "a2185e50-57a0-11e8-af57-a1d645d2b569", 
+                                                "id": "b5fc8810-57a0-11e8-af57-a1d645d2b569", 
+                                                "name": "count"
+                                            }
+                                        ]
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none", 
+                                "value_template": "{{value}} ms"
+                            }, 
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "rgba(22,165,165,1)", 
+                                "fill": 0.5, 
+                                "formatter": "number", 
+                                "id": "c0019340-57a1-11e8-a049-ff54cef064a2", 
+                                "label": "Requests rate", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "kubernetes.apiserver.request.count", 
+                                        "id": "c001ba50-57a1-11e8-a049-ff54cef064a2", 
+                                        "type": "sum"
+                                    }, 
+                                    {
+                                        "field": "c001ba50-57a1-11e8-a049-ff54cef064a2", 
+                                        "id": "dc83b390-57a1-11e8-a049-ff54cef064a2", 
+                                        "type": "derivative", 
+                                        "unit": ""
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 1, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "timeseries"
+                    }, 
+                    "title": "API Server Requests [Metricbeat Kubernetes] ECS", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "ec360ff0-57a0-11e8-afa2-e9067ea62228-ecs", 
+            "type": "visualization", 
+            "updated_at": "2018-05-14T18:21:27.515Z", 
+            "version": 4
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "API Server Top clients by resource [Metricbeat Kubernetes] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "bar_color_rules": [
+                            {
+                                "id": "61a13010-5794-11e8-8bd0-2180975e72dd"
+                            }
+                        ], 
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "5m", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "rgba(104,188,0,1)", 
+                                "fill": 0.5, 
+                                "filter": "", 
+                                "formatter": "number", 
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417", 
+                                "label": "Top clients by number of requests (5m)", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "kubernetes.apiserver.request.count", 
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "type": "sum"
+                                    }, 
+                                    {
+                                        "field": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "id": "0e6ff4a0-5792-11e8-8bd0-2180975e72dd", 
+                                        "type": "derivative", 
+                                        "unit": ""
+                                    }
+                                ], 
+                                "override_index_pattern": 0, 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "series_drop_last_bucket": 1, 
+                                "split_filters": [
+                                    {
+                                        "color": "#68BC00", 
+                                        "id": "9e4b8030-5792-11e8-8bd0-2180975e72dd"
+                                    }
+                                ], 
+                                "split_mode": "terms", 
+                                "stacked": "stacked", 
+                                "terms_field": "kubernetes.apiserver.request.resource", 
+                                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                "terms_size": "10"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "top_n"
+                    }, 
+                    "title": "API Server Top clients by resource [Metricbeat Kubernetes] ECS", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "95a7f110-57a2-11e8-afa2-e9067ea62228-ecs", 
+            "type": "visualization", 
+            "updated_at": "2018-05-14T18:23:50.093Z", 
+            "version": 4
+        }, 
+        {
+            "attributes": {
+                "description": "Kubernetes API server metrics",
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlightAll": true, 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "optionsJSON": {
+                    "darkTheme": false, 
+                    "hidePanelTitles": false, 
+                    "useMargins": false
+                }, 
+                "panelsJSON": [
+                    {
+                        "embeddableConfig": {}, 
+                        "gridData": {
+                            "h": 24, 
+                            "i": "1", 
+                            "w": 24, 
+                            "x": 0, 
+                            "y": 22
+                        }, 
+                        "id": "7cbeb750-5794-11e8-afa2-e9067ea62228-ecs", 
+                        "panelIndex": "1", 
+                        "type": "visualization", 
+                        "version": "6.3.0"
+                    }, 
+                    {
+                        "embeddableConfig": {}, 
+                        "gridData": {
+                            "h": 22, 
+                            "i": "3", 
+                            "w": 48, 
+                            "x": 0, 
+                            "y": 0
+                        }, 
+                        "id": "ec360ff0-57a0-11e8-afa2-e9067ea62228-ecs", 
+                        "panelIndex": "3", 
+                        "type": "visualization", 
+                        "version": "6.3.0"
+                    }, 
+                    {
+                        "embeddableConfig": {}, 
+                        "gridData": {
+                            "h": 24, 
+                            "i": "4", 
+                            "w": 24, 
+                            "x": 24, 
+                            "y": 22
+                        }, 
+                        "id": "95a7f110-57a2-11e8-afa2-e9067ea62228-ecs", 
+                        "panelIndex": "4", 
+                        "type": "visualization", 
+                        "version": "6.3.0"
+                    }
+                ], 
+                "timeRestore": false, 
+                "title": "[Metricbeat Kubernetes] API server ECS", 
+                "version": 1
+            }, 
+            "id": "af7225b0-5794-11e8-afa2-e9067ea62228-ecs", 
+            "type": "dashboard", 
+            "updated_at": "2018-05-14T18:23:55.202Z", 
+            "version": 5
+        }
+    ], 
+    "version": "6.3.0"
+}

--- a/dev/package-beats/kubernetes-1.0.0/kibana/dashboard/Metricbeat-kubernetes-controller-manager.json
+++ b/dev/package-beats/kubernetes-1.0.0/kibana/dashboard/Metricbeat-kubernetes-controller-manager.json
@@ -1,0 +1,1027 @@
+{
+  "objects": [
+    {
+      "attributes": {
+        "description": "Kubernetes Controller Manager metrics",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [
+              {
+                "$state": {
+                  "store": "appState"
+                },
+                "meta": {
+                  "alias": null,
+                  "disabled": false,
+                  "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                  "key": "event.dataset",
+                  "negate": false,
+                  "params": {
+                    "query": "kubernetes.controllermanager"
+                  },
+                  "type": "phrase",
+                  "value": "kubernetes.controllermanager"
+                },
+                "query": {
+                  "match": {
+                    "event.dataset": {
+                      "query": "kubernetes.controllermanager",
+                      "type": "phrase"
+                    }
+                  }
+                }
+              }
+            ],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "optionsJSON": {
+          "hidePanelTitles": false,
+          "useMargins": true
+        },
+        "panelsJSON": [
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 14,
+              "i": "1",
+              "w": 11,
+              "x": 0,
+              "y": 0
+            },
+            "panelIndex": "1",
+            "panelRefName": "panel_0",
+            "version": "7.1.1"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 14,
+              "i": "2",
+              "w": 11,
+              "x": 11,
+              "y": 0
+            },
+            "panelIndex": "2",
+            "panelRefName": "panel_1",
+            "version": "7.1.1"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 14,
+              "i": "3",
+              "w": 26,
+              "x": 22,
+              "y": 0
+            },
+            "panelIndex": "3",
+            "panelRefName": "panel_2",
+            "version": "7.1.1"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 12,
+              "i": "5",
+              "w": 24,
+              "x": 0,
+              "y": 39
+            },
+            "panelIndex": "5",
+            "panelRefName": "panel_3",
+            "version": "7.1.1"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 12,
+              "i": "6",
+              "w": 24,
+              "x": 24,
+              "y": 39
+            },
+            "panelIndex": "6",
+            "panelRefName": "panel_4",
+            "version": "7.1.1"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 13,
+              "i": "7",
+              "w": 24,
+              "x": 24,
+              "y": 14
+            },
+            "panelIndex": "7",
+            "panelRefName": "panel_5",
+            "version": "7.1.1"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 12,
+              "i": "8",
+              "w": 24,
+              "x": 0,
+              "y": 27
+            },
+            "panelIndex": "8",
+            "panelRefName": "panel_6",
+            "version": "7.1.1"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 12,
+              "i": "9",
+              "w": 24,
+              "x": 24,
+              "y": 27
+            },
+            "panelIndex": "9",
+            "panelRefName": "panel_7",
+            "version": "7.1.1"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 13,
+              "i": "10",
+              "w": 24,
+              "x": 0,
+              "y": 14
+            },
+            "panelIndex": "10",
+            "panelRefName": "panel_8",
+            "version": "7.2.0"
+          }
+        ],
+        "timeRestore": false,
+        "title": "[Metricbeat Kubernetes] Controller Manager",
+        "version": 1
+      },
+      "id": "97312060-9c1b-11e9-9dc8-fd27291d427f",
+      "migrationVersion": {
+        "dashboard": "7.0.0"
+      },
+      "references": [
+        {
+          "id": "metricbeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+          "type": "index-pattern"
+        },
+        {
+          "id": "bcb194a0-9bf8-11e9-9dc8-fd27291d427f",
+          "name": "panel_0",
+          "type": "visualization"
+        },
+        {
+          "id": "3dbf6230-9c20-11e9-9dc8-fd27291d427f",
+          "name": "panel_1",
+          "type": "visualization"
+        },
+        {
+          "id": "d86b2da0-9c20-11e9-9dc8-fd27291d427f",
+          "name": "panel_2",
+          "type": "visualization"
+        },
+        {
+          "id": "0ca95350-9c24-11e9-9dc8-fd27291d427f",
+          "name": "panel_3",
+          "type": "visualization"
+        },
+        {
+          "id": "3e1e1fd0-9c27-11e9-9dc8-fd27291d427f",
+          "name": "panel_4",
+          "type": "visualization"
+        },
+        {
+          "id": "2ba628e0-9c2a-11e9-9dc8-fd27291d427f",
+          "name": "panel_5",
+          "type": "visualization"
+        },
+        {
+          "id": "8a95de50-9c38-11e9-9dc8-fd27291d427f",
+          "name": "panel_6",
+          "type": "visualization"
+        },
+        {
+          "id": "485c8550-9c3a-11e9-9dc8-fd27291d427f",
+          "name": "panel_7",
+          "type": "visualization"
+        },
+        {
+          "id": "7d80f790-9d96-11e9-b2ae-49acc4cbcea9",
+          "name": "panel_8",
+          "type": "visualization"
+        }
+      ],
+      "type": "dashboard",
+      "updated_at": "2019-07-03T16:33:10.995Z",
+      "version": "WzI5OSwyXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Host selector [Metricbeat Kubernetes]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "controls": [
+              {
+                "fieldName": "host.hostname",
+                "id": "1561982488150",
+                "indexPatternRefName": "control_0_index_pattern",
+                "label": "Hostname",
+                "options": {
+                  "dynamicOptions": true,
+                  "multiselect": true,
+                  "order": "desc",
+                  "size": 5,
+                  "type": "terms"
+                },
+                "parent": "",
+                "type": "list"
+              },
+              {
+                "fieldName": "service.address",
+                "id": "1561982723711",
+                "indexPatternRefName": "control_1_index_pattern",
+                "label": "Service address",
+                "options": {
+                  "dynamicOptions": true,
+                  "multiselect": false,
+                  "order": "desc",
+                  "size": 5,
+                  "type": "terms"
+                },
+                "parent": "",
+                "type": "list"
+              }
+            ],
+            "pinFilters": false,
+            "updateFiltersOnChange": false,
+            "useTimeFilter": false
+          },
+          "title": "Host selector [Metricbeat Kubernetes]",
+          "type": "input_control_vis"
+        }
+      },
+      "id": "bcb194a0-9bf8-11e9-9dc8-fd27291d427f",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [
+        {
+          "id": "metricbeat-*",
+          "name": "control_0_index_pattern",
+          "type": "index-pattern"
+        },
+        {
+          "id": "metricbeat-*",
+          "name": "control_1_index_pattern",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-07-03T07:20:34.226Z",
+      "version": "WzEzMywxXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Controller Process [Metricbeat Kubernetes]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "drop_last_bucket": 1,
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "",
+            "interval": "30s",
+            "markdown": "|  |   |\n|---|---|\n|**Days running**|{{ math.started.last.raw }}|\n|**File descriptors open**|{{ average_of_kubernetes_controllermanager_process_fds_open_count.fds.last.raw }}|\n|**Resident Memory**|{{ average_of_kubernetes_controllermanager_process_memory_resident_bytes.resident_memory.last.formatted }}|\n|**Virtual Memory**|{{ average_of_kubernetes_controllermanager_process_memory_virtual_bytes.virtual_memory.last.formatted }}|\n",
+            "markdown_css": "#markdown-61ca57f0-469d-11e7-af02-69e470af7417 table,#markdown-61ca57f0-469d-11e7-af02-69e470af7417 tr,#markdown-61ca57f0-469d-11e7-af02-69e470af7417 td,#markdown-61ca57f0-469d-11e7-af02-69e470af7417 th{border:none}",
+            "markdown_less": "\ntable, tr, td, th {\n    border: none;\n}\n\n",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "number",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "kubernetes.controllermanager.process.started.sec",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "max"
+                  },
+                  {
+                    "id": "ebfdb1c0-9c1c-11e9-b29f-d55be9348723",
+                    "script": "round( (params._timestamp /1000 - params.started) / 86400, 2)",
+                    "type": "math",
+                    "variables": [
+                      {
+                        "field": "61ca57f2-469d-11e7-af02-69e470af7417",
+                        "id": "ef30a230-9c1c-11e9-b29f-d55be9348723",
+                        "name": "started"
+                      }
+                    ]
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "var_name": "started"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "number",
+                "id": "1212ba80-9c1e-11e9-b29f-d55be9348723",
+                "label": "",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "kubernetes.controllermanager.process.fds.open.count",
+                    "id": "1212ba81-9c1e-11e9-b29f-d55be9348723",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "var_name": "fds"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "bytes",
+                "id": "3f3b17a0-9c1e-11e9-b29f-d55be9348723",
+                "label": "",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "kubernetes.controllermanager.process.memory.resident.bytes",
+                    "id": "3f3b17a1-9c1e-11e9-b29f-d55be9348723",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "var_name": "resident_memory"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "bytes",
+                "id": "b1a01b50-9c1f-11e9-b29f-d55be9348723",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "kubernetes.controllermanager.process.memory.virtual.bytes",
+                    "id": "b1a01b51-9c1f-11e9-b29f-d55be9348723",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "var_name": "virtual_memory"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "markdown"
+          },
+          "title": "Controller Process [Metricbeat Kubernetes]",
+          "type": "metrics"
+        }
+      },
+      "id": "3dbf6230-9c20-11e9-9dc8-fd27291d427f",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-07-03T14:46:23.136Z",
+      "version": "WzI5MSwyXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Controller HTTP request duration [Metricbeat Kubernetes]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(165,228,85,1)",
+                "fill": 0.5,
+                "formatter": "us,ms,2",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "P99",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "kubernetes.controllermanager.http.request.duration.us.percentile.99",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "us,ms,2",
+                "id": "24fb4960-9c22-11e9-b29f-d55be9348723",
+                "label": "P90",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "kubernetes.controllermanager.http.request.duration.us.percentile.90",
+                    "id": "24fb4961-9c22-11e9-b29f-d55be9348723",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(65,117,0,1)",
+                "fill": 0.5,
+                "formatter": "us,ms,2",
+                "id": "2e397790-9c22-11e9-b29f-d55be9348723",
+                "label": "P50",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "kubernetes.controllermanager.http.request.duration.us.percentile.50",
+                    "id": "2e397791-9c22-11e9-b29f-d55be9348723",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Controller HTTP request duration [Metricbeat Kubernetes]",
+          "type": "metrics"
+        }
+      },
+      "id": "d86b2da0-9c20-11e9-9dc8-fd27291d427f",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-07-03T13:31:57.207Z",
+      "version": "WzI2MywyXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Controller Longest running processor [Metricbeat Kubernetes]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_min": "0",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "number",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "kubernetes.controllermanager.workqueue.longestrunning.sec",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_color_mode": "rainbow",
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_direction": "desc",
+                "terms_field": "kubernetes.controllermanager.name",
+                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417",
+                "terms_size": "5"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Controller Longest running processor [Metricbeat Kubernetes]",
+          "type": "metrics"
+        }
+      },
+      "id": "0ca95350-9c24-11e9-9dc8-fd27291d427f",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-07-03T16:31:08.744Z",
+      "version": "WzI5OCwyXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Controller Unfinished jobs sec [Metricbeat Kubernetes]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_min": "0",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "number",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "kubernetes.controllermanager.workqueue.unfinished.sec",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_color_mode": "rainbow",
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "kubernetes.controllermanager.name",
+                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417",
+                "terms_size": "5"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Controller Unfinished jobs sec [Metricbeat Kubernetes]",
+          "type": "metrics"
+        }
+      },
+      "id": "3e1e1fd0-9c27-11e9-9dc8-fd27291d427f",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-07-03T16:30:46.554Z",
+      "version": "WzI5NywyXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Controller Memory [Metricbeat Kubernetes]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(251,158,0,1)",
+                "fill": 0.5,
+                "formatter": "bytes",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Resident",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "kubernetes.controllermanager.process.memory.resident.bytes",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(164,221,0,1)",
+                "fill": 0.5,
+                "formatter": "bytes",
+                "id": "ac896b30-9c29-11e9-92c1-f7d03186c592",
+                "label": "Virtual",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "kubernetes.controllermanager.process.memory.virtual.bytes",
+                    "id": "ac896b31-9c29-11e9-92c1-f7d03186c592",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Controller Memory [Metricset Kubernetes]",
+          "type": "metrics"
+        }
+      },
+      "id": "2ba628e0-9c2a-11e9-9dc8-fd27291d427f",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-07-03T14:04:36.575Z",
+      "version": "WzI3NSwyXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Controller Workqueue adds [Metricbeat Kubernetes]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "number",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "kubernetes.controllermanager.workqueue.adds.count",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  },
+                  {
+                    "field": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "id": "9b5d85d0-9c38-11e9-92c1-f7d03186c592",
+                    "type": "derivative",
+                    "unit": ""
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_color_mode": "rainbow",
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "kubernetes.controllermanager.name",
+                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417",
+                "terms_size": "5"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Controller Workqueue adds [Metricbeat Kubernetes]",
+          "type": "metrics"
+        }
+      },
+      "id": "8a95de50-9c38-11e9-9dc8-fd27291d427f",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-07-03T16:30:20.439Z",
+      "version": "WzI5NiwyXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Controller Workqueue retries [Metricbeat Kubernetes]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_min": "0",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "number",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "kubernetes.controllermanager.workqueue.retries.count",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  },
+                  {
+                    "field": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "id": "b3107560-9c39-11e9-92c1-f7d03186c592",
+                    "type": "derivative",
+                    "unit": ""
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_color_mode": "rainbow",
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_direction": "desc",
+                "terms_field": "kubernetes.controllermanager.name",
+                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417",
+                "terms_size": "5"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Controller Workqueue retries [Metricbeat Kubernetes]",
+          "type": "metrics"
+        }
+      },
+      "id": "485c8550-9c3a-11e9-9dc8-fd27291d427f",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-07-03T16:29:29.303Z",
+      "version": "WzI5NSwyXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Controller CPU [Metricbeat Kubernetes]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_min": "0",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "",
+            "interval": "",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "number",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "CPU time",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "kubernetes.controllermanager.process.cpu.sec",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  },
+                  {
+                    "field": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "id": "47731390-9d96-11e9-9e81-115d18bcfeaa",
+                    "type": "derivative",
+                    "unit": ""
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}} s"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "",
+            "type": "timeseries"
+          },
+          "title": "Controller CPU [Metricbeat Kubernetes]",
+          "type": "metrics"
+        }
+      },
+      "id": "7d80f790-9d96-11e9-b2ae-49acc4cbcea9",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-07-03T14:12:01.291Z",
+      "version": "WzI3OCwyXQ=="
+    }
+  ],
+  "version": "7.2.0"
+}

--- a/dev/package-beats/kubernetes-1.0.0/kibana/dashboard/Metricbeat-kubernetes-overview.json
+++ b/dev/package-beats/kubernetes-1.0.0/kibana/dashboard/Metricbeat-kubernetes-overview.json
@@ -1,0 +1,1357 @@
+{
+    "objects": [
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                },
+                "title": "Available pods per deployment [Metricbeat Kubernetes] ECS",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "params": {
+                        "axis_formatter": "number",
+                        "axis_position": "left",
+                        "filter": "event.module:kubernetes AND metricset.name:state_deployment",
+                        "id": "117fadf0-30df-11e7-8df8-6d3604a72912",
+                        "index_pattern": "metricbeat-*",
+                        "interval": "auto",
+                        "series": [
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "rgba(104,188,0,1)",
+                                "fill": 0.5,
+                                "formatter": "number",
+                                "id": "64456840-30df-11e7-8df8-6d3604a72912",
+                                "label": "Available pods",
+                                "line_width": 1,
+                                "metrics": [
+                                    {
+                                        "field": "kubernetes.deployment.replicas.available",
+                                        "id": "64456841-30df-11e7-8df8-6d3604a72912",
+                                        "type": "avg"
+                                    }
+                                ],
+                                "point_size": 1,
+                                "seperate_axis": 0,
+                                "split_filters": [
+                                    {
+                                        "color": "#68BC00",
+                                        "id": "53d35ad0-30df-11e7-8df8-6d3604a72912"
+                                    }
+                                ],
+                                "split_mode": "terms",
+                                "stacked": "stacked",
+                                "terms_field": "kubernetes.deployment.name",
+                                "terms_size": "10000"
+                            }
+                        ],
+                        "show_grid": 1,
+                        "show_legend": 1,
+                        "time_field": "@timestamp",
+                        "type": "timeseries"
+                    },
+                    "title": "Available pods per deployment [Metricbeat Kubernetes] ECS",
+                    "type": "metrics"
+                }
+            },
+            "id": "022a54c0-2bf5-11e7-859b-f78b612cde28-ecs",
+            "type": "visualization",
+            "updated_at": "2018-03-11T20:59:01.845Z",
+            "version": 4
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                },
+                "title": "CPU usage by node  [Metricbeat Kubernetes] ECS",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "listeners": {},
+                    "params": {
+                        "axis_formatter": "number",
+                        "axis_position": "left",
+                        "background_color_rules": [
+                            {
+                                "id": "12c1f2f0-2bf2-11e7-859b-f78b612cde28"
+                            }
+                        ],
+                        "bar_color_rules": [
+                            {
+                                "id": "1373ddd0-2bf2-11e7-859b-f78b612cde28"
+                            }
+                        ],
+                        "filter": "event.module:kubernetes AND (metricset.name:container OR metricset.name:state_node)",
+                        "gauge_color_rules": [
+                            {
+                                "id": "140e4910-2bf2-11e7-859b-f78b612cde28"
+                            }
+                        ],
+                        "gauge_inner_width": 10,
+                        "gauge_style": "half",
+                        "gauge_width": 10,
+                        "id": "0d5c6b10-2bf2-11e7-859b-f78b612cde28",
+                        "index_pattern": "metricbeat-*",
+                        "interval": "auto",
+                        "series": [
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "#68BC00",
+                                "fill": "0.5",
+                                "formatter": "0.0a",
+                                "id": "0d5c9220-2bf2-11e7-859b-f78b612cde28",
+                                "line_width": 1,
+                                "metrics": [
+                                    {
+                                        "field": "kubernetes.container.cpu.usage.nanocores",
+                                        "id": "0d5c9221-2bf2-11e7-859b-f78b612cde28",
+                                        "type": "sum"
+                                    }
+                                ],
+                                "override_index_pattern": 0,
+                                "point_size": 1,
+                                "seperate_axis": 0,
+                                "series_interval": "10s",
+                                "series_time_field": "@timestamp",
+                                "split_mode": "terms",
+                                "stacked": "none",
+                                "terms_field": "kubernetes.node.name",
+                                "terms_order_by": "0d5c9221-2bf2-11e7-859b-f78b612cde28",
+                                "terms_size": "10000",
+                                "value_template": "{{value}} nanocores"
+                            },
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "rgba(211,49,21,1)",
+                                "fill": "0",
+                                "formatter": "0.0a",
+                                "hide_in_legend": 1,
+                                "id": "22f65d40-31a7-11e7-84cc-096d2b38e6e5",
+                                "label": "",
+                                "line_width": 1,
+                                "metrics": [
+                                    {
+                                        "field": "kubernetes.node.cpu.capacity.cores",
+                                        "id": "22f65d41-31a7-11e7-84cc-096d2b38e6e5",
+                                        "type": "avg"
+                                    },
+                                    {
+                                        "id": "4af4c390-34d6-11e7-be88-cb6a123dc1bb",
+                                        "script": "params.cores * 1000000000",
+                                        "type": "calculation",
+                                        "variables": [
+                                            {
+                                                "field": "22f65d41-31a7-11e7-84cc-096d2b38e6e5",
+                                                "id": "4cd32080-34d6-11e7-be88-cb6a123dc1bb",
+                                                "name": "cores"
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "override_index_pattern": 0,
+                                "point_size": "0",
+                                "seperate_axis": 0,
+                                "series_interval": "10s",
+                                "series_time_field": "@timestamp",
+                                "split_mode": "terms",
+                                "stacked": "none",
+                                "terms_field": "kubernetes.node.name",
+                                "terms_order_by": "22f65d41-31a7-11e7-84cc-096d2b38e6e5",
+                                "terms_size": "10000",
+                                "value_template": "{{value}} nanocores"
+                            }
+                        ],
+                        "show_legend": 1,
+                        "time_field": "@timestamp",
+                        "type": "timeseries"
+                    },
+                    "title": "CPU usage by node  [Metricbeat Kubernetes] ECS",
+                    "type": "metrics"
+                }
+            },
+            "id": "44f12b40-2bf4-11e7-859b-f78b612cde28-ecs",
+            "type": "visualization",
+            "updated_at": "2018-03-01T18:58:07.906Z",
+            "version": 3
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                },
+                "title": "Deployments [Metricbeat Kubernetes] ECS",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "listeners": {},
+                    "params": {
+                        "axis_formatter": "number",
+                        "axis_position": "left",
+                        "background_color_rules": [
+                            {
+                                "id": "67ee7da0-30e0-11e7-8df8-6d3604a72912"
+                            }
+                        ],
+                        "bar_color_rules": [
+                            {
+                                "id": "68cdba10-30e0-11e7-8df8-6d3604a72912"
+                            }
+                        ],
+                        "filter": "event.module:kubernetes AND metricset.name:state_deployment",
+                        "gauge_color_rules": [
+                            {
+                                "id": "69765620-30e0-11e7-8df8-6d3604a72912"
+                            }
+                        ],
+                        "gauge_inner_width": 10,
+                        "gauge_style": "half",
+                        "gauge_width": 10,
+                        "id": "4c4690b0-30e0-11e7-8df8-6d3604a72912",
+                        "index_pattern": "metricbeat-*",
+                        "interval": "auto",
+                        "series": [
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "#68BC00",
+                                "fill": 0.5,
+                                "formatter": "number",
+                                "id": "4c4690b1-30e0-11e7-8df8-6d3604a72912",
+                                "label": "Deployments",
+                                "line_width": 1,
+                                "metrics": [
+                                    {
+                                        "field": "kubernetes.deployment.name",
+                                        "id": "4c4690b2-30e0-11e7-8df8-6d3604a72912",
+                                        "type": "cardinality"
+                                    }
+                                ],
+                                "point_size": 1,
+                                "seperate_axis": 0,
+                                "split_mode": "everything",
+                                "stacked": "none",
+                                "terms_field": "kubernetes.deployment.name"
+                            }
+                        ],
+                        "show_legend": 1,
+                        "time_field": "@timestamp",
+                        "type": "metric"
+                    },
+                    "title": "Deployments [Metricbeat Kubernetes] ECS",
+                    "type": "metrics"
+                }
+            },
+            "id": "cd059410-2bfb-11e7-859b-f78b612cde28-ecs",
+            "type": "visualization",
+            "updated_at": "2018-03-01T18:58:07.906Z",
+            "version": 3
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                },
+                "title": "Desired pods [Metricbeat Kubernetes] ECS",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "listeners": {},
+                    "params": {
+                        "axis_formatter": "number",
+                        "axis_position": "left",
+                        "background_color_rules": [
+                            {
+                                "id": "508ffb30-30d5-11e7-8df8-6d3604a72912"
+                            }
+                        ],
+                        "bar_color_rules": [
+                            {
+                                "id": "674d83b0-30d5-11e7-8df8-6d3604a72912"
+                            }
+                        ],
+                        "filter": "event.module:kubernetes AND metricset.name:state_deployment",
+                        "gauge_color_rules": [
+                            {
+                                "id": "50f9b980-30d5-11e7-8df8-6d3604a72912"
+                            }
+                        ],
+                        "gauge_inner_width": "10",
+                        "gauge_max": "5",
+                        "gauge_style": "half",
+                        "gauge_width": "10",
+                        "id": "2fe9d3b0-30d5-11e7-8df8-6d3604a72912",
+                        "index_pattern": "metricbeat-*",
+                        "interval": "auto",
+                        "series": [
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "#68BC00",
+                                "fill": 0.5,
+                                "formatter": "number",
+                                "id": "2fe9d3b1-30d5-11e7-8df8-6d3604a72912",
+                                "label": "Desired Pods",
+                                "line_width": 1,
+                                "metrics": [
+                                    {
+                                        "field": "kubernetes.deployment.replicas.desired",
+                                        "id": "54cf79a0-30d5-11e7-8df8-6d3604a72912",
+                                        "type": "sum"
+                                    }
+                                ],
+                                "override_index_pattern": 1,
+                                "point_size": 1,
+                                "seperate_axis": 0,
+                                "series_interval": "10s",
+                                "series_time_field": "@timestamp",
+                                "split_mode": "everything",
+                                "stacked": "none"
+                            }
+                        ],
+                        "show_legend": 1,
+                        "time_field": "@timestamp",
+                        "type": "metric"
+                    },
+                    "title": "Desired pods [Metricbeat Kubernetes] ECS",
+                    "type": "metrics"
+                }
+            },
+            "id": "e1018b90-2bfb-11e7-859b-f78b612cde28-ecs",
+            "type": "visualization",
+            "updated_at": "2018-03-01T18:58:07.906Z",
+            "version": 3
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                },
+                "title": "Memory usage by node  [Metricbeat Kubernetes] ECS",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "params": {
+                        "axis_formatter": "number",
+                        "axis_position": "left",
+                        "background_color_rules": [
+                            {
+                                "id": "12c1f2f0-2bf2-11e7-859b-f78b612cde28"
+                            }
+                        ],
+                        "bar_color_rules": [
+                            {
+                                "id": "1373ddd0-2bf2-11e7-859b-f78b612cde28"
+                            }
+                        ],
+                        "filter": "event.module:kubernetes AND (metricset.name:container OR metricset.name:state_node)",
+                        "gauge_color_rules": [
+                            {
+                                "id": "140e4910-2bf2-11e7-859b-f78b612cde28"
+                            }
+                        ],
+                        "gauge_inner_width": 10,
+                        "gauge_style": "half",
+                        "gauge_width": 10,
+                        "id": "0d5c6b10-2bf2-11e7-859b-f78b612cde28",
+                        "index_pattern": "metricbeat-*",
+                        "interval": "auto",
+                        "series": [
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "#68BC00",
+                                "fill": 0.5,
+                                "formatter": "bytes",
+                                "id": "0d5c9220-2bf2-11e7-859b-f78b612cde28",
+                                "line_width": 1,
+                                "metrics": [
+                                    {
+                                        "field": "kubernetes.container.memory.usage.bytes",
+                                        "id": "0d5c9221-2bf2-11e7-859b-f78b612cde28",
+                                        "type": "sum"
+                                    },
+                                    {
+                                        "field": "0d5c9221-2bf2-11e7-859b-f78b612cde28",
+                                        "id": "9f0cf900-1ffb-11e8-81f2-43be86397500",
+                                        "type": "cumulative_sum"
+                                    },
+                                    {
+                                        "field": "9f0cf900-1ffb-11e8-81f2-43be86397500",
+                                        "id": "a926e130-1ffb-11e8-81f2-43be86397500",
+                                        "type": "derivative",
+                                        "unit": "10s"
+                                    }
+                                ],
+                                "point_size": 1,
+                                "seperate_axis": 0,
+                                "split_mode": "terms",
+                                "stacked": "none",
+                                "terms_field": "kubernetes.node.name",
+                                "terms_order_by": "0d5c9221-2bf2-11e7-859b-f78b612cde28",
+                                "terms_size": "10000"
+                            },
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "rgba(211,49,21,1)",
+                                "fill": "0",
+                                "formatter": "bytes",
+                                "hide_in_legend": 1,
+                                "id": "8ba3b270-31a7-11e7-84cc-096d2b38e6e5",
+                                "label": "Node capacity",
+                                "line_width": 1,
+                                "metrics": [
+                                    {
+                                        "field": "kubernetes.node.memory.capacity.bytes",
+                                        "id": "8ba3b271-31a7-11e7-84cc-096d2b38e6e5",
+                                        "type": "sum"
+                                    },
+                                    {
+                                        "field": "8ba3b271-31a7-11e7-84cc-096d2b38e6e5",
+                                        "id": "d1fb2670-1ffb-11e8-81f2-43be86397500",
+                                        "type": "cumulative_sum"
+                                    },
+                                    {
+                                        "field": "d1fb2670-1ffb-11e8-81f2-43be86397500",
+                                        "id": "dc8b01f0-1ffb-11e8-81f2-43be86397500",
+                                        "type": "derivative",
+                                        "unit": "10s"
+                                    }
+                                ],
+                                "point_size": "0",
+                                "seperate_axis": 0,
+                                "split_mode": "terms",
+                                "stacked": "none",
+                                "terms_field": "kubernetes.node.name",
+                                "terms_order_by": "8ba3b271-31a7-11e7-84cc-096d2b38e6e5",
+                                "terms_size": "10000"
+                            }
+                        ],
+                        "show_grid": 1,
+                        "show_legend": 1,
+                        "time_field": "@timestamp",
+                        "type": "timeseries"
+                    },
+                    "title": "Memory usage by node  [Metricbeat Kubernetes] ECS",
+                    "type": "metrics"
+                }
+            },
+            "id": "d6564360-2bfc-11e7-859b-f78b612cde28-ecs",
+            "type": "visualization",
+            "updated_at": "2018-03-04T23:15:29.035Z",
+            "version": 4
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                },
+                "title": "Network in by node  [Metricbeat Kubernetes] ECS",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "listeners": {},
+                    "params": {
+                        "axis_formatter": "number",
+                        "axis_position": "left",
+                        "background_color_rules": [
+                            {
+                                "id": "12c1f2f0-2bf2-11e7-859b-f78b612cde28"
+                            }
+                        ],
+                        "bar_color_rules": [
+                            {
+                                "id": "1373ddd0-2bf2-11e7-859b-f78b612cde28"
+                            }
+                        ],
+                        "filter": "event.module:kubernetes AND metricset.name:pod",
+                        "gauge_color_rules": [
+                            {
+                                "id": "140e4910-2bf2-11e7-859b-f78b612cde28"
+                            }
+                        ],
+                        "gauge_inner_width": 10,
+                        "gauge_style": "half",
+                        "gauge_width": 10,
+                        "id": "0d5c6b10-2bf2-11e7-859b-f78b612cde28",
+                        "index_pattern": "metricbeat-*",
+                        "interval": "auto",
+                        "series": [
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "rgba(104,188,0,1)",
+                                "fill": 0.5,
+                                "formatter": "bytes",
+                                "id": "0d5c9220-2bf2-11e7-859b-f78b612cde28",
+                                "label": "",
+                                "line_width": 1,
+                                "metrics": [
+                                    {
+                                        "field": "kubernetes.pod.network.rx.bytes",
+                                        "id": "0d5c9221-2bf2-11e7-859b-f78b612cde28",
+                                        "type": "sum"
+                                    },
+                                    {
+                                        "field": "0d5c9221-2bf2-11e7-859b-f78b612cde28",
+                                        "id": "494fc310-2bf7-11e7-859b-f78b612cde28",
+                                        "type": "derivative",
+                                        "unit": ""
+                                    },
+                                    {
+                                        "field": "494fc310-2bf7-11e7-859b-f78b612cde28",
+                                        "id": "37c72a70-3598-11e7-aa4a-8313a0c92a88",
+                                        "type": "positive_only",
+                                        "unit": ""
+                                    }
+                                ],
+                                "point_size": 1,
+                                "seperate_axis": 0,
+                                "split_mode": "terms",
+                                "stacked": "stacked",
+                                "terms_field": "kubernetes.node.name",
+                                "terms_order_by": "0d5c9221-2bf2-11e7-859b-f78b612cde28",
+                                "terms_size": "100000"
+                            }
+                        ],
+                        "show_legend": 1,
+                        "time_field": "@timestamp",
+                        "type": "timeseries"
+                    },
+                    "title": "Network in by node  [Metricbeat Kubernetes] ECS",
+                    "type": "metrics"
+                }
+            },
+            "id": "16fa4470-2bfd-11e7-859b-f78b612cde28-ecs",
+            "type": "visualization",
+            "updated_at": "2018-03-01T18:58:07.906Z",
+            "version": 3
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                },
+                "title": "Network out by node  [Metricbeat Kubernetes] ECS",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "listeners": {},
+                    "params": {
+                        "axis_formatter": "number",
+                        "axis_position": "left",
+                        "background_color_rules": [
+                            {
+                                "id": "12c1f2f0-2bf2-11e7-859b-f78b612cde28"
+                            }
+                        ],
+                        "bar_color_rules": [
+                            {
+                                "id": "1373ddd0-2bf2-11e7-859b-f78b612cde28"
+                            }
+                        ],
+                        "filter": "event.module:kubernetes AND metricset.name:pod",
+                        "gauge_color_rules": [
+                            {
+                                "id": "140e4910-2bf2-11e7-859b-f78b612cde28"
+                            }
+                        ],
+                        "gauge_inner_width": 10,
+                        "gauge_style": "half",
+                        "gauge_width": 10,
+                        "id": "0d5c6b10-2bf2-11e7-859b-f78b612cde28",
+                        "index_pattern": "metricbeat-*",
+                        "interval": "auto",
+                        "series": [
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "rgba(104,188,0,1)",
+                                "fill": 0.5,
+                                "formatter": "bytes",
+                                "id": "0d5c9220-2bf2-11e7-859b-f78b612cde28",
+                                "label": "",
+                                "line_width": 1,
+                                "metrics": [
+                                    {
+                                        "field": "kubernetes.pod.network.tx.bytes",
+                                        "id": "0d5c9221-2bf2-11e7-859b-f78b612cde28",
+                                        "type": "sum"
+                                    },
+                                    {
+                                        "field": "0d5c9221-2bf2-11e7-859b-f78b612cde28",
+                                        "id": "494fc310-2bf7-11e7-859b-f78b612cde28",
+                                        "type": "derivative",
+                                        "unit": ""
+                                    },
+                                    {
+                                        "field": "494fc310-2bf7-11e7-859b-f78b612cde28",
+                                        "id": "244c70e0-3598-11e7-aa4a-8313a0c92a88",
+                                        "type": "positive_only",
+                                        "unit": ""
+                                    }
+                                ],
+                                "point_size": 1,
+                                "seperate_axis": 0,
+                                "split_mode": "terms",
+                                "stacked": "stacked",
+                                "terms_field": "kubernetes.node.name",
+                                "terms_order_by": "0d5c9221-2bf2-11e7-859b-f78b612cde28",
+                                "terms_size": "10000"
+                            }
+                        ],
+                        "show_legend": 1,
+                        "time_field": "@timestamp",
+                        "type": "timeseries"
+                    },
+                    "title": "Network out by node  [Metricbeat Kubernetes] ECS",
+                    "type": "metrics"
+                }
+            },
+            "id": "294546b0-30d6-11e7-8df8-6d3604a72912-ecs",
+            "type": "visualization",
+            "updated_at": "2018-03-01T18:58:07.906Z",
+            "version": 3
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                },
+                "title": "Nodes [Metricbeat Kubernetes] ECS",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "listeners": {},
+                    "params": {
+                        "axis_formatter": "number",
+                        "axis_position": "left",
+                        "background_color_rules": [
+                            {
+                                "id": "67ee7da0-30e0-11e7-8df8-6d3604a72912"
+                            }
+                        ],
+                        "bar_color_rules": [
+                            {
+                                "id": "68cdba10-30e0-11e7-8df8-6d3604a72912"
+                            }
+                        ],
+                        "filter": "event.module:kubernetes AND metricset.name:state_node",
+                        "gauge_color_rules": [
+                            {
+                                "id": "69765620-30e0-11e7-8df8-6d3604a72912"
+                            }
+                        ],
+                        "gauge_inner_width": 10,
+                        "gauge_style": "half",
+                        "gauge_width": 10,
+                        "id": "4c4690b0-30e0-11e7-8df8-6d3604a72912",
+                        "index_pattern": "metricbeat-*",
+                        "interval": "auto",
+                        "series": [
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "#68BC00",
+                                "fill": 0.5,
+                                "formatter": "number",
+                                "id": "4c4690b1-30e0-11e7-8df8-6d3604a72912",
+                                "label": "Nodes",
+                                "line_width": 1,
+                                "metrics": [
+                                    {
+                                        "field": "kubernetes.node.name",
+                                        "id": "4c4690b2-30e0-11e7-8df8-6d3604a72912",
+                                        "type": "cardinality"
+                                    }
+                                ],
+                                "point_size": 1,
+                                "seperate_axis": 0,
+                                "split_mode": "everything",
+                                "stacked": "none",
+                                "terms_field": "kubernetes.deployment.name"
+                            }
+                        ],
+                        "show_legend": 1,
+                        "time_field": "@timestamp",
+                        "type": "metric"
+                    },
+                    "title": "Nodes [Metricbeat Kubernetes] ECS",
+                    "type": "metrics"
+                }
+            },
+            "id": "408fccf0-30d6-11e7-8df8-6d3604a72912-ecs",
+            "type": "visualization",
+            "updated_at": "2018-03-01T18:58:07.906Z",
+            "version": 3
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                },
+                "title": "Top CPU intensive pods  [Metricbeat Kubernetes] ECS",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "listeners": {},
+                    "params": {
+                        "axis_formatter": "number",
+                        "axis_position": "left",
+                        "bar_color_rules": [
+                            {
+                                "id": "802104d0-2bfc-11e7-859b-f78b612cde28"
+                            }
+                        ],
+                        "filter": "event.module:kubernetes AND metricset.name:container",
+                        "id": "5d3692a0-2bfc-11e7-859b-f78b612cde28",
+                        "index_pattern": "metricbeat-*",
+                        "interval": "auto",
+                        "series": [
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "#68BC00",
+                                "fill": 0.5,
+                                "formatter": "0.0 a",
+                                "id": "5d3692a1-2bfc-11e7-859b-f78b612cde28",
+                                "line_width": 1,
+                                "metrics": [
+                                    {
+                                        "field": "kubernetes.container.cpu.usage.core.ns",
+                                        "id": "5d3692a2-2bfc-11e7-859b-f78b612cde28",
+                                        "type": "sum"
+                                    },
+                                    {
+                                        "field": "5d3692a2-2bfc-11e7-859b-f78b612cde28",
+                                        "id": "6c905240-2bfc-11e7-859b-f78b612cde28",
+                                        "type": "derivative",
+                                        "unit": "1s"
+                                    },
+                                    {
+                                        "field": "6c905240-2bfc-11e7-859b-f78b612cde28",
+                                        "id": "9a51f710-359d-11e7-aa4a-8313a0c92a88",
+                                        "type": "positive_only",
+                                        "unit": ""
+                                    }
+                                ],
+                                "offset_time": "",
+                                "override_index_pattern": 0,
+                                "point_size": 1,
+                                "seperate_axis": 0,
+                                "split_mode": "terms",
+                                "stacked": "none",
+                                "terms_field": "kubernetes.pod.name",
+                                "terms_order_by": "5d3692a2-2bfc-11e7-859b-f78b612cde28",
+                                "value_template": "{{value}} ns"
+                            }
+                        ],
+                        "show_legend": 1,
+                        "time_field": "@timestamp",
+                        "type": "top_n"
+                    },
+                    "title": "Top CPU intensive pods  [Metricbeat Kubernetes] ECS",
+                    "type": "metrics"
+                }
+            },
+            "id": "58e644f0-30d6-11e7-8df8-6d3604a72912-ecs",
+            "type": "visualization",
+            "updated_at": "2018-03-01T18:58:07.906Z",
+            "version": 3
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                },
+                "title": "Top memory intensive pods  [Metricbeat Kubernetes] ECS",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "params": {
+                        "axis_formatter": "number",
+                        "axis_position": "left",
+                        "bar_color_rules": [
+                            {
+                                "id": "802104d0-2bfc-11e7-859b-f78b612cde28"
+                            }
+                        ],
+                        "filter": "event.module:kubernetes AND metricset.name:container",
+                        "id": "5d3692a0-2bfc-11e7-859b-f78b612cde28",
+                        "index_pattern": "metricbeat-*",
+                        "interval": "auto",
+                        "series": [
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "#68BC00",
+                                "fill": 0.5,
+                                "formatter": "bytes",
+                                "id": "5d3692a1-2bfc-11e7-859b-f78b612cde28",
+                                "line_width": 1,
+                                "metrics": [
+                                    {
+                                        "field": "kubernetes.container.memory.usage.bytes",
+                                        "id": "5d3692a2-2bfc-11e7-859b-f78b612cde28",
+                                        "type": "sum"
+                                    },
+                                    {
+                                        "field": "5d3692a2-2bfc-11e7-859b-f78b612cde28",
+                                        "id": "3972e9f0-256f-11e8-84e6-87221f87ae3b",
+                                        "type": "cumulative_sum"
+                                    },
+                                    {
+                                        "field": "3972e9f0-256f-11e8-84e6-87221f87ae3b",
+                                        "id": "3e9fd5a0-256f-11e8-84e6-87221f87ae3b",
+                                        "type": "derivative",
+                                        "unit": "10s"
+                                    }
+                                ],
+                                "offset_time": "",
+                                "override_index_pattern": 0,
+                                "point_size": 1,
+                                "seperate_axis": 0,
+                                "split_mode": "terms",
+                                "stacked": "none",
+                                "terms_field": "kubernetes.pod.name",
+                                "terms_order_by": "5d3692a2-2bfc-11e7-859b-f78b612cde28",
+                                "terms_size": "10",
+                                "value_template": ""
+                            }
+                        ],
+                        "show_grid": 1,
+                        "show_legend": 1,
+                        "time_field": "@timestamp",
+                        "type": "top_n"
+                    },
+                    "title": "Top memory intensive pods  [Metricbeat Kubernetes] ECS",
+                    "type": "metrics"
+                }
+            },
+            "id": "a4c9d360-30df-11e7-8df8-6d3604a72912-ecs",
+            "type": "visualization",
+            "updated_at": "2018-03-11T21:00:49.028Z",
+            "version": 4
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                },
+                "title": "Unavailable pods [Metricbeat Kubernetes] ECS",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "listeners": {},
+                    "params": {
+                        "axis_formatter": "number",
+                        "axis_position": "left",
+                        "background_color_rules": [
+                            {
+                                "id": "508ffb30-30d5-11e7-8df8-6d3604a72912"
+                            }
+                        ],
+                        "bar_color_rules": [
+                            {
+                                "id": "674d83b0-30d5-11e7-8df8-6d3604a72912"
+                            }
+                        ],
+                        "filter": "event.module:kubernetes AND metricset.name:state_deployment",
+                        "gauge_color_rules": [
+                            {
+                                "id": "50f9b980-30d5-11e7-8df8-6d3604a72912"
+                            }
+                        ],
+                        "gauge_inner_width": "10",
+                        "gauge_max": "",
+                        "gauge_style": "half",
+                        "gauge_width": "10",
+                        "id": "2fe9d3b0-30d5-11e7-8df8-6d3604a72912",
+                        "index_pattern": "metricbeat-*",
+                        "interval": "auto",
+                        "series": [
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "#68BC00",
+                                "fill": 0.5,
+                                "formatter": "number",
+                                "id": "2fe9d3b1-30d5-11e7-8df8-6d3604a72912",
+                                "label": "Unavailable Pods",
+                                "line_width": 1,
+                                "metrics": [
+                                    {
+                                        "field": "kubernetes.deployment.replicas.unavailable",
+                                        "id": "54cf79a0-30d5-11e7-8df8-6d3604a72912",
+                                        "type": "sum"
+                                    }
+                                ],
+                                "override_index_pattern": 1,
+                                "point_size": 1,
+                                "seperate_axis": 0,
+                                "series_interval": "10s",
+                                "split_mode": "everything",
+                                "stacked": "none"
+                            }
+                        ],
+                        "show_legend": 1,
+                        "time_field": "@timestamp",
+                        "type": "metric"
+                    },
+                    "title": "Unavailable pods [Metricbeat Kubernetes] ECS",
+                    "type": "metrics"
+                }
+            },
+            "id": "174a6ad0-30e0-11e7-8df8-6d3604a72912-ecs",
+            "type": "visualization",
+            "updated_at": "2018-03-01T18:58:07.906Z",
+            "version": 3
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                },
+                "title": "Unavailable pods per deployment [Metricbeat Kubernetes] ECS",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "params": {
+                        "axis_formatter": "number",
+                        "axis_position": "left",
+                        "filter": "event.module:kubernetes AND metricset.name:state_deployment",
+                        "id": "117fadf0-30df-11e7-8df8-6d3604a72912",
+                        "index_pattern": "metricbeat-*",
+                        "interval": "auto",
+                        "series": [
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "rgba(254,146,0,1)",
+                                "fill": 0.5,
+                                "formatter": "number",
+                                "id": "64456840-30df-11e7-8df8-6d3604a72912",
+                                "label": "Unavailable pods",
+                                "line_width": 1,
+                                "metrics": [
+                                    {
+                                        "field": "kubernetes.deployment.replicas.unavailable",
+                                        "id": "64456841-30df-11e7-8df8-6d3604a72912",
+                                        "type": "avg"
+                                    }
+                                ],
+                                "point_size": 1,
+                                "seperate_axis": 0,
+                                "split_filters": [
+                                    {
+                                        "color": "#68BC00",
+                                        "id": "53d35ad0-30df-11e7-8df8-6d3604a72912"
+                                    }
+                                ],
+                                "split_mode": "terms",
+                                "stacked": "stacked",
+                                "terms_field": "kubernetes.deployment.name",
+                                "terms_size": "10000"
+                            }
+                        ],
+                        "show_grid": 1,
+                        "show_legend": 1,
+                        "time_field": "@timestamp",
+                        "type": "timeseries"
+                    },
+                    "title": "Unavailable pods per deployment [Metricbeat Kubernetes] ECS",
+                    "type": "metrics"
+                }
+            },
+            "id": "7aac4fd0-30e0-11e7-8df8-6d3604a72912-ecs",
+            "type": "visualization",
+            "updated_at": "2018-03-11T20:59:18.668Z",
+            "version": 4
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                },
+                "title": "Available pods [Metricbeat Kubernetes] ECS",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "listeners": {},
+                    "params": {
+                        "axis_formatter": "number",
+                        "axis_position": "left",
+                        "background_color_rules": [
+                            {
+                                "id": "508ffb30-30d5-11e7-8df8-6d3604a72912"
+                            }
+                        ],
+                        "bar_color_rules": [
+                            {
+                                "id": "674d83b0-30d5-11e7-8df8-6d3604a72912"
+                            }
+                        ],
+                        "filter": "event.module:kubernetes AND metricset.name:state_deployment",
+                        "gauge_color_rules": [
+                            {
+                                "id": "50f9b980-30d5-11e7-8df8-6d3604a72912"
+                            }
+                        ],
+                        "gauge_inner_width": "10",
+                        "gauge_max": "5",
+                        "gauge_style": "half",
+                        "gauge_width": "10",
+                        "id": "2fe9d3b0-30d5-11e7-8df8-6d3604a72912",
+                        "index_pattern": "metricbeat-*",
+                        "interval": "auto",
+                        "series": [
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "#68BC00",
+                                "fill": 0.5,
+                                "formatter": "number",
+                                "id": "2fe9d3b1-30d5-11e7-8df8-6d3604a72912",
+                                "label": "Available Pods",
+                                "line_width": 1,
+                                "metrics": [
+                                    {
+                                        "field": "kubernetes.deployment.replicas.available",
+                                        "id": "54cf79a0-30d5-11e7-8df8-6d3604a72912",
+                                        "type": "sum"
+                                    }
+                                ],
+                                "override_index_pattern": 1,
+                                "point_size": 1,
+                                "seperate_axis": 0,
+                                "series_index_pattern": "*",
+                                "series_interval": "10s",
+                                "series_time_field": "@timestamp",
+                                "split_mode": "everything",
+                                "stacked": "none"
+                            }
+                        ],
+                        "show_legend": 1,
+                        "time_field": "@timestamp",
+                        "type": "metric"
+                    },
+                    "title": "Available pods [Metricbeat Kubernetes] ECS",
+                    "type": "metrics"
+                }
+            },
+            "id": "da1ff7c0-30ed-11e7-b9e5-2b5b07213ab3-ecs",
+            "type": "visualization",
+            "updated_at": "2018-03-01T18:58:07.906Z",
+            "version": 3
+        },
+        {
+            "attributes": {
+                "description": "Overview of Kubernetes cluster metrics",
+                "hits": 0,
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "highlightAll": true,
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        },
+                        "version": true
+                    }
+                },
+                "optionsJSON": {
+                    "darkTheme": false,
+                    "useMargins": false
+                },
+                "panelsJSON": [
+                    {
+                        "gridData": {
+                            "h": 3,
+                            "i": "1",
+                            "w": 6,
+                            "x": 6,
+                            "y": 0
+                        },
+                        "id": "022a54c0-2bf5-11e7-859b-f78b612cde28-ecs",
+                        "panelIndex": "1",
+                        "type": "visualization",
+                        "version": "6.2.2"
+                    },
+                    {
+                        "gridData": {
+                            "h": 3,
+                            "i": "2",
+                            "w": 6,
+                            "x": 0,
+                            "y": 6
+                        },
+                        "id": "44f12b40-2bf4-11e7-859b-f78b612cde28-ecs",
+                        "panelIndex": "2",
+                        "type": "visualization",
+                        "version": "6.2.2"
+                    },
+                    {
+                        "gridData": {
+                            "h": 3,
+                            "i": "5",
+                            "w": 3,
+                            "x": 3,
+                            "y": 0
+                        },
+                        "id": "cd059410-2bfb-11e7-859b-f78b612cde28-ecs",
+                        "panelIndex": "5",
+                        "type": "visualization",
+                        "version": "6.2.2"
+                    },
+                    {
+                        "gridData": {
+                            "h": 3,
+                            "i": "6",
+                            "w": 2,
+                            "x": 0,
+                            "y": 3
+                        },
+                        "id": "e1018b90-2bfb-11e7-859b-f78b612cde28-ecs",
+                        "panelIndex": "6",
+                        "type": "visualization",
+                        "version": "6.2.2"
+                    },
+                    {
+                        "gridData": {
+                            "h": 3,
+                            "i": "7",
+                            "w": 6,
+                            "x": 6,
+                            "y": 6
+                        },
+                        "id": "d6564360-2bfc-11e7-859b-f78b612cde28-ecs",
+                        "panelIndex": "7",
+                        "type": "visualization",
+                        "version": "6.2.2"
+                    },
+                    {
+                        "gridData": {
+                            "h": 3,
+                            "i": "8",
+                            "w": 6,
+                            "x": 6,
+                            "y": 9
+                        },
+                        "id": "16fa4470-2bfd-11e7-859b-f78b612cde28-ecs",
+                        "panelIndex": "8",
+                        "type": "visualization",
+                        "version": "6.2.2"
+                    },
+                    {
+                        "gridData": {
+                            "h": 3,
+                            "i": "9",
+                            "w": 6,
+                            "x": 0,
+                            "y": 9
+                        },
+                        "id": "294546b0-30d6-11e7-8df8-6d3604a72912-ecs",
+                        "panelIndex": "9",
+                        "type": "visualization",
+                        "version": "6.2.2"
+                    },
+                    {
+                        "gridData": {
+                            "h": 3,
+                            "i": "10",
+                            "w": 3,
+                            "x": 0,
+                            "y": 0
+                        },
+                        "id": "408fccf0-30d6-11e7-8df8-6d3604a72912-ecs",
+                        "panelIndex": "10",
+                        "type": "visualization",
+                        "version": "6.2.2"
+                    },
+                    {
+                        "gridData": {
+                            "h": 3,
+                            "i": "11",
+                            "w": 6,
+                            "x": 0,
+                            "y": 12
+                        },
+                        "id": "58e644f0-30d6-11e7-8df8-6d3604a72912-ecs",
+                        "panelIndex": "11",
+                        "type": "visualization",
+                        "version": "6.2.2"
+                    },
+                    {
+                        "gridData": {
+                            "h": 3,
+                            "i": "12",
+                            "w": 6,
+                            "x": 6,
+                            "y": 12
+                        },
+                        "id": "a4c9d360-30df-11e7-8df8-6d3604a72912-ecs",
+                        "panelIndex": "12",
+                        "type": "visualization",
+                        "version": "6.2.2"
+                    },
+                    {
+                        "gridData": {
+                            "h": 3,
+                            "i": "13",
+                            "w": 2,
+                            "x": 4,
+                            "y": 3
+                        },
+                        "id": "174a6ad0-30e0-11e7-8df8-6d3604a72912-ecs",
+                        "panelIndex": "13",
+                        "type": "visualization",
+                        "version": "6.2.2"
+                    },
+                    {
+                        "gridData": {
+                            "h": 3,
+                            "i": "14",
+                            "w": 6,
+                            "x": 6,
+                            "y": 3
+                        },
+                        "id": "7aac4fd0-30e0-11e7-8df8-6d3604a72912-ecs",
+                        "panelIndex": "14",
+                        "type": "visualization",
+                        "version": "6.2.2"
+                    },
+                    {
+                        "gridData": {
+                            "h": 3,
+                            "i": "15",
+                            "w": 2,
+                            "x": 2,
+                            "y": 3
+                        },
+                        "id": "da1ff7c0-30ed-11e7-b9e5-2b5b07213ab3-ecs",
+                        "panelIndex": "15",
+                        "type": "visualization",
+                        "version": "6.2.2"
+                    }
+                ],
+                "timeRestore": false,
+                "title": "[Metricbeat Kubernetes] Overview ECS",
+                "version": 1
+            },
+            "id": "AV4RGUqo5NkDleZmzKuZ-ecs",
+            "type": "dashboard",
+            "updated_at": "2018-03-11T21:00:58.354Z",
+            "version": 4
+        }
+    ],
+    "version": "6.2.2"
+}

--- a/dev/package-beats/kubernetes-1.0.0/kibana/dashboard/Metricbeat-kubernetes-proxy.json
+++ b/dev/package-beats/kubernetes-1.0.0/kibana/dashboard/Metricbeat-kubernetes-proxy.json
@@ -1,0 +1,1197 @@
+{
+  "objects": [
+    {
+      "attributes": {
+        "description": "Kubernetes Proxy metrics",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [
+              {
+                "$state": {
+                  "store": "appState"
+                },
+                "meta": {
+                  "alias": null,
+                  "disabled": false,
+                  "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                  "key": "event.dataset",
+                  "negate": false,
+                  "params": {
+                    "query": "kubernetes.proxy"
+                  },
+                  "type": "phrase",
+                  "value": "kubernetes.proxy"
+                },
+                "query": {
+                  "match": {
+                    "event.dataset": {
+                      "query": "kubernetes.proxy",
+                      "type": "phrase"
+                    }
+                  }
+                }
+              }
+            ],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "optionsJSON": {
+          "hidePanelTitles": false,
+          "useMargins": true
+        },
+        "panelsJSON": [
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 12,
+              "i": "1",
+              "w": 23,
+              "x": 0,
+              "y": 12
+            },
+            "panelIndex": "1",
+            "panelRefName": "panel_0",
+            "version": "7.1.1"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 12,
+              "i": "2",
+              "w": 25,
+              "x": 23,
+              "y": 12
+            },
+            "panelIndex": "2",
+            "panelRefName": "panel_1",
+            "version": "7.1.1"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 12,
+              "i": "3",
+              "w": 9,
+              "x": 12,
+              "y": 0
+            },
+            "panelIndex": "3",
+            "panelRefName": "panel_2",
+            "version": "7.1.1"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 12,
+              "i": "4",
+              "w": 27,
+              "x": 21,
+              "y": 0
+            },
+            "panelIndex": "4",
+            "panelRefName": "panel_3",
+            "version": "7.1.1"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 13,
+              "i": "5",
+              "w": 48,
+              "x": 0,
+              "y": 24
+            },
+            "panelIndex": "5",
+            "panelRefName": "panel_4",
+            "version": "7.1.1"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 10,
+              "i": "6",
+              "w": 48,
+              "x": 0,
+              "y": 37
+            },
+            "panelIndex": "6",
+            "panelRefName": "panel_5",
+            "version": "7.1.1"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 12,
+              "i": "7",
+              "w": 12,
+              "x": 0,
+              "y": 0
+            },
+            "panelIndex": "7",
+            "panelRefName": "panel_6",
+            "version": "7.1.1"
+          }
+        ],
+        "timeRestore": false,
+        "title": "[Metricbeat Kubernetes] Proxy",
+        "version": 1
+      },
+      "id": "5e649d60-9901-11e9-ba57-b7ab4e2d4b58",
+      "migrationVersion": {
+        "dashboard": "7.0.0"
+      },
+      "references": [
+        {
+          "id": "metricbeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+          "type": "index-pattern"
+        },
+        {
+          "id": "e0ddd3e0-98fe-11e9-ba57-b7ab4e2d4b58",
+          "name": "panel_0",
+          "type": "visualization"
+        },
+        {
+          "id": "cac89fb0-9906-11e9-ba57-b7ab4e2d4b58",
+          "name": "panel_1",
+          "type": "visualization"
+        },
+        {
+          "id": "09b404f0-99af-11e9-ba57-b7ab4e2d4b58",
+          "name": "panel_2",
+          "type": "visualization"
+        },
+        {
+          "id": "8c6c2690-9bd8-11e9-9dc8-fd27291d427f",
+          "name": "panel_3",
+          "type": "visualization"
+        },
+        {
+          "id": "b8a24790-9bf0-11e9-9dc8-fd27291d427f",
+          "name": "panel_4",
+          "type": "visualization"
+        },
+        {
+          "id": "ba7bf750-9bf5-11e9-9dc8-fd27291d427f",
+          "name": "panel_5",
+          "type": "visualization"
+        },
+        {
+          "id": "bcb194a0-9bf8-11e9-9dc8-fd27291d427f",
+          "name": "panel_6",
+          "type": "visualization"
+        }
+      ],
+      "type": "dashboard",
+      "updated_at": "2019-07-03T14:46:55.299Z",
+      "version": "WzI5MywyXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Proxy CPU [Metricbeat Kubernetes]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_min": "0",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "number",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "CPU time",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "kubernetes.proxy.process.cpu.sec",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  },
+                  {
+                    "field": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "id": "35da60d0-98fe-11e9-b4e1-6dc893538542",
+                    "type": "derivative",
+                    "unit": ""
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}} s"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Proxy CPU [Metricbeat Kubernetes]",
+          "type": "metrics"
+        }
+      },
+      "id": "e0ddd3e0-98fe-11e9-ba57-b7ab4e2d4b58",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-07-03T14:03:00.189Z",
+      "version": "WzI3NCwyXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Proxy memory [Metricbeat Kubernetes]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(251,158,0,1)",
+                "fill": 0.5,
+                "formatter": "bytes",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Resident",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "kubernetes.proxy.process.memory.resident.bytes",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(164,221,0,1)",
+                "fill": 0.5,
+                "formatter": "bytes",
+                "id": "1ea6cee0-9907-11e9-b4e1-6dc893538542",
+                "label": "Virtual",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "kubernetes.proxy.process.memory.virtual.bytes",
+                    "id": "1ea6cee1-9907-11e9-b4e1-6dc893538542",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Proxy memory [Metricbeat Kubernetes]",
+          "type": "metrics"
+        }
+      },
+      "id": "cac89fb0-9906-11e9-ba57-b7ab4e2d4b58",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-07-03T11:26:56.138Z",
+      "version": "WzI1NiwyXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Proxy process [Metricbeat Kubernetes]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "",
+            "interval": "30s",
+            "markdown": "\n|  |   |\n|---|---|\n|**Days running**|{{ math.started.last.raw }}|\n|**File descriptors open**|{{ average_of_kubernetes_proxy_process_fds_open_count.fds.last.raw }}|\n|**Resident Memory**|{{ average_of_kubernetes_proxy_process_memory_resident_bytes.resident_memory.last.formatted }}|\n|**Virtual Memory**|{{ average_of_kubernetes_proxy_process_memory_virtual_bytes.virtual_memory.last.formatted }}|\n\n",
+            "markdown_css": "#markdown-61ca57f0-469d-11e7-af02-69e470af7417 table,#markdown-61ca57f0-469d-11e7-af02-69e470af7417 tr,#markdown-61ca57f0-469d-11e7-af02-69e470af7417 td,#markdown-61ca57f0-469d-11e7-af02-69e470af7417 th{border:none}",
+            "markdown_less": "\ntable, tr, td, th {\n    border: none;\n}\n\n",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "number",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "kubernetes.proxy.process.started.sec",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "script": "",
+                    "type": "max",
+                    "variables": [
+                      {
+                        "id": "1bbc4a20-99ac-11e9-8beb-c3bf9b9dfc43",
+                        "name": "v"
+                      }
+                    ]
+                  },
+                  {
+                    "field": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "id": "1f34f620-99ac-11e9-8beb-c3bf9b9dfc43",
+                    "script": "round( (params._timestamp /1000 - params.started) / 86400, 2)",
+                    "type": "math",
+                    "variables": [
+                      {
+                        "field": "61ca57f2-469d-11e7-af02-69e470af7417",
+                        "id": "1f371900-99ac-11e9-8beb-c3bf9b9dfc43",
+                        "name": "started"
+                      }
+                    ]
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "var_name": "started"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "number",
+                "id": "cc3b1700-99ac-11e9-8beb-c3bf9b9dfc43",
+                "label": "",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "kubernetes.proxy.process.fds.open.count",
+                    "id": "cc3b1701-99ac-11e9-8beb-c3bf9b9dfc43",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "var_name": "fds"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "bytes",
+                "id": "da1b1270-99ad-11e9-8beb-c3bf9b9dfc43",
+                "label": "",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "kubernetes.proxy.process.memory.resident.bytes",
+                    "id": "da1b1271-99ad-11e9-8beb-c3bf9b9dfc43",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "var_name": "resident_memory"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "bytes",
+                "id": "50f54000-99ae-11e9-8beb-c3bf9b9dfc43",
+                "label": "",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "kubernetes.proxy.process.memory.virtual.bytes",
+                    "id": "50f54001-99ae-11e9-8beb-c3bf9b9dfc43",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "var_name": "virtual_memory"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "markdown"
+          },
+          "title": "Proxy process [Metricbeat Kubernetes]",
+          "type": "metrics"
+        }
+      },
+      "id": "09b404f0-99af-11e9-ba57-b7ab4e2d4b58",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-07-03T14:46:47.946Z",
+      "version": "WzI5MiwyXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Proxy HTTP request duration [Metricbeat Kubernetes]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(165,228,85,1)",
+                "fill": 0.5,
+                "formatter": "us,ms,2",
+                "id": "05a03f20-9bd8-11e9-871d-d3c7d4c337ef",
+                "label": "P99",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "kubernetes.proxy.http.request.duration.us.percentile.99",
+                    "id": "05a06630-9bd8-11e9-871d-d3c7d4c337ef",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "us,ms,2",
+                "id": "dc0faec0-9bd7-11e9-871d-d3c7d4c337ef",
+                "label": "P90",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "kubernetes.proxy.http.request.duration.us.percentile.90",
+                    "id": "dc0faec1-9bd7-11e9-871d-d3c7d4c337ef",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(65,117,0,1)",
+                "fill": 0.5,
+                "formatter": "us,ms,2",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "P50",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "kubernetes.proxy.http.request.duration.us.percentile.50",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Proxy HTTP request duration [Metricbeat Kubernetes]",
+          "type": "metrics"
+        }
+      },
+      "id": "8c6c2690-9bd8-11e9-9dc8-fd27291d427f",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-07-03T11:25:27.941Z",
+      "version": "WzI1MiwyXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Proxy network programming [Metricbeat Kubernetes]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_min": "0",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "background_color_rules": [
+              {
+                "id": "4fb3cbb0-9be5-11e9-871d-d3c7d4c337ef"
+              }
+            ],
+            "bar_color_rules": [
+              {
+                "id": "4b459c20-9be5-11e9-871d-d3c7d4c337ef"
+              }
+            ],
+            "default_index_pattern": "metricbeat-*",
+            "gauge_color_rules": [
+              {
+                "id": "4de1cad0-9be5-11e9-871d-d3c7d4c337ef"
+              }
+            ],
+            "gauge_inner_width": 10,
+            "gauge_style": "half",
+            "gauge_width": 10,
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(63,112,2,1)",
+                "fill": 0.5,
+                "formatter": "number",
+                "hidden": false,
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Under 16ms",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "kubernetes.proxy.sync.networkprogramming.duration.us.bucket.16000",
+                    "id": "4dbb3a90-9be6-11e9-871d-d3c7d4c337ef",
+                    "type": "avg"
+                  },
+                  {
+                    "field": "4dbb3a90-9be6-11e9-871d-d3c7d4c337ef",
+                    "id": "189688a0-9be7-11e9-871d-d3c7d4c337ef",
+                    "type": "derivative",
+                    "unit": ""
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(138,223,24,1)",
+                "fill": "0.4",
+                "formatter": "number",
+                "hidden": false,
+                "id": "a60dbe60-9be7-11e9-871d-d3c7d4c337ef",
+                "label": "Under 512ms",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "kubernetes.proxy.sync.networkprogramming.duration.us.bucket.512000",
+                    "id": "a60dbe61-9be7-11e9-871d-d3c7d4c337ef",
+                    "type": "avg"
+                  },
+                  {
+                    "field": "a60dbe61-9be7-11e9-871d-d3c7d4c337ef",
+                    "id": "b55a1080-9be7-11e9-871d-d3c7d4c337ef",
+                    "type": "derivative",
+                    "unit": ""
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(174,161,255,1)",
+                "fill": "0.4",
+                "formatter": "number",
+                "hidden": false,
+                "id": "c5cc4f90-9be8-11e9-871d-d3c7d4c337ef",
+                "label": "Under 1024 ms",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "kubernetes.proxy.sync.networkprogramming.duration.us.bucket.1024000",
+                    "id": "c5cc4f91-9be8-11e9-871d-d3c7d4c337ef",
+                    "type": "avg"
+                  },
+                  {
+                    "field": "c5cc4f91-9be8-11e9-871d-d3c7d4c337ef",
+                    "id": "f17cb2b0-9be8-11e9-871d-d3c7d4c337ef",
+                    "type": "derivative",
+                    "unit": ""
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(115,216,255,1)",
+                "fill": "0.2",
+                "formatter": "number",
+                "hidden": false,
+                "id": "e0901380-9be7-11e9-871d-d3c7d4c337ef",
+                "label": "Under 4096 ms",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "kubernetes.proxy.sync.networkprogramming.duration.us.bucket.4096000",
+                    "id": "e0901381-9be7-11e9-871d-d3c7d4c337ef",
+                    "type": "avg"
+                  },
+                  {
+                    "field": "e0901381-9be7-11e9-871d-d3c7d4c337ef",
+                    "id": "f2b6fce0-9be7-11e9-871d-d3c7d4c337ef",
+                    "type": "derivative",
+                    "unit": ""
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(252,196,0,1)",
+                "fill": "0.2",
+                "formatter": "number",
+                "id": "882fa5a0-9be9-11e9-871d-d3c7d4c337ef",
+                "label": "Under 8192 ms",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "kubernetes.proxy.sync.networkprogramming.duration.us.bucket.8192000",
+                    "id": "882fccb0-9be9-11e9-871d-d3c7d4c337ef",
+                    "type": "avg"
+                  },
+                  {
+                    "field": "882fccb0-9be9-11e9-871d-d3c7d4c337ef",
+                    "id": "9adb9d80-9be9-11e9-871d-d3c7d4c337ef",
+                    "type": "derivative",
+                    "unit": ""
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(209,119,103,1)",
+                "fill": "0",
+                "formatter": "number",
+                "id": "86549550-9bef-11e9-871d-d3c7d4c337ef",
+                "label": "Under 16384 ms",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "kubernetes.proxy.sync.networkprogramming.duration.us.bucket.16384000",
+                    "id": "86549551-9bef-11e9-871d-d3c7d4c337ef",
+                    "type": "avg"
+                  },
+                  {
+                    "field": "86549551-9bef-11e9-871d-d3c7d4c337ef",
+                    "id": "86549552-9bef-11e9-871d-d3c7d4c337ef",
+                    "type": "derivative",
+                    "unit": ""
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": "0",
+                "formatter": "number",
+                "id": "c66bf580-9be9-11e9-871d-d3c7d4c337ef",
+                "label": "All",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "kubernetes.proxy.sync.networkprogramming.duration.us.bucket.+Inf",
+                    "id": "c66bf581-9be9-11e9-871d-d3c7d4c337ef",
+                    "type": "avg"
+                  },
+                  {
+                    "field": "c66bf581-9be9-11e9-871d-d3c7d4c337ef",
+                    "id": "d48b3950-9be9-11e9-871d-d3c7d4c337ef",
+                    "type": "derivative",
+                    "unit": ""
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Proxy network programming [Metricbeat Kubernetes]",
+          "type": "metrics"
+        }
+      },
+      "id": "b8a24790-9bf0-11e9-9dc8-fd27291d427f",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-07-03T11:26:26.595Z",
+      "version": "WzI1NSwyXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Proxy sync rules [Metricbeat Kubernetes]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(63,112,2,1)",
+                "fill": 0.5,
+                "formatter": "number",
+                "hidden": false,
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Under 16 ms",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "kubernetes.proxy.sync.rules.duration.us.bucket.16000",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  },
+                  {
+                    "field": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "id": "038a94d0-9bf4-11e9-9f03-d58417b2a60d",
+                    "type": "derivative",
+                    "unit": ""
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(138,223,24,1)",
+                "fill": "0.4",
+                "formatter": "number",
+                "hidden": false,
+                "id": "250daed0-9bf4-11e9-9f03-d58417b2a60d",
+                "label": "Under 512 ms",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "kubernetes.proxy.sync.rules.duration.us.bucket.512000",
+                    "id": "250dd5e0-9bf4-11e9-9f03-d58417b2a60d",
+                    "type": "avg"
+                  },
+                  {
+                    "field": "250dd5e0-9bf4-11e9-9f03-d58417b2a60d",
+                    "id": "250dd5e1-9bf4-11e9-9f03-d58417b2a60d",
+                    "type": "derivative",
+                    "unit": ""
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(174,161,255,1)",
+                "fill": "0.3",
+                "formatter": "number",
+                "hidden": false,
+                "id": "744141b0-9bf4-11e9-9f03-d58417b2a60d",
+                "label": "Under 1024 ms",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "kubernetes.proxy.sync.rules.duration.us.bucket.1024000",
+                    "id": "744141b1-9bf4-11e9-9f03-d58417b2a60d",
+                    "type": "avg"
+                  },
+                  {
+                    "field": "744141b1-9bf4-11e9-9f03-d58417b2a60d",
+                    "id": "744141b2-9bf4-11e9-9f03-d58417b2a60d",
+                    "type": "derivative",
+                    "unit": ""
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(115,216,255,1)",
+                "fill": "0.2",
+                "formatter": "number",
+                "hidden": false,
+                "id": "e4454060-9bf4-11e9-9f03-d58417b2a60d",
+                "label": "Under 4096 ms",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "kubernetes.proxy.sync.rules.duration.us.bucket.4096000",
+                    "id": "e4454061-9bf4-11e9-9f03-d58417b2a60d",
+                    "type": "avg"
+                  },
+                  {
+                    "field": "e4454061-9bf4-11e9-9f03-d58417b2a60d",
+                    "id": "e4456770-9bf4-11e9-9f03-d58417b2a60d",
+                    "type": "derivative",
+                    "unit": ""
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(252,196,0,1)",
+                "fill": "0.1",
+                "formatter": "number",
+                "hidden": false,
+                "id": "1ac14f80-9bf5-11e9-9f03-d58417b2a60d",
+                "label": "Under 8192 ms",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "kubernetes.proxy.sync.rules.duration.us.bucket.8192000",
+                    "id": "1ac17690-9bf5-11e9-9f03-d58417b2a60d",
+                    "type": "avg"
+                  },
+                  {
+                    "field": "1ac17690-9bf5-11e9-9f03-d58417b2a60d",
+                    "id": "1ac17691-9bf5-11e9-9f03-d58417b2a60d",
+                    "type": "derivative",
+                    "unit": ""
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(209,119,103,1)",
+                "fill": "0",
+                "formatter": "number",
+                "hidden": false,
+                "id": "3cbf17c0-9bf5-11e9-9f03-d58417b2a60d",
+                "label": "Under 16384 ms",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "kubernetes.proxy.sync.rules.duration.us.bucket.16384000",
+                    "id": "3cbf17c1-9bf5-11e9-9f03-d58417b2a60d",
+                    "type": "avg"
+                  },
+                  {
+                    "field": "3cbf17c1-9bf5-11e9-9f03-d58417b2a60d",
+                    "id": "3cbf17c2-9bf5-11e9-9f03-d58417b2a60d",
+                    "type": "derivative",
+                    "unit": ""
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(104,188,0,1)",
+                "fill": "0",
+                "formatter": "number",
+                "id": "58fb7c80-9bf5-11e9-9f03-d58417b2a60d",
+                "label": "All",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "kubernetes.proxy.sync.rules.duration.us.bucket.+Inf",
+                    "id": "58fb7c81-9bf5-11e9-9f03-d58417b2a60d",
+                    "type": "avg"
+                  },
+                  {
+                    "field": "58fb7c81-9bf5-11e9-9f03-d58417b2a60d",
+                    "id": "58fb7c82-9bf5-11e9-9f03-d58417b2a60d",
+                    "type": "derivative",
+                    "unit": ""
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Proxy sync rules [Metricbeat Kubernetes]",
+          "type": "metrics"
+        }
+      },
+      "id": "ba7bf750-9bf5-11e9-9dc8-fd27291d427f",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-07-03T11:27:49.230Z",
+      "version": "WzI1OSwyXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Host selector [Metricbeat Kubernetes]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "controls": [
+              {
+                "fieldName": "host.hostname",
+                "id": "1561982488150",
+                "indexPatternRefName": "control_0_index_pattern",
+                "label": "Hostname",
+                "options": {
+                  "dynamicOptions": true,
+                  "multiselect": true,
+                  "order": "desc",
+                  "size": 5,
+                  "type": "terms"
+                },
+                "parent": "",
+                "type": "list"
+              },
+              {
+                "fieldName": "service.address",
+                "id": "1561982723711",
+                "indexPatternRefName": "control_1_index_pattern",
+                "label": "Service address",
+                "options": {
+                  "dynamicOptions": true,
+                  "multiselect": false,
+                  "order": "desc",
+                  "size": 5,
+                  "type": "terms"
+                },
+                "parent": "",
+                "type": "list"
+              }
+            ],
+            "pinFilters": false,
+            "updateFiltersOnChange": false,
+            "useTimeFilter": false
+          },
+          "title": "Host selector [Metricbeat Kubernetes]",
+          "type": "input_control_vis"
+        }
+      },
+      "id": "bcb194a0-9bf8-11e9-9dc8-fd27291d427f",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [
+        {
+          "id": "metricbeat-*",
+          "name": "control_0_index_pattern",
+          "type": "index-pattern"
+        },
+        {
+          "id": "metricbeat-*",
+          "name": "control_1_index_pattern",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-07-03T07:20:34.226Z",
+      "version": "WzEzMywxXQ=="
+    }
+  ],
+  "version": "7.2.0"
+}

--- a/dev/package-beats/kubernetes-1.0.0/kibana/dashboard/Metricbeat-kubernetes-scheduler.json
+++ b/dev/package-beats/kubernetes-1.0.0/kibana/dashboard/Metricbeat-kubernetes-scheduler.json
@@ -1,0 +1,1016 @@
+{
+  "objects": [
+    {
+      "attributes": {
+        "description": "Kubernetes Scheduler metrics",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [
+              {
+                "$state": {
+                  "store": "appState"
+                },
+                "meta": {
+                  "alias": null,
+                  "disabled": false,
+                  "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                  "key": "event.dataset",
+                  "negate": false,
+                  "params": {
+                    "query": "kubernetes.scheduler"
+                  },
+                  "type": "phrase",
+                  "value": "kubernetes.scheduler"
+                },
+                "query": {
+                  "match": {
+                    "event.dataset": {
+                      "query": "kubernetes.scheduler",
+                      "type": "phrase"
+                    }
+                  }
+                }
+              }
+            ],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "optionsJSON": {
+          "hidePanelTitles": false,
+          "useMargins": true
+        },
+        "panelsJSON": [
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 14,
+              "i": "1",
+              "w": 14,
+              "x": 0,
+              "y": 0
+            },
+            "panelIndex": "1",
+            "panelRefName": "panel_0",
+            "version": "7.2.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 14,
+              "i": "2",
+              "w": 11,
+              "x": 14,
+              "y": 0
+            },
+            "panelIndex": "2",
+            "panelRefName": "panel_1",
+            "version": "7.2.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 14,
+              "i": "3",
+              "w": 23,
+              "x": 25,
+              "y": 0
+            },
+            "panelIndex": "3",
+            "panelRefName": "panel_2",
+            "version": "7.2.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 11,
+              "i": "4",
+              "w": 24,
+              "x": 0,
+              "y": 29
+            },
+            "panelIndex": "4",
+            "panelRefName": "panel_3",
+            "version": "7.2.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 11,
+              "i": "5",
+              "w": 24,
+              "x": 24,
+              "y": 29
+            },
+            "panelIndex": "5",
+            "panelRefName": "panel_4",
+            "version": "7.2.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 15,
+              "i": "6",
+              "w": 24,
+              "x": 0,
+              "y": 14
+            },
+            "panelIndex": "6",
+            "panelRefName": "panel_5",
+            "version": "7.2.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 15,
+              "i": "7",
+              "w": 24,
+              "x": 24,
+              "y": 14
+            },
+            "panelIndex": "7",
+            "panelRefName": "panel_6",
+            "version": "7.2.0"
+          }
+        ],
+        "timeRestore": false,
+        "title": "[Metricbeat Kubernetes] Scheduler",
+        "version": 1
+      },
+      "id": "f5ab5510-9c94-11e9-94fd-c91206cd5249",
+      "migrationVersion": {
+        "dashboard": "7.0.0"
+      },
+      "references": [
+        {
+          "id": "metricbeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+          "type": "index-pattern"
+        },
+        {
+          "id": "bcb194a0-9bf8-11e9-9dc8-fd27291d427f",
+          "name": "panel_0",
+          "type": "visualization"
+        },
+        {
+          "id": "826d80c0-9c97-11e9-94fd-c91206cd5249",
+          "name": "panel_1",
+          "type": "visualization"
+        },
+        {
+          "id": "15bd4420-9c9b-11e9-94fd-c91206cd5249",
+          "name": "panel_2",
+          "type": "visualization"
+        },
+        {
+          "id": "d9fc1b80-9c9c-11e9-94fd-c91206cd5249",
+          "name": "panel_3",
+          "type": "visualization"
+        },
+        {
+          "id": "95595810-9ca8-11e9-94fd-c91206cd5249",
+          "name": "panel_4",
+          "type": "visualization"
+        },
+        {
+          "id": "382ace30-9d98-11e9-b2ae-49acc4cbcea9",
+          "name": "panel_5",
+          "type": "visualization"
+        },
+        {
+          "id": "84d9b200-9d98-11e9-b2ae-49acc4cbcea9",
+          "name": "panel_6",
+          "type": "visualization"
+        }
+      ],
+      "type": "dashboard",
+      "updated_at": "2019-07-03T14:42:40.028Z",
+      "version": "WzI4OSwyXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Host selector [Metricbeat Kubernetes]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "controls": [
+              {
+                "fieldName": "host.hostname",
+                "id": "1561982488150",
+                "indexPatternRefName": "control_0_index_pattern",
+                "label": "Hostname",
+                "options": {
+                  "dynamicOptions": true,
+                  "multiselect": true,
+                  "order": "desc",
+                  "size": 5,
+                  "type": "terms"
+                },
+                "parent": "",
+                "type": "list"
+              },
+              {
+                "fieldName": "service.address",
+                "id": "1561982723711",
+                "indexPatternRefName": "control_1_index_pattern",
+                "label": "Service address",
+                "options": {
+                  "dynamicOptions": true,
+                  "multiselect": false,
+                  "order": "desc",
+                  "size": 5,
+                  "type": "terms"
+                },
+                "parent": "",
+                "type": "list"
+              }
+            ],
+            "pinFilters": false,
+            "updateFiltersOnChange": false,
+            "useTimeFilter": false
+          },
+          "title": "Host selector [Metricbeat Kubernetes]",
+          "type": "input_control_vis"
+        }
+      },
+      "id": "bcb194a0-9bf8-11e9-9dc8-fd27291d427f",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [
+        {
+          "id": "metricbeat-*",
+          "name": "control_0_index_pattern",
+          "type": "index-pattern"
+        },
+        {
+          "id": "metricbeat-*",
+          "name": "control_1_index_pattern",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-07-03T07:20:34.226Z",
+      "version": "WzEzMywxXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Process summary [Metricbeat Kubernetes]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "drop_last_bucket": 1,
+            "filter": "_exists_:\"kubernetes.scheduler.process.started.sec\"",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "",
+            "interval": "30s",
+            "markdown": "|  |   |\n|---|---|\n|**Days running**|{{ math.started.last.raw }}|\n|**File descriptors open**|{{ max_of_kubernetes_scheduler_process_fds_open_count.fds.last.raw }}|\n|**Resident Memory**|{{ max_of_kubernetes_scheduler_process_memory_resident_bytes.resident_memory.last.formatted }}|\n|**Virtual Memory**|{{ max_of_kubernetes_scheduler_process_memory_virtual_bytes.virtual_memory.last.formatted }}|\n",
+            "markdown_css": "#markdown-61ca57f0-469d-11e7-af02-69e470af7417 table,#markdown-61ca57f0-469d-11e7-af02-69e470af7417 tr,#markdown-61ca57f0-469d-11e7-af02-69e470af7417 td,#markdown-61ca57f0-469d-11e7-af02-69e470af7417 th{border:none}",
+            "markdown_less": "\ntable, tr, td, th {\n    border: none;\n}\n\n",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "number",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "kubernetes.scheduler.process.started.sec",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "max"
+                  },
+                  {
+                    "id": "94b52370-9c95-11e9-87bc-455cc45f013a",
+                    "script": "round( (params._timestamp /1000 - params.started) / 86400, 2)",
+                    "type": "math",
+                    "variables": [
+                      {
+                        "field": "61ca57f2-469d-11e7-af02-69e470af7417",
+                        "id": "97cc0060-9c95-11e9-87bc-455cc45f013a",
+                        "name": "started"
+                      }
+                    ]
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "var_name": "started"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "number",
+                "id": "a8475ca0-9c95-11e9-87bc-455cc45f013a",
+                "label": "",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "kubernetes.scheduler.process.fds.open.count",
+                    "id": "a8475ca1-9c95-11e9-87bc-455cc45f013a",
+                    "type": "max"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "var_name": "fds"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "bytes",
+                "id": "cdc6d190-9c95-11e9-87bc-455cc45f013a",
+                "label": "",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "kubernetes.scheduler.process.memory.resident.bytes",
+                    "id": "cdc6d191-9c95-11e9-87bc-455cc45f013a",
+                    "type": "max"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "var_name": "resident_memory"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "bytes",
+                "id": "dfa0fa80-9c95-11e9-87bc-455cc45f013a",
+                "label": "",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "kubernetes.scheduler.process.memory.virtual.bytes",
+                    "id": "dfa0fa81-9c95-11e9-87bc-455cc45f013a",
+                    "type": "max"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "var_name": "virtual_memory"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "",
+            "type": "markdown"
+          },
+          "title": "Process summary [Metricbeat Kubernetes]",
+          "type": "metrics"
+        }
+      },
+      "id": "826d80c0-9c97-11e9-94fd-c91206cd5249",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-07-03T14:45:05.521Z",
+      "version": "WzI5MCwyXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Scheduler HTTP request duration [Metricbeat Kubernetes]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "",
+            "interval": "",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(165,228,85,1)",
+                "fill": 0.5,
+                "formatter": "us,ms,2",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "P99",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "kubernetes.scheduler.http.request.duration.us.percentile.99",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "us,ms,2",
+                "id": "708a5a50-9c9b-11e9-b248-53caaa33a2c5",
+                "label": "P90",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "kubernetes.scheduler.http.request.duration.us.percentile.90",
+                    "id": "708a8160-9c9b-11e9-b248-53caaa33a2c5",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(65,117,0,1)",
+                "fill": 0.5,
+                "formatter": "us,ms,2",
+                "id": "9ba449d0-9c9b-11e9-b248-53caaa33a2c5",
+                "label": "P50",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "kubernetes.scheduler.http.request.duration.us.percentile.50",
+                    "id": "9ba449d1-9c9b-11e9-b248-53caaa33a2c5",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "",
+            "type": "timeseries"
+          },
+          "title": "Scheduler HTTP request duration [Metricbeat Kubernetes]",
+          "type": "metrics"
+        }
+      },
+      "id": "15bd4420-9c9b-11e9-94fd-c91206cd5249",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-07-03T07:20:34.226Z",
+      "version": "WzEzNSwxXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Scheduler end to end scheduling duration [Metricbeat Kubernetes]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_min": "0",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "",
+            "interval": "",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(63,112,2,1)",
+                "fill": 0.5,
+                "formatter": "number",
+                "hidden": false,
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Under 16ms",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "kubernetes.scheduler.scheduling.e2e.duration.us.bucket.16000",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  },
+                  {
+                    "field": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "id": "2a21d690-9c9d-11e9-8174-4589c2c40897",
+                    "type": "derivative",
+                    "unit": ""
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(138,223,24,1)",
+                "fill": "0.4",
+                "formatter": "number",
+                "hidden": false,
+                "id": "a0344a80-9ca1-11e9-9b2f-4dae0cc2bdf1",
+                "label": "Under 512ms",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "kubernetes.scheduler.scheduling.e2e.duration.us.bucket.512000",
+                    "id": "a0347190-9ca1-11e9-9b2f-4dae0cc2bdf1",
+                    "type": "avg"
+                  },
+                  {
+                    "field": "a0347190-9ca1-11e9-9b2f-4dae0cc2bdf1",
+                    "id": "9a865d10-9ca3-11e9-9b2f-4dae0cc2bdf1",
+                    "type": "derivative",
+                    "unit": ""
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(174,161,255,1)",
+                "fill": "0.3",
+                "formatter": "number",
+                "hidden": false,
+                "id": "c456c780-9ca1-11e9-9b2f-4dae0cc2bdf1",
+                "label": "Under 1024ms",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "kubernetes.scheduler.scheduling.e2e.duration.us.bucket.1024000",
+                    "id": "c456c781-9ca1-11e9-9b2f-4dae0cc2bdf1",
+                    "type": "avg"
+                  },
+                  {
+                    "field": "c456c781-9ca1-11e9-9b2f-4dae0cc2bdf1",
+                    "id": "a77cd850-9ca3-11e9-9b2f-4dae0cc2bdf1",
+                    "type": "derivative",
+                    "unit": ""
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(115,216,255,1)",
+                "fill": "0.2",
+                "formatter": "number",
+                "hidden": false,
+                "id": "127a9810-9ca2-11e9-9b2f-4dae0cc2bdf1",
+                "label": "Under 4096ms",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "kubernetes.scheduler.scheduling.e2e.duration.us.bucket.4096000",
+                    "id": "127a9811-9ca2-11e9-9b2f-4dae0cc2bdf1",
+                    "type": "avg"
+                  },
+                  {
+                    "field": "127a9811-9ca2-11e9-9b2f-4dae0cc2bdf1",
+                    "id": "b48a0fe0-9ca3-11e9-9b2f-4dae0cc2bdf1",
+                    "type": "derivative",
+                    "unit": ""
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(252,196,0,1)",
+                "fill": "0.1",
+                "formatter": "number",
+                "hidden": false,
+                "id": "6a2ba130-9ca2-11e9-9b2f-4dae0cc2bdf1",
+                "label": "Under 8192ms",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "kubernetes.scheduler.scheduling.e2e.duration.us.bucket.8192000",
+                    "id": "6a2ba131-9ca2-11e9-9b2f-4dae0cc2bdf1",
+                    "type": "avg"
+                  },
+                  {
+                    "field": "6a2ba131-9ca2-11e9-9b2f-4dae0cc2bdf1",
+                    "id": "c727fe00-9ca3-11e9-9b2f-4dae0cc2bdf1",
+                    "type": "derivative",
+                    "unit": ""
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(209,119,103,1)",
+                "fill": "0",
+                "formatter": "number",
+                "hidden": false,
+                "id": "f93a66e0-9ca2-11e9-9b2f-4dae0cc2bdf1",
+                "label": "Under 16384ms",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "kubernetes.scheduler.scheduling.e2e.duration.us.bucket.16384000",
+                    "id": "f93a66e1-9ca2-11e9-9b2f-4dae0cc2bdf1",
+                    "type": "avg"
+                  },
+                  {
+                    "field": "f93a66e1-9ca2-11e9-9b2f-4dae0cc2bdf1",
+                    "id": "ce42d700-9ca3-11e9-9b2f-4dae0cc2bdf1",
+                    "type": "derivative",
+                    "unit": ""
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(104,188,0,1)",
+                "fill": "0",
+                "formatter": "number",
+                "hidden": false,
+                "id": "310452c0-9ca3-11e9-9b2f-4dae0cc2bdf1",
+                "label": "All",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "kubernetes.scheduler.scheduling.e2e.duration.us.bucket.+Inf",
+                    "id": "310452c1-9ca3-11e9-9b2f-4dae0cc2bdf1",
+                    "type": "avg"
+                  },
+                  {
+                    "field": "310452c1-9ca3-11e9-9b2f-4dae0cc2bdf1",
+                    "id": "e0692420-9ca3-11e9-9b2f-4dae0cc2bdf1",
+                    "type": "derivative",
+                    "unit": ""
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "",
+            "type": "timeseries"
+          },
+          "title": "Scheduler end to end scheduling duration [Metricbeat Kubernetes]",
+          "type": "metrics"
+        }
+      },
+      "id": "d9fc1b80-9c9c-11e9-94fd-c91206cd5249",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-07-03T07:20:34.226Z",
+      "version": "WzEzNiwxXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Scheduler scheduling attempts [Metricbeat Kubernetes]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_min": "0",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "",
+            "interval": "",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "number",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Attempts",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "kubernetes.scheduler.scheduling.pod.attempts.count",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  },
+                  {
+                    "field": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "id": "18aae5d0-9ca9-11e9-b8ef-3ddf5d748ddb",
+                    "type": "derivative",
+                    "unit": ""
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_color_mode": "rainbow",
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "kubernetes.scheduler.result",
+                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "",
+            "type": "timeseries"
+          },
+          "title": "Scheduler scheduling attempts [Metricbeat Kubernetes]",
+          "type": "metrics"
+        }
+      },
+      "id": "95595810-9ca8-11e9-94fd-c91206cd5249",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-07-03T07:20:34.226Z",
+      "version": "WzEzNywxXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Scheduler CPU [Metricbeat Kubernetes]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_min": "0",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "",
+            "interval": "",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "number",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "CPU time",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "kubernetes.scheduler.process.cpu.sec",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  },
+                  {
+                    "field": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "id": "11331120-9d98-11e9-9e81-115d18bcfeaa",
+                    "type": "derivative",
+                    "unit": ""
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}} s"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "",
+            "type": "timeseries"
+          },
+          "title": "Scheduler CPU [Metricbeat Kubernetes]",
+          "type": "metrics"
+        }
+      },
+      "id": "382ace30-9d98-11e9-b2ae-49acc4cbcea9",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-07-03T14:10:38.608Z",
+      "version": "WzI3NywyXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Scheduler Memory [Metricbeat Kubernetes]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "",
+            "interval": "",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(251,158,0,1)",
+                "fill": 0.5,
+                "formatter": "bytes",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Resident",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "kubernetes.scheduler.process.memory.resident.bytes",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "bytes",
+                "id": "a14defa0-9d98-11e9-9e81-115d18bcfeaa",
+                "label": "Virtual",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "kubernetes.scheduler.process.memory.virtual.bytes",
+                    "id": "a14defa1-9d98-11e9-9e81-115d18bcfeaa",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "",
+            "type": "timeseries"
+          },
+          "title": "Scheduler Memory [Metricset Kubernetes]",
+          "type": "metrics"
+        }
+      },
+      "id": "84d9b200-9d98-11e9-b2ae-49acc4cbcea9",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-07-03T13:45:33.315Z",
+      "version": "WzI3MiwyXQ=="
+    }
+  ],
+  "version": "7.2.0"
+}

--- a/dev/package-beats/kubernetes-1.0.0/manifest.yml
+++ b/dev/package-beats/kubernetes-1.0.0/manifest.yml
@@ -1,0 +1,13 @@
+name: kubernetes
+title: Kubernetes
+version: 1.0.0
+description: |
+  Kubernetes metrics
+type: ""
+categories:
+- metrics
+requirement:
+  kibana:
+    version:
+      min: 6.7.0
+      max: 7.6.0

--- a/dev/package-beats/kvm-1.0.0/manifest.yml
+++ b/dev/package-beats/kvm-1.0.0/manifest.yml
@@ -1,0 +1,13 @@
+name: kvm
+title: kvm
+version: 1.0.0
+description: |
+  kvm module
+type: ""
+categories:
+- metrics
+requirement:
+  kibana:
+    version:
+      min: 6.7.0
+      max: 7.6.0

--- a/dev/package-beats/logstash-1.0.0/kibana/dashboard/Filebeat-logstash-log.json
+++ b/dev/package-beats/logstash-1.0.0/kibana/dashboard/Filebeat-logstash-log.json
@@ -1,0 +1,337 @@
+{
+    "objects": [
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                }, 
+                "savedSearchId": "cfaba090-cbda-11e7-9852-73e0a9df1bb6-ecs", 
+                "title": "Logs Severity [Filebeat Logstash] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "field": "log.level", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "segment", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "params": {
+                        "addLegend": true, 
+                        "addTooltip": true, 
+                        "isDonut": true, 
+                        "legendPosition": "right", 
+                        "type": "pie"
+                    }, 
+                    "title": "Logs Severity [Filebeat Logstash] ECS", 
+                    "type": "pie"
+                }
+            }, 
+            "id": "0b1dace0-cbdb-11e7-9852-73e0a9df1bb6-ecs", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                }, 
+                "savedSearchId": "cfaba090-cbda-11e7-9852-73e0a9df1bb6-ecs", 
+                "title": "logs over time [Filebeat Logstash] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "field": "log.level", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "group", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "categoryAxes": [
+                            {
+                                "id": "CategoryAxis-1", 
+                                "labels": {
+                                    "show": true, 
+                                    "truncate": 100
+                                }, 
+                                "position": "bottom", 
+                                "scale": {
+                                    "type": "linear"
+                                }, 
+                                "show": true, 
+                                "style": {}, 
+                                "title": {}, 
+                                "type": "category"
+                            }
+                        ], 
+                        "grid": {
+                            "categoryLines": false, 
+                            "style": {
+                                "color": "#eee"
+                            }
+                        }, 
+                        "legendPosition": "right", 
+                        "seriesParams": [
+                            {
+                                "data": {
+                                    "id": "1", 
+                                    "label": "Count"
+                                }, 
+                                "drawLinesBetweenPoints": true, 
+                                "mode": "stacked", 
+                                "show": "true", 
+                                "showCircles": true, 
+                                "type": "histogram", 
+                                "valueAxis": "ValueAxis-1"
+                            }
+                        ], 
+                        "times": [], 
+                        "type": "histogram", 
+                        "valueAxes": [
+                            {
+                                "id": "ValueAxis-1", 
+                                "labels": {
+                                    "filter": false, 
+                                    "rotate": 0, 
+                                    "show": true, 
+                                    "truncate": 100
+                                }, 
+                                "name": "LeftAxis-1", 
+                                "position": "left", 
+                                "scale": {
+                                    "mode": "normal", 
+                                    "type": "linear"
+                                }, 
+                                "show": true, 
+                                "style": {}, 
+                                "title": {
+                                    "text": "Count"
+                                }, 
+                                "type": "value"
+                            }
+                        ]
+                    }, 
+                    "title": "logs over time [Filebeat Logstash] ECS", 
+                    "type": "histogram"
+                }
+            }, 
+            "id": "e90b7240-cbda-11e7-9852-73e0a9df1bb6-ecs", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "columns": [
+                    "log.level", 
+                    "logstash.log.module", 
+                    "message", 
+                    "source"
+                ], 
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [
+                            {
+                                "$state": {
+                                    "store": "appState"
+                                }, 
+                                "meta": {
+                                    "alias": null, 
+                                    "disabled": false, 
+                                    "index": "filebeat-*", 
+                                    "key": "event.module", 
+                                    "negate": false, 
+                                    "params": {
+                                        "query": "logstash", 
+                                        "type": "phrase"
+                                    }, 
+                                    "type": "phrase", 
+                                    "value": "logstash"
+                                }, 
+                                "query": {
+                                    "match": {
+                                        "event.module": {
+                                            "query": "logstash", 
+                                            "type": "phrase"
+                                        }
+                                    }
+                                }
+                            }, 
+                            {
+                                "$state": {
+                                    "store": "appState"
+                                }, 
+                                "meta": {
+                                    "alias": null, 
+                                    "disabled": false, 
+                                    "index": "filebeat-*", 
+                                    "key": "fileset.name", 
+                                    "negate": false, 
+                                    "params": {
+                                        "query": "log", 
+                                        "type": "phrase"
+                                    }, 
+                                    "type": "phrase", 
+                                    "value": "log"
+                                }, 
+                                "query": {
+                                    "match": {
+                                        "fileset.name": {
+                                            "query": "log", 
+                                            "type": "phrase"
+                                        }
+                                    }
+                                }
+                            }
+                        ], 
+                        "highlightAll": true, 
+                        "index": "filebeat-*", 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "sort": [
+                    "@timestamp", 
+                    "desc"
+                ], 
+                "title": "logs [Filebeat Logstash] ECS", 
+                "version": 1
+            }, 
+            "id": "cfaba090-cbda-11e7-9852-73e0a9df1bb6-ecs", 
+            "type": "search", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "Overview of Logstash logs", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlightAll": true, 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "optionsJSON": {
+                    "darkTheme": false
+                }, 
+                "panelsJSON": [
+                    {
+                        "col": 7, 
+                        "id": "0b1dace0-cbdb-11e7-9852-73e0a9df1bb6-ecs", 
+                        "panelIndex": 2, 
+                        "row": 1, 
+                        "size_x": 6, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "e90b7240-cbda-11e7-9852-73e0a9df1bb6-ecs", 
+                        "panelIndex": 3, 
+                        "row": 1, 
+                        "size_x": 6, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "columns": [
+                            "log.level", 
+                            "logstash.log.module", 
+                            "message", 
+                            "source"
+                        ], 
+                        "id": "cfaba090-cbda-11e7-9852-73e0a9df1bb6-ecs", 
+                        "panelIndex": 4, 
+                        "row": 4, 
+                        "size_x": 12, 
+                        "size_y": 10, 
+                        "sort": [
+                            "@timestamp", 
+                            "desc"
+                        ], 
+                        "type": "search"
+                    }
+                ], 
+                "timeRestore": false, 
+                "title": "[Filebeat Logstash] Logstash Logs ECS", 
+                "uiStateJSON": {}, 
+                "version": 1
+            }, 
+            "id": "Filebeat-Logstash-Log-Dashboard-ecs", 
+            "type": "dashboard", 
+            "version": 1
+        }
+    ], 
+    "version": "6.0.0"
+}

--- a/dev/package-beats/logstash-1.0.0/kibana/dashboard/Filebeat-logstash-slowlog.json
+++ b/dev/package-beats/logstash-1.0.0/kibana/dashboard/Filebeat-logstash-slowlog.json
@@ -1,0 +1,550 @@
+{
+    "objects": [
+        {
+            "attributes": {
+                "columns": [
+                    "log.level", 
+                    "logstash.slowlog.plugin_type", 
+                    "logstash.slowlog.plugin_name", 
+                    "logstash.slowlog.message", 
+                    "logstash.slowlog.plugin_params", 
+                    "logstash.slowlog.execution_time_ns"
+                ], 
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [
+                            {
+                                "$state": {
+                                    "store": "appState"
+                                }, 
+                                "meta": {
+                                    "alias": null, 
+                                    "disabled": false, 
+                                    "index": "filebeat-*", 
+                                    "key": "event.module", 
+                                    "negate": false, 
+                                    "params": {
+                                        "query": "logstash", 
+                                        "type": "phrase"
+                                    }, 
+                                    "type": "phrase", 
+                                    "value": "logstash"
+                                }, 
+                                "query": {
+                                    "match": {
+                                        "event.module": {
+                                            "query": "logstash", 
+                                            "type": "phrase"
+                                        }
+                                    }
+                                }
+                            }, 
+                            {
+                                "$state": {
+                                    "store": "appState"
+                                }, 
+                                "meta": {
+                                    "alias": null, 
+                                    "disabled": false, 
+                                    "index": "filebeat-*", 
+                                    "key": "fileset.name", 
+                                    "negate": false, 
+                                    "params": {
+                                        "query": "slowlog", 
+                                        "type": "phrase"
+                                    }, 
+                                    "type": "phrase", 
+                                    "value": "slowlog"
+                                }, 
+                                "query": {
+                                    "match": {
+                                        "fileset.name": {
+                                            "query": "slowlog", 
+                                            "type": "phrase"
+                                        }
+                                    }
+                                }
+                            }
+                        ], 
+                        "highlightAll": true, 
+                        "index": "filebeat-*", 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "sort": [
+                    "log.level", 
+                    "asc"
+                ], 
+                "title": "Slow logs [Filebeat Logstash] ECS", 
+                "version": 1
+            }, 
+            "id": "742e45d0-cbdd-11e7-9852-73e0a9df1bb6-ecs", 
+            "type": "search", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                }, 
+                "savedSearchId": "cfaba090-cbda-11e7-9852-73e0a9df1bb6-ecs", 
+                "title": "Logs Severity [Filebeat Logstash] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "field": "log.level", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "segment", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "params": {
+                        "addLegend": true, 
+                        "addTooltip": true, 
+                        "isDonut": true, 
+                        "legendPosition": "right", 
+                        "type": "pie"
+                    }, 
+                    "title": "Logs Severity [Filebeat Logstash] ECS", 
+                    "type": "pie"
+                }
+            }, 
+            "id": "0b1dace0-cbdb-11e7-9852-73e0a9df1bb6-ecs", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                }, 
+                "savedSearchId": "cfaba090-cbda-11e7-9852-73e0a9df1bb6-ecs", 
+                "title": "logs over time [Filebeat Logstash] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "field": "log.level", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "group", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "categoryAxes": [
+                            {
+                                "id": "CategoryAxis-1", 
+                                "labels": {
+                                    "show": true, 
+                                    "truncate": 100
+                                }, 
+                                "position": "bottom", 
+                                "scale": {
+                                    "type": "linear"
+                                }, 
+                                "show": true, 
+                                "style": {}, 
+                                "title": {}, 
+                                "type": "category"
+                            }
+                        ], 
+                        "grid": {
+                            "categoryLines": false, 
+                            "style": {
+                                "color": "#eee"
+                            }
+                        }, 
+                        "legendPosition": "right", 
+                        "seriesParams": [
+                            {
+                                "data": {
+                                    "id": "1", 
+                                    "label": "Count"
+                                }, 
+                                "drawLinesBetweenPoints": true, 
+                                "mode": "stacked", 
+                                "show": "true", 
+                                "showCircles": true, 
+                                "type": "histogram", 
+                                "valueAxis": "ValueAxis-1"
+                            }
+                        ], 
+                        "times": [], 
+                        "type": "histogram", 
+                        "valueAxes": [
+                            {
+                                "id": "ValueAxis-1", 
+                                "labels": {
+                                    "filter": false, 
+                                    "rotate": 0, 
+                                    "show": true, 
+                                    "truncate": 100
+                                }, 
+                                "name": "LeftAxis-1", 
+                                "position": "left", 
+                                "scale": {
+                                    "mode": "normal", 
+                                    "type": "linear"
+                                }, 
+                                "show": true, 
+                                "style": {}, 
+                                "title": {
+                                    "text": "Count"
+                                }, 
+                                "type": "value"
+                            }
+                        ]
+                    }, 
+                    "title": "logs over time [Filebeat Logstash] ECS", 
+                    "type": "histogram"
+                }
+            }, 
+            "id": "e90b7240-cbda-11e7-9852-73e0a9df1bb6-ecs", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                }, 
+                "savedSearchId": "742e45d0-cbdd-11e7-9852-73e0a9df1bb6-ecs", 
+                "title": "Slowest plugins [Filebeat Logstash] ECS", 
+                "uiStateJSON": {
+                    "vis": {
+                        "params": {
+                            "sort": {
+                                "columnIndex": 3, 
+                                "direction": null
+                            }
+                        }
+                    }
+                }, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "6", 
+                            "params": {
+                                "customLabel": "Average", 
+                                "field": "logstash.slowlog.took_in_millis"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "5", 
+                            "params": {
+                                "customLabel": "Min", 
+                                "field": "logstash.slowlog.took_in_millis"
+                            }, 
+                            "schema": "metric", 
+                            "type": "min"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "8", 
+                            "params": {
+                                "customLabel": "Plugin Name", 
+                                "field": "logstash.slowlog.plugin_name", 
+                                "order": "desc", 
+                                "orderBy": "5", 
+                                "size": 5
+                            }, 
+                            "schema": "bucket", 
+                            "type": "terms"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "7", 
+                            "params": {
+                                "customLabel": "Max", 
+                                "field": "logstash.slowlog.took_in_millis"
+                            }, 
+                            "schema": "metric", 
+                            "type": "max"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "9", 
+                            "params": {
+                                "customLabel": "Plugin Type", 
+                                "field": "logstash.slowlog.plugin_type", 
+                                "order": "desc", 
+                                "orderBy": "5", 
+                                "size": 5
+                            }, 
+                            "schema": "bucket", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "params": {
+                        "perPage": 10, 
+                        "showMeticsAtAllLevels": false, 
+                        "showPartialRows": false, 
+                        "showTotal": false, 
+                        "sort": {
+                            "columnIndex": null, 
+                            "direction": null
+                        }, 
+                        "totalFunc": "sum"
+                    }, 
+                    "title": "Slowest plugins [Filebeat Logstash] ECS", 
+                    "type": "table"
+                }
+            }, 
+            "id": "b3315630-cbdf-11e7-9852-73e0a9df1bb6-ecs", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "columns": [
+                    "log.level", 
+                    "logstash.log.module", 
+                    "message", 
+                    "source"
+                ], 
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [
+                            {
+                                "$state": {
+                                    "store": "appState"
+                                }, 
+                                "meta": {
+                                    "alias": null, 
+                                    "disabled": false, 
+                                    "index": "filebeat-*", 
+                                    "key": "event.module", 
+                                    "negate": false, 
+                                    "params": {
+                                        "query": "logstash", 
+                                        "type": "phrase"
+                                    }, 
+                                    "type": "phrase", 
+                                    "value": "logstash"
+                                }, 
+                                "query": {
+                                    "match": {
+                                        "event.module": {
+                                            "query": "logstash", 
+                                            "type": "phrase"
+                                        }
+                                    }
+                                }
+                            }, 
+                            {
+                                "$state": {
+                                    "store": "appState"
+                                }, 
+                                "meta": {
+                                    "alias": null, 
+                                    "disabled": false, 
+                                    "index": "filebeat-*", 
+                                    "key": "fileset.name", 
+                                    "negate": false, 
+                                    "params": {
+                                        "query": "log", 
+                                        "type": "phrase"
+                                    }, 
+                                    "type": "phrase", 
+                                    "value": "log"
+                                }, 
+                                "query": {
+                                    "match": {
+                                        "fileset.name": {
+                                            "query": "log", 
+                                            "type": "phrase"
+                                        }
+                                    }
+                                }
+                            }
+                        ], 
+                        "highlightAll": true, 
+                        "index": "filebeat-*", 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "sort": [
+                    "@timestamp", 
+                    "desc"
+                ], 
+                "title": "logs [Filebeat Logstash] ECS", 
+                "version": 1
+            }, 
+            "id": "cfaba090-cbda-11e7-9852-73e0a9df1bb6-ecs", 
+            "type": "search", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "Overview of Logstash Slowlogs", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlightAll": true, 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "optionsJSON": {
+                    "darkTheme": false
+                }, 
+                "panelsJSON": [
+                    {
+                        "col": 1, 
+                        "columns": [
+                            "log.level", 
+                            "logstash.slowlog.plugin_type", 
+                            "logstash.slowlog.plugin_name", 
+                            "logstash.slowlog.message", 
+                            "logstash.slowlog.plugin_params", 
+                            "logstash.slowlog.execution_time_ns"
+                        ], 
+                        "id": "742e45d0-cbdd-11e7-9852-73e0a9df1bb6-ecs", 
+                        "panelIndex": 1, 
+                        "row": 7, 
+                        "size_x": 12, 
+                        "size_y": 9, 
+                        "sort": [
+                            "@timestamp", 
+                            "desc"
+                        ], 
+                        "type": "search"
+                    }, 
+                    {
+                        "col": 7, 
+                        "id": "0b1dace0-cbdb-11e7-9852-73e0a9df1bb6-ecs", 
+                        "panelIndex": 2, 
+                        "row": 1, 
+                        "size_x": 6, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "e90b7240-cbda-11e7-9852-73e0a9df1bb6-ecs", 
+                        "panelIndex": 3, 
+                        "row": 1, 
+                        "size_x": 6, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "b3315630-cbdf-11e7-9852-73e0a9df1bb6-ecs", 
+                        "panelIndex": 4, 
+                        "row": 4, 
+                        "size_x": 12, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }
+                ], 
+                "timeRestore": false, 
+                "title": "[Filebeat Logstash] Slowlogs ECS", 
+                "uiStateJSON": {
+                    "P-4": {
+                        "vis": {
+                            "params": {
+                                "sort": {
+                                    "columnIndex": 3, 
+                                    "direction": null
+                                }
+                            }
+                        }
+                    }
+                }, 
+                "version": 1
+            }, 
+            "id": "Filebeat-Logstash-Slowlog-Dashboard-ecs", 
+            "type": "dashboard", 
+            "version": 1
+        }
+    ], 
+    "version": "6.0.0"
+}

--- a/dev/package-beats/logstash-1.0.0/manifest.yml
+++ b/dev/package-beats/logstash-1.0.0/manifest.yml
@@ -1,0 +1,14 @@
+name: logstash
+title: logstash
+version: 1.0.0
+description: |
+  Logstash module
+type: ""
+categories:
+- logs
+- metrics
+requirement:
+  kibana:
+    version:
+      min: 6.7.0
+      max: 7.6.0

--- a/dev/package-beats/memcached-1.0.0/manifest.yml
+++ b/dev/package-beats/memcached-1.0.0/manifest.yml
@@ -1,0 +1,13 @@
+name: memcached
+title: Memcached
+version: 1.0.0
+description: |
+  Memcached module
+type: ""
+categories:
+- metrics
+requirement:
+  kibana:
+    version:
+      min: 6.7.0
+      max: 7.6.0

--- a/dev/package-beats/misp-1.0.0/kibana/dashboard/Filebeat-MISP-Overview.json
+++ b/dev/package-beats/misp-1.0.0/kibana/dashboard/Filebeat-MISP-Overview.json
@@ -1,0 +1,417 @@
+{
+  "objects": [
+    {
+      "attributes": {
+        "description": "Overview dashboard for Filebeat MSIP module.",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "optionsJSON": {
+          "hidePanelTitles": false,
+          "useMargins": true
+        },
+        "panelsJSON": [
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 15,
+              "i": "1",
+              "w": 24,
+              "x": 0,
+              "y": 0
+            },
+            "panelIndex": "1",
+            "panelRefName": "panel_0",
+            "version": "8.0.0-SNAPSHOT"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 15,
+              "i": "2",
+              "w": 24,
+              "x": 24,
+              "y": 0
+            },
+            "panelIndex": "2",
+            "panelRefName": "panel_1",
+            "version": "8.0.0-SNAPSHOT"
+          },
+          {
+            "embeddableConfig": {
+              "mapCenter": [
+                24.686952411999155,
+                12.128906250000002
+              ],
+              "mapZoom": 3
+            },
+            "gridData": {
+              "h": 24,
+              "i": "3",
+              "w": 48,
+              "x": 0,
+              "y": 15
+            },
+            "panelIndex": "3",
+            "panelRefName": "panel_2",
+            "version": "8.0.0-SNAPSHOT"
+          }
+        ],
+        "timeRestore": false,
+        "title": "[Filebeat MISP] Overview",
+        "version": 1
+      },
+      "id": "c6cac9e0-f105-11e9-9a88-690b10c8ee99",
+      "migrationVersion": {
+        "dashboard": "7.0.0"
+      },
+      "references": [
+        {
+          "id": "8fc4b140-ed36-11e9-9a88-690b10c8ee99",
+          "name": "panel_0",
+          "type": "visualization"
+        },
+        {
+          "id": "7d369390-f105-11e9-9a88-690b10c8ee99",
+          "name": "panel_1",
+          "type": "visualization"
+        },
+        {
+          "id": "73287f70-f1fb-11e9-9a88-690b10c8ee99",
+          "name": "panel_2",
+          "type": "visualization"
+        }
+      ],
+      "type": "dashboard",
+      "updated_at": "2019-10-19T18:56:55.244Z",
+      "version": "WzM2NCwxNV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Threat Indicator Type [Filebeat MISP]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "field": "misp.threat_indicator.type",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 20
+              },
+              "schema": "segment",
+              "type": "terms"
+            }
+          ],
+          "params": {
+            "addLegend": true,
+            "addTooltip": true,
+            "isDonut": true,
+            "labels": {
+              "last_level": true,
+              "show": false,
+              "truncate": 100,
+              "values": true
+            },
+            "legendPosition": "right",
+            "type": "pie"
+          },
+          "title": "Threat Indicator Type [Filebeat MISP]",
+          "type": "pie"
+        }
+      },
+      "id": "8fc4b140-ed36-11e9-9a88-690b10c8ee99",
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-10-19T19:03:26.386Z",
+      "version": "WzM2NSwxNV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Threat Indicators per Month  [Filebeat MISP]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "Indicators Per Month"
+              },
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customInterval": "2h",
+                "drop_partials": false,
+                "extended_bounds": {},
+                "field": "@timestamp",
+                "interval": "M",
+                "min_doc_count": 1,
+                "timeRange": {
+                  "from": "now-15M",
+                  "to": "now"
+                },
+                "time_zone": "America/Los_Angeles",
+                "useNormalizedEsInterval": true
+              },
+              "schema": "segment",
+              "type": "date_histogram"
+            },
+            {
+              "enabled": true,
+              "id": "3",
+              "params": {
+                "field": "misp.threat_indicator.type",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 10
+              },
+              "schema": "group",
+              "type": "terms"
+            }
+          ],
+          "params": {
+            "addLegend": true,
+            "addTimeMarker": false,
+            "addTooltip": true,
+            "categoryAxes": [
+              {
+                "id": "CategoryAxis-1",
+                "labels": {
+                  "show": true,
+                  "truncate": 100
+                },
+                "position": "bottom",
+                "scale": {
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {},
+                "type": "category"
+              }
+            ],
+            "grid": {
+              "categoryLines": false
+            },
+            "legendPosition": "right",
+            "seriesParams": [
+              {
+                "data": {
+                  "id": "1",
+                  "label": "Indicators Per Month"
+                },
+                "drawLinesBetweenPoints": true,
+                "mode": "stacked",
+                "show": "true",
+                "showCircles": true,
+                "type": "histogram",
+                "valueAxis": "ValueAxis-1"
+              }
+            ],
+            "times": [],
+            "type": "histogram",
+            "valueAxes": [
+              {
+                "id": "ValueAxis-1",
+                "labels": {
+                  "filter": false,
+                  "rotate": 0,
+                  "show": true,
+                  "truncate": 100
+                },
+                "name": "LeftAxis-1",
+                "position": "left",
+                "scale": {
+                  "mode": "normal",
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {
+                  "text": "Indicators Per Month"
+                },
+                "type": "value"
+              }
+            ]
+          },
+          "title": "Threat Indicators per Month  [Filebeat MISP]",
+          "type": "histogram"
+        }
+      },
+      "id": "7d369390-f105-11e9-9a88-690b10c8ee99",
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-10-19T19:03:46.399Z",
+      "version": "WzM2NiwxNV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Threat Indicator Geo Map [Filebeat MISP]",
+        "uiStateJSON": {
+          "mapCenter": [
+            -0.17578097424708533,
+            0
+          ],
+          "mapZoom": 2
+        },
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "autoPrecision": true,
+                "field": "source.geo.location",
+                "isFilteredByCollar": true,
+                "mapBounds": {
+                  "bottom_right": {
+                    "lat": -42.68243539838622,
+                    "lon": 60.99609375000001
+                  },
+                  "top_left": {
+                    "lat": 42.35854391749705,
+                    "lon": -60.99609375000001
+                  }
+                },
+                "mapCenter": {
+                  "lat": -0.17578097424708533,
+                  "lon": 0
+                },
+                "mapZoom": 4,
+                "precision": 2,
+                "useGeocentroid": true
+              },
+              "schema": "segment",
+              "type": "geohash_grid"
+            }
+          ],
+          "params": {
+            "addTooltip": true,
+            "colorSchema": "Yellow to Red",
+            "heatClusterSize": 1.5,
+            "isDesaturated": true,
+            "legendPosition": "bottomright",
+            "mapCenter": [
+              0,
+              0
+            ],
+            "mapType": "Scaled Circle Markers",
+            "mapZoom": 2,
+            "wms": {
+              "enabled": false,
+              "options": {
+                "format": "image/png",
+                "transparent": true
+              },
+              "selectedTmsLayer": {
+                "attribution": "\u003cp\u003e\u0026#169; \u003ca href=\"https://www.openstreetmap.org/copyright\"\u003eOpenStreetMap contributors\u003c/a\u003e|\u003ca href=\"https://openmaptiles.org\"\u003eOpenMapTiles\u003c/a\u003e|\u003ca href=\"https://www.maptiler.com\"\u003eMapTiler\u003c/a\u003e|\u003ca href=\"https://www.elastic.co/elastic-maps-service\"\u003eElastic Maps Service\u003c/a\u003e\u003c/p\u003e\u0026#10;",
+                "id": "road_map",
+                "maxZoom": 18,
+                "minZoom": 0,
+                "origin": "elastic_maps_service"
+              }
+            }
+          },
+          "title": "Threat Indicator Geo Map [Filebeat MISP]",
+          "type": "tile_map"
+        }
+      },
+      "id": "73287f70-f1fb-11e9-9a88-690b10c8ee99",
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-10-19T19:04:04.029Z",
+      "version": "WzM2NywxNV0="
+    }
+  ],
+  "version": "8.0.0-SNAPSHOT"
+}

--- a/dev/package-beats/misp-1.0.0/manifest.yml
+++ b/dev/package-beats/misp-1.0.0/manifest.yml
@@ -1,0 +1,13 @@
+name: misp
+title: MISP
+version: 1.0.0
+description: |
+  Module for handling threat information from MISP.
+type: ""
+categories:
+- logs
+requirement:
+  kibana:
+    version:
+      min: 6.7.0
+      max: 7.6.0

--- a/dev/package-beats/mongodb-1.0.0/kibana/dashboard/Filebeat-Mongodb-overview.json
+++ b/dev/package-beats/mongodb-1.0.0/kibana/dashboard/Filebeat-Mongodb-overview.json
@@ -1,0 +1,205 @@
+{
+    "objects": [
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                }, 
+                "savedSearchId": "bfc96a60-0a80-11e8-bffe-ff7d4f68cf94-ecs", 
+                "title": "Logs Severity [Filebeat MongoDB] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customLabel": "Log severity", 
+                                "field": "log.level", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "segment", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "params": {
+                        "addLegend": true, 
+                        "addTooltip": true, 
+                        "isDonut": true, 
+                        "legendPosition": "right", 
+                        "type": "pie"
+                    }, 
+                    "title": "Logs Severity [Filebeat MongoDB] ECS", 
+                    "type": "pie"
+                }
+            }, 
+            "id": "0fef5710-0a82-11e8-bffe-ff7d4f68cf94-ecs", 
+            "type": "visualization", 
+            "version": 3
+        }, 
+        {
+            "attributes": {
+                "columns": [
+                    "mongodb.log.timestamp", 
+                    "log.level", 
+                    "mongodb.log.component", 
+                    "mongodb.log.context", 
+                    "message"
+                ], 
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlightAll": true, 
+                        "index": "filebeat-*", 
+                        "query": {
+                            "language": "kuery",
+                            "query": "log.level: F or log.level: W"
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "sort": [
+                    "@timestamp", 
+                    "desc"
+                ], 
+                "title": "Error logs [Filebeat MongoDB] ECS", 
+                "version": 1
+            }, 
+            "id": "e49fe000-0a7e-11e8-bffe-ff7d4f68cf94-ecs", 
+            "type": "search", 
+            "version": 3
+        }, 
+        {
+            "attributes": {
+                "columns": [
+                    "mongodb.log.timestamp", 
+                    "log.level", 
+                    "mongodb.log.component", 
+                    "mongodb.log.context", 
+                    "message"
+                ], 
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlightAll": true, 
+                        "index": "filebeat-*", 
+                        "query": {
+                            "language": "kuery",
+                            "query": "log.level: *"
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "sort": [
+                    "mongodb.log.timestamp", 
+                    "asc"
+                ], 
+                "title": "All logs [Filebeat MongoDB] ECS", 
+                "version": 1
+            }, 
+            "id": "bfc96a60-0a80-11e8-bffe-ff7d4f68cf94-ecs", 
+            "type": "search", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "Filebeat MongoDB module overview", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlightAll": true, 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "optionsJSON": {
+                    "darkTheme": false
+                }, 
+                "panelsJSON": [
+                    {
+                        "col": 1, 
+                        "id": "0fef5710-0a82-11e8-bffe-ff7d4f68cf94-ecs", 
+                        "panelIndex": 1, 
+                        "row": 1, 
+                        "size_x": 4, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 5, 
+                        "columns": [
+                            "mongodb.log.timestamp", 
+                            "log.level", 
+                            "mongodb.log.component", 
+                            "mongodb.log.context", 
+                            "message"
+                        ], 
+                        "id": "e49fe000-0a7e-11e8-bffe-ff7d4f68cf94-ecs", 
+                        "panelIndex": 2, 
+                        "row": 1, 
+                        "size_x": 8, 
+                        "size_y": 3, 
+                        "sort": [
+                            "@timestamp", 
+                            "desc"
+                        ], 
+                        "type": "search"
+                    }, 
+                    {
+                        "col": 1, 
+                        "columns": [
+                            "mongodb.log.timestamp", 
+                            "log.level", 
+                            "mongodb.log.component", 
+                            "mongodb.log.context", 
+                            "message"
+                        ], 
+                        "id": "bfc96a60-0a80-11e8-bffe-ff7d4f68cf94-ecs", 
+                        "panelIndex": 3, 
+                        "row": 4, 
+                        "size_x": 12, 
+                        "size_y": 6, 
+                        "sort": [
+                            "mongodb.log.timestamp", 
+                            "asc"
+                        ], 
+                        "type": "search"
+                    }
+                ], 
+                "timeRestore": false, 
+                "title": "[Filebeat MongoDB] Overview ECS", 
+                "uiStateJSON": {}, 
+                "version": 1
+            }, 
+            "id": "abcf35b0-0a82-11e8-bffe-ff7d4f68cf94-ecs", 
+            "type": "dashboard", 
+            "version": 2
+        }
+    ], 
+    "version": "6.0.0"
+}

--- a/dev/package-beats/mongodb-1.0.0/kibana/dashboard/Metricbeat-mongodb-overview.json
+++ b/dev/package-beats/mongodb-1.0.0/kibana/dashboard/Metricbeat-mongodb-overview.json
@@ -1,0 +1,1232 @@
+{
+    "objects": [
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "MongoDB-search-ecs", 
+                "title": "Hosts [Metricbeat MongoDB] ECS", 
+                "uiStateJSON": {
+                    "vis": {
+                        "params": {
+                            "sort": {
+                                "columnIndex": null, 
+                                "direction": null
+                            }
+                        }
+                    }
+                }, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "Number of connections", 
+                                "field": "mongodb.status.connections.current"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "field": "service.address", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "bucket", 
+                            "type": "terms"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "customLabel": "Arch", 
+                                "field": "mongodb.status.memory.bits"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "4", 
+                            "params": {
+                                "customLabel": "Resident memory", 
+                                "field": "mongodb.status.memory.resident.mb"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "5", 
+                            "params": {
+                                "customLabel": "Virtual memory", 
+                                "field": "mongodb.status.memory.virtual.mb"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }
+                    ], 
+                    "params": {
+                        "perPage": 10, 
+                        "showMeticsAtAllLevels": false, 
+                        "showPartialRows": false, 
+                        "showTotal": false, 
+                        "sort": {
+                            "columnIndex": null, 
+                            "direction": null
+                        }, 
+                        "totalFunc": "sum"
+                    }, 
+                    "title": "Hosts [Metricbeat MongoDB] ECS", 
+                    "type": "table"
+                }
+            }, 
+            "id": "MongoDB-hosts-ecs", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "MongoDB-search-ecs", 
+                "title": "Engine & Version [Metricbeat MongoDB] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "field": "service.address"
+                            }, 
+                            "schema": "metric", 
+                            "type": "cardinality"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customLabel": "Engine", 
+                                "field": "mongodb.status.storage_engine.name", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "segment", 
+                            "type": "terms"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "customLabel": "Version", 
+                                "field": "service.version", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "segment", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "params": {
+                        "addLegend": true, 
+                        "addTooltip": true, 
+                        "isDonut": true, 
+                        "legendPosition": "bottom", 
+                        "shareYAxis": true, 
+                        "type": "pie"
+                    }, 
+                    "title": "Engine & Version [Metricbeat MongoDB] ECS", 
+                    "type": "pie"
+                }
+            }, 
+            "id": "MongoDB-Engine-ampersand-Version-ecs", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "MongoDB-search-ecs", 
+                "title": "Operation counters [Metricbeat MongoDB] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "command", 
+                                "field": "mongodb.status.ops.counters.command"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "customLabel": "delete", 
+                                "field": "mongodb.status.ops.counters.delete"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "4", 
+                            "params": {
+                                "customLabel": "getmore", 
+                                "field": "mongodb.status.ops.counters.getmore"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "5", 
+                            "params": {
+                                "customLabel": "insert", 
+                                "field": "mongodb.status.ops.counters.insert"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "6", 
+                            "params": {
+                                "customLabel": "query", 
+                                "field": "mongodb.status.ops.counters.query"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "7", 
+                            "params": {
+                                "customLabel": "update", 
+                                "field": "mongodb.status.ops.replicated.update"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }
+                    ], 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "categoryAxes": [
+                            {
+                                "id": "CategoryAxis-1", 
+                                "labels": {
+                                    "show": true, 
+                                    "truncate": 100
+                                }, 
+                                "position": "bottom", 
+                                "scale": {
+                                    "type": "linear"
+                                }, 
+                                "show": true, 
+                                "style": {}, 
+                                "title": {}, 
+                                "type": "category"
+                            }
+                        ], 
+                        "defaultYExtents": false, 
+                        "grid": {
+                            "categoryLines": false, 
+                            "style": {
+                                "color": "#eee"
+                            }
+                        }, 
+                        "interpolate": "linear", 
+                        "legendPosition": "bottom", 
+                        "mode": "stacked", 
+                        "scale": "linear", 
+                        "seriesParams": [
+                            {
+                                "data": {
+                                    "id": "1", 
+                                    "label": "Count"
+                                }, 
+                                "drawLinesBetweenPoints": true, 
+                                "interpolate": "linear", 
+                                "mode": "stacked", 
+                                "show": "true", 
+                                "showCircles": true, 
+                                "type": "area", 
+                                "valueAxis": "ValueAxis-1"
+                            }
+                        ], 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "smoothLines": false, 
+                        "times": [], 
+                        "type": "area", 
+                        "valueAxes": [
+                            {
+                                "id": "ValueAxis-1", 
+                                "labels": {
+                                    "filter": false, 
+                                    "rotate": 0, 
+                                    "show": true, 
+                                    "truncate": 100
+                                }, 
+                                "name": "LeftAxis-1", 
+                                "position": "left", 
+                                "scale": {
+                                    "mode": "normal", 
+                                    "type": "linear"
+                                }, 
+                                "show": true, 
+                                "style": {}, 
+                                "title": {
+                                    "text": "Count"
+                                }, 
+                                "type": "value"
+                            }
+                        ], 
+                        "yAxis": {}
+                    }, 
+                    "title": "Operation counters [Metricbeat MongoDB] ECS", 
+                    "type": "area"
+                }
+            }, 
+            "id": "MongoDB-operation-counters-ecs", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "MongoDB-search-ecs", 
+                "title": "Concurrent transactions Read [Metricbeat MongoDB] ECS", 
+                "uiStateJSON": {
+                    "vis": {
+                        "colors": {
+                            "Read Available": "#508642", 
+                            "Read Used": "#BF1B00"
+                        }
+                    }
+                }, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "Read Available", 
+                                "field": "mongodb.status.wired_tiger.concurrent_transactions.read.available"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "customLabel": "Read Used", 
+                                "field": "mongodb.status.wired_tiger.concurrent_transactions.read.out"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }
+                    ], 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "categoryAxes": [
+                            {
+                                "id": "CategoryAxis-1", 
+                                "labels": {
+                                    "show": true, 
+                                    "truncate": 100
+                                }, 
+                                "position": "bottom", 
+                                "scale": {
+                                    "type": "linear"
+                                }, 
+                                "show": true, 
+                                "style": {}, 
+                                "title": {}, 
+                                "type": "category"
+                            }
+                        ], 
+                        "defaultYExtents": false, 
+                        "grid": {
+                            "categoryLines": false, 
+                            "style": {
+                                "color": "#eee"
+                            }
+                        }, 
+                        "interpolate": "linear", 
+                        "legendPosition": "bottom", 
+                        "mode": "stacked", 
+                        "scale": "linear", 
+                        "seriesParams": [
+                            {
+                                "data": {
+                                    "id": "1", 
+                                    "label": "Count"
+                                }, 
+                                "drawLinesBetweenPoints": true, 
+                                "interpolate": "linear", 
+                                "mode": "stacked", 
+                                "show": "true", 
+                                "showCircles": true, 
+                                "type": "area", 
+                                "valueAxis": "ValueAxis-1"
+                            }
+                        ], 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "smoothLines": false, 
+                        "times": [], 
+                        "type": "area", 
+                        "valueAxes": [
+                            {
+                                "id": "ValueAxis-1", 
+                                "labels": {
+                                    "filter": false, 
+                                    "rotate": 0, 
+                                    "show": true, 
+                                    "truncate": 100
+                                }, 
+                                "name": "LeftAxis-1", 
+                                "position": "left", 
+                                "scale": {
+                                    "mode": "normal", 
+                                    "type": "linear"
+                                }, 
+                                "show": true, 
+                                "style": {}, 
+                                "title": {
+                                    "text": "Count"
+                                }, 
+                                "type": "value"
+                            }
+                        ], 
+                        "yAxis": {}
+                    }, 
+                    "title": "Concurrent transactions Read [Metricbeat MongoDB] ECS", 
+                    "type": "area"
+                }
+            }, 
+            "id": "MongoDB-Concurrent-transactions-Read-ecs", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "MongoDB-search-ecs", 
+                "title": "Concurrent transactions Write [Metricbeat MongoDB] ECS", 
+                "uiStateJSON": {
+                    "vis": {
+                        "colors": {
+                            "Write Available": "#629E51", 
+                            "Write Used": "#BF1B00"
+                        }
+                    }
+                }, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "Write Available", 
+                                "field": "mongodb.status.wired_tiger.concurrent_transactions.write.available"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "customLabel": "Write Used", 
+                                "field": "mongodb.status.wired_tiger.concurrent_transactions.write.out"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }
+                    ], 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "categoryAxes": [
+                            {
+                                "id": "CategoryAxis-1", 
+                                "labels": {
+                                    "show": true, 
+                                    "truncate": 100
+                                }, 
+                                "position": "bottom", 
+                                "scale": {
+                                    "type": "linear"
+                                }, 
+                                "show": true, 
+                                "style": {}, 
+                                "title": {}, 
+                                "type": "category"
+                            }
+                        ], 
+                        "defaultYExtents": false, 
+                        "grid": {
+                            "categoryLines": false, 
+                            "style": {
+                                "color": "#eee"
+                            }
+                        }, 
+                        "interpolate": "linear", 
+                        "legendPosition": "bottom", 
+                        "mode": "stacked", 
+                        "scale": "linear", 
+                        "seriesParams": [
+                            {
+                                "data": {
+                                    "id": "1", 
+                                    "label": "Count"
+                                }, 
+                                "drawLinesBetweenPoints": true, 
+                                "interpolate": "linear", 
+                                "mode": "stacked", 
+                                "show": "true", 
+                                "showCircles": true, 
+                                "type": "area", 
+                                "valueAxis": "ValueAxis-1"
+                            }
+                        ], 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "smoothLines": false, 
+                        "times": [], 
+                        "type": "area", 
+                        "valueAxes": [
+                            {
+                                "id": "ValueAxis-1", 
+                                "labels": {
+                                    "filter": false, 
+                                    "rotate": 0, 
+                                    "show": true, 
+                                    "truncate": 100
+                                }, 
+                                "name": "LeftAxis-1", 
+                                "position": "left", 
+                                "scale": {
+                                    "mode": "normal", 
+                                    "type": "linear"
+                                }, 
+                                "show": true, 
+                                "style": {}, 
+                                "title": {
+                                    "text": "Count"
+                                }, 
+                                "type": "value"
+                            }
+                        ], 
+                        "yAxis": {}
+                    }, 
+                    "title": "Concurrent transactions Write [Metricbeat MongoDB] ECS", 
+                    "type": "area"
+                }
+            }, 
+            "id": "MongoDB-Concurrent-transactions-Write-ecs", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "MongoDB-search-ecs", 
+                "title": "Memory stats [Metricbeat MongoDB] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "Mapped", 
+                                "field": "mongodb.status.memory.mapped.mb"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "customLabel": "Mapped with journal", 
+                                "field": "mongodb.status.memory.mapped_with_journal.mb"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "4", 
+                            "params": {
+                                "customLabel": "Rezident", 
+                                "field": "mongodb.status.memory.resident.mb"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "5", 
+                            "params": {
+                                "customLabel": "Virtual", 
+                                "field": "mongodb.status.memory.virtual.mb"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }
+                    ], 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "categoryAxes": [
+                            {
+                                "id": "CategoryAxis-1", 
+                                "labels": {
+                                    "show": true, 
+                                    "truncate": 100
+                                }, 
+                                "position": "bottom", 
+                                "scale": {
+                                    "type": "linear"
+                                }, 
+                                "show": true, 
+                                "style": {}, 
+                                "title": {}, 
+                                "type": "category"
+                            }
+                        ], 
+                        "defaultYExtents": false, 
+                        "drawLinesBetweenPoints": true, 
+                        "grid": {
+                            "categoryLines": false, 
+                            "style": {
+                                "color": "#eee"
+                            }
+                        }, 
+                        "interpolate": "linear", 
+                        "legendPosition": "bottom", 
+                        "radiusRatio": 9, 
+                        "scale": "log", 
+                        "seriesParams": [
+                            {
+                                "data": {
+                                    "id": "1", 
+                                    "label": "Count"
+                                }, 
+                                "drawLinesBetweenPoints": true, 
+                                "mode": "normal", 
+                                "show": "true", 
+                                "showCircles": true, 
+                                "type": "line", 
+                                "valueAxis": "ValueAxis-1"
+                            }
+                        ], 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "showCircles": true, 
+                        "smoothLines": false, 
+                        "times": [], 
+                        "type": "line", 
+                        "valueAxes": [
+                            {
+                                "id": "ValueAxis-1", 
+                                "labels": {
+                                    "filter": false, 
+                                    "rotate": 0, 
+                                    "show": true, 
+                                    "truncate": 100
+                                }, 
+                                "name": "LeftAxis-1", 
+                                "position": "left", 
+                                "scale": {
+                                    "mode": "normal", 
+                                    "type": "linear"
+                                }, 
+                                "show": true, 
+                                "style": {}, 
+                                "title": {
+                                    "text": "Count"
+                                }, 
+                                "type": "value"
+                            }
+                        ], 
+                        "yAxis": {}
+                    }, 
+                    "title": "Memory stats [Metricbeat MongoDB] ECS", 
+                    "type": "line"
+                }
+            }, 
+            "id": "MongoDB-memory-stats-ecs", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "MongoDB-search-ecs", 
+                "title": "Asserts [Metricbeat MongoDB] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "message", 
+                                "field": "mongodb.status.asserts.msg"
+                            }, 
+                            "schema": "metric", 
+                            "type": "max"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "customLabel": "regular", 
+                                "field": "mongodb.status.asserts.regular"
+                            }, 
+                            "schema": "metric", 
+                            "type": "max"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "4", 
+                            "params": {
+                                "customLabel": "rollover", 
+                                "field": "mongodb.status.asserts.rollovers"
+                            }, 
+                            "schema": "metric", 
+                            "type": "max"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "5", 
+                            "params": {
+                                "customLabel": "user", 
+                                "field": "mongodb.status.asserts.user"
+                            }, 
+                            "schema": "metric", 
+                            "type": "max"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "6", 
+                            "params": {
+                                "customLabel": "warning", 
+                                "field": "mongodb.status.asserts.warning"
+                            }, 
+                            "schema": "metric", 
+                            "type": "max"
+                        }
+                    ], 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "categoryAxes": [
+                            {
+                                "id": "CategoryAxis-1", 
+                                "labels": {
+                                    "show": true, 
+                                    "truncate": 100
+                                }, 
+                                "position": "bottom", 
+                                "scale": {
+                                    "type": "linear"
+                                }, 
+                                "show": true, 
+                                "style": {}, 
+                                "title": {}, 
+                                "type": "category"
+                            }
+                        ], 
+                        "defaultYExtents": false, 
+                        "grid": {
+                            "categoryLines": false, 
+                            "style": {
+                                "color": "#eee"
+                            }
+                        }, 
+                        "interpolate": "linear", 
+                        "legendPosition": "bottom", 
+                        "mode": "stacked", 
+                        "scale": "linear", 
+                        "seriesParams": [
+                            {
+                                "data": {
+                                    "id": "1", 
+                                    "label": "Count"
+                                }, 
+                                "drawLinesBetweenPoints": true, 
+                                "interpolate": "linear", 
+                                "mode": "stacked", 
+                                "show": "true", 
+                                "showCircles": true, 
+                                "type": "area", 
+                                "valueAxis": "ValueAxis-1"
+                            }
+                        ], 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "smoothLines": false, 
+                        "times": [], 
+                        "type": "area", 
+                        "valueAxes": [
+                            {
+                                "id": "ValueAxis-1", 
+                                "labels": {
+                                    "filter": false, 
+                                    "rotate": 0, 
+                                    "show": true, 
+                                    "truncate": 100
+                                }, 
+                                "name": "LeftAxis-1", 
+                                "position": "left", 
+                                "scale": {
+                                    "mode": "normal", 
+                                    "type": "linear"
+                                }, 
+                                "show": true, 
+                                "style": {}, 
+                                "title": {
+                                    "text": "Count"
+                                }, 
+                                "type": "value"
+                            }
+                        ], 
+                        "yAxis": {}
+                    }, 
+                    "title": "Asserts [Metricbeat MongoDB] ECS", 
+                    "type": "area"
+                }
+            }, 
+            "id": "MongoDB-asserts-ecs", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "MongoDB-search-ecs", 
+                "title": "WiredTiger Cache [Metricbeat MongoDB] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "max", 
+                                "field": "mongodb.status.wired_tiger.cache.maximum.bytes"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "customLabel": "used", 
+                                "field": "mongodb.status.wired_tiger.cache.used.bytes"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "4", 
+                            "params": {
+                                "customLabel": "dirty", 
+                                "field": "mongodb.status.wired_tiger.cache.dirty.bytes"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }
+                    ], 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "categoryAxes": [
+                            {
+                                "id": "CategoryAxis-1", 
+                                "labels": {
+                                    "show": true, 
+                                    "truncate": 100
+                                }, 
+                                "position": "bottom", 
+                                "scale": {
+                                    "type": "linear"
+                                }, 
+                                "show": true, 
+                                "style": {}, 
+                                "title": {}, 
+                                "type": "category"
+                            }
+                        ], 
+                        "defaultYExtents": false, 
+                        "grid": {
+                            "categoryLines": false, 
+                            "style": {
+                                "color": "#eee"
+                            }
+                        }, 
+                        "interpolate": "linear", 
+                        "legendPosition": "bottom", 
+                        "mode": "overlap", 
+                        "scale": "linear", 
+                        "seriesParams": [
+                            {
+                                "data": {
+                                    "id": "1", 
+                                    "label": "Count"
+                                }, 
+                                "drawLinesBetweenPoints": true, 
+                                "interpolate": "linear", 
+                                "mode": "stacked", 
+                                "show": "true", 
+                                "showCircles": true, 
+                                "type": "area", 
+                                "valueAxis": "ValueAxis-1"
+                            }
+                        ], 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "smoothLines": false, 
+                        "times": [], 
+                        "type": "area", 
+                        "valueAxes": [
+                            {
+                                "id": "ValueAxis-1", 
+                                "labels": {
+                                    "filter": false, 
+                                    "rotate": 0, 
+                                    "show": true, 
+                                    "truncate": 100
+                                }, 
+                                "name": "LeftAxis-1", 
+                                "position": "left", 
+                                "scale": {
+                                    "mode": "normal", 
+                                    "type": "linear"
+                                }, 
+                                "show": true, 
+                                "style": {}, 
+                                "title": {
+                                    "text": "Count"
+                                }, 
+                                "type": "value"
+                            }
+                        ], 
+                        "yAxis": {}
+                    }, 
+                    "title": "WiredTiger Cache [Metricbeat MongoDB] ECS", 
+                    "type": "area"
+                }
+            }, 
+            "id": "MongoDB-WiredTiger-Cache-ecs", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "columns": [
+                    "_source"
+                ], 
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlight": {
+                            "fields": {
+                                "*": {}
+                            }, 
+                            "fragment_size": 2147483647, 
+                            "post_tags": [
+                                "@/kibana-highlighted-field@"
+                            ], 
+                            "pre_tags": [
+                                "@kibana-highlighted-field@"
+                            ], 
+                            "require_field_match": false
+                        }, 
+                        "index": "metricbeat-*", 
+                        "query": {
+                            "language": "kuery",
+                                "query": "event.module:mongodb"
+                            }
+                    }
+                }, 
+                "sort": [
+                    "@timestamp", 
+                    "desc"
+                ], 
+                "title": "MongoDB search ECS", 
+                "version": 1
+            }, 
+            "id": "MongoDB-search-ecs", 
+            "type": "search", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "Overview of MongoDB server status",
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlightAll": true, 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "optionsJSON": {
+                    "darkTheme": false
+                }, 
+                "panelsJSON": [
+                    {
+                        "col": 1, 
+                        "id": "MongoDB-hosts-ecs", 
+                        "panelIndex": 1, 
+                        "row": 1, 
+                        "size_x": 8, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 9, 
+                        "id": "MongoDB-Engine-ampersand-Version-ecs", 
+                        "panelIndex": 4, 
+                        "row": 1, 
+                        "size_x": 4, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "MongoDB-operation-counters-ecs", 
+                        "panelIndex": 2, 
+                        "row": 4, 
+                        "size_x": 6, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 7, 
+                        "id": "MongoDB-Concurrent-transactions-Read-ecs", 
+                        "panelIndex": 6, 
+                        "row": 4, 
+                        "size_x": 3, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 10, 
+                        "id": "MongoDB-Concurrent-transactions-Write-ecs", 
+                        "panelIndex": 7, 
+                        "row": 4, 
+                        "size_x": 3, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "MongoDB-memory-stats-ecs", 
+                        "panelIndex": 5, 
+                        "row": 10, 
+                        "size_x": 12, 
+                        "size_y": 4, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 7, 
+                        "id": "MongoDB-asserts-ecs", 
+                        "panelIndex": 3, 
+                        "row": 7, 
+                        "size_x": 6, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "MongoDB-WiredTiger-Cache-ecs", 
+                        "panelIndex": 8, 
+                        "row": 7, 
+                        "size_x": 6, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }
+                ], 
+                "timeRestore": false, 
+                "title": "[Metricbeat MongoDB] Overview ECS", 
+                "uiStateJSON": {
+                    "P-1": {
+                        "vis": {
+                            "params": {
+                                "sort": {
+                                    "columnIndex": null, 
+                                    "direction": null
+                                }
+                            }
+                        }
+                    }
+                }, 
+                "version": 1
+            }, 
+            "id": "Metricbeat-MongoDB-ecs", 
+            "type": "dashboard", 
+            "version": 3
+        }
+    ], 
+    "version": "6.0.0-beta1-SNAPSHOT"
+}

--- a/dev/package-beats/mongodb-1.0.0/manifest.yml
+++ b/dev/package-beats/mongodb-1.0.0/manifest.yml
@@ -1,0 +1,14 @@
+name: mongodb
+title: mongodb
+version: 1.0.0
+description: |
+  Metrics collected from MongoDB servers.
+type: ""
+categories:
+- logs
+- metrics
+requirement:
+  kibana:
+    version:
+      min: 6.7.0
+      max: 7.6.0

--- a/dev/package-beats/mssql-1.0.0/kibana/dashboard/Metricbeat-mssql-performance.json
+++ b/dev/package-beats/mssql-1.0.0/kibana/dashboard/Metricbeat-mssql-performance.json
@@ -1,0 +1,773 @@
+{
+  "objects": [
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "index": "metricbeat-*",
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "User Connections [Metricbeat MSSQL] ECS",
+        "uiStateJSON": {
+          "vis": {
+            "legendOpen": false
+          }
+        },
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "",
+                "field": "mssql.performance.user_connections"
+              },
+              "schema": "metric",
+              "type": "avg"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customInterval": "2h",
+                "drop_partials": false,
+                "extended_bounds": {},
+                "field": "@timestamp",
+                "interval": "auto",
+                "min_doc_count": 1,
+                "time_zone": "Europe/Madrid",
+                "useNormalizedEsInterval": true
+              },
+              "schema": "segment",
+              "type": "date_histogram"
+            }
+          ],
+          "params": {
+            "addLegend": true,
+            "addTimeMarker": false,
+            "addTooltip": true,
+            "categoryAxes": [
+              {
+                "id": "CategoryAxis-1",
+                "labels": {
+                  "show": true,
+                  "truncate": 100
+                },
+                "position": "bottom",
+                "scale": {
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {},
+                "type": "category"
+              }
+            ],
+            "grid": {
+              "categoryLines": true,
+              "style": {
+                "color": "#eee"
+              },
+              "valueAxis": "ValueAxis-1"
+            },
+            "legendPosition": "right",
+            "seriesParams": [
+              {
+                "data": {
+                  "id": "1",
+                  "label": "Average mssql.performance.user_connections"
+                },
+                "drawLinesBetweenPoints": true,
+                "interpolate": "linear",
+                "mode": "normal",
+                "show": "true",
+                "showCircles": true,
+                "type": "line",
+                "valueAxis": "ValueAxis-1"
+              }
+            ],
+            "times": [],
+            "type": "line",
+            "valueAxes": [
+              {
+                "id": "ValueAxis-1",
+                "labels": {
+                  "filter": false,
+                  "rotate": 0,
+                  "show": true,
+                  "truncate": 100
+                },
+                "name": "LeftAxis-1",
+                "position": "left",
+                "scale": {
+                  "mode": "normal",
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {
+                  "text": ""
+                },
+                "type": "value"
+              }
+            ]
+          },
+          "title": "User Connections [Metricbeat MSSQL] ECS",
+          "type": "line"
+        }
+      },
+      "id": "7784db10-18ba-11e9-9836-f37dedd3b411-ecs",
+      "type": "visualization",
+      "updated_at": "2019-01-22T13:04:43.827Z",
+      "version": 8
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "index": "metricbeat-*",
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Transactions [Metricbeat MSSQL] ECS",
+        "uiStateJSON": {
+          "vis": {
+            "legendOpen": false
+          }
+        },
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "",
+                "field": "mssql.performance.transactions"
+              },
+              "schema": "metric",
+              "type": "avg"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customInterval": "2h",
+                "drop_partials": false,
+                "extended_bounds": {},
+                "field": "@timestamp",
+                "interval": "auto",
+                "min_doc_count": 1,
+                "time_zone": "Europe/Madrid",
+                "useNormalizedEsInterval": true
+              },
+              "schema": "segment",
+              "type": "date_histogram"
+            }
+          ],
+          "params": {
+            "addLegend": true,
+            "addTimeMarker": false,
+            "addTooltip": true,
+            "categoryAxes": [
+              {
+                "id": "CategoryAxis-1",
+                "labels": {
+                  "show": true,
+                  "truncate": 100
+                },
+                "position": "bottom",
+                "scale": {
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {},
+                "type": "category"
+              }
+            ],
+            "grid": {
+              "categoryLines": true,
+              "style": {
+                "color": "#eee"
+              },
+              "valueAxis": "ValueAxis-1"
+            },
+            "legendPosition": "right",
+            "seriesParams": [
+              {
+                "data": {
+                  "id": "1",
+                  "label": "Average mssql.performance.transactions"
+                },
+                "drawLinesBetweenPoints": true,
+                "interpolate": "linear",
+                "mode": "normal",
+                "show": "true",
+                "showCircles": true,
+                "type": "line",
+                "valueAxis": "ValueAxis-1"
+              }
+            ],
+            "times": [],
+            "type": "line",
+            "valueAxes": [
+              {
+                "id": "ValueAxis-1",
+                "labels": {
+                  "filter": false,
+                  "rotate": 0,
+                  "show": true,
+                  "truncate": 100
+                },
+                "name": "LeftAxis-1",
+                "position": "left",
+                "scale": {
+                  "mode": "normal",
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {
+                  "text": ""
+                },
+                "type": "value"
+              }
+            ]
+          },
+          "title": "Transactions [Metricbeat MSSQL] ECS",
+          "type": "line"
+        }
+      },
+      "id": "910f3f30-18ba-11e9-9836-f37dedd3b411-ecs",
+      "type": "visualization",
+      "updated_at": "2019-01-22T13:04:34.757Z",
+      "version": 8
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "index": "metricbeat-*",
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Lock Waits/sec [Metricbeat MSSQL] ECS",
+        "uiStateJSON": {
+          "vis": {
+            "legendOpen": false
+          }
+        },
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "",
+                "field": "mssql.performance.lock_waits_per_sec"
+              },
+              "schema": "metric",
+              "type": "avg"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customInterval": "2h",
+                "drop_partials": false,
+                "extended_bounds": {},
+                "field": "@timestamp",
+                "interval": "auto",
+                "min_doc_count": 1,
+                "time_zone": "Europe/Madrid",
+                "useNormalizedEsInterval": true
+              },
+              "schema": "segment",
+              "type": "date_histogram"
+            }
+          ],
+          "params": {
+            "addLegend": true,
+            "addTimeMarker": false,
+            "addTooltip": true,
+            "categoryAxes": [
+              {
+                "id": "CategoryAxis-1",
+                "labels": {
+                  "show": true,
+                  "truncate": 100
+                },
+                "position": "bottom",
+                "scale": {
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {},
+                "type": "category"
+              }
+            ],
+            "grid": {
+              "categoryLines": true,
+              "style": {
+                "color": "#eee"
+              },
+              "valueAxis": "ValueAxis-1"
+            },
+            "legendPosition": "right",
+            "seriesParams": [
+              {
+                "data": {
+                  "id": "1",
+                  "label": "Average mssql.performance.lock_waits_per_sec"
+                },
+                "drawLinesBetweenPoints": true,
+                "interpolate": "linear",
+                "mode": "normal",
+                "show": "true",
+                "showCircles": true,
+                "type": "line",
+                "valueAxis": "ValueAxis-1"
+              }
+            ],
+            "times": [],
+            "type": "line",
+            "valueAxes": [
+              {
+                "id": "ValueAxis-1",
+                "labels": {
+                  "filter": false,
+                  "rotate": 0,
+                  "show": true,
+                  "truncate": 100
+                },
+                "name": "LeftAxis-1",
+                "position": "left",
+                "scale": {
+                  "mode": "normal",
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {
+                  "text": ""
+                },
+                "type": "value"
+              }
+            ]
+          },
+          "title": "Lock Waits/sec [Metricbeat MSSQL] ECS",
+          "type": "line"
+        }
+      },
+      "id": "5bd5c230-18ba-11e9-9836-f37dedd3b411-ecs",
+      "type": "visualization",
+      "updated_at": "2019-01-22T13:04:24.139Z",
+      "version": 7
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "index": "metricbeat-*",
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Batch Requests/sec [Metricbeat MSSQL] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "",
+                "customMetric": {
+                  "enabled": true,
+                  "id": "1-metric",
+                  "params": {
+                    "field": "mssql.performance.batch_requests_per_sec"
+                  },
+                  "schema": "metricAgg",
+                  "type": "avg"
+                },
+                "metricAgg": "custom"
+              },
+              "schema": "metric",
+              "type": "derivative"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customInterval": "2h",
+                "drop_partials": false,
+                "extended_bounds": {},
+                "field": "@timestamp",
+                "interval": "auto",
+                "min_doc_count": 0,
+                "time_zone": "Europe/Madrid",
+                "useNormalizedEsInterval": true
+              },
+              "schema": "segment",
+              "type": "date_histogram"
+            }
+          ],
+          "params": {
+            "addLegend": true,
+            "addTimeMarker": false,
+            "addTooltip": true,
+            "categoryAxes": [
+              {
+                "id": "CategoryAxis-1",
+                "labels": {
+                  "show": true,
+                  "truncate": 100
+                },
+                "position": "bottom",
+                "scale": {
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {},
+                "type": "category"
+              }
+            ],
+            "grid": {
+              "categoryLines": true,
+              "style": {
+                "color": "#eee"
+              },
+              "valueAxis": "ValueAxis-1"
+            },
+            "legendPosition": "right",
+            "seriesParams": [
+              {
+                "data": {
+                  "id": "1",
+                  "label": "Derivative of Average mssql.performance.batch_requests_per_sec"
+                },
+                "drawLinesBetweenPoints": true,
+                "interpolate": "linear",
+                "mode": "normal",
+                "show": "true",
+                "showCircles": true,
+                "type": "line",
+                "valueAxis": "ValueAxis-1"
+              }
+            ],
+            "times": [],
+            "type": "line",
+            "valueAxes": [
+              {
+                "id": "ValueAxis-1",
+                "labels": {
+                  "filter": false,
+                  "rotate": 0,
+                  "show": true,
+                  "truncate": 100
+                },
+                "name": "LeftAxis-1",
+                "position": "left",
+                "scale": {
+                  "mode": "normal",
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {
+                  "text": ""
+                },
+                "type": "value"
+              }
+            ]
+          },
+          "title": "Batch Requests/sec [Metricbeat MSSQL] ECS",
+          "type": "line"
+        }
+      },
+      "id": "b29a2160-18ba-11e9-9836-f37dedd3b411-ecs",
+      "type": "visualization",
+      "updated_at": "2019-01-22T13:03:10.853Z",
+      "version": 9
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "index": "metricbeat-*",
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Buffer Cache Hit Ratio [Metricbeat MSSQL] ECS",
+        "uiStateJSON": {
+          "vis": {
+            "legendOpen": false
+          }
+        },
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "field": "mssql.performance.buffer.cache_hit.pct",
+                "percents": [
+                  50
+                ]
+              },
+              "schema": "metric",
+              "type": "median"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customInterval": "2h",
+                "drop_partials": false,
+                "extended_bounds": {},
+                "field": "@timestamp",
+                "interval": "auto",
+                "min_doc_count": 0,
+                "time_zone": "Europe/Madrid",
+                "useNormalizedEsInterval": true
+              },
+              "schema": "segment",
+              "type": "date_histogram"
+            }
+          ],
+          "params": {
+            "addLegend": true,
+            "addTimeMarker": false,
+            "addTooltip": true,
+            "categoryAxes": [
+              {
+                "id": "CategoryAxis-1",
+                "labels": {
+                  "show": true,
+                  "truncate": 100
+                },
+                "position": "bottom",
+                "scale": {
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {},
+                "type": "category"
+              }
+            ],
+            "grid": {
+              "categoryLines": true,
+              "style": {
+                "color": "#eee"
+              },
+              "valueAxis": "ValueAxis-1"
+            },
+            "legendPosition": "right",
+            "seriesParams": [
+              {
+                "data": {
+                  "id": "1",
+                  "label": "Median mssql.performance.buffer.cache_hit.pct"
+                },
+                "drawLinesBetweenPoints": true,
+                "interpolate": "linear",
+                "mode": "normal",
+                "show": "true",
+                "showCircles": true,
+                "type": "line",
+                "valueAxis": "ValueAxis-1"
+              }
+            ],
+            "times": [],
+            "type": "line",
+            "valueAxes": [
+              {
+                "id": "ValueAxis-1",
+                "labels": {
+                  "filter": false,
+                  "rotate": 0,
+                  "show": true,
+                  "truncate": 100
+                },
+                "name": "LeftAxis-1",
+                "position": "left",
+                "scale": {
+                  "defaultYExtents": false,
+                  "mode": "normal",
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {
+                  "text": ""
+                },
+                "type": "value"
+              }
+            ]
+          },
+          "title": "Buffer Cache Hit Ratio [Metricbeat MSSQL] ECS",
+          "type": "line"
+        }
+      },
+      "id": "2e795230-1b2a-11e9-8b36-136038bb307a-ecs",
+      "type": "visualization",
+      "updated_at": "2019-01-22T13:04:16.184Z",
+      "version": 8
+    },
+    {
+      "attributes": {
+        "description": "A dashboard with key metrics about a MSSQL instance performance",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "optionsJSON": {
+          "darkTheme": false,
+          "hidePanelTitles": false,
+          "useMargins": true
+        },
+        "panelsJSON": [
+          {
+            "embeddableConfig": {
+              "vis": {
+                "legendOpen": false
+              }
+            },
+            "gridData": {
+              "h": 15,
+              "i": "1",
+              "w": 16,
+              "x": 0,
+              "y": 0
+            },
+            "id": "7784db10-18ba-11e9-9836-f37dedd3b411-ecs",
+            "panelIndex": "1",
+            "title": "User Connections",
+            "type": "visualization",
+            "version": "7.0.0-alpha2"
+          },
+          {
+            "embeddableConfig": {
+              "vis": {
+                "legendOpen": false
+              }
+            },
+            "gridData": {
+              "h": 15,
+              "i": "2",
+              "w": 32,
+              "x": 16,
+              "y": 15
+            },
+            "id": "910f3f30-18ba-11e9-9836-f37dedd3b411-ecs",
+            "panelIndex": "2",
+            "title": "Transactions",
+            "type": "visualization",
+            "version": "7.0.0-alpha2"
+          },
+          {
+            "embeddableConfig": {
+              "vis": {
+                "legendOpen": false
+              }
+            },
+            "gridData": {
+              "h": 15,
+              "i": "3",
+              "w": 16,
+              "x": 32,
+              "y": 0
+            },
+            "id": "5bd5c230-18ba-11e9-9836-f37dedd3b411-ecs",
+            "panelIndex": "3",
+            "title": "Lock Waits/sec",
+            "type": "visualization",
+            "version": "7.0.0-alpha2"
+          },
+          {
+            "embeddableConfig": {
+              "vis": {
+                "legendOpen": false
+              }
+            },
+            "gridData": {
+              "h": 15,
+              "i": "4",
+              "w": 16,
+              "x": 16,
+              "y": 0
+            },
+            "id": "b29a2160-18ba-11e9-9836-f37dedd3b411-ecs",
+            "panelIndex": "4",
+            "title": "Batch Requests/sec",
+            "type": "visualization",
+            "version": "7.0.0-alpha2"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 15,
+              "i": "5",
+              "w": 16,
+              "x": 0,
+              "y": 15
+            },
+            "id": "2e795230-1b2a-11e9-8b36-136038bb307a-ecs",
+            "panelIndex": "5",
+            "title": "Buffer Cache Hit Ratio",
+            "type": "visualization",
+            "version": "7.0.0-alpha2"
+          }
+        ],
+        "timeRestore": false,
+        "title": "[Metricbeat MSSQL] Performance ECS",
+        "version": 1
+      },
+      "id": "a2ead240-18bb-11e9-9836-f37dedd3b411-ecs",
+      "type": "dashboard",
+      "updated_at": "2019-01-22T12:55:59.857Z",
+      "version": 11
+    }
+  ],
+  "version": "7.0.0-alpha2"
+}

--- a/dev/package-beats/mssql-1.0.0/kibana/dashboard/Metricbeat-mssql-transaction_log.json
+++ b/dev/package-beats/mssql-1.0.0/kibana/dashboard/Metricbeat-mssql-transaction_log.json
@@ -1,0 +1,665 @@
+{
+  "objects": [
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Recovery size of transaction log [Metricbeat MSSQL] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "bytes",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Recovery size of transaction log",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "mssql.transaction_log.stats.recovery_size.bytes",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_filters": [
+                  {
+                    "color": "#68BC00",
+                    "id": "de4cb6c0-1fb2-11e9-9c8a-cb3f85dff2a3"
+                  }
+                ],
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "mssql.database.name"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Recovery size of transaction log [Metricbeat MSSQL] ECS",
+          "type": "metrics"
+        }
+      },
+      "id": "e9654a40-1fb2-11e9-8a4d-eb34d2834f6b-ecs",
+      "migrationVersion": {
+        "visualization": "7.0.0"
+      },
+      "type": "visualization",
+      "updated_at": "2019-02-01T10:13:18.406Z",
+      "version": 1
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Transaction log size since last checkpoint [Metricbeat MSSQL] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "bytes",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Transaction log size since last checkpoint",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "mssql.transaction_log.stats.since_last_checkpoint.bytes",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "mssql.database.name"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Transaction log size since last checkpoint [Metricbeat MSSQL] ECS",
+          "type": "metrics"
+        }
+      },
+      "id": "1757d530-1fb3-11e9-8a4d-eb34d2834f6b-ecs",
+      "migrationVersion": {
+        "visualization": "7.0.0"
+      },
+      "type": "visualization",
+      "updated_at": "2019-02-01T10:13:18.406Z",
+      "version": 1
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Percentage of used space of transaction log [Metricbeat MSSQL] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "percent",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Percentage of used space of transaction log",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "mssql.transaction_log.space_usage.used.pct",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "terms",
+                "stacked": "percent",
+                "terms_field": "mssql.database.name"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Percentage of used space of transaction log [Metricbeat MSSQL] ECS",
+          "type": "metrics"
+        }
+      },
+      "id": "a55bb000-1fb2-11e9-8a4d-eb34d2834f6b-ecs",
+      "migrationVersion": {
+        "visualization": "7.0.0"
+      },
+      "type": "visualization",
+      "updated_at": "2019-02-01T10:13:18.406Z",
+      "version": 1
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Log space size since last backup [Metricbeat MSSQL] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "number",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "mssql.transaction_log.space_usage.since_last_backup.bytes",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "mssql.database.name"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Log space size since last backup [Metricbeat MSSQL] ECS",
+          "type": "metrics"
+        }
+      },
+      "id": "edb7a0c0-1f2b-11e9-8a4d-eb34d2834f6b-ecs",
+      "migrationVersion": {
+        "visualization": "7.0.0"
+      },
+      "type": "visualization",
+      "updated_at": "2019-02-01T10:13:18.406Z",
+      "version": 1
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Active size of transaction log [Metricbeat MSSQL] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "bytes",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Active size of transaction log",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "mssql.transaction_log.stats.active_size.bytes",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "mssql.database.name"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Active size of transaction log [Metricbeat MSSQL] ECS",
+          "type": "metrics"
+        }
+      },
+      "id": "c9ead180-1fb2-11e9-8a4d-eb34d2834f6b-ecs",
+      "migrationVersion": {
+        "visualization": "7.0.0"
+      },
+      "type": "visualization",
+      "updated_at": "2019-02-01T10:13:18.406Z",
+      "version": 1
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Used space of transaction log [Metricbeat MSSQL] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "bytes",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Used space of transaction log",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "mssql.transaction_log.space_usage.used.bytes",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "mssql.database.name"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Used space of transaction log [Metricbeat MSSQL] ECS",
+          "type": "metrics"
+        }
+      },
+      "id": "68fa61b0-1fb2-11e9-8a4d-eb34d2834f6b-ecs",
+      "migrationVersion": {
+        "visualization": "7.0.0"
+      },
+      "type": "visualization",
+      "updated_at": "2019-02-01T10:13:18.406Z",
+      "version": 1
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Total log space usage [Metricbeat MSSQL] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "bytes",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Total log space usage",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "mssql.transaction_log.space_usage.total.bytes",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "terms",
+                "stacked": "stacked",
+                "terms_field": "mssql.database.name"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Total log space usage [Metricbeat MSSQL] ECS",
+          "type": "metrics"
+        }
+      },
+      "id": "6710ff20-1f2c-11e9-8a4d-eb34d2834f6b-ecs",
+      "migrationVersion": {
+        "visualization": "7.0.0"
+      },
+      "type": "visualization",
+      "updated_at": "2019-02-01T10:13:18.406Z",
+      "version": 1
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Database selector [Metricbeat MSSQL] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "controls": [
+              {
+                "fieldName": "mssql.database.name",
+                "id": "1549016598264",
+                "indexPattern": "metricbeat-*",
+                "label": "",
+                "options": {
+                  "dynamicOptions": true,
+                  "multiselect": true,
+                  "order": "desc",
+                  "size": 5,
+                  "type": "terms"
+                },
+                "parent": "",
+                "type": "list"
+              }
+            ],
+            "pinFilters": false,
+            "updateFiltersOnChange": false,
+            "useTimeFilter": false
+          },
+          "title": "Database selector [Metricbeat MSSQL] ECS",
+          "type": "input_control_vis"
+        }
+      },
+      "id": "82bf9480-260b-11e9-a46a-471d2a76b305-ecs",
+      "migrationVersion": {
+        "visualization": "7.0.0"
+      },
+      "type": "visualization",
+      "updated_at": "2019-02-01T10:24:09.159Z",
+      "version": 1
+    },
+    {
+      "attributes": {
+        "description": "An overview of the transaction log of each database in a MSSQL instance",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "optionsJSON": {
+          "darkTheme": false,
+          "hidePanelTitles": false,
+          "useMargins": true
+        },
+        "panelsJSON": [
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 12,
+              "i": "1",
+              "w": 24,
+              "x": 0,
+              "y": 12
+            },
+            "id": "e9654a40-1fb2-11e9-8a4d-eb34d2834f6b-ecs",
+            "panelIndex": "1",
+            "title": "Recovery size of transaction log",
+            "type": "visualization",
+            "version": "7.0.0-alpha2"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 13,
+              "i": "2",
+              "w": 24,
+              "x": 24,
+              "y": 24
+            },
+            "id": "1757d530-1fb3-11e9-8a4d-eb34d2834f6b-ecs",
+            "panelIndex": "2",
+            "title": "Transaction log size since last checkpoint",
+            "type": "visualization",
+            "version": "7.0.0-alpha2"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 12,
+              "i": "3",
+              "w": 18,
+              "x": 30,
+              "y": 0
+            },
+            "id": "a55bb000-1fb2-11e9-8a4d-eb34d2834f6b-ecs",
+            "panelIndex": "3",
+            "title": "Percentage of used space of transaction log",
+            "type": "visualization",
+            "version": "7.0.0-alpha2"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 13,
+              "i": "4",
+              "w": 24,
+              "x": 0,
+              "y": 37
+            },
+            "id": "edb7a0c0-1f2b-11e9-8a4d-eb34d2834f6b-ecs",
+            "panelIndex": "4",
+            "title": "Log space size since last backup",
+            "type": "visualization",
+            "version": "7.0.0-alpha2"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 13,
+              "i": "5",
+              "w": 24,
+              "x": 0,
+              "y": 24
+            },
+            "id": "c9ead180-1fb2-11e9-8a4d-eb34d2834f6b-ecs",
+            "panelIndex": "5",
+            "title": "Active size of transaction log",
+            "type": "visualization",
+            "version": "7.0.0-alpha2"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 12,
+              "i": "6",
+              "w": 24,
+              "x": 24,
+              "y": 12
+            },
+            "id": "68fa61b0-1fb2-11e9-8a4d-eb34d2834f6b-ecs",
+            "panelIndex": "6",
+            "title": "Used space of transaction log",
+            "type": "visualization",
+            "version": "7.0.0-alpha2"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 12,
+              "i": "7",
+              "w": 18,
+              "x": 12,
+              "y": 0
+            },
+            "id": "6710ff20-1f2c-11e9-8a4d-eb34d2834f6b-ecs",
+            "panelIndex": "7",
+            "title": "Total log space usage",
+            "type": "visualization",
+            "version": "7.0.0-alpha2"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 12,
+              "i": "8",
+              "w": 12,
+              "x": 0,
+              "y": 0
+            },
+            "id": "82bf9480-260b-11e9-a46a-471d2a76b305-ecs",
+            "panelIndex": "8",
+            "type": "visualization",
+            "version": "7.0.0-SNAPSHOT"
+          }
+        ],
+        "timeRestore": false,
+        "title": "[Metricbeat MSSQL] Transaction log ECS",
+        "version": 1
+      },
+      "id": "18d66970-1fb4-11e9-8a4d-eb34d2834f6b-ecs",
+      "type": "dashboard",
+      "updated_at": "2019-02-01T10:39:36.585Z",
+      "version": 3
+    }
+  ],
+  "version": "7.0.0-SNAPSHOT"
+}

--- a/dev/package-beats/mssql-1.0.0/manifest.yml
+++ b/dev/package-beats/mssql-1.0.0/manifest.yml
@@ -1,0 +1,13 @@
+name: mssql
+title: MSSQL
+version: 1.0.0
+description: MS SQL Filebeat Module
+type: ""
+categories:
+- metrics
+- logs
+requirement:
+  kibana:
+    version:
+      min: 6.7.0
+      max: 7.6.0

--- a/dev/package-beats/munin-1.0.0/manifest.yml
+++ b/dev/package-beats/munin-1.0.0/manifest.yml
@@ -1,0 +1,13 @@
+name: munin
+title: Munin
+version: 1.0.0
+description: |
+  Munin node metrics exporter
+type: ""
+categories:
+- metrics
+requirement:
+  kibana:
+    version:
+      min: 6.7.0
+      max: 7.6.0

--- a/dev/package-beats/mysql-1.0.0/kibana/dashboard/Filebeat-mysql.json
+++ b/dev/package-beats/mysql-1.0.0/kibana/dashboard/Filebeat-mysql.json
@@ -1,0 +1,742 @@
+{
+    "objects": [
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "Filebeat-MySQL-Slow-log-ecs", 
+                "title": "Top slowest queries [Filebeat MySQL] ECS", 
+                "uiStateJSON": {
+                    "vis": {
+                        "params": {
+                            "sort": {
+                                "columnIndex": null, 
+                                "direction": null
+                            }
+                        }
+                    }
+                }, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "Query time", 
+                                "field": "event.duration"
+                            }, 
+                            "schema": "metric", 
+                            "type": "max"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customLabel": "Query", 
+                                "field": "mysql.slowlog.query", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "bucket", 
+                            "type": "terms"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "customLabel": "User", 
+                                "field": "user.name", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "bucket", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "params": {
+                        "perPage": 10, 
+                        "showMeticsAtAllLevels": false, 
+                        "showPartialRows": false, 
+                        "showTotal": false, 
+                        "sort": {
+                            "columnIndex": null, 
+                            "direction": null
+                        }, 
+                        "totalFunc": "sum"
+                    }, 
+                    "title": "Top slowest queries [Filebeat MySQL] ECS", 
+                    "type": "table"
+                }
+            }, 
+            "id": "MySQL-slowest-queries-ecs", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "Filebeat-MySQL-Slow-log-ecs", 
+                "title": "Slow queries over time [Filebeat MySQL] ECS", 
+                "uiStateJSON": {
+                    "vis": {
+                        "colors": {
+                            "Slow queries": "#EF843C"
+                        }
+                    }
+                }, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "Slow queries"
+                            }, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }
+                    ], 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "categoryAxes": [
+                            {
+                                "id": "CategoryAxis-1", 
+                                "labels": {
+                                    "show": true, 
+                                    "truncate": 100
+                                }, 
+                                "position": "bottom", 
+                                "scale": {
+                                    "type": "linear"
+                                }, 
+                                "show": true, 
+                                "style": {}, 
+                                "title": {
+                                    "text": "@timestamp per 30 seconds"
+                                }, 
+                                "type": "category"
+                            }
+                        ], 
+                        "defaultYExtents": false, 
+                        "grid": {
+                            "categoryLines": false, 
+                            "style": {
+                                "color": "#eee"
+                            }
+                        }, 
+                        "legendPosition": "right", 
+                        "mode": "stacked", 
+                        "scale": "linear", 
+                        "seriesParams": [
+                            {
+                                "data": {
+                                    "id": "1", 
+                                    "label": "Slow queries"
+                                }, 
+                                "drawLinesBetweenPoints": true, 
+                                "mode": "stacked", 
+                                "show": "true", 
+                                "showCircles": true, 
+                                "type": "histogram", 
+                                "valueAxis": "ValueAxis-1"
+                            }
+                        ], 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "times": [], 
+                        "type": "histogram", 
+                        "valueAxes": [
+                            {
+                                "id": "ValueAxis-1", 
+                                "labels": {
+                                    "filter": false, 
+                                    "rotate": 0, 
+                                    "show": true, 
+                                    "truncate": 100
+                                }, 
+                                "name": "LeftAxis-1", 
+                                "position": "left", 
+                                "scale": {
+                                    "mode": "normal", 
+                                    "type": "linear"
+                                }, 
+                                "show": true, 
+                                "style": {}, 
+                                "title": {
+                                    "text": "Slow queries"
+                                }, 
+                                "type": "value"
+                            }
+                        ], 
+                        "yAxis": {}
+                    }, 
+                    "title": "Slow queries over time [Filebeat MySQL] ECS", 
+                    "type": "histogram"
+                }
+            }, 
+            "id": "MySQL-Slow-queries-over-time-ecs", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "Filebeat-MySQL-error-log-ecs", 
+                "title": "Error logs over time [Filebeat MySQL] ECS", 
+                "uiStateJSON": {
+                    "vis": {
+                        "colors": {
+                            "Count": "#447EBC", 
+                            "Error logs": "#1F78C1"
+                        }
+                    }
+                }, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "Error logs"
+                            }, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }
+                    ], 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "categoryAxes": [
+                            {
+                                "id": "CategoryAxis-1", 
+                                "labels": {
+                                    "show": true, 
+                                    "truncate": 100
+                                }, 
+                                "position": "bottom", 
+                                "scale": {
+                                    "type": "linear"
+                                }, 
+                                "show": true, 
+                                "style": {}, 
+                                "title": {
+                                    "text": "@timestamp per 30 seconds"
+                                }, 
+                                "type": "category"
+                            }
+                        ], 
+                        "defaultYExtents": false, 
+                        "grid": {
+                            "categoryLines": false, 
+                            "style": {
+                                "color": "#eee"
+                            }
+                        }, 
+                        "legendPosition": "right", 
+                        "mode": "stacked", 
+                        "scale": "linear", 
+                        "seriesParams": [
+                            {
+                                "data": {
+                                    "id": "1", 
+                                    "label": "Error logs"
+                                }, 
+                                "drawLinesBetweenPoints": true, 
+                                "mode": "stacked", 
+                                "show": "true", 
+                                "showCircles": true, 
+                                "type": "histogram", 
+                                "valueAxis": "ValueAxis-1"
+                            }
+                        ], 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "times": [], 
+                        "type": "histogram", 
+                        "valueAxes": [
+                            {
+                                "id": "ValueAxis-1", 
+                                "labels": {
+                                    "filter": false, 
+                                    "rotate": 0, 
+                                    "show": true, 
+                                    "truncate": 100
+                                }, 
+                                "name": "LeftAxis-1", 
+                                "position": "left", 
+                                "scale": {
+                                    "mode": "normal", 
+                                    "type": "linear"
+                                }, 
+                                "show": true, 
+                                "style": {}, 
+                                "title": {
+                                    "text": "Error logs"
+                                }, 
+                                "type": "value"
+                            }
+                        ], 
+                        "yAxis": {}
+                    }, 
+                    "title": "Error logs over time [Filebeat MySQL] ECS", 
+                    "type": "histogram"
+                }
+            }, 
+            "id": "MySQL-error-logs-ecs", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "columns": [
+                    "log.level", 
+                    "message"
+                ], 
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [
+                            {
+                                "$state": {
+                                    "store": "appState"
+                                }, 
+                                "meta": {
+                                    "alias": null, 
+                                    "disabled": false, 
+                                    "index": "filebeat-*", 
+                                    "key": "event.module", 
+                                    "negate": false, 
+                                    "params": {
+                                        "query": "mysql", 
+                                        "type": "phrase"
+                                    }, 
+                                    "type": "phrase", 
+                                    "value": "mysql"
+                                }, 
+                                "query": {
+                                    "match": {
+                                        "event.module": {
+                                            "query": "mysql", 
+                                            "type": "phrase"
+                                        }
+                                    }
+                                }
+                            }, 
+                            {
+                                "$state": {
+                                    "store": "appState"
+                                }, 
+                                "meta": {
+                                    "alias": null, 
+                                    "disabled": false, 
+                                    "index": "filebeat-*", 
+                                    "key": "fileset.name", 
+                                    "negate": false, 
+                                    "params": {
+                                        "query": "error", 
+                                        "type": "phrase"
+                                    }, 
+                                    "type": "phrase", 
+                                    "value": "error"
+                                }, 
+                                "query": {
+                                    "match": {
+                                        "fileset.name": {
+                                            "query": "error", 
+                                            "type": "phrase"
+                                        }
+                                    }
+                                }
+                            }
+                        ], 
+                        "highlight": {
+                            "fields": {
+                                "*": {}
+                            }, 
+                            "fragment_size": 2147483647, 
+                            "post_tags": [
+                                "@/kibana-highlighted-field@"
+                            ], 
+                            "pre_tags": [
+                                "@kibana-highlighted-field@"
+                            ], 
+                            "require_field_match": false
+                        }, 
+                        "highlightAll": true, 
+                        "index": "filebeat-*", 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "sort": [
+                    "@timestamp", 
+                    "desc"
+                ], 
+                "title": "Error logs [Filebeat MySQL] ECS", 
+                "version": 1
+            }, 
+            "id": "Filebeat-MySQL-error-log-ecs", 
+            "type": "search", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "Filebeat-MySQL-error-log-ecs", 
+                "title": "Error logs levels breakdown [Filebeat MySQL] ECS", 
+                "uiStateJSON": {
+                    "vis": {
+                        "colors": {
+                            "ERROR": "#E24D42", 
+                            "Note": "#9AC48A", 
+                            "Warning": "#F9934E"
+                        }
+                    }
+                }, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "field": "log.level", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "segment", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "params": {
+                        "addLegend": true, 
+                        "addTooltip": true, 
+                        "isDonut": false, 
+                        "legendPosition": "bottom", 
+                        "shareYAxis": true, 
+                        "type": "pie"
+                    }, 
+                    "title": "Error logs levels breakdown [Filebeat MySQL] ECS", 
+                    "type": "pie"
+                }
+            }, 
+            "id": "MySQL-Error-logs-levels-ecs", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "Filebeat-MySQL-Slow-log-ecs", 
+                "title": "Slow logs breakdown [Filebeat MySQL] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "field": "mysql.slowlog.query", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "segment", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "params": {
+                        "addLegend": true, 
+                        "addTooltip": true, 
+                        "isDonut": false, 
+                        "legendPosition": "bottom", 
+                        "shareYAxis": true, 
+                        "type": "pie"
+                    }, 
+                    "title": "Slow logs breakdown [Filebeat MySQL] ECS", 
+                    "type": "pie"
+                }
+            }, 
+            "id": "MySQL-Slow-logs-by-count-ecs", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "columns": [
+                    "_source"
+                ], 
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [
+                            {
+                                "$state": {
+                                    "store": "appState"
+                                }, 
+                                "meta": {
+                                    "alias": null, 
+                                    "disabled": false, 
+                                    "index": "filebeat-*", 
+                                    "key": "event.module", 
+                                    "negate": false, 
+                                    "params": {
+                                        "query": "mysql", 
+                                        "type": "phrase"
+                                    }, 
+                                    "type": "phrase", 
+                                    "value": "mysql"
+                                }, 
+                                "query": {
+                                    "match": {
+                                        "event.module": {
+                                            "query": "mysql", 
+                                            "type": "phrase"
+                                        }
+                                    }
+                                }
+                            }, 
+                            {
+                                "$state": {
+                                    "store": "appState"
+                                }, 
+                                "meta": {
+                                    "alias": null, 
+                                    "disabled": false, 
+                                    "index": "filebeat-*", 
+                                    "key": "fileset.name", 
+                                    "negate": false, 
+                                    "params": {
+                                        "query": "slowlog", 
+                                        "type": "phrase"
+                                    }, 
+                                    "type": "phrase", 
+                                    "value": "slowlog"
+                                }, 
+                                "query": {
+                                    "match": {
+                                        "fileset.name": {
+                                            "query": "slowlog", 
+                                            "type": "phrase"
+                                        }
+                                    }
+                                }
+                            }
+                        ], 
+                        "highlight": {
+                            "fields": {
+                                "*": {}
+                            }, 
+                            "fragment_size": 2147483647, 
+                            "post_tags": [
+                                "@/kibana-highlighted-field@"
+                            ], 
+                            "pre_tags": [
+                                "@kibana-highlighted-field@"
+                            ], 
+                            "require_field_match": false
+                        }, 
+                        "highlightAll": true, 
+                        "index": "filebeat-*", 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "sort": [
+                    "@timestamp", 
+                    "desc"
+                ], 
+                "title": "Slow logs [Filebeat MySQL] ECS", 
+                "version": 1
+            }, 
+            "id": "Filebeat-MySQL-Slow-log-ecs", 
+            "type": "search", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "Overview dashboard for the Filebeat MySQL module", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlightAll": true, 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "optionsJSON": {
+                    "darkTheme": false
+                }, 
+                "panelsJSON": [
+                    {
+                        "col": 1, 
+                        "id": "MySQL-slowest-queries-ecs", 
+                        "panelIndex": 1, 
+                        "row": 8, 
+                        "size_x": 6, 
+                        "size_y": 4, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "MySQL-Slow-queries-over-time-ecs", 
+                        "panelIndex": 2, 
+                        "row": 1, 
+                        "size_x": 6, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 7, 
+                        "id": "MySQL-error-logs-ecs", 
+                        "panelIndex": 3, 
+                        "row": 1, 
+                        "size_x": 6, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 7, 
+                        "columns": [
+                            "log.level", 
+                            "message"
+                        ], 
+                        "id": "Filebeat-MySQL-error-log-ecs", 
+                        "panelIndex": 4, 
+                        "row": 8, 
+                        "size_x": 6, 
+                        "size_y": 5, 
+                        "sort": [
+                            "@timestamp", 
+                            "desc"
+                        ], 
+                        "type": "search"
+                    }, 
+                    {
+                        "col": 7, 
+                        "id": "MySQL-Error-logs-levels-ecs", 
+                        "panelIndex": 5, 
+                        "row": 4, 
+                        "size_x": 6, 
+                        "size_y": 4, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "MySQL-Slow-logs-by-count-ecs", 
+                        "panelIndex": 6, 
+                        "row": 4, 
+                        "size_x": 6, 
+                        "size_y": 4, 
+                        "type": "visualization"
+                    }
+                ], 
+                "timeRestore": false, 
+                "title": "[Filebeat MySQL] Overview ECS", 
+                "uiStateJSON": {
+                    "P-1": {
+                        "vis": {
+                            "params": {
+                                "sort": {
+                                    "columnIndex": null, 
+                                    "direction": null
+                                }
+                            }
+                        }
+                    }
+                }, 
+                "version": 1
+            }, 
+            "id": "Filebeat-MySQL-Dashboard-ecs", 
+            "type": "dashboard", 
+            "version": 2
+        }
+    ], 
+    "version": "6.0.0-beta1-SNAPSHOT"
+}

--- a/dev/package-beats/mysql-1.0.0/kibana/dashboard/Metricbeat-mysql-overview.json
+++ b/dev/package-beats/mysql-1.0.0/kibana/dashboard/Metricbeat-mysql-overview.json
@@ -1,0 +1,648 @@
+{
+    "objects": [
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "Connections rate [Metricbeat MySQL] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "legend_position": "bottom", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": 0.5, 
+                                "formatter": "number", 
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417", 
+                                "label": "Connections rate", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "mysql.status.connections", 
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "type": "avg"
+                                    }, 
+                                    {
+                                        "field": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "id": "aee9bbf0-f1f3-11e7-a752-236fe3270d99", 
+                                        "type": "derivative", 
+                                        "unit": ""
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "timeseries"
+                    }, 
+                    "title": "Connections rate [Metricbeat MySQL] ECS", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "d7e6bee0-f1f3-11e7-85ab-594b1652e0d1-ecs", 
+            "type": "visualization", 
+            "updated_at": "2018-01-05T09:14:45.934Z", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "Command rates [Metricbeat MySQL] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": "0.2", 
+                                "formatter": "number", 
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417", 
+                                "label": "SELECT", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "mysql.status.command.select", 
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "type": "avg"
+                                    }, 
+                                    {
+                                        "field": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "id": "2d149f90-f1f4-11e7-a752-236fe3270d99", 
+                                        "type": "derivative", 
+                                        "unit": ""
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }, 
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "rgba(104,204,202,1)", 
+                                "fill": "0.2", 
+                                "formatter": "number", 
+                                "id": "3c2a2a40-f1f4-11e7-a752-236fe3270d99", 
+                                "label": "INSERT", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "mysql.status.command.insert", 
+                                        "id": "3c2a2a41-f1f4-11e7-a752-236fe3270d99", 
+                                        "type": "avg"
+                                    }, 
+                                    {
+                                        "field": "3c2a2a41-f1f4-11e7-a752-236fe3270d99", 
+                                        "id": "3c2a2a42-f1f4-11e7-a752-236fe3270d99", 
+                                        "type": "derivative", 
+                                        "unit": ""
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }, 
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "rgba(252,220,0,1)", 
+                                "fill": "0.2", 
+                                "formatter": "number", 
+                                "id": "485ce050-f1f4-11e7-a752-236fe3270d99", 
+                                "label": "UPDATE", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "mysql.status.command.update", 
+                                        "id": "485ce051-f1f4-11e7-a752-236fe3270d99", 
+                                        "type": "avg"
+                                    }, 
+                                    {
+                                        "field": "485ce051-f1f4-11e7-a752-236fe3270d99", 
+                                        "id": "485ce052-f1f4-11e7-a752-236fe3270d99", 
+                                        "type": "derivative", 
+                                        "unit": ""
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }, 
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "rgba(244,78,59,1)", 
+                                "fill": "0.2", 
+                                "formatter": "number", 
+                                "id": "543a4a70-f1f4-11e7-a752-236fe3270d99", 
+                                "label": "DELETE", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "mysql.status.command.delete", 
+                                        "id": "543a4a71-f1f4-11e7-a752-236fe3270d99", 
+                                        "type": "avg"
+                                    }, 
+                                    {
+                                        "field": "543a4a71-f1f4-11e7-a752-236fe3270d99", 
+                                        "id": "543a4a72-f1f4-11e7-a752-236fe3270d99", 
+                                        "type": "derivative", 
+                                        "unit": ""
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "timeseries"
+                    }, 
+                    "title": "Command rates [Metricbeat MySQL] ECS", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "695a4f90-f1f4-11e7-85ab-594b1652e0d1-ecs", 
+            "type": "visualization", 
+            "updated_at": "2018-01-05T09:14:45.934Z", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "Running threads [Metricbeat MySQL] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "legend_position": "bottom", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "rgba(174,161,255,1)", 
+                                "fill": 0.5, 
+                                "formatter": "number", 
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417", 
+                                "label": "Running threads", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "mysql.status.threads.running", 
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "type": "avg"
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "timeseries"
+                    }, 
+                    "title": "Running threads [Metricbeat MySQL] ECS", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "124dce60-f1f5-11e7-85ab-594b1652e0d1-ecs", 
+            "type": "visualization", 
+            "updated_at": "2018-01-05T09:14:45.934Z", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "Opened tables rate [Metricbeat MySQL] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "legend_position": "bottom", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "rgba(252,196,0,1)", 
+                                "fill": 0.5, 
+                                "formatter": "number", 
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417", 
+                                "label": "Opened tables rate", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "mysql.status.opened_tables", 
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "type": "avg"
+                                    }, 
+                                    {
+                                        "field": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "id": "9972d250-f1f5-11e7-a752-236fe3270d99", 
+                                        "type": "derivative", 
+                                        "unit": ""
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "timeseries"
+                    }, 
+                    "title": "Opened tables rate [Metricbeat MySQL] ECS", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "aaa326b0-f1f5-11e7-85ab-594b1652e0d1-ecs", 
+            "type": "visualization", 
+            "updated_at": "2018-01-05T09:14:45.934Z", 
+            "version": 3
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "Threads created rate [Metricbeat MySQL] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "legend_position": "bottom", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "rgba(123,100,255,1)", 
+                                "fill": 0.5, 
+                                "formatter": "number", 
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417", 
+                                "label": "Threads created rate", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "mysql.status.threads.created", 
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "type": "avg"
+                                    }, 
+                                    {
+                                        "field": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "id": "9972d250-f1f5-11e7-a752-236fe3270d99", 
+                                        "type": "derivative", 
+                                        "unit": ""
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "timeseries"
+                    }, 
+                    "title": "Threads created rate [Metricbeat MySQL] ECS", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "fb1f3f20-f1f5-11e7-85ab-594b1652e0d1-ecs", 
+            "type": "visualization", 
+            "updated_at": "2018-01-05T09:14:45.934Z", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "Open files [Metricbeat MySQL] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "legend_position": "bottom", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "rgba(22,165,165,1)", 
+                                "fill": 0.5, 
+                                "formatter": "number", 
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417", 
+                                "label": "Open files", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "mysql.status.open.files", 
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "type": "avg"
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "timeseries"
+                    }, 
+                    "title": "Open files [Metricbeat MySQL] ECS", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "f5b35930-f1f6-11e7-85ab-594b1652e0d1-ecs", 
+            "type": "visualization", 
+            "updated_at": "2018-01-05T09:14:45.934Z", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "Sent and received bytes rates [Metricbeat MySQL] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "legend_position": "bottom", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "rgba(0,98,177,1)", 
+                                "fill": 0.5, 
+                                "formatter": "number", 
+                                "id": "2b1c2390-f1f7-11e7-a752-236fe3270d99", 
+                                "label": "Received bytes", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "mysql.status.bytes.received", 
+                                        "id": "2b1c2391-f1f7-11e7-a752-236fe3270d99", 
+                                        "type": "avg"
+                                    }, 
+                                    {
+                                        "field": "2b1c2391-f1f7-11e7-a752-236fe3270d99", 
+                                        "id": "2b1c2392-f1f7-11e7-a752-236fe3270d99", 
+                                        "type": "derivative", 
+                                        "unit": ""
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }, 
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": 0.5, 
+                                "formatter": "number", 
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417", 
+                                "label": "Sent bytes", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "mysql.status.bytes.sent", 
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "type": "avg"
+                                    }, 
+                                    {
+                                        "field": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "id": "23cfda50-f1f7-11e7-a752-236fe3270d99", 
+                                        "type": "derivative", 
+                                        "unit": ""
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "timeseries"
+                    }, 
+                    "title": "Sent and received bytes rates [Metricbeat MySQL] ECS", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "7404feb0-f1f7-11e7-85ab-594b1652e0d1-ecs", 
+            "type": "visualization", 
+            "updated_at": "2018-01-05T09:15:49.714Z", 
+            "version": 3
+        }, 
+        {
+            "attributes": {
+                "description": "Overview of MySQL server",
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlightAll": true, 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "optionsJSON": {
+                    "darkTheme": false, 
+                    "useMargins": false
+                }, 
+                "panelsJSON": [
+                    {
+                        "gridData": {
+                            "h": 3, 
+                            "i": "10", 
+                            "w": 6, 
+                            "x": 0, 
+                            "y": 3
+                        }, 
+                        "id": "d7e6bee0-f1f3-11e7-85ab-594b1652e0d1-ecs", 
+                        "panelIndex": "10", 
+                        "type": "visualization", 
+                        "version": "6.2.4"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 3, 
+                            "i": "11", 
+                            "w": 12, 
+                            "x": 0, 
+                            "y": 0
+                        }, 
+                        "id": "695a4f90-f1f4-11e7-85ab-594b1652e0d1-ecs", 
+                        "panelIndex": "11", 
+                        "type": "visualization", 
+                        "version": "6.2.4"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 3, 
+                            "i": "13", 
+                            "w": 6, 
+                            "x": 6, 
+                            "y": 3
+                        }, 
+                        "id": "124dce60-f1f5-11e7-85ab-594b1652e0d1-ecs", 
+                        "panelIndex": "13", 
+                        "type": "visualization", 
+                        "version": "6.2.4"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 3, 
+                            "i": "14", 
+                            "w": 6, 
+                            "x": 0, 
+                            "y": 6
+                        }, 
+                        "id": "aaa326b0-f1f5-11e7-85ab-594b1652e0d1-ecs", 
+                        "panelIndex": "14", 
+                        "type": "visualization", 
+                        "version": "6.2.4"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 3, 
+                            "i": "15", 
+                            "w": 6, 
+                            "x": 6, 
+                            "y": 6
+                        }, 
+                        "id": "fb1f3f20-f1f5-11e7-85ab-594b1652e0d1-ecs", 
+                        "panelIndex": "15", 
+                        "type": "visualization", 
+                        "version": "6.2.4"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 3, 
+                            "i": "16", 
+                            "w": 6, 
+                            "x": 6, 
+                            "y": 9
+                        }, 
+                        "id": "f5b35930-f1f6-11e7-85ab-594b1652e0d1-ecs", 
+                        "panelIndex": "16", 
+                        "type": "visualization", 
+                        "version": "6.2.4"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 3, 
+                            "i": "17", 
+                            "w": 6, 
+                            "x": 0, 
+                            "y": 9
+                        }, 
+                        "id": "7404feb0-f1f7-11e7-85ab-594b1652e0d1-ecs", 
+                        "panelIndex": "17", 
+                        "type": "visualization", 
+                        "version": "6.2.4"
+                    }
+                ], 
+                "timeRestore": false, 
+                "title": "[Metricbeat MySQL] Overview ECS", 
+                "version": 1
+            }, 
+            "id": "66881e90-0006-11e7-bf7f-c9acc3d3e306-ecs", 
+            "type": "dashboard", 
+            "updated_at": "2018-01-05T09:14:45.934Z", 
+            "version": 3
+        }
+    ], 
+    "version": "6.2.4"
+}

--- a/dev/package-beats/mysql-1.0.0/manifest.yml
+++ b/dev/package-beats/mysql-1.0.0/manifest.yml
@@ -1,0 +1,14 @@
+name: mysql
+title: MySQL
+version: 1.0.0
+description: |
+  MySQL server status metrics collected from MySQL.
+type: ""
+categories:
+- logs
+- metrics
+requirement:
+  kibana:
+    version:
+      min: 6.7.0
+      max: 7.6.0

--- a/dev/package-beats/nats-1.0.0/kibana/dashboard/Filebeat-nats-overview.json
+++ b/dev/package-beats/nats-1.0.0/kibana/dashboard/Filebeat-nats-overview.json
@@ -1,0 +1,1081 @@
+{
+  "objects": [
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "index": "filebeat-*",
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Message Types Timeline [Filebeat NATS] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": ""
+              },
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "schema": "segment",
+              "type": "date_histogram"
+            },
+            {
+              "enabled": true,
+              "id": "3",
+              "params": {
+                "field": "nats.log.msg.type",
+                "size": 15
+              },
+              "schema": "group",
+              "type": "significant_terms"
+            }
+          ],
+          "params": {
+            "addLegend": true,
+            "addTimeMarker": false,
+            "addTooltip": true,
+            "categoryAxes": [
+              {
+                "id": "CategoryAxis-1",
+                "labels": {
+                  "show": true,
+                  "truncate": 100
+                },
+                "position": "bottom",
+                "scale": {
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {},
+                "type": "category"
+              }
+            ],
+            "grid": {
+              "categoryLines": false,
+              "style": {
+                "color": "#eee"
+              }
+            },
+            "legendPosition": "right",
+            "seriesParams": [
+              {
+                "data": {
+                  "id": "1",
+                  "label": "Count"
+                },
+                "drawLinesBetweenPoints": true,
+                "interpolate": "cardinal",
+                "mode": "normal",
+                "show": "true",
+                "showCircles": true,
+                "type": "line",
+                "valueAxis": "ValueAxis-1"
+              }
+            ],
+            "times": [],
+            "type": "line",
+            "valueAxes": [
+              {
+                "id": "ValueAxis-1",
+                "labels": {
+                  "filter": false,
+                  "rotate": 0,
+                  "show": true,
+                  "truncate": 100
+                },
+                "name": "LeftAxis-1",
+                "position": "left",
+                "scale": {
+                  "mode": "normal",
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {
+                  "text": "Count"
+                },
+                "type": "value"
+              }
+            ]
+          },
+          "title": "Message Types Timeline [Filebeat NATS] ECS",
+          "type": "line"
+        }
+      },
+      "id": "6987a800-41a8-11e9-a4da-b1df688edbcd-ecs",
+      "type": "visualization",
+      "updated_at": "2019-03-08T21:47:49.627Z",
+      "version": 3
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "index": "filebeat-*",
+            "query": {
+              "language": "kuery",
+              "query": "service.type: nats"
+            }
+          }
+        },
+        "title": "Communication Directions [Filebeat NATS] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "schema": "segment",
+              "type": "date_histogram"
+            },
+            {
+              "enabled": true,
+              "id": "3",
+              "params": {
+                "field": "network.direction",
+                "size": 2
+              },
+              "schema": "group",
+              "type": "significant_terms"
+            }
+          ],
+          "params": {
+            "addLegend": true,
+            "addTimeMarker": false,
+            "addTooltip": true,
+            "categoryAxes": [
+              {
+                "id": "CategoryAxis-1",
+                "labels": {
+                  "show": true,
+                  "truncate": 100
+                },
+                "position": "bottom",
+                "scale": {
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {},
+                "type": "category"
+              }
+            ],
+            "grid": {
+              "categoryLines": false,
+              "style": {
+                "color": "#eee"
+              }
+            },
+            "legendPosition": "right",
+            "seriesParams": [
+              {
+                "data": {
+                  "id": "1",
+                  "label": "Count"
+                },
+                "drawLinesBetweenPoints": true,
+                "mode": "normal",
+                "show": "true",
+                "showCircles": true,
+                "type": "line",
+                "valueAxis": "ValueAxis-1"
+              }
+            ],
+            "times": [],
+            "type": "line",
+            "valueAxes": [
+              {
+                "id": "ValueAxis-1",
+                "labels": {
+                  "filter": false,
+                  "rotate": 0,
+                  "show": true,
+                  "truncate": 100
+                },
+                "name": "LeftAxis-1",
+                "position": "left",
+                "scale": {
+                  "mode": "normal",
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {
+                  "text": "Count"
+                },
+                "type": "value"
+              }
+            ]
+          },
+          "title": "Communication Directions [Filebeat NATS] ECS",
+          "type": "line"
+        }
+      },
+      "id": "0b2061d0-41ad-11e9-a4da-b1df688edbcd-ecs",
+      "type": "visualization",
+      "updated_at": "2019-03-08T21:54:53.381Z",
+      "version": 3
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "index": "filebeat-*",
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Topics Timeline [Filebeat NATS] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "schema": "segment",
+              "type": "date_histogram"
+            },
+            {
+              "enabled": true,
+              "id": "3",
+              "params": {
+                "field": "nats.log.msg.subject",
+                "size": 5
+              },
+              "schema": "group",
+              "type": "significant_terms"
+            }
+          ],
+          "params": {
+            "addLegend": true,
+            "addTimeMarker": false,
+            "addTooltip": true,
+            "categoryAxes": [
+              {
+                "id": "CategoryAxis-1",
+                "labels": {
+                  "show": true,
+                  "truncate": 100
+                },
+                "position": "bottom",
+                "scale": {
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {},
+                "type": "category"
+              }
+            ],
+            "grid": {
+              "categoryLines": false,
+              "style": {
+                "color": "#eee"
+              }
+            },
+            "legendPosition": "right",
+            "seriesParams": [
+              {
+                "data": {
+                  "id": "1",
+                  "label": "Count"
+                },
+                "drawLinesBetweenPoints": true,
+                "mode": "normal",
+                "show": "true",
+                "showCircles": true,
+                "type": "line",
+                "valueAxis": "ValueAxis-1"
+              }
+            ],
+            "times": [],
+            "type": "line",
+            "valueAxes": [
+              {
+                "id": "ValueAxis-1",
+                "labels": {
+                  "filter": false,
+                  "rotate": 0,
+                  "show": true,
+                  "truncate": 100
+                },
+                "name": "LeftAxis-1",
+                "position": "left",
+                "scale": {
+                  "mode": "normal",
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {
+                  "text": "Count"
+                },
+                "type": "value"
+              }
+            ]
+          },
+          "title": "Topics Timeline [Filebeat NATS] ECS",
+          "type": "line"
+        }
+      },
+      "id": "4a6d9ec0-41a8-11e9-a4da-b1df688edbcd-ecs",
+      "type": "visualization",
+      "updated_at": "2019-03-08T21:49:49.112Z",
+      "version": 3
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "index": "filebeat-*",
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": " Bytes Timeline [Filebeat NATS] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "Sum of Message Bytes",
+                "field": "nats.log.msg.bytes"
+              },
+              "schema": "metric",
+              "type": "sum"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "schema": "segment",
+              "type": "date_histogram"
+            }
+          ],
+          "params": {
+            "addLegend": true,
+            "addTimeMarker": false,
+            "addTooltip": true,
+            "categoryAxes": [
+              {
+                "id": "CategoryAxis-1",
+                "labels": {
+                  "show": true,
+                  "truncate": 100
+                },
+                "position": "bottom",
+                "scale": {
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {},
+                "type": "category"
+              }
+            ],
+            "grid": {
+              "categoryLines": false,
+              "style": {
+                "color": "#eee"
+              }
+            },
+            "legendPosition": "right",
+            "seriesParams": [
+              {
+                "data": {
+                  "id": "1",
+                  "label": "Sum of Message Bytes"
+                },
+                "drawLinesBetweenPoints": true,
+                "mode": "normal",
+                "show": "true",
+                "showCircles": true,
+                "type": "line",
+                "valueAxis": "ValueAxis-1"
+              }
+            ],
+            "times": [],
+            "type": "line",
+            "valueAxes": [
+              {
+                "id": "ValueAxis-1",
+                "labels": {
+                  "filter": false,
+                  "rotate": 0,
+                  "show": true,
+                  "truncate": 100
+                },
+                "name": "LeftAxis-1",
+                "position": "left",
+                "scale": {
+                  "mode": "normal",
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {
+                  "text": "Sum of Message Bytes"
+                },
+                "type": "value"
+              }
+            ]
+          },
+          "title": " Bytes Timeline [Filebeat NATS] ECS",
+          "type": "line"
+        }
+      },
+      "id": "c3d1ab80-41a8-11e9-a4da-b1df688edbcd-ecs",
+      "type": "visualization",
+      "updated_at": "2019-03-08T21:38:11.578Z",
+      "version": 3
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "index": "filebeat-*",
+            "query": {
+              "language": "kuery",
+              "query": "service.type: nats"
+            }
+          }
+        },
+        "title": "Communication Directions Distribution [Filebeat NATS] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "field": "network.direction",
+                "size": 2
+              },
+              "schema": "segment",
+              "type": "significant_terms"
+            }
+          ],
+          "params": {
+            "addLegend": true,
+            "addTooltip": true,
+            "isDonut": true,
+            "labels": {
+              "last_level": true,
+              "show": true,
+              "truncate": 100,
+              "values": true
+            },
+            "legendPosition": "right",
+            "type": "pie"
+          },
+          "title": "Communication Directions Distribution [Filebeat NATS] ECS",
+          "type": "pie"
+        }
+      },
+      "id": "7716c780-41ad-11e9-a4da-b1df688edbcd-ecs",
+      "type": "visualization",
+      "updated_at": "2019-03-08T21:39:03.899Z",
+      "version": 5
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "index": "filebeat-*",
+            "query": {
+              "language": "kuery",
+              "query": "service.type: nats"
+            }
+          }
+        },
+        "title": "Log Level Distribution [Filebeat NATS] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "field": "log.level",
+                "size": 10
+              },
+              "schema": "segment",
+              "type": "significant_terms"
+            }
+          ],
+          "params": {
+            "addLegend": true,
+            "addTooltip": true,
+            "isDonut": true,
+            "labels": {
+              "last_level": true,
+              "show": true,
+              "truncate": 100,
+              "values": true
+            },
+            "legendPosition": "right",
+            "type": "pie"
+          },
+          "title": "Log Level Distribution [Filebeat NATS] ECS",
+          "type": "pie"
+        }
+      },
+      "id": "3f6cca40-41ae-11e9-a4da-b1df688edbcd-ecs",
+      "type": "visualization",
+      "updated_at": "2019-03-08T21:44:31.263Z",
+      "version": 3
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "index": "filebeat-*",
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Message Type Distribution [Filebeat NATS] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "field": "nats.log.msg.type",
+                "size": 15
+              },
+              "schema": "segment",
+              "type": "significant_terms"
+            }
+          ],
+          "params": {
+            "addLegend": true,
+            "addTooltip": true,
+            "isDonut": true,
+            "labels": {
+              "last_level": true,
+              "show": true,
+              "truncate": 100,
+              "values": true
+            },
+            "legendPosition": "right",
+            "type": "pie"
+          },
+          "title": "Message Type Distribution [Filebeat NATS] ECS",
+          "type": "pie"
+        }
+      },
+      "id": "7ed62870-41ae-11e9-a4da-b1df688edbcd-ecs",
+      "type": "visualization",
+      "updated_at": "2019-03-08T21:48:10.554Z",
+      "version": 3
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "index": "filebeat-*",
+            "query": {
+              "language": "kuery",
+              "query": "service.type: nats"
+            }
+          }
+        },
+        "title": "Log Level Timeline [Filebeat NATS] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "schema": "segment",
+              "type": "date_histogram"
+            },
+            {
+              "enabled": true,
+              "id": "3",
+              "params": {
+                "field": "log.level",
+                "size": 10
+              },
+              "schema": "group",
+              "type": "significant_terms"
+            }
+          ],
+          "params": {
+            "addLegend": true,
+            "addTimeMarker": false,
+            "addTooltip": true,
+            "categoryAxes": [
+              {
+                "id": "CategoryAxis-1",
+                "labels": {
+                  "show": true,
+                  "truncate": 100
+                },
+                "position": "bottom",
+                "scale": {
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {},
+                "type": "category"
+              }
+            ],
+            "grid": {
+              "categoryLines": false,
+              "style": {
+                "color": "#eee"
+              }
+            },
+            "legendPosition": "right",
+            "seriesParams": [
+              {
+                "data": {
+                  "id": "1",
+                  "label": "Count"
+                },
+                "drawLinesBetweenPoints": true,
+                "interpolate": "linear",
+                "mode": "stacked",
+                "show": "true",
+                "showCircles": true,
+                "type": "area",
+                "valueAxis": "ValueAxis-1"
+              }
+            ],
+            "times": [],
+            "type": "area",
+            "valueAxes": [
+              {
+                "id": "ValueAxis-1",
+                "labels": {
+                  "filter": false,
+                  "rotate": 0,
+                  "show": true,
+                  "truncate": 100
+                },
+                "name": "LeftAxis-1",
+                "position": "left",
+                "scale": {
+                  "mode": "normal",
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {
+                  "text": "Count"
+                },
+                "type": "value"
+              }
+            ]
+          },
+          "title": "Log Level Timeline [Filebeat NATS] ECS",
+          "type": "area"
+        }
+      },
+      "id": "04083600-41af-11e9-a4da-b1df688edbcd-ecs",
+      "type": "visualization",
+      "updated_at": "2019-03-08T21:48:44.582Z",
+      "version": 2
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "index": "filebeat-*",
+            "query": {
+              "language": "kuery",
+              "query": "service.type: nats"
+            }
+          }
+        },
+        "title": "Client IP Count Timeline [Filebeat NATS] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "schema": "segment",
+              "type": "date_histogram"
+            },
+            {
+              "enabled": true,
+              "id": "3",
+              "params": {
+                "field": "client.ip",
+                "ipRangeType": "fromTo",
+                "ranges": {
+                  "fromTo": [
+                    {
+                      "from": "0.0.0.0",
+                      "to": "127.255.255.255"
+                    },
+                    {
+                      "from": "128.0.0.0",
+                      "to": "191.255.255.255"
+                    }
+                  ],
+                  "mask": [
+                    {
+                      "mask": "0.0.0.0/1"
+                    },
+                    {
+                      "mask": "128.0.0.0/2"
+                    }
+                  ]
+                }
+              },
+              "schema": "group",
+              "type": "ip_range"
+            }
+          ],
+          "params": {
+            "addLegend": true,
+            "addTimeMarker": false,
+            "addTooltip": true,
+            "categoryAxes": [
+              {
+                "id": "CategoryAxis-1",
+                "labels": {
+                  "show": true,
+                  "truncate": 100
+                },
+                "position": "bottom",
+                "scale": {
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {},
+                "type": "category"
+              }
+            ],
+            "grid": {
+              "categoryLines": false,
+              "style": {
+                "color": "#eee"
+              }
+            },
+            "legendPosition": "right",
+            "seriesParams": [
+              {
+                "data": {
+                  "id": "1",
+                  "label": "Count"
+                },
+                "drawLinesBetweenPoints": true,
+                "mode": "normal",
+                "show": "true",
+                "showCircles": true,
+                "type": "line",
+                "valueAxis": "ValueAxis-1"
+              }
+            ],
+            "times": [],
+            "type": "line",
+            "valueAxes": [
+              {
+                "id": "ValueAxis-1",
+                "labels": {
+                  "filter": false,
+                  "rotate": 0,
+                  "show": true,
+                  "truncate": 100
+                },
+                "name": "LeftAxis-1",
+                "position": "left",
+                "scale": {
+                  "mode": "normal",
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {
+                  "text": "Count"
+                },
+                "type": "value"
+              }
+            ]
+          },
+          "title": "Client IP Count Timeline [Filebeat NATS] ECS",
+          "type": "line"
+        }
+      },
+      "id": "c669ae20-41ed-11e9-ac5c-71ffa38a62e3-ecs",
+      "type": "visualization",
+      "updated_at": "2019-03-08T22:01:50.337Z",
+      "version": 1
+    },
+    {
+      "attributes": {
+        "description": "Overview of NATS server statistics",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "optionsJSON": {
+          "darkTheme": false,
+          "hidePanelTitles": false,
+          "useMargins": true
+        },
+        "panelsJSON": [
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 11,
+              "i": "1",
+              "w": 17,
+              "x": 0,
+              "y": 0
+            },
+            "id": "6987a800-41a8-11e9-a4da-b1df688edbcd-ecs",
+            "panelIndex": "1",
+            "type": "visualization",
+            "version": "6.6.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 11,
+              "i": "2",
+              "w": 17,
+              "x": 31,
+              "y": 0
+            },
+            "id": "0b2061d0-41ad-11e9-a4da-b1df688edbcd-ecs",
+            "panelIndex": "2",
+            "type": "visualization",
+            "version": "6.6.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 12,
+              "i": "3",
+              "w": 25,
+              "x": 0,
+              "y": 20
+            },
+            "id": "4a6d9ec0-41a8-11e9-a4da-b1df688edbcd-ecs",
+            "panelIndex": "3",
+            "type": "visualization",
+            "version": "6.6.0"
+          },
+          {
+            "embeddableConfig": {
+              "vis": {
+                "legendOpen": false
+              }
+            },
+            "gridData": {
+              "h": 9,
+              "i": "4",
+              "w": 12,
+              "x": 11,
+              "y": 11
+            },
+            "id": "c3d1ab80-41a8-11e9-a4da-b1df688edbcd-ecs",
+            "panelIndex": "4",
+            "type": "visualization",
+            "version": "6.6.0"
+          },
+          {
+            "embeddableConfig": {
+              "vis": {
+                "legendOpen": false
+              }
+            },
+            "gridData": {
+              "h": 9,
+              "i": "5",
+              "w": 11,
+              "x": 0,
+              "y": 11
+            },
+            "id": "7716c780-41ad-11e9-a4da-b1df688edbcd-ecs",
+            "panelIndex": "5",
+            "type": "visualization",
+            "version": "6.6.0"
+          },
+          {
+            "embeddableConfig": {
+              "vis": {
+                "legendOpen": false
+              }
+            },
+            "gridData": {
+              "h": 9,
+              "i": "6",
+              "w": 11,
+              "x": 37,
+              "y": 11
+            },
+            "id": "3f6cca40-41ae-11e9-a4da-b1df688edbcd-ecs",
+            "panelIndex": "6",
+            "type": "visualization",
+            "version": "6.6.0"
+          },
+          {
+            "embeddableConfig": {
+              "vis": {
+                "legendOpen": false
+              }
+            },
+            "gridData": {
+              "h": 11,
+              "i": "7",
+              "w": 14,
+              "x": 17,
+              "y": 0
+            },
+            "id": "7ed62870-41ae-11e9-a4da-b1df688edbcd-ecs",
+            "panelIndex": "7",
+            "type": "visualization",
+            "version": "6.6.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 9,
+              "i": "8",
+              "w": 14,
+              "x": 23,
+              "y": 11
+            },
+            "id": "04083600-41af-11e9-a4da-b1df688edbcd-ecs",
+            "panelIndex": "8",
+            "type": "visualization",
+            "version": "6.6.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 12,
+              "i": "9",
+              "w": 22,
+              "x": 25,
+              "y": 20
+            },
+            "id": "c669ae20-41ed-11e9-ac5c-71ffa38a62e3-ecs",
+            "panelIndex": "9",
+            "type": "visualization",
+            "version": "6.6.0"
+          }
+        ],
+        "timeRestore": false,
+        "title": "[Filebeat NATS] Overview ECS",
+        "version": 1
+      },
+      "id": "Filebeat-nats-overview-ecs",
+      "type": "dashboard",
+      "updated_at": "2019-03-08T22:02:50.580Z",
+      "version": 5
+    }
+  ],
+  "version": "6.6.0"
+}

--- a/dev/package-beats/nats-1.0.0/kibana/dashboard/Metricbeat-nats-overview.json
+++ b/dev/package-beats/nats-1.0.0/kibana/dashboard/Metricbeat-nats-overview.json
@@ -1,0 +1,1689 @@
+{
+  "objects": [
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "index": "metricbeat-*",
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Subscriptions Info [Metricbeat NATS] ECS",
+        "uiStateJSON": {
+          "vis": {
+            "params": {
+              "sort": {
+                "columnIndex": null,
+                "direction": null
+              }
+            }
+          }
+        },
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "Cache Fanout Avg",
+                "field": "nats.subscriptions.cache.fanout.avg"
+              },
+              "schema": "metric",
+              "type": "avg"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customLabel": "Cache Fanout Max",
+                "field": "nats.subscriptions.cache.fanout.max"
+              },
+              "schema": "metric",
+              "type": "avg"
+            },
+            {
+              "enabled": true,
+              "id": "3",
+              "params": {
+                "customLabel": "Cache Hit Rate",
+                "field": "nats.subscriptions.cache.hit_rate"
+              },
+              "schema": "metric",
+              "type": "avg"
+            },
+            {
+              "enabled": true,
+              "id": "4",
+              "params": {
+                "customLabel": "Cache Size",
+                "field": "nats.subscriptions.cache.size"
+              },
+              "schema": "metric",
+              "type": "avg"
+            },
+            {
+              "enabled": true,
+              "id": "5",
+              "params": {
+                "customLabel": "Inserts",
+                "field": "nats.subscriptions.inserts"
+              },
+              "schema": "metric",
+              "type": "avg"
+            },
+            {
+              "enabled": true,
+              "id": "6",
+              "params": {
+                "customLabel": "Matches",
+                "field": "nats.subscriptions.matches"
+              },
+              "schema": "metric",
+              "type": "avg"
+            },
+            {
+              "enabled": true,
+              "id": "7",
+              "params": {
+                "customLabel": "Removes",
+                "field": "nats.subscriptions.removes"
+              },
+              "schema": "metric",
+              "type": "avg"
+            },
+            {
+              "enabled": true,
+              "id": "8",
+              "params": {
+                "customLabel": "Total",
+                "field": "nats.subscriptions.total"
+              },
+              "schema": "metric",
+              "type": "avg"
+            }
+          ],
+          "params": {
+            "perPage": 1,
+            "showMeticsAtAllLevels": false,
+            "showMetricsAtAllLevels": false,
+            "showPartialRows": false,
+            "showTotal": false,
+            "sort": {
+              "columnIndex": null,
+              "direction": null
+            },
+            "totalFunc": "sum"
+          },
+          "title": "Subscriptions Info [Metricbeat NATS] ECS",
+          "type": "table"
+        }
+      },
+      "id": "b129b220-1e44-11e9-a1b4-79a7ae42ab61-ecs",
+      "type": "visualization",
+      "updated_at": "2019-01-24T07:54:30.301Z",
+      "version": 3
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "index": "metricbeat-*",
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Current Memory Usage [Metricbeat NATS] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "Memory (Bytes)",
+                "field": "nats.stats.mem.bytes"
+              },
+              "schema": "metric",
+              "type": "avg"
+            }
+          ],
+          "params": {
+            "addLegend": false,
+            "addTooltip": true,
+            "metric": {
+              "colorSchema": "Green to Red",
+              "colorsRange": [
+                {
+                  "from": 0,
+                  "to": 10000
+                }
+              ],
+              "invertColors": false,
+              "labels": {
+                "show": true
+              },
+              "metricColorMode": "None",
+              "percentageMode": false,
+              "style": {
+                "bgColor": false,
+                "bgFill": "#000",
+                "fontSize": 42,
+                "labelColor": false,
+                "subText": ""
+              },
+              "useRanges": false
+            },
+            "type": "metric"
+          },
+          "title": "Current Memory Usage [Metricbeat NATS] ECS",
+          "type": "metric"
+        }
+      },
+      "id": "30a61c00-1e45-11e9-a1b4-79a7ae42ab61-ecs",
+      "type": "visualization",
+      "updated_at": "2019-01-24T07:56:32.097Z",
+      "version": 4
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "index": "metricbeat-*",
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Server Uptime [Metricbeat NATS] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "Server Uptime",
+                "field": "nats.stats.uptime"
+              },
+              "schema": "metric",
+              "type": "avg"
+            }
+          ],
+          "params": {
+            "addLegend": false,
+            "addTooltip": true,
+            "metric": {
+              "colorSchema": "Green to Red",
+              "colorsRange": [
+                {
+                  "from": 0,
+                  "to": 10000
+                }
+              ],
+              "invertColors": false,
+              "labels": {
+                "show": true
+              },
+              "metricColorMode": "None",
+              "percentageMode": false,
+              "style": {
+                "bgColor": false,
+                "bgFill": "#000",
+                "fontSize": 42,
+                "labelColor": false,
+                "subText": ""
+              },
+              "useRanges": false
+            },
+            "type": "metric"
+          },
+          "title": "Server Uptime [Metricbeat NATS] ECS",
+          "type": "metric"
+        }
+      },
+      "id": "206f1bc0-1e45-11e9-a1b4-79a7ae42ab61-ecs",
+      "type": "visualization",
+      "updated_at": "2019-01-24T07:57:04.084Z",
+      "version": 4
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "index": "metricbeat-*",
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Total Connections [Metricbeat NATS] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "Total Connections",
+                "field": "nats.stats.total_connections"
+              },
+              "schema": "metric",
+              "type": "avg"
+            }
+          ],
+          "params": {
+            "addLegend": false,
+            "addTooltip": true,
+            "metric": {
+              "colorSchema": "Green to Red",
+              "colorsRange": [
+                {
+                  "from": 0,
+                  "to": 10000
+                }
+              ],
+              "invertColors": false,
+              "labels": {
+                "show": true
+              },
+              "metricColorMode": "None",
+              "percentageMode": false,
+              "style": {
+                "bgColor": false,
+                "bgFill": "#000",
+                "fontSize": 42,
+                "labelColor": false,
+                "subText": ""
+              },
+              "useRanges": false
+            },
+            "type": "metric"
+          },
+          "title": "Total Connections [Metricbeat NATS] ECS",
+          "type": "metric"
+        }
+      },
+      "id": "4c380ff0-1e45-11e9-a1b4-79a7ae42ab61-ecs",
+      "type": "visualization",
+      "updated_at": "2019-01-24T07:57:32.006Z",
+      "version": 4
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "index": "metricbeat-*",
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Remotes-Subsz-Connz-Routez Timeline [Metricbeat NATS] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "Connections",
+                "field": "nats.connections.total"
+              },
+              "schema": "metric",
+              "type": "avg"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customInterval": "2h",
+                "extended_bounds": {},
+                "field": "@timestamp",
+                "interval": "auto",
+                "min_doc_count": 1
+              },
+              "schema": "segment",
+              "type": "date_histogram"
+            },
+            {
+              "enabled": true,
+              "id": "3",
+              "params": {
+                "customLabel": "Routes",
+                "field": "nats.routes.total"
+              },
+              "schema": "metric",
+              "type": "avg"
+            },
+            {
+              "enabled": true,
+              "id": "4",
+              "params": {
+                "customLabel": "Remotes",
+                "field": "nats.stats.remotes"
+              },
+              "schema": "metric",
+              "type": "avg"
+            },
+            {
+              "enabled": true,
+              "id": "5",
+              "params": {
+                "customLabel": "Subscriptions",
+                "field": "nats.subscriptions.total"
+              },
+              "schema": "metric",
+              "type": "avg"
+            }
+          ],
+          "params": {
+            "addLegend": true,
+            "addTimeMarker": false,
+            "addTooltip": true,
+            "categoryAxes": [
+              {
+                "id": "CategoryAxis-1",
+                "labels": {
+                  "show": true,
+                  "truncate": 100
+                },
+                "position": "bottom",
+                "scale": {
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {},
+                "type": "category"
+              }
+            ],
+            "grid": {
+              "categoryLines": false,
+              "style": {
+                "color": "#eee"
+              }
+            },
+            "legendPosition": "right",
+            "seriesParams": [
+              {
+                "data": {
+                  "id": "1",
+                  "label": "Connections"
+                },
+                "drawLinesBetweenPoints": true,
+                "interpolate": "linear",
+                "mode": "stacked",
+                "show": "true",
+                "showCircles": true,
+                "type": "area",
+                "valueAxis": "ValueAxis-1"
+              },
+              {
+                "data": {
+                  "id": "3",
+                  "label": "Routes"
+                },
+                "drawLinesBetweenPoints": true,
+                "interpolate": "linear",
+                "mode": "stacked",
+                "show": true,
+                "showCircles": true,
+                "type": "area",
+                "valueAxis": "ValueAxis-1"
+              },
+              {
+                "data": {
+                  "id": "4",
+                  "label": "Remotes"
+                },
+                "drawLinesBetweenPoints": true,
+                "interpolate": "linear",
+                "mode": "stacked",
+                "show": true,
+                "showCircles": true,
+                "type": "area",
+                "valueAxis": "ValueAxis-1"
+              },
+              {
+                "data": {
+                  "id": "5",
+                  "label": "Subscriptions"
+                },
+                "drawLinesBetweenPoints": true,
+                "interpolate": "linear",
+                "mode": "stacked",
+                "show": true,
+                "showCircles": true,
+                "type": "area",
+                "valueAxis": "ValueAxis-1"
+              }
+            ],
+            "times": [],
+            "type": "area",
+            "valueAxes": [
+              {
+                "id": "ValueAxis-1",
+                "labels": {
+                  "filter": false,
+                  "rotate": 0,
+                  "show": true,
+                  "truncate": 100
+                },
+                "name": "LeftAxis-1",
+                "position": "left",
+                "scale": {
+                  "mode": "normal",
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {
+                  "text": "Connections"
+                },
+                "type": "value"
+              }
+            ]
+          },
+          "title": "Remotes-Subsz-Connz-Routez Timeline [Metricbeat NATS] ECS",
+          "type": "area"
+        }
+      },
+      "id": "199d3d30-1e46-11e9-a1b4-79a7ae42ab61-ecs",
+      "type": "visualization",
+      "updated_at": "2019-01-24T07:53:31.785Z",
+      "version": 3
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "index": "metricbeat-*",
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Subscription Stats Timeline [Metricbeat NATS] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "Cache Fanout Avg",
+                "field": "nats.subscriptions.cache.fanout.avg"
+              },
+              "schema": "metric",
+              "type": "avg"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customInterval": "2h",
+                "extended_bounds": {},
+                "field": "@timestamp",
+                "interval": "auto",
+                "min_doc_count": 1
+              },
+              "schema": "segment",
+              "type": "date_histogram"
+            },
+            {
+              "enabled": true,
+              "id": "3",
+              "params": {
+                "customLabel": "Cache Fanout Max",
+                "field": "nats.subscriptions.cache.fanout.max"
+              },
+              "schema": "metric",
+              "type": "avg"
+            },
+            {
+              "enabled": true,
+              "id": "5",
+              "params": {
+                "customLabel": "Inserts",
+                "field": "nats.subscriptions.inserts"
+              },
+              "schema": "metric",
+              "type": "avg"
+            },
+            {
+              "enabled": true,
+              "id": "6",
+              "params": {
+                "customLabel": "Removes",
+                "field": "nats.subscriptions.removes"
+              },
+              "schema": "metric",
+              "type": "avg"
+            },
+            {
+              "enabled": true,
+              "id": "7",
+              "params": {
+                "customLabel": "Matches",
+                "field": "nats.subscriptions.matches"
+              },
+              "schema": "metric",
+              "type": "avg"
+            }
+          ],
+          "params": {
+            "addLegend": true,
+            "addTimeMarker": false,
+            "addTooltip": true,
+            "categoryAxes": [
+              {
+                "id": "CategoryAxis-1",
+                "labels": {
+                  "show": true,
+                  "truncate": 100
+                },
+                "position": "bottom",
+                "scale": {
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {},
+                "type": "category"
+              }
+            ],
+            "grid": {
+              "categoryLines": false,
+              "style": {
+                "color": "#eee"
+              }
+            },
+            "legendPosition": "right",
+            "seriesParams": [
+              {
+                "data": {
+                  "id": "1",
+                  "label": "Cache Fanout Avg"
+                },
+                "drawLinesBetweenPoints": true,
+                "mode": "normal",
+                "show": "true",
+                "showCircles": true,
+                "type": "line",
+                "valueAxis": "ValueAxis-1"
+              },
+              {
+                "data": {
+                  "id": "3",
+                  "label": "Cache Fanout Max"
+                },
+                "drawLinesBetweenPoints": true,
+                "mode": "normal",
+                "show": true,
+                "showCircles": true,
+                "type": "line",
+                "valueAxis": "ValueAxis-1"
+              },
+              {
+                "data": {
+                  "id": "5",
+                  "label": "Inserts"
+                },
+                "drawLinesBetweenPoints": true,
+                "mode": "normal",
+                "show": true,
+                "showCircles": true,
+                "type": "line",
+                "valueAxis": "ValueAxis-1"
+              },
+              {
+                "data": {
+                  "id": "6",
+                  "label": "Removes"
+                },
+                "drawLinesBetweenPoints": true,
+                "mode": "normal",
+                "show": true,
+                "showCircles": true,
+                "type": "line",
+                "valueAxis": "ValueAxis-1"
+              },
+              {
+                "data": {
+                  "id": "7",
+                  "label": "Matches"
+                },
+                "drawLinesBetweenPoints": true,
+                "mode": "normal",
+                "show": true,
+                "showCircles": true,
+                "type": "line",
+                "valueAxis": "ValueAxis-1"
+              }
+            ],
+            "times": [],
+            "type": "line",
+            "valueAxes": [
+              {
+                "id": "ValueAxis-1",
+                "labels": {
+                  "filter": false,
+                  "rotate": 0,
+                  "show": true,
+                  "truncate": 100
+                },
+                "name": "LeftAxis-1",
+                "position": "left",
+                "scale": {
+                  "mode": "normal",
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {
+                  "text": "Cache Fanout Avg"
+                },
+                "type": "value"
+              }
+            ]
+          },
+          "title": "Subscription Stats Timeline [Metricbeat NATS] ECS",
+          "type": "line"
+        }
+      },
+      "id": "754215c0-1e46-11e9-a1b4-79a7ae42ab61-ecs",
+      "type": "visualization",
+      "updated_at": "2019-01-23T14:55:04.899Z",
+      "version": 3
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "index": "metricbeat-*",
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Slow Consumers Timeline [Metricbeat NATS] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "Slow Consumers",
+                "field": "nats.stats.slow_consumers"
+              },
+              "schema": "metric",
+              "type": "avg"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customInterval": "2h",
+                "extended_bounds": {},
+                "field": "@timestamp",
+                "interval": "auto",
+                "min_doc_count": 1
+              },
+              "schema": "segment",
+              "type": "date_histogram"
+            }
+          ],
+          "params": {
+            "addLegend": true,
+            "addTimeMarker": false,
+            "addTooltip": true,
+            "categoryAxes": [
+              {
+                "id": "CategoryAxis-1",
+                "labels": {
+                  "show": true,
+                  "truncate": 100
+                },
+                "position": "bottom",
+                "scale": {
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {},
+                "type": "category"
+              }
+            ],
+            "grid": {
+              "categoryLines": false,
+              "style": {
+                "color": "#eee"
+              }
+            },
+            "legendPosition": "right",
+            "seriesParams": [
+              {
+                "data": {
+                  "id": "1",
+                  "label": "Slow Consumers"
+                },
+                "drawLinesBetweenPoints": true,
+                "mode": "normal",
+                "show": "true",
+                "showCircles": true,
+                "type": "line",
+                "valueAxis": "ValueAxis-1"
+              }
+            ],
+            "times": [],
+            "type": "line",
+            "valueAxes": [
+              {
+                "id": "ValueAxis-1",
+                "labels": {
+                  "filter": false,
+                  "rotate": 0,
+                  "show": true,
+                  "truncate": 100
+                },
+                "name": "LeftAxis-1",
+                "position": "left",
+                "scale": {
+                  "mode": "normal",
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {
+                  "text": "Slow Consumers"
+                },
+                "type": "value"
+              }
+            ]
+          },
+          "title": "Slow Consumers Timeline [Metricbeat NATS] ECS",
+          "type": "line"
+        }
+      },
+      "id": "94534190-1e97-11e9-b9e7-93b3bd2eec90-ecs",
+      "type": "visualization",
+      "updated_at": "2019-01-23T14:53:57.137Z",
+      "version": 2
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "index": "metricbeat-*",
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "IO Bytes Stats [Metricbeat NATS] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "In Bytes",
+                "field": "nats.stats.in.bytes"
+              },
+              "schema": "metric",
+              "type": "avg"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customLabel": "Out Bytes",
+                "field": "nats.stats.out.bytes"
+              },
+              "schema": "metric",
+              "type": "avg"
+            },
+            {
+              "enabled": true,
+              "id": "3",
+              "params": {
+                "customInterval": "2h",
+                "extended_bounds": {},
+                "field": "@timestamp",
+                "interval": "auto",
+                "min_doc_count": 1
+              },
+              "schema": "segment",
+              "type": "date_histogram"
+            }
+          ],
+          "params": {
+            "addLegend": true,
+            "addTimeMarker": false,
+            "addTooltip": true,
+            "categoryAxes": [
+              {
+                "id": "CategoryAxis-1",
+                "labels": {
+                  "show": true,
+                  "truncate": 100
+                },
+                "position": "bottom",
+                "scale": {
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {},
+                "type": "category"
+              }
+            ],
+            "grid": {
+              "categoryLines": false,
+              "style": {
+                "color": "#eee"
+              }
+            },
+            "legendPosition": "right",
+            "seriesParams": [
+              {
+                "data": {
+                  "id": "1",
+                  "label": "In Bytes"
+                },
+                "drawLinesBetweenPoints": true,
+                "mode": "normal",
+                "show": "true",
+                "showCircles": true,
+                "type": "line",
+                "valueAxis": "ValueAxis-1"
+              },
+              {
+                "data": {
+                  "id": "2",
+                  "label": "Out Bytes"
+                },
+                "drawLinesBetweenPoints": true,
+                "mode": "normal",
+                "show": true,
+                "showCircles": true,
+                "type": "line",
+                "valueAxis": "ValueAxis-1"
+              }
+            ],
+            "times": [],
+            "type": "line",
+            "valueAxes": [
+              {
+                "id": "ValueAxis-1",
+                "labels": {
+                  "filter": false,
+                  "rotate": 0,
+                  "show": true,
+                  "truncate": 100
+                },
+                "name": "LeftAxis-1",
+                "position": "left",
+                "scale": {
+                  "mode": "normal",
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {
+                  "text": "IO Bytes"
+                },
+                "type": "value"
+              }
+            ]
+          },
+          "title": "IO Bytes Stats [Metricbeat NATS] ECS",
+          "type": "line"
+        }
+      },
+      "id": "be1d8a20-1e98-11e9-b9e7-93b3bd2eec90-ecs",
+      "type": "visualization",
+      "updated_at": "2019-01-24T07:48:22.914Z",
+      "version": 4
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "index": "metricbeat-*",
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Memory Utilization Timeline [Metricbeat NATS] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "Memory Avg",
+                "field": "nats.stats.mem.bytes"
+              },
+              "schema": "metric",
+              "type": "avg"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customInterval": "2h",
+                "extended_bounds": {},
+                "field": "@timestamp",
+                "interval": "auto",
+                "min_doc_count": 1
+              },
+              "schema": "segment",
+              "type": "date_histogram"
+            }
+          ],
+          "params": {
+            "addLegend": true,
+            "addTimeMarker": false,
+            "addTooltip": true,
+            "categoryAxes": [
+              {
+                "id": "CategoryAxis-1",
+                "labels": {
+                  "show": true,
+                  "truncate": 100
+                },
+                "position": "bottom",
+                "scale": {
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {},
+                "type": "category"
+              }
+            ],
+            "grid": {
+              "categoryLines": false,
+              "style": {
+                "color": "#eee"
+              }
+            },
+            "legendPosition": "right",
+            "seriesParams": [
+              {
+                "data": {
+                  "id": "1",
+                  "label": "Memory Avg"
+                },
+                "drawLinesBetweenPoints": true,
+                "mode": "normal",
+                "show": "true",
+                "showCircles": true,
+                "type": "line",
+                "valueAxis": "ValueAxis-1"
+              }
+            ],
+            "times": [],
+            "type": "line",
+            "valueAxes": [
+              {
+                "id": "ValueAxis-1",
+                "labels": {
+                  "filter": false,
+                  "rotate": 0,
+                  "show": true,
+                  "truncate": 100
+                },
+                "name": "LeftAxis-1",
+                "position": "left",
+                "scale": {
+                  "mode": "normal",
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {
+                  "text": "Memory Avg (Bytes)"
+                },
+                "type": "value"
+              }
+            ]
+          },
+          "title": "Memory Utilization Timeline [Metricbeat NATS] ECS",
+          "type": "line"
+        }
+      },
+      "id": "8204e820-1e99-11e9-b9e7-93b3bd2eec90-ecs",
+      "type": "visualization",
+      "updated_at": "2019-01-24T07:52:55.445Z",
+      "version": 5
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "index": "metricbeat-*",
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "IO Messages Stats [Metricbeat NATS] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "In Messages",
+                "field": "nats.stats.in.messages"
+              },
+              "schema": "metric",
+              "type": "avg"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customLabel": "Out Messages",
+                "field": "nats.stats.out.messages"
+              },
+              "schema": "metric",
+              "type": "avg"
+            },
+            {
+              "enabled": true,
+              "id": "3",
+              "params": {
+                "customInterval": "2h",
+                "extended_bounds": {},
+                "field": "@timestamp",
+                "interval": "auto",
+                "min_doc_count": 1
+              },
+              "schema": "segment",
+              "type": "date_histogram"
+            }
+          ],
+          "params": {
+            "addLegend": true,
+            "addTimeMarker": false,
+            "addTooltip": true,
+            "categoryAxes": [
+              {
+                "id": "CategoryAxis-1",
+                "labels": {
+                  "show": true,
+                  "truncate": 100
+                },
+                "position": "bottom",
+                "scale": {
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {},
+                "type": "category"
+              }
+            ],
+            "grid": {
+              "categoryLines": false,
+              "style": {
+                "color": "#eee"
+              }
+            },
+            "legendPosition": "right",
+            "seriesParams": [
+              {
+                "data": {
+                  "id": "1",
+                  "label": "In Messages"
+                },
+                "drawLinesBetweenPoints": true,
+                "mode": "normal",
+                "show": "true",
+                "showCircles": true,
+                "type": "line",
+                "valueAxis": "ValueAxis-1"
+              },
+              {
+                "data": {
+                  "id": "2",
+                  "label": "Out Messages"
+                },
+                "drawLinesBetweenPoints": true,
+                "mode": "normal",
+                "show": true,
+                "showCircles": true,
+                "type": "line",
+                "valueAxis": "ValueAxis-1"
+              }
+            ],
+            "times": [],
+            "type": "line",
+            "valueAxes": [
+              {
+                "id": "ValueAxis-1",
+                "labels": {
+                  "filter": false,
+                  "rotate": 0,
+                  "show": true,
+                  "truncate": 100
+                },
+                "name": "LeftAxis-1",
+                "position": "left",
+                "scale": {
+                  "mode": "normal",
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {
+                  "text": "IO Messages"
+                },
+                "type": "value"
+              }
+            ]
+          },
+          "title": "IO Messages Stats [Metricbeat NATS] ECS",
+          "type": "line"
+        }
+      },
+      "id": "cdbf4110-1f0d-11e9-a673-d9577e5e50eb-ecs",
+      "type": "visualization",
+      "updated_at": "2019-01-24T07:47:25.774Z",
+      "version": 2
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "index": "metricbeat-*",
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "CPU Utilization Timeline [Metricbeat NATS] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "CPU Avg",
+                "field": "nats.stats.cpu"
+              },
+              "schema": "metric",
+              "type": "avg"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customInterval": "2h",
+                "extended_bounds": {},
+                "field": "@timestamp",
+                "interval": "auto",
+                "min_doc_count": 1
+              },
+              "schema": "segment",
+              "type": "date_histogram"
+            }
+          ],
+          "params": {
+            "addLegend": true,
+            "addTimeMarker": false,
+            "addTooltip": true,
+            "categoryAxes": [
+              {
+                "id": "CategoryAxis-1",
+                "labels": {
+                  "show": true,
+                  "truncate": 100
+                },
+                "position": "bottom",
+                "scale": {
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {},
+                "type": "category"
+              }
+            ],
+            "grid": {
+              "categoryLines": false,
+              "style": {
+                "color": "#eee"
+              }
+            },
+            "legendPosition": "right",
+            "seriesParams": [
+              {
+                "data": {
+                  "id": "1",
+                  "label": "CPU Avg"
+                },
+                "drawLinesBetweenPoints": true,
+                "mode": "normal",
+                "show": "true",
+                "showCircles": true,
+                "type": "line",
+                "valueAxis": "ValueAxis-1"
+              }
+            ],
+            "times": [],
+            "type": "line",
+            "valueAxes": [
+              {
+                "id": "ValueAxis-1",
+                "labels": {
+                  "filter": false,
+                  "rotate": 0,
+                  "show": true,
+                  "truncate": 100
+                },
+                "name": "LeftAxis-1",
+                "position": "left",
+                "scale": {
+                  "mode": "normal",
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {
+                  "text": "CPU Avg (%)"
+                },
+                "type": "value"
+              }
+            ]
+          },
+          "title": "CPU Utilization Timeline [Metricbeat NATS] ECS",
+          "type": "line"
+        }
+      },
+      "id": "138dc660-1f1a-11e9-a673-d9577e5e50eb-ecs",
+      "type": "visualization",
+      "updated_at": "2019-01-24T07:51:51.767Z",
+      "version": 2
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "index": "metricbeat-*",
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Cache Hit Rate Timeline [Metricbeat NATS] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "Cache Hit Rate",
+                "field": "nats.subscriptions.cache.hit_rate"
+              },
+              "schema": "metric",
+              "type": "avg"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customInterval": "2h",
+                "extended_bounds": {},
+                "field": "@timestamp",
+                "interval": "auto",
+                "min_doc_count": 1
+              },
+              "schema": "segment",
+              "type": "date_histogram"
+            }
+          ],
+          "params": {
+            "addLegend": true,
+            "addTimeMarker": false,
+            "addTooltip": true,
+            "categoryAxes": [
+              {
+                "id": "CategoryAxis-1",
+                "labels": {
+                  "show": true,
+                  "truncate": 100
+                },
+                "position": "bottom",
+                "scale": {
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {},
+                "type": "category"
+              }
+            ],
+            "grid": {
+              "categoryLines": false,
+              "style": {
+                "color": "#eee"
+              }
+            },
+            "legendPosition": "right",
+            "seriesParams": [
+              {
+                "data": {
+                  "id": "1",
+                  "label": "Cache Hit Rate"
+                },
+                "drawLinesBetweenPoints": true,
+                "mode": "normal",
+                "show": "true",
+                "showCircles": true,
+                "type": "line",
+                "valueAxis": "ValueAxis-1"
+              }
+            ],
+            "times": [],
+            "type": "line",
+            "valueAxes": [
+              {
+                "id": "ValueAxis-1",
+                "labels": {
+                  "filter": false,
+                  "rotate": 0,
+                  "show": true,
+                  "truncate": 100
+                },
+                "name": "LeftAxis-1",
+                "position": "left",
+                "scale": {
+                  "mode": "normal",
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {
+                  "text": "Cache Hit Rate (%)"
+                },
+                "type": "value"
+              }
+            ]
+          },
+          "title": "Cache Hit Rate Timeline [Metricbeat NATS] ECS",
+          "type": "line"
+        }
+      },
+      "id": "dff743a0-1f1c-11e9-a673-d9577e5e50eb-ecs",
+      "type": "visualization",
+      "updated_at": "2019-01-23T14:57:20.994Z",
+      "version": 2
+    },
+    {
+      "attributes": {
+        "description": "Overview of NATS server status",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "highlightAll": true,
+            "query": {
+              "language": "kuery",
+              "query": ""
+            },
+            "version": true
+          }
+        },
+        "optionsJSON": {
+          "darkTheme": false,
+          "hidePanelTitles": false,
+          "useMargins": true
+        },
+        "panelsJSON": [
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 11,
+              "i": "6",
+              "w": 24,
+              "x": 0,
+              "y": 45
+            },
+            "id": "b129b220-1e44-11e9-a1b4-79a7ae42ab61-ecs",
+            "panelIndex": "6",
+            "type": "visualization",
+            "version": "6.5.4"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 7,
+              "i": "7",
+              "w": 13,
+              "x": 24,
+              "y": 34
+            },
+            "id": "30a61c00-1e45-11e9-a1b4-79a7ae42ab61-ecs",
+            "panelIndex": "7",
+            "type": "visualization",
+            "version": "6.5.4"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 7,
+              "i": "8",
+              "w": 11,
+              "x": 37,
+              "y": 34
+            },
+            "id": "206f1bc0-1e45-11e9-a1b4-79a7ae42ab61-ecs",
+            "panelIndex": "8",
+            "type": "visualization",
+            "version": "6.5.4"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 8,
+              "i": "9",
+              "w": 8,
+              "x": 24,
+              "y": 41
+            },
+            "id": "4c380ff0-1e45-11e9-a1b4-79a7ae42ab61-ecs",
+            "panelIndex": "9",
+            "type": "visualization",
+            "version": "6.5.4"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 11,
+              "i": "11",
+              "w": 24,
+              "x": 0,
+              "y": 34
+            },
+            "id": "199d3d30-1e46-11e9-a1b4-79a7ae42ab61-ecs",
+            "panelIndex": "11",
+            "type": "visualization",
+            "version": "6.5.4"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 10,
+              "i": "12",
+              "w": 18,
+              "x": 15,
+              "y": 0
+            },
+            "id": "754215c0-1e46-11e9-a1b4-79a7ae42ab61-ecs",
+            "panelIndex": "12",
+            "type": "visualization",
+            "version": "6.5.4"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 10,
+              "i": "13",
+              "w": 15,
+              "x": 0,
+              "y": 0
+            },
+            "id": "94534190-1e97-11e9-b9e7-93b3bd2eec90-ecs",
+            "panelIndex": "13",
+            "type": "visualization",
+            "version": "6.5.4"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 12,
+              "i": "14",
+              "w": 24,
+              "x": 24,
+              "y": 10
+            },
+            "id": "be1d8a20-1e98-11e9-b9e7-93b3bd2eec90-ecs",
+            "panelIndex": "14",
+            "type": "visualization",
+            "version": "6.5.4"
+          },
+          {
+            "embeddableConfig": {
+              "vis": {
+                "legendOpen": true
+              }
+            },
+            "gridData": {
+              "h": 12,
+              "i": "15",
+              "w": 24,
+              "x": 24,
+              "y": 22
+            },
+            "id": "8204e820-1e99-11e9-b9e7-93b3bd2eec90-ecs",
+            "panelIndex": "15",
+            "type": "visualization",
+            "version": "6.5.4"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 12,
+              "i": "16",
+              "w": 24,
+              "x": 0,
+              "y": 10
+            },
+            "id": "cdbf4110-1f0d-11e9-a673-d9577e5e50eb-ecs",
+            "panelIndex": "16",
+            "type": "visualization",
+            "version": "6.3.2"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 12,
+              "i": "17",
+              "w": 24,
+              "x": 0,
+              "y": 22
+            },
+            "id": "138dc660-1f1a-11e9-a673-d9577e5e50eb-ecs",
+            "panelIndex": "17",
+            "type": "visualization",
+            "version": "6.3.2"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 10,
+              "i": "18",
+              "w": 15,
+              "x": 33,
+              "y": 0
+            },
+            "id": "dff743a0-1f1c-11e9-a673-d9577e5e50eb-ecs",
+            "panelIndex": "18",
+            "type": "visualization",
+            "version": "6.3.2"
+          }
+        ],
+        "timeRestore": false,
+        "title": "[Metricbeat NATS] Overview ECS",
+        "version": 1
+      },
+      "id": "Metricbeat-Nats-Dashboard-ecs",
+      "type": "dashboard",
+      "updated_at": "2019-01-24T08:13:29.732Z",
+      "version": 4
+    }
+  ],
+  "version": "6.3.2"
+}

--- a/dev/package-beats/nats-1.0.0/manifest.yml
+++ b/dev/package-beats/nats-1.0.0/manifest.yml
@@ -1,0 +1,14 @@
+name: nats
+title: nats
+version: 1.0.0
+description: |
+  nats Module
+type: ""
+categories:
+- logs
+- metrics
+requirement:
+  kibana:
+    version:
+      min: 6.7.0
+      max: 7.6.0

--- a/dev/package-beats/netflow-module-1.0.0/kibana/dashboard/filebeat-netflow-autonomous-systems.json
+++ b/dev/package-beats/netflow-module-1.0.0/kibana/dashboard/filebeat-netflow-autonomous-systems.json
@@ -1,0 +1,597 @@
+{
+  "objects": [
+    {
+      "attributes": {
+        "description": "Autonomous systems Netflow",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [
+              {
+                "$state": {
+                  "store": "globalState"
+                },
+                "meta": {
+                  "alias": null,
+                  "disabled": false,
+                  "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                  "key": "input.type",
+                  "negate": false,
+                  "params": {
+                    "query": "netflow"
+                  },
+                  "type": "phrase",
+                  "value": "netflow"
+                },
+                "query": {
+                  "match": {
+                    "input.type": {
+                      "query": "netflow",
+                      "type": "phrase"
+                    }
+                  }
+                }
+              }
+            ],
+            "highlightAll": true,
+            "version": true
+          }
+        },
+        "optionsJSON": {
+          "darkTheme": false
+        },
+        "panelsJSON": [
+          {
+            "col": 1,
+            "panelIndex": 1,
+            "panelRefName": "panel_0",
+            "row": 1,
+            "size_x": 12,
+            "size_y": 1
+          },
+          {
+            "col": 7,
+            "panelIndex": 2,
+            "panelRefName": "panel_1",
+            "row": 4,
+            "size_x": 6,
+            "size_y": 2
+          },
+          {
+            "col": 7,
+            "panelIndex": 3,
+            "panelRefName": "panel_2",
+            "row": 6,
+            "size_x": 6,
+            "size_y": 2
+          },
+          {
+            "col": 1,
+            "panelIndex": 4,
+            "panelRefName": "panel_3",
+            "row": 4,
+            "size_x": 6,
+            "size_y": 2
+          },
+          {
+            "col": 1,
+            "panelIndex": 5,
+            "panelRefName": "panel_4",
+            "row": 6,
+            "size_x": 6,
+            "size_y": 2
+          },
+          {
+            "col": 1,
+            "panelIndex": 6,
+            "panelRefName": "panel_5",
+            "row": 2,
+            "size_x": 4,
+            "size_y": 2
+          },
+          {
+            "col": 5,
+            "panelIndex": 7,
+            "panelRefName": "panel_6",
+            "row": 2,
+            "size_x": 4,
+            "size_y": 2
+          },
+          {
+            "col": 9,
+            "panelIndex": 8,
+            "panelRefName": "panel_7",
+            "row": 2,
+            "size_x": 4,
+            "size_y": 2
+          }
+        ],
+        "timeRestore": false,
+        "title": "[Filebeat Netflow] Autonomous Systems",
+        "uiStateJSON": {},
+        "version": 1
+      },
+      "id": "c64665f9-d222-421e-90b0-c7310d944b8a",
+      "migrationVersion": {
+        "dashboard": "7.0.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+          "type": "index-pattern"
+        },
+        {
+          "id": "d4e6520a-9ced-47c9-a8f2-7246e8cbd2d3",
+          "name": "panel_0",
+          "type": "visualization"
+        },
+        {
+          "id": "12aad647-c45d-4667-a029-152c1a97cbbc",
+          "name": "panel_1",
+          "type": "visualization"
+        },
+        {
+          "id": "d27b5d74-b3b4-4311-a0e6-08ff8f4345df",
+          "name": "panel_2",
+          "type": "visualization"
+        },
+        {
+          "id": "751ecb6f-11c3-458d-b039-f6d57a6379fa",
+          "name": "panel_3",
+          "type": "visualization"
+        },
+        {
+          "id": "f75063c7-48b7-4de4-b8cb-d07eb2cea0e9",
+          "name": "panel_4",
+          "type": "visualization"
+        },
+        {
+          "id": "f7808e70-df2a-4532-a350-966704567c24",
+          "name": "panel_5",
+          "type": "visualization"
+        },
+        {
+          "id": "aed09724-0a69-4331-84f5-3d2067c43930",
+          "name": "panel_6",
+          "type": "visualization"
+        },
+        {
+          "id": "f531f957-e8c0-497a-ad41-ef39c2d29671",
+          "name": "panel_7",
+          "type": "visualization"
+        }
+      ],
+      "type": "dashboard",
+      "updated_at": "2019-07-11T04:44:31.601Z",
+      "version": "WzM0MDMsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "query_string": {
+                "analyze_wildcard": true,
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "Dashboard Navigation [Filebeat Netflow]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "listeners": {},
+          "params": {
+            "markdown": "[Overview](#/dashboard/34e26884-161a-4448-9556-43b5bf2f62a2) | [Conversation Partners](#/dashboard/acd7a630-0c71-4840-bc9e-4a3801374a32) | [Traffic Analysis](#/dashboard/38012abe-c611-4124-8497-381fcd85acc8) | [Top-N](#/dashboard/14387a13-53bc-43a4-b9cd-63977aa8d87c) | [Geo Location](#/dashboard/77326664-23be-4bf1-a126-6d7e60cfc024) | [Autonomous Systems](#/dashboard/c64665f9-d222-421e-90b0-c7310d944b8a) | [Flow Exporters](#/dashboard/feebb4e6-b13e-4e4e-b9fc-d3a178276425) | [Raw Flow Records](#/dashboard/94972700-de4a-4272-9143-2fa8d4981365)\n***"
+          },
+          "title": "Dashboard Navigation [Filebeat Netflow]",
+          "type": "markdown"
+        }
+      },
+      "id": "d4e6520a-9ced-47c9-a8f2-7246e8cbd2d3",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:38.685Z",
+      "version": "WzM0NjQsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "query_string": {
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "Destination Autonomous Systems (bytes) [Filebeat Netflow]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "listeners": {},
+          "params": {
+            "expression": ".es(index=\"filebeat-*\", metric=\"sum:network.bytes\", split=\"destination.as.organization.name:10\", kibana=true).scale_interval(1s).fit(mode=scale).if(operator=\"lt\", if=0, then=0).trim(start=2,end=1).label(regex=\"^.* destination.as.organization.name:(.+) \u003e .*$\", label=\"$1\").lines(width=1, stack=true, fill=1).yaxis(label=\"bytes / sec\", min=0)",
+            "interval": "auto"
+          },
+          "title": "Destination Autonomous Systems (bytes) [Filebeat Netflow]",
+          "type": "timelion"
+        }
+      },
+      "id": "12aad647-c45d-4667-a029-152c1a97cbbc",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:31.601Z",
+      "version": "WzM0MDUsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "query_string": {
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "Destination Autonomous Systems (packets) [Filebeat Netflow]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "listeners": {},
+          "params": {
+            "expression": ".es(index=\"filebeat-*\", metric=\"sum:network.packets\", split=\"destination.as.organization.name:10\", kibana=true).scale_interval(1s).fit(mode=scale).if(operator=\"lt\", if=0, then=0).trim(start=2,end=1).label(regex=\"^.* destination.as.organization.name:(.+) \u003e .*$\", label=\"$1\").lines(width=1, stack=true, fill=1).yaxis(label=\"packets / sec\", min=0)",
+            "interval": "auto"
+          },
+          "title": "Destination Autonomous Systems (packets) [Filebeat Netflow]",
+          "type": "timelion"
+        }
+      },
+      "id": "d27b5d74-b3b4-4311-a0e6-08ff8f4345df",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:31.601Z",
+      "version": "WzM0MDYsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "query_string": {
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "Source Autonomous Systems (bytes) [Filebeat Netflow]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "listeners": {},
+          "params": {
+            "expression": ".es(index=\"filebeat-*\", metric=\"sum:network.bytes\", split=\"source.as.organization.name:10\", kibana=true).scale_interval(1s).fit(mode=scale).if(operator=\"lt\", if=0, then=0).trim(start=2,end=1).label(regex=\"^.* source.as.organization.name:(.+) \u003e .*$\", label=\"$1\").lines(width=1, stack=true, fill=1).yaxis(label=\"bytes / sec\", min=0)",
+            "interval": "auto"
+          },
+          "title": "Source Autonomous Systems (bytes) [Filebeat Netflow]",
+          "type": "timelion"
+        }
+      },
+      "id": "751ecb6f-11c3-458d-b039-f6d57a6379fa",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:31.601Z",
+      "version": "WzM0MDcsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "query_string": {
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "Source Autonomous Systems (packets) [Filebeat Netflow]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "listeners": {},
+          "params": {
+            "expression": ".es(index=\"filebeat-*\", metric=\"sum:network.packets\", split=\"source.as.organization.name:10\", kibana=true).scale_interval(1s).fit(mode=scale).if(operator=\"lt\", if=0, then=0).trim(start=2,end=1).label(regex=\"^.* source.as.organization.name:(.+) \u003e .*$\", label=\"$1\").lines(width=1, stack=true, fill=1).yaxis(label=\"packets / sec\", min=0)",
+            "interval": "auto"
+          },
+          "title": "Source Autonomous Systems (packets) [Filebeat Netflow]",
+          "type": "timelion"
+        }
+      },
+      "id": "f75063c7-48b7-4de4-b8cb-d07eb2cea0e9",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:31.601Z",
+      "version": "WzM0MDgsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "query_string": {
+                "analyze_wildcard": true,
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "Destination and Source ASs (flow records) [Filebeat Netflow]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "Flow Records"
+              },
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customLabel": "Destination AS",
+                "field": "destination.as.organization.name",
+                "order": "desc",
+                "orderBy": "1",
+                "size": 50
+              },
+              "schema": "segment",
+              "type": "terms"
+            },
+            {
+              "enabled": true,
+              "id": "3",
+              "params": {
+                "customLabel": "Source AS",
+                "field": "source.as.organization.name",
+                "order": "desc",
+                "orderBy": "1",
+                "size": 50
+              },
+              "schema": "segment",
+              "type": "terms"
+            }
+          ],
+          "listeners": {},
+          "params": {
+            "addLegend": true,
+            "addTooltip": true,
+            "isDonut": true,
+            "legendPosition": "right"
+          },
+          "title": "Destination and Source ASs (flow records) [Filebeat Netflow]",
+          "type": "pie"
+        }
+      },
+      "id": "f7808e70-df2a-4532-a350-966704567c24",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:31.601Z",
+      "version": "WzM0MDksMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "query_string": {
+                "analyze_wildcard": true,
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "Destinations and Sources (flow records) [Filebeat Netflow]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "Flow Records"
+              },
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customLabel": "Destination",
+                "field": "destination.ip",
+                "order": "desc",
+                "orderBy": "1",
+                "size": 50
+              },
+              "schema": "segment",
+              "type": "terms"
+            },
+            {
+              "enabled": true,
+              "id": "3",
+              "params": {
+                "customLabel": "Source",
+                "field": "source.ip",
+                "order": "desc",
+                "orderBy": "1",
+                "size": 50
+              },
+              "schema": "segment",
+              "type": "terms"
+            }
+          ],
+          "listeners": {},
+          "params": {
+            "addLegend": true,
+            "addTooltip": true,
+            "isDonut": true,
+            "legendPosition": "right"
+          },
+          "title": "Destinations and Sources (flow records) [Filebeat Netflow]",
+          "type": "pie"
+        }
+      },
+      "id": "aed09724-0a69-4331-84f5-3d2067c43930",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:35.630Z",
+      "version": "WzM0MzUsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "query_string": {
+                "analyze_wildcard": true,
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "Destination and Source Ports (flow records) [Filebeat Netflow]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "Flow Records"
+              },
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customLabel": "Destination Port",
+                "field": "destination.port",
+                "order": "desc",
+                "orderBy": "1",
+                "size": 50
+              },
+              "schema": "segment",
+              "type": "terms"
+            },
+            {
+              "enabled": true,
+              "id": "3",
+              "params": {
+                "customLabel": "Source Port",
+                "field": "source.port",
+                "order": "desc",
+                "orderBy": "1",
+                "size": 50
+              },
+              "schema": "segment",
+              "type": "terms"
+            }
+          ],
+          "listeners": {},
+          "params": {
+            "addLegend": true,
+            "addTooltip": true,
+            "isDonut": true,
+            "legendPosition": "right"
+          },
+          "title": "Destination and Source Ports (flow records) [Filebeat Netflow]",
+          "type": "pie"
+        }
+      },
+      "id": "f531f957-e8c0-497a-ad41-ef39c2d29671",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:35.630Z",
+      "version": "WzM0MzYsMV0="
+    }
+  ],
+  "version": "7.2.0"
+}

--- a/dev/package-beats/netflow-module-1.0.0/kibana/dashboard/filebeat-netflow-conversation-partners.json
+++ b/dev/package-beats/netflow-module-1.0.0/kibana/dashboard/filebeat-netflow-conversation-partners.json
@@ -1,0 +1,599 @@
+{
+  "objects": [
+    {
+      "attributes": {
+        "description": "Netflow conversation partners",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [
+              {
+                "$state": {
+                  "store": "globalState"
+                },
+                "meta": {
+                  "alias": null,
+                  "disabled": false,
+                  "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                  "key": "input.type",
+                  "negate": false,
+                  "params": {
+                    "query": "netflow"
+                  },
+                  "type": "phrase",
+                  "value": "netflow"
+                },
+                "query": {
+                  "match": {
+                    "input.type": {
+                      "query": "netflow",
+                      "type": "phrase"
+                    }
+                  }
+                }
+              }
+            ],
+            "highlightAll": true,
+            "version": true
+          }
+        },
+        "optionsJSON": {
+          "darkTheme": false
+        },
+        "panelsJSON": [
+          {
+            "col": 1,
+            "panelIndex": 1,
+            "panelRefName": "panel_0",
+            "row": 4,
+            "size_x": 12,
+            "size_y": 5
+          },
+          {
+            "col": 9,
+            "panelIndex": 2,
+            "panelRefName": "panel_1",
+            "row": 2,
+            "size_x": 4,
+            "size_y": 2
+          },
+          {
+            "col": 1,
+            "panelIndex": 3,
+            "panelRefName": "panel_2",
+            "row": 2,
+            "size_x": 4,
+            "size_y": 2
+          },
+          {
+            "col": 5,
+            "panelIndex": 4,
+            "panelRefName": "panel_3",
+            "row": 2,
+            "size_x": 4,
+            "size_y": 2
+          },
+          {
+            "col": 1,
+            "panelIndex": 5,
+            "panelRefName": "panel_4",
+            "row": 1,
+            "size_x": 12,
+            "size_y": 1
+          }
+        ],
+        "timeRestore": false,
+        "title": "[Filebeat Netflow] Conversation Partners",
+        "uiStateJSON": {
+          "P-1": {
+            "vis": {
+              "params": {
+                "sort": {
+                  "columnIndex": 2,
+                  "direction": "desc"
+                }
+              }
+            }
+          }
+        },
+        "version": 1
+      },
+      "id": "acd7a630-0c71-4840-bc9e-4a3801374a32",
+      "migrationVersion": {
+        "dashboard": "7.0.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+          "type": "index-pattern"
+        },
+        {
+          "id": "ebea013f-9b5b-4f61-a9c8-c62bebf62ae9",
+          "name": "panel_0",
+          "type": "visualization"
+        },
+        {
+          "id": "ae334aec-31fa-4df7-a064-40b18831d819",
+          "name": "panel_1",
+          "type": "visualization"
+        },
+        {
+          "id": "e822f94c-5f65-4963-a540-74ca9c25bd2d",
+          "name": "panel_2",
+          "type": "visualization"
+        },
+        {
+          "id": "c54f5529-e6d7-4c26-8e8e-3b35de132035",
+          "name": "panel_3",
+          "type": "visualization"
+        },
+        {
+          "id": "d4e6520a-9ced-47c9-a8f2-7246e8cbd2d3",
+          "name": "panel_4",
+          "type": "visualization"
+        }
+      ],
+      "type": "dashboard",
+      "updated_at": "2019-07-11T04:44:32.531Z",
+      "version": "WzM0MTIsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "query_string": {
+                "analyze_wildcard": true,
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "Conversation Partners [Filebeat Netflow]",
+        "uiStateJSON": {
+          "vis": {
+            "params": {
+              "sort": {
+                "columnIndex": 2,
+                "direction": "desc"
+              }
+            }
+          }
+        },
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "Bytes",
+                "field": "network.bytes"
+              },
+              "schema": "metric",
+              "type": "sum"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customLabel": "Packets",
+                "field": "network.packets"
+              },
+              "schema": "metric",
+              "type": "sum"
+            },
+            {
+              "enabled": true,
+              "id": "3",
+              "params": {
+                "customLabel": "Source",
+                "field": "source.ip",
+                "order": "desc",
+                "orderBy": "1",
+                "size": 50
+              },
+              "schema": "bucket",
+              "type": "terms"
+            },
+            {
+              "enabled": true,
+              "id": "4",
+              "params": {
+                "customLabel": "Destination",
+                "field": "destination.ip",
+                "order": "desc",
+                "orderBy": "1",
+                "size": 50
+              },
+              "schema": "bucket",
+              "type": "terms"
+            },
+            {
+              "enabled": true,
+              "id": "5",
+              "params": {
+                "customLabel": "Flow Records"
+              },
+              "schema": "metric",
+              "type": "count"
+            }
+          ],
+          "listeners": {},
+          "params": {
+            "perPage": 10,
+            "showMeticsAtAllLevels": false,
+            "showPartialRows": false,
+            "showTotal": false,
+            "sort": {
+              "columnIndex": 2,
+              "direction": "desc"
+            },
+            "totalFunc": "sum"
+          },
+          "title": "Conversation Partners [Filebeat Netflow]",
+          "type": "table"
+        }
+      },
+      "id": "ebea013f-9b5b-4f61-a9c8-c62bebf62ae9",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:32.531Z",
+      "version": "WzM0MTMsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "language": "lucene",
+              "query": {
+                "query_string": {
+                  "analyze_wildcard": true,
+                  "query": "*"
+                }
+              }
+            }
+          }
+        },
+        "title": "IP Version and Protocols (bytes) [Filebeat Netflow]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "Bytes",
+                "field": "network.bytes"
+              },
+              "schema": "metric",
+              "type": "sum"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customLabel": "IP Version",
+                "field": "network.type",
+                "missingBucket": true,
+                "missingBucketLabel": "unset ip version",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 5
+              },
+              "schema": "segment",
+              "type": "terms"
+            },
+            {
+              "enabled": true,
+              "id": "3",
+              "params": {
+                "customLabel": "Protocol",
+                "field": "network.transport",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 50
+              },
+              "schema": "segment",
+              "type": "terms"
+            }
+          ],
+          "params": {
+            "addLegend": true,
+            "addTooltip": true,
+            "dimensions": {
+              "buckets": [
+                {
+                  "accessor": 0,
+                  "aggType": "terms",
+                  "format": {
+                    "id": "terms",
+                    "params": {
+                      "id": "string",
+                      "missingBucketLabel": "Missing",
+                      "otherBucketLabel": "Other"
+                    }
+                  },
+                  "params": {}
+                },
+                {
+                  "accessor": 2,
+                  "aggType": "terms",
+                  "format": {
+                    "id": "terms",
+                    "params": {
+                      "id": "string",
+                      "missingBucketLabel": "Missing",
+                      "otherBucketLabel": "Other"
+                    }
+                  },
+                  "params": {}
+                }
+              ],
+              "metric": {
+                "accessor": 1,
+                "aggType": "sum",
+                "format": {
+                  "id": "bytes"
+                },
+                "params": {}
+              }
+            },
+            "isDonut": true,
+            "labels": {
+              "last_level": true,
+              "show": false,
+              "truncate": 100,
+              "values": true
+            },
+            "legendPosition": "right",
+            "type": "pie"
+          },
+          "title": "IP Version and Protocols (bytes) [Filebeat Netflow]",
+          "type": "pie"
+        }
+      },
+      "id": "ae334aec-31fa-4df7-a064-40b18831d819",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:36.725Z",
+      "version": "WzM0MzksMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "query_string": {
+                "analyze_wildcard": true,
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "Destinations and Sources (bytes) [Filebeat Netflow]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "Bytes",
+                "field": "network.bytes"
+              },
+              "schema": "metric",
+              "type": "sum"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customLabel": "Destination",
+                "field": "destination.ip",
+                "order": "desc",
+                "orderBy": "1",
+                "size": 50
+              },
+              "schema": "segment",
+              "type": "terms"
+            },
+            {
+              "enabled": true,
+              "id": "3",
+              "params": {
+                "customLabel": "Source",
+                "field": "source.ip",
+                "order": "desc",
+                "orderBy": "1",
+                "size": 50
+              },
+              "schema": "segment",
+              "type": "terms"
+            }
+          ],
+          "listeners": {},
+          "params": {
+            "addLegend": true,
+            "addTooltip": true,
+            "isDonut": true,
+            "legendPosition": "right"
+          },
+          "title": "Destinations and Sources (bytes) [Filebeat Netflow]",
+          "type": "pie"
+        }
+      },
+      "id": "e822f94c-5f65-4963-a540-74ca9c25bd2d",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:32.531Z",
+      "version": "WzM0MTUsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "query_string": {
+                "analyze_wildcard": true,
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "Destination and Source Ports (bytes) [Filebeat Netflow]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "Bytes",
+                "field": "network.bytes"
+              },
+              "schema": "metric",
+              "type": "sum"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customLabel": "Destination Port",
+                "field": "destination.port",
+                "order": "desc",
+                "orderBy": "1",
+                "size": 50
+              },
+              "schema": "segment",
+              "type": "terms"
+            },
+            {
+              "enabled": true,
+              "id": "3",
+              "params": {
+                "customLabel": "Source Port",
+                "field": "source.port",
+                "order": "desc",
+                "orderBy": "1",
+                "size": 50
+              },
+              "schema": "segment",
+              "type": "terms"
+            }
+          ],
+          "listeners": {},
+          "params": {
+            "addLegend": true,
+            "addTooltip": true,
+            "isDonut": true,
+            "legendPosition": "right"
+          },
+          "title": "Destination and Source Ports (bytes) [Filebeat Netflow]",
+          "type": "pie"
+        }
+      },
+      "id": "c54f5529-e6d7-4c26-8e8e-3b35de132035",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:32.531Z",
+      "version": "WzM0MTYsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "query_string": {
+                "analyze_wildcard": true,
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "Dashboard Navigation [Filebeat Netflow]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "listeners": {},
+          "params": {
+            "markdown": "[Overview](#/dashboard/34e26884-161a-4448-9556-43b5bf2f62a2) | [Conversation Partners](#/dashboard/acd7a630-0c71-4840-bc9e-4a3801374a32) | [Traffic Analysis](#/dashboard/38012abe-c611-4124-8497-381fcd85acc8) | [Top-N](#/dashboard/14387a13-53bc-43a4-b9cd-63977aa8d87c) | [Geo Location](#/dashboard/77326664-23be-4bf1-a126-6d7e60cfc024) | [Autonomous Systems](#/dashboard/c64665f9-d222-421e-90b0-c7310d944b8a) | [Flow Exporters](#/dashboard/feebb4e6-b13e-4e4e-b9fc-d3a178276425) | [Raw Flow Records](#/dashboard/94972700-de4a-4272-9143-2fa8d4981365)\n***"
+          },
+          "title": "Dashboard Navigation [Filebeat Netflow]",
+          "type": "markdown"
+        }
+      },
+      "id": "d4e6520a-9ced-47c9-a8f2-7246e8cbd2d3",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:38.685Z",
+      "version": "WzM0NjQsMV0="
+    }
+  ],
+  "version": "7.2.0"
+}

--- a/dev/package-beats/netflow-module-1.0.0/kibana/dashboard/filebeat-netflow-flow-exporters.json
+++ b/dev/package-beats/netflow-module-1.0.0/kibana/dashboard/filebeat-netflow-flow-exporters.json
@@ -1,0 +1,554 @@
+{
+  "objects": [
+    {
+      "attributes": {
+        "description": "Netflow exporters",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [
+              {
+                "$state": {
+                  "store": "globalState"
+                },
+                "meta": {
+                  "alias": null,
+                  "disabled": false,
+                  "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                  "key": "input.type",
+                  "negate": false,
+                  "params": {
+                    "query": "netflow"
+                  },
+                  "type": "phrase",
+                  "value": "netflow"
+                },
+                "query": {
+                  "match": {
+                    "input.type": {
+                      "query": "netflow",
+                      "type": "phrase"
+                    }
+                  }
+                }
+              }
+            ],
+            "highlightAll": true,
+            "version": true
+          }
+        },
+        "optionsJSON": {
+          "darkTheme": false
+        },
+        "panelsJSON": [
+          {
+            "col": 1,
+            "panelIndex": 1,
+            "panelRefName": "panel_0",
+            "row": 1,
+            "size_x": 12,
+            "size_y": 1
+          },
+          {
+            "col": 1,
+            "panelIndex": 2,
+            "panelRefName": "panel_1",
+            "row": 2,
+            "size_x": 4,
+            "size_y": 2
+          },
+          {
+            "col": 5,
+            "panelIndex": 3,
+            "panelRefName": "panel_2",
+            "row": 2,
+            "size_x": 4,
+            "size_y": 2
+          },
+          {
+            "col": 9,
+            "panelIndex": 4,
+            "panelRefName": "panel_3",
+            "row": 2,
+            "size_x": 4,
+            "size_y": 2
+          },
+          {
+            "col": 7,
+            "panelIndex": 5,
+            "panelRefName": "panel_4",
+            "row": 4,
+            "size_x": 6,
+            "size_y": 2
+          },
+          {
+            "col": 7,
+            "panelIndex": 6,
+            "panelRefName": "panel_5",
+            "row": 6,
+            "size_x": 6,
+            "size_y": 2
+          },
+          {
+            "col": 1,
+            "panelIndex": 8,
+            "panelRefName": "panel_6",
+            "row": 6,
+            "size_x": 6,
+            "size_y": 2
+          },
+          {
+            "col": 1,
+            "panelIndex": 10,
+            "panelRefName": "panel_7",
+            "row": 4,
+            "size_x": 6,
+            "size_y": 2
+          }
+        ],
+        "timeRestore": false,
+        "title": "[Filebeat Netflow] Flow Exporters",
+        "uiStateJSON": {},
+        "version": 1
+      },
+      "id": "feebb4e6-b13e-4e4e-b9fc-d3a178276425",
+      "migrationVersion": {
+        "dashboard": "7.0.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+          "type": "index-pattern"
+        },
+        {
+          "id": "d4e6520a-9ced-47c9-a8f2-7246e8cbd2d3",
+          "name": "panel_0",
+          "type": "visualization"
+        },
+        {
+          "id": "441c6c50-fa1a-489c-96c6-76f7925dea24",
+          "name": "panel_1",
+          "type": "visualization"
+        },
+        {
+          "id": "14c7136d-b4aa-4367-9461-52bf8b5c4796",
+          "name": "panel_2",
+          "type": "visualization"
+        },
+        {
+          "id": "4ac97841-c89f-4d50-b3c6-6253f7e1dd1a",
+          "name": "panel_3",
+          "type": "visualization"
+        },
+        {
+          "id": "85ebf558-402b-45d2-a186-e15f8673ec07",
+          "name": "panel_4",
+          "type": "visualization"
+        },
+        {
+          "id": "f86a7769-8ef6-408d-bbe3-985d0ea0a3f7",
+          "name": "panel_5",
+          "type": "visualization"
+        },
+        {
+          "id": "1cd36f5d-d9c7-4098-acdb-14d312ecfb72",
+          "name": "panel_6",
+          "type": "visualization"
+        },
+        {
+          "id": "d3df8d28-65f8-4ea1-8b33-f479380a0600",
+          "name": "panel_7",
+          "type": "visualization"
+        }
+      ],
+      "type": "dashboard",
+      "updated_at": "2019-07-11T04:44:33.653Z",
+      "version": "WzM0MTgsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "query_string": {
+                "analyze_wildcard": true,
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "Dashboard Navigation [Filebeat Netflow]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "listeners": {},
+          "params": {
+            "markdown": "[Overview](#/dashboard/34e26884-161a-4448-9556-43b5bf2f62a2) | [Conversation Partners](#/dashboard/acd7a630-0c71-4840-bc9e-4a3801374a32) | [Traffic Analysis](#/dashboard/38012abe-c611-4124-8497-381fcd85acc8) | [Top-N](#/dashboard/14387a13-53bc-43a4-b9cd-63977aa8d87c) | [Geo Location](#/dashboard/77326664-23be-4bf1-a126-6d7e60cfc024) | [Autonomous Systems](#/dashboard/c64665f9-d222-421e-90b0-c7310d944b8a) | [Flow Exporters](#/dashboard/feebb4e6-b13e-4e4e-b9fc-d3a178276425) | [Raw Flow Records](#/dashboard/94972700-de4a-4272-9143-2fa8d4981365)\n***"
+          },
+          "title": "Dashboard Navigation [Filebeat Netflow]",
+          "type": "markdown"
+        }
+      },
+      "id": "d4e6520a-9ced-47c9-a8f2-7246e8cbd2d3",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:38.685Z",
+      "version": "WzM0NjQsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "query_string": {
+                "analyze_wildcard": true,
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "Flow Exporters (flow records) [Filebeat Netflow]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customLabel": "Flow Exporter",
+                "field": "agent.hostname",
+                "order": "desc",
+                "orderBy": "1",
+                "size": 50
+              },
+              "schema": "segment",
+              "type": "terms"
+            }
+          ],
+          "listeners": {},
+          "params": {
+            "addLegend": true,
+            "addTooltip": true,
+            "isDonut": true,
+            "legendPosition": "right"
+          },
+          "title": "Flow Exporters (flow records) [Filebeat Netflow]",
+          "type": "pie"
+        }
+      },
+      "id": "441c6c50-fa1a-489c-96c6-76f7925dea24",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:33.653Z",
+      "version": "WzM0MjAsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "query_string": {
+                "analyze_wildcard": true,
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "Ingress Interfaces (flow records) [Filebeat Netflow]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customLabel": "Ingress Interface",
+                "field": "netflow.ingress_interface",
+                "order": "desc",
+                "orderBy": "1",
+                "size": 50
+              },
+              "schema": "segment",
+              "type": "terms"
+            }
+          ],
+          "listeners": {},
+          "params": {
+            "addLegend": true,
+            "addTooltip": true,
+            "isDonut": true,
+            "legendPosition": "right"
+          },
+          "title": "Ingress Interfaces (flow records) [Filebeat Netflow]",
+          "type": "pie"
+        }
+      },
+      "id": "14c7136d-b4aa-4367-9461-52bf8b5c4796",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:33.653Z",
+      "version": "WzM0MjEsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "query_string": {
+                "analyze_wildcard": true,
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "Egress Interfaces (flow records) [Filebeat Netflow]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "Flow Records"
+              },
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customLabel": "Egress Interface",
+                "field": "netflow.egress_interface",
+                "order": "desc",
+                "orderBy": "1",
+                "size": 50
+              },
+              "schema": "segment",
+              "type": "terms"
+            }
+          ],
+          "listeners": {},
+          "params": {
+            "addLegend": true,
+            "addTooltip": true,
+            "isDonut": true,
+            "legendPosition": "right"
+          },
+          "title": "Egress Interfaces (flow records) [Filebeat Netflow]",
+          "type": "pie"
+        }
+      },
+      "id": "4ac97841-c89f-4d50-b3c6-6253f7e1dd1a",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:33.653Z",
+      "version": "WzM0MjIsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "query_string": {
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "Egress Interfaces (bytes) [Filebeat Netflow]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "listeners": {},
+          "params": {
+            "expression": ".es(index=\"filebeat-*\", metric=\"sum:network.bytes\", split=\"netflow.egress_interface:10\", kibana=true).scale_interval(1s).fit(mode=scale).if(operator=\"lt\", if=0, then=0).trim(start=2,end=1).label(regex=\"^.* netflow.egress_interface:(.+) \u003e .*$\", label=\"$1\").lines(width=1, stack=true, fill=1).yaxis(label=\"bytes / sec\", min=0)",
+            "interval": "auto"
+          },
+          "title": "Egress Interfaces (bytes) [Filebeat Netflow]",
+          "type": "timelion"
+        }
+      },
+      "id": "85ebf558-402b-45d2-a186-e15f8673ec07",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:33.653Z",
+      "version": "WzM0MjMsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "query_string": {
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "Egress Interfaces (packets) [Filebeat Netflow]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "listeners": {},
+          "params": {
+            "expression": ".es(index=\"filebeat-*\", metric=\"sum:network.packets\", split=\"netflow.egress_interface:10\", kibana=true).scale_interval(1s).fit(mode=scale).if(operator=\"lt\", if=0, then=0).trim(start=2,end=1).label(regex=\"^.* netflow.egress_interface:(.+) \u003e .*$\", label=\"$1\").lines(width=1, stack=true, fill=1).yaxis(label=\"packets / sec\", min=0)",
+            "interval": "auto"
+          },
+          "title": "Egress Interfaces (packets) [Filebeat Netflow]",
+          "type": "timelion"
+        }
+      },
+      "id": "f86a7769-8ef6-408d-bbe3-985d0ea0a3f7",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:33.653Z",
+      "version": "WzM0MjQsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "query_string": {
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "Ingress Interfaces (packets) [Filebeat Netflow]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "listeners": {},
+          "params": {
+            "expression": ".es(index=\"filebeat-*\", metric=\"sum:network.packets\", split=\"netflow.ingress_interface:10\", kibana=true).scale_interval(1s).fit(mode=scale).if(operator=\"lt\", if=0, then=0).trim(start=2,end=1).label(regex=\"^.* netflow.ingress_interface:(.+) \u003e .*$\", label=\"$1\").lines(width=1, stack=true, fill=1).yaxis(label=\"packets / sec\", min=0)",
+            "interval": "auto"
+          },
+          "title": "Ingress Interfaces (packets) [Filebeat Netflow]",
+          "type": "timelion"
+        }
+      },
+      "id": "1cd36f5d-d9c7-4098-acdb-14d312ecfb72",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:33.653Z",
+      "version": "WzM0MjUsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "query_string": {
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "Ingress Interfaces (bytes) [Filebeat Netflow]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "listeners": {},
+          "params": {
+            "expression": ".es(index=\"filebeat-*\", metric=\"sum:network.bytes\", split=\"netflow.ingress_interface:10\", kibana=true).scale_interval(1s).fit(mode=scale).if(operator=\"lt\", if=0, then=0).trim(start=2,end=1).label(regex=\"^.* netflow.ingress_interface:(.+) \u003e .*$\", label=\"$1\").lines(width=1, stack=true, fill=1).yaxis(label=\"bytes / sec\", min=0)",
+            "interval": "auto"
+          },
+          "title": "Ingress Interfaces (bytes) [Filebeat Netflow]",
+          "type": "timelion"
+        }
+      },
+      "id": "d3df8d28-65f8-4ea1-8b33-f479380a0600",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:33.653Z",
+      "version": "WzM0MjYsMV0="
+    }
+  ],
+  "version": "7.2.0"
+}

--- a/dev/package-beats/netflow-module-1.0.0/kibana/dashboard/filebeat-netflow-flow-records.json
+++ b/dev/package-beats/netflow-module-1.0.0/kibana/dashboard/filebeat-netflow-flow-records.json
@@ -1,0 +1,476 @@
+{
+  "objects": [
+    {
+      "attributes": {
+        "description": "Netflow flow records",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [
+              {
+                "$state": {
+                  "store": "globalState"
+                },
+                "meta": {
+                  "alias": null,
+                  "disabled": false,
+                  "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                  "key": "input.type",
+                  "negate": false,
+                  "params": {
+                    "query": "netflow"
+                  },
+                  "type": "phrase",
+                  "value": "netflow"
+                },
+                "query": {
+                  "match": {
+                    "input.type": {
+                      "query": "netflow",
+                      "type": "phrase"
+                    }
+                  }
+                }
+              }
+            ],
+            "highlightAll": true,
+            "version": true
+          }
+        },
+        "optionsJSON": {
+          "darkTheme": false
+        },
+        "panelsJSON": [
+          {
+            "col": 4,
+            "panelIndex": 2,
+            "panelRefName": "panel_0",
+            "row": 2,
+            "size_x": 9,
+            "size_y": 2
+          },
+          {
+            "col": 1,
+            "panelIndex": 3,
+            "panelRefName": "panel_1",
+            "row": 2,
+            "size_x": 3,
+            "size_y": 2
+          },
+          {
+            "col": 1,
+            "panelIndex": 4,
+            "panelRefName": "panel_2",
+            "row": 1,
+            "size_x": 12,
+            "size_y": 1
+          },
+          {
+            "col": 1,
+            "columns": [
+              "source.ip",
+              "source.port",
+              "destination.ip",
+              "destination.port",
+              "network.transport",
+              "network.bytes",
+              "network.packets"
+            ],
+            "panelIndex": 5,
+            "panelRefName": "panel_3",
+            "row": 4,
+            "size_x": 12,
+            "size_y": 4,
+            "sort": [
+              "@timestamp",
+              "desc"
+            ]
+          }
+        ],
+        "timeRestore": false,
+        "title": "[Filebeat Netflow] Flow records",
+        "uiStateJSON": {
+          "P-3": {
+            "vis": {
+              "defaultColors": {
+                "0 - 100": "rgb(0,104,55)"
+              }
+            }
+          }
+        },
+        "version": 1
+      },
+      "id": "94972700-de4a-4272-9143-2fa8d4981365",
+      "migrationVersion": {
+        "dashboard": "7.0.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+          "type": "index-pattern"
+        },
+        {
+          "id": "4bb0255e-18ed-45e4-bfb9-de8e35b12094",
+          "name": "panel_0",
+          "type": "visualization"
+        },
+        {
+          "id": "c27c6a3b-93ee-44d5-8d0c-9b097e575f52",
+          "name": "panel_1",
+          "type": "visualization"
+        },
+        {
+          "id": "d4e6520a-9ced-47c9-a8f2-7246e8cbd2d3",
+          "name": "panel_2",
+          "type": "visualization"
+        },
+        {
+          "id": "a34c6611-79d8-4b50-ae3f-8b328d28e24a",
+          "name": "panel_3",
+          "type": "search"
+        }
+      ],
+      "type": "dashboard",
+      "updated_at": "2019-07-11T04:44:34.680Z",
+      "version": "WzM0MjcsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "query_string": {
+                "analyze_wildcard": true,
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "Flow Records [Filebeat Netflow]",
+        "uiStateJSON": {
+          "vis": {
+            "legendOpen": true
+          }
+        },
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "Flow Records"
+              },
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customLabel": "Timeline",
+                "extended_bounds": {},
+                "field": "event.end",
+                "interval": "s",
+                "min_doc_count": 1
+              },
+              "schema": "segment",
+              "type": "date_histogram"
+            },
+            {
+              "enabled": true,
+              "id": "3",
+              "params": {
+                "customLabel": "Version",
+                "field": "netflow.exporter.version",
+                "order": "desc",
+                "orderBy": "1",
+                "size": 5
+              },
+              "schema": "group",
+              "type": "terms"
+            }
+          ],
+          "listeners": {},
+          "params": {
+            "addLegend": true,
+            "addTimeMarker": false,
+            "addTooltip": true,
+            "categoryAxes": [
+              {
+                "id": "CategoryAxis-1",
+                "labels": {
+                  "show": true,
+                  "truncate": 100
+                },
+                "position": "bottom",
+                "scale": {
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {},
+                "type": "category"
+              }
+            ],
+            "defaultYExtents": false,
+            "grid": {
+              "categoryLines": false,
+              "style": {
+                "color": "#eee"
+              }
+            },
+            "legendPosition": "right",
+            "mode": "stacked",
+            "scale": "linear",
+            "seriesParams": [
+              {
+                "data": {
+                  "id": "1",
+                  "label": "Flow Records"
+                },
+                "drawLinesBetweenPoints": true,
+                "mode": "stacked",
+                "show": "true",
+                "showCircles": true,
+                "type": "histogram",
+                "valueAxis": "ValueAxis-1"
+              }
+            ],
+            "setYExtents": false,
+            "times": [],
+            "valueAxes": [
+              {
+                "id": "ValueAxis-1",
+                "labels": {
+                  "filter": false,
+                  "rotate": 0,
+                  "show": true,
+                  "truncate": 100
+                },
+                "name": "LeftAxis-1",
+                "position": "left",
+                "scale": {
+                  "mode": "normal",
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {
+                  "text": "Count"
+                },
+                "type": "value"
+              }
+            ]
+          },
+          "title": "Flow Records [Filebeat Netflow]",
+          "type": "histogram"
+        }
+      },
+      "id": "4bb0255e-18ed-45e4-bfb9-de8e35b12094",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:34.680Z",
+      "version": "WzM0MjgsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "query_string": {
+                "analyze_wildcard": true,
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "Flow Records [Filebeat Netflow]",
+        "uiStateJSON": {
+          "vis": {
+            "defaultColors": {
+              "0 - 100": "rgb(0,104,55)"
+            }
+          }
+        },
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "Flow Records"
+              },
+              "schema": "metric",
+              "type": "count"
+            }
+          ],
+          "listeners": {},
+          "params": {
+            "addLegend": false,
+            "addTooltip": true,
+            "fontSize": "32",
+            "gauge": {
+              "autoExtend": false,
+              "backStyle": "Full",
+              "colorSchema": "Green to Red",
+              "colorsRange": [
+                {
+                  "from": 0,
+                  "to": 100
+                }
+              ],
+              "gaugeColorMode": "None",
+              "gaugeStyle": "Full",
+              "gaugeType": "Metric",
+              "invertColors": false,
+              "labels": {
+                "color": "black",
+                "show": true
+              },
+              "orientation": "vertical",
+              "percentageMode": false,
+              "scale": {
+                "color": "#333",
+                "labels": false,
+                "show": false,
+                "width": 2
+              },
+              "style": {
+                "bgColor": false,
+                "bgFill": "#000",
+                "fontSize": "36",
+                "labelColor": false,
+                "subText": ""
+              },
+              "type": "simple",
+              "useRange": false,
+              "verticalSplit": false
+            },
+            "handleNoResults": true,
+            "type": "gauge"
+          },
+          "title": "Flow Records [Filebeat Netflow]",
+          "type": "metric"
+        }
+      },
+      "id": "c27c6a3b-93ee-44d5-8d0c-9b097e575f52",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:34.680Z",
+      "version": "WzM0MjksMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "query_string": {
+                "analyze_wildcard": true,
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "Dashboard Navigation [Filebeat Netflow]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "listeners": {},
+          "params": {
+            "markdown": "[Overview](#/dashboard/34e26884-161a-4448-9556-43b5bf2f62a2) | [Conversation Partners](#/dashboard/acd7a630-0c71-4840-bc9e-4a3801374a32) | [Traffic Analysis](#/dashboard/38012abe-c611-4124-8497-381fcd85acc8) | [Top-N](#/dashboard/14387a13-53bc-43a4-b9cd-63977aa8d87c) | [Geo Location](#/dashboard/77326664-23be-4bf1-a126-6d7e60cfc024) | [Autonomous Systems](#/dashboard/c64665f9-d222-421e-90b0-c7310d944b8a) | [Flow Exporters](#/dashboard/feebb4e6-b13e-4e4e-b9fc-d3a178276425) | [Raw Flow Records](#/dashboard/94972700-de4a-4272-9143-2fa8d4981365)\n***"
+          },
+          "title": "Dashboard Navigation [Filebeat Netflow]",
+          "type": "markdown"
+        }
+      },
+      "id": "d4e6520a-9ced-47c9-a8f2-7246e8cbd2d3",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:38.685Z",
+      "version": "WzM0NjQsMV0="
+    },
+    {
+      "attributes": {
+        "columns": [
+          "source.ip",
+          "source.port",
+          "destination.ip",
+          "destination.port",
+          "network.transport",
+          "network.bytes",
+          "network.packets"
+        ],
+        "description": "",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "highlightAll": true,
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "query_string": {
+                "analyze_wildcard": true,
+                "query": "*"
+              }
+            },
+            "version": true
+          }
+        },
+        "sort": [
+          "@timestamp",
+          "desc"
+        ],
+        "title": "Flow Records [Filebeat Netflow]",
+        "version": 1
+      },
+      "id": "a34c6611-79d8-4b50-ae3f-8b328d28e24a",
+      "migrationVersion": {
+        "search": "7.0.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "search",
+      "updated_at": "2019-07-11T04:44:34.680Z",
+      "version": "WzM0MzEsMV0="
+    }
+  ],
+  "version": "7.2.0"
+}

--- a/dev/package-beats/netflow-module-1.0.0/kibana/dashboard/filebeat-netflow-geo-location.json
+++ b/dev/package-beats/netflow-module-1.0.0/kibana/dashboard/filebeat-netflow-geo-location.json
@@ -1,0 +1,515 @@
+{
+  "objects": [
+    {
+      "attributes": {
+        "description": "Netflow geo location",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [
+              {
+                "$state": {
+                  "store": "globalState"
+                },
+                "meta": {
+                  "alias": null,
+                  "disabled": false,
+                  "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                  "key": "input.type",
+                  "negate": false,
+                  "params": {
+                    "query": "netflow"
+                  },
+                  "type": "phrase",
+                  "value": "netflow"
+                },
+                "query": {
+                  "match": {
+                    "input.type": {
+                      "query": "netflow",
+                      "type": "phrase"
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        },
+        "optionsJSON": {
+          "darkTheme": false
+        },
+        "panelsJSON": [
+          {
+            "col": 5,
+            "panelIndex": 16,
+            "panelRefName": "panel_0",
+            "row": 2,
+            "size_x": 8,
+            "size_y": 6
+          },
+          {
+            "col": 1,
+            "panelIndex": 17,
+            "panelRefName": "panel_1",
+            "row": 2,
+            "size_x": 4,
+            "size_y": 2
+          },
+          {
+            "col": 1,
+            "panelIndex": 18,
+            "panelRefName": "panel_2",
+            "row": 4,
+            "size_x": 4,
+            "size_y": 2
+          },
+          {
+            "col": 1,
+            "panelIndex": 19,
+            "panelRefName": "panel_3",
+            "row": 6,
+            "size_x": 4,
+            "size_y": 2
+          },
+          {
+            "col": 1,
+            "panelIndex": 20,
+            "panelRefName": "panel_4",
+            "row": 1,
+            "size_x": 12,
+            "size_y": 1
+          }
+        ],
+        "timeRestore": false,
+        "title": "[Filebeat Netflow] Geo Location",
+        "uiStateJSON": {
+          "P-16": {
+            "mapCenter": [
+              20.632784250388028,
+              16.69921875
+            ],
+            "mapZoom": 2
+          }
+        },
+        "version": 1
+      },
+      "id": "77326664-23be-4bf1-a126-6d7e60cfc024",
+      "migrationVersion": {
+        "dashboard": "7.0.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+          "type": "index-pattern"
+        },
+        {
+          "id": "f4c8cb5a-7336-449e-ab99-6e867b435b85",
+          "name": "panel_0",
+          "type": "visualization"
+        },
+        {
+          "id": "2316bb53-d98a-4f0f-8cd8-51e9fb317823",
+          "name": "panel_1",
+          "type": "visualization"
+        },
+        {
+          "id": "aed09724-0a69-4331-84f5-3d2067c43930",
+          "name": "panel_2",
+          "type": "visualization"
+        },
+        {
+          "id": "f531f957-e8c0-497a-ad41-ef39c2d29671",
+          "name": "panel_3",
+          "type": "visualization"
+        },
+        {
+          "id": "d4e6520a-9ced-47c9-a8f2-7246e8cbd2d3",
+          "name": "panel_4",
+          "type": "visualization"
+        }
+      ],
+      "type": "dashboard",
+      "updated_at": "2019-07-11T04:44:35.630Z",
+      "version": "WzM0MzIsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "query_string": {
+                "analyze_wildcard": true,
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "Destination Geo Location Heatmap [Filebeat Netflow]",
+        "uiStateJSON": {
+          "mapCenter": [
+            8.407168163601076,
+            9.4921875
+          ]
+        },
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "Records"
+              },
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "autoPrecision": true,
+                "customLabel": "Location",
+                "field": "destination.geo.location",
+                "precision": 2
+              },
+              "schema": "segment",
+              "type": "geohash_grid"
+            }
+          ],
+          "listeners": {},
+          "params": {
+            "addTooltip": true,
+            "heatBlur": "16",
+            "heatMaxZoom": 16,
+            "heatMinOpacity": "0.32",
+            "heatNormalizeData": true,
+            "heatRadius": "24",
+            "isDesaturated": true,
+            "legendPosition": "bottomright",
+            "mapCenter": [
+              15,
+              5
+            ],
+            "mapType": "Heatmap",
+            "mapZoom": 2,
+            "wms": {
+              "enabled": false,
+              "options": {
+                "attribution": "Maps provided by USGS",
+                "format": "image/png",
+                "layers": "0",
+                "styles": "",
+                "transparent": true,
+                "version": "1.3.0"
+              },
+              "url": "https://basemap.nationalmap.gov/arcgis/services/USGSTopo/MapServer/WMSServer"
+            }
+          },
+          "title": "Destination Geo Location Heatmap [Filebeat Netflow]",
+          "type": "tile_map"
+        }
+      },
+      "id": "f4c8cb5a-7336-449e-ab99-6e867b435b85",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:35.630Z",
+      "version": "WzM0MzMsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "query_string": {
+                "analyze_wildcard": true,
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "Countries and Cities (flow records) [Filebeat Netflow]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "Flow Records"
+              },
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customLabel": "Country",
+                "field": "destination.geo.country_name",
+                "order": "desc",
+                "orderBy": "1",
+                "size": 10
+              },
+              "schema": "segment",
+              "type": "terms"
+            },
+            {
+              "enabled": true,
+              "id": "3",
+              "params": {
+                "customLabel": "City",
+                "field": "destination.geo.city_name",
+                "order": "desc",
+                "orderBy": "1",
+                "size": 10
+              },
+              "schema": "segment",
+              "type": "terms"
+            }
+          ],
+          "listeners": {},
+          "params": {
+            "addLegend": true,
+            "addTooltip": true,
+            "isDonut": true,
+            "legendPosition": "right"
+          },
+          "title": "Countries and Cities (flow records) [Filebeat Netflow]",
+          "type": "pie"
+        }
+      },
+      "id": "2316bb53-d98a-4f0f-8cd8-51e9fb317823",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:35.630Z",
+      "version": "WzM0MzQsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "query_string": {
+                "analyze_wildcard": true,
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "Destinations and Sources (flow records) [Filebeat Netflow]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "Flow Records"
+              },
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customLabel": "Destination",
+                "field": "destination.ip",
+                "order": "desc",
+                "orderBy": "1",
+                "size": 50
+              },
+              "schema": "segment",
+              "type": "terms"
+            },
+            {
+              "enabled": true,
+              "id": "3",
+              "params": {
+                "customLabel": "Source",
+                "field": "source.ip",
+                "order": "desc",
+                "orderBy": "1",
+                "size": 50
+              },
+              "schema": "segment",
+              "type": "terms"
+            }
+          ],
+          "listeners": {},
+          "params": {
+            "addLegend": true,
+            "addTooltip": true,
+            "isDonut": true,
+            "legendPosition": "right"
+          },
+          "title": "Destinations and Sources (flow records) [Filebeat Netflow]",
+          "type": "pie"
+        }
+      },
+      "id": "aed09724-0a69-4331-84f5-3d2067c43930",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:35.630Z",
+      "version": "WzM0MzUsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "query_string": {
+                "analyze_wildcard": true,
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "Destination and Source Ports (flow records) [Filebeat Netflow]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "Flow Records"
+              },
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customLabel": "Destination Port",
+                "field": "destination.port",
+                "order": "desc",
+                "orderBy": "1",
+                "size": 50
+              },
+              "schema": "segment",
+              "type": "terms"
+            },
+            {
+              "enabled": true,
+              "id": "3",
+              "params": {
+                "customLabel": "Source Port",
+                "field": "source.port",
+                "order": "desc",
+                "orderBy": "1",
+                "size": 50
+              },
+              "schema": "segment",
+              "type": "terms"
+            }
+          ],
+          "listeners": {},
+          "params": {
+            "addLegend": true,
+            "addTooltip": true,
+            "isDonut": true,
+            "legendPosition": "right"
+          },
+          "title": "Destination and Source Ports (flow records) [Filebeat Netflow]",
+          "type": "pie"
+        }
+      },
+      "id": "f531f957-e8c0-497a-ad41-ef39c2d29671",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:35.630Z",
+      "version": "WzM0MzYsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "query_string": {
+                "analyze_wildcard": true,
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "Dashboard Navigation [Filebeat Netflow]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "listeners": {},
+          "params": {
+            "markdown": "[Overview](#/dashboard/34e26884-161a-4448-9556-43b5bf2f62a2) | [Conversation Partners](#/dashboard/acd7a630-0c71-4840-bc9e-4a3801374a32) | [Traffic Analysis](#/dashboard/38012abe-c611-4124-8497-381fcd85acc8) | [Top-N](#/dashboard/14387a13-53bc-43a4-b9cd-63977aa8d87c) | [Geo Location](#/dashboard/77326664-23be-4bf1-a126-6d7e60cfc024) | [Autonomous Systems](#/dashboard/c64665f9-d222-421e-90b0-c7310d944b8a) | [Flow Exporters](#/dashboard/feebb4e6-b13e-4e4e-b9fc-d3a178276425) | [Raw Flow Records](#/dashboard/94972700-de4a-4272-9143-2fa8d4981365)\n***"
+          },
+          "title": "Dashboard Navigation [Filebeat Netflow]",
+          "type": "markdown"
+        }
+      },
+      "id": "d4e6520a-9ced-47c9-a8f2-7246e8cbd2d3",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:38.685Z",
+      "version": "WzM0NjQsMV0="
+    }
+  ],
+  "version": "7.2.0"
+}

--- a/dev/package-beats/netflow-module-1.0.0/kibana/dashboard/filebeat-netflow-overview.json
+++ b/dev/package-beats/netflow-module-1.0.0/kibana/dashboard/filebeat-netflow-overview.json
@@ -1,0 +1,1219 @@
+{
+  "objects": [
+    {
+      "attributes": {
+        "description": "Overview of Netflow",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [
+              {
+                "$state": {
+                  "store": "globalState"
+                },
+                "meta": {
+                  "alias": null,
+                  "disabled": false,
+                  "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                  "key": "input.type",
+                  "negate": false,
+                  "params": {
+                    "query": "netflow"
+                  },
+                  "type": "phrase",
+                  "value": "netflow"
+                },
+                "query": {
+                  "match": {
+                    "input.type": {
+                      "query": "netflow",
+                      "type": "phrase"
+                    }
+                  }
+                }
+              }
+            ],
+            "highlightAll": true,
+            "version": true
+          }
+        },
+        "optionsJSON": {
+          "darkTheme": false
+        },
+        "panelsJSON": [
+          {
+            "col": 1,
+            "panelIndex": 12,
+            "panelRefName": "panel_0",
+            "row": 2,
+            "size_x": 4,
+            "size_y": 2
+          },
+          {
+            "col": 5,
+            "panelIndex": 13,
+            "panelRefName": "panel_1",
+            "row": 2,
+            "size_x": 4,
+            "size_y": 2
+          },
+          {
+            "col": 9,
+            "panelIndex": 14,
+            "panelRefName": "panel_2",
+            "row": 2,
+            "size_x": 4,
+            "size_y": 2
+          },
+          {
+            "col": 5,
+            "panelIndex": 15,
+            "panelRefName": "panel_3",
+            "row": 4,
+            "size_x": 4,
+            "size_y": 2
+          },
+          {
+            "col": 1,
+            "panelIndex": 17,
+            "panelRefName": "panel_4",
+            "row": 1,
+            "size_x": 12,
+            "size_y": 1
+          },
+          {
+            "col": 9,
+            "panelIndex": 21,
+            "panelRefName": "panel_5",
+            "row": 4,
+            "size_x": 4,
+            "size_y": 2
+          },
+          {
+            "col": 5,
+            "panelIndex": 22,
+            "panelRefName": "panel_6",
+            "row": 6,
+            "size_x": 4,
+            "size_y": 2
+          },
+          {
+            "col": 1,
+            "panelIndex": 23,
+            "panelRefName": "panel_7",
+            "row": 4,
+            "size_x": 4,
+            "size_y": 2
+          },
+          {
+            "col": 1,
+            "panelIndex": 24,
+            "panelRefName": "panel_8",
+            "row": 6,
+            "size_x": 4,
+            "size_y": 2
+          },
+          {
+            "col": 9,
+            "panelIndex": 25,
+            "panelRefName": "panel_9",
+            "row": 6,
+            "size_x": 4,
+            "size_y": 2
+          },
+          {
+            "col": 1,
+            "panelIndex": 26,
+            "panelRefName": "panel_10",
+            "row": 8,
+            "size_x": 4,
+            "size_y": 2
+          },
+          {
+            "col": 5,
+            "panelIndex": 27,
+            "panelRefName": "panel_11",
+            "row": 8,
+            "size_x": 4,
+            "size_y": 2
+          },
+          {
+            "col": 9,
+            "panelIndex": 29,
+            "panelRefName": "panel_12",
+            "row": 8,
+            "size_x": 4,
+            "size_y": 2
+          }
+        ],
+        "timeRestore": false,
+        "title": "[Filebeat Netflow] Overview",
+        "uiStateJSON": {},
+        "version": 1
+      },
+      "id": "34e26884-161a-4448-9556-43b5bf2f62a2",
+      "migrationVersion": {
+        "dashboard": "7.0.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+          "type": "index-pattern"
+        },
+        {
+          "id": "ae334aec-31fa-4df7-a064-40b18831d819",
+          "name": "panel_0",
+          "type": "visualization"
+        },
+        {
+          "id": "67fdca65-a9df-47f0-a8a4-1e8b056325de",
+          "name": "panel_1",
+          "type": "visualization"
+        },
+        {
+          "id": "1558508d-591c-49be-bef4-85fdac18a960",
+          "name": "panel_2",
+          "type": "visualization"
+        },
+        {
+          "id": "1cf30eac-aae8-47fa-a156-37f6346d2d5a",
+          "name": "panel_3",
+          "type": "visualization"
+        },
+        {
+          "id": "d4e6520a-9ced-47c9-a8f2-7246e8cbd2d3",
+          "name": "panel_4",
+          "type": "visualization"
+        },
+        {
+          "id": "7fa6cb0a-518d-46e9-a228-15cd4253a957",
+          "name": "panel_5",
+          "type": "visualization"
+        },
+        {
+          "id": "f772028b-d5a6-4d55-b441-493871981a60",
+          "name": "panel_6",
+          "type": "visualization"
+        },
+        {
+          "id": "57e13a20-e94f-4465-a942-42148634a1d2",
+          "name": "panel_7",
+          "type": "visualization"
+        },
+        {
+          "id": "b02c2713-17f0-41dd-88a3-ce33b446f19d",
+          "name": "panel_8",
+          "type": "visualization"
+        },
+        {
+          "id": "5ccac452-e90a-4dde-ae9b-1be36ce3f761",
+          "name": "panel_9",
+          "type": "visualization"
+        },
+        {
+          "id": "31708a70-4957-4a8a-8065-5c88a344ad02",
+          "name": "panel_10",
+          "type": "visualization"
+        },
+        {
+          "id": "b677cd82-b33e-49b3-8b6e-0e110177b163",
+          "name": "panel_11",
+          "type": "visualization"
+        },
+        {
+          "id": "3dec20c0-0d4f-43ef-8864-3779e1a1b33f",
+          "name": "panel_12",
+          "type": "visualization"
+        }
+      ],
+      "type": "dashboard",
+      "updated_at": "2019-07-11T04:44:36.725Z",
+      "version": "WzM0MzgsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "language": "lucene",
+              "query": {
+                "query_string": {
+                  "analyze_wildcard": true,
+                  "query": "*"
+                }
+              }
+            }
+          }
+        },
+        "title": "IP Version and Protocols (bytes) [Filebeat Netflow]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "Bytes",
+                "field": "network.bytes"
+              },
+              "schema": "metric",
+              "type": "sum"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customLabel": "IP Version",
+                "field": "network.type",
+                "missingBucket": true,
+                "missingBucketLabel": "unset ip version",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 5
+              },
+              "schema": "segment",
+              "type": "terms"
+            },
+            {
+              "enabled": true,
+              "id": "3",
+              "params": {
+                "customLabel": "Protocol",
+                "field": "network.transport",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 50
+              },
+              "schema": "segment",
+              "type": "terms"
+            }
+          ],
+          "params": {
+            "addLegend": true,
+            "addTooltip": true,
+            "dimensions": {
+              "buckets": [
+                {
+                  "accessor": 0,
+                  "aggType": "terms",
+                  "format": {
+                    "id": "terms",
+                    "params": {
+                      "id": "string",
+                      "missingBucketLabel": "Missing",
+                      "otherBucketLabel": "Other"
+                    }
+                  },
+                  "params": {}
+                },
+                {
+                  "accessor": 2,
+                  "aggType": "terms",
+                  "format": {
+                    "id": "terms",
+                    "params": {
+                      "id": "string",
+                      "missingBucketLabel": "Missing",
+                      "otherBucketLabel": "Other"
+                    }
+                  },
+                  "params": {}
+                }
+              ],
+              "metric": {
+                "accessor": 1,
+                "aggType": "sum",
+                "format": {
+                  "id": "bytes"
+                },
+                "params": {}
+              }
+            },
+            "isDonut": true,
+            "labels": {
+              "last_level": true,
+              "show": false,
+              "truncate": 100,
+              "values": true
+            },
+            "legendPosition": "right",
+            "type": "pie"
+          },
+          "title": "IP Version and Protocols (bytes) [Filebeat Netflow]",
+          "type": "pie"
+        }
+      },
+      "id": "ae334aec-31fa-4df7-a064-40b18831d819",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:36.725Z",
+      "version": "WzM0MzksMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "query_string": {
+                "analyze_wildcard": true,
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "Destinations and Ports (bytes) [Filebeat Netflow]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "Bytes",
+                "field": "network.bytes"
+              },
+              "schema": "metric",
+              "type": "sum"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customLabel": "Destination",
+                "field": "destination.ip",
+                "order": "desc",
+                "orderBy": "1",
+                "size": 10
+              },
+              "schema": "segment",
+              "type": "terms"
+            },
+            {
+              "enabled": true,
+              "id": "3",
+              "params": {
+                "customLabel": "Port",
+                "field": "destination.port",
+                "order": "desc",
+                "orderBy": "1",
+                "size": 10
+              },
+              "schema": "segment",
+              "type": "terms"
+            }
+          ],
+          "listeners": {},
+          "params": {
+            "addLegend": true,
+            "addTooltip": true,
+            "isDonut": true,
+            "legendPosition": "right"
+          },
+          "title": "Destinations and Ports (bytes) [Filebeat Netflow]",
+          "type": "pie"
+        }
+      },
+      "id": "67fdca65-a9df-47f0-a8a4-1e8b056325de",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:36.725Z",
+      "version": "WzM0NDAsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "query_string": {
+                "analyze_wildcard": true,
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "Sources and Ports (bytes) [Filebeat Netflow]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "Bytes",
+                "field": "network.bytes"
+              },
+              "schema": "metric",
+              "type": "sum"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customLabel": "Source",
+                "field": "source.ip",
+                "order": "desc",
+                "orderBy": "1",
+                "size": 10
+              },
+              "schema": "segment",
+              "type": "terms"
+            },
+            {
+              "enabled": true,
+              "id": "3",
+              "params": {
+                "customLabel": "Port",
+                "field": "source.port",
+                "order": "desc",
+                "orderBy": "1",
+                "size": 10
+              },
+              "schema": "segment",
+              "type": "terms"
+            }
+          ],
+          "listeners": {},
+          "params": {
+            "addLegend": true,
+            "addTooltip": true,
+            "isDonut": true,
+            "legendPosition": "right"
+          },
+          "title": "Sources and Ports (bytes) [Filebeat Netflow]",
+          "type": "pie"
+        }
+      },
+      "id": "1558508d-591c-49be-bef4-85fdac18a960",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:36.725Z",
+      "version": "WzM0NDEsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "query_string": {
+                "analyze_wildcard": true,
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "Types of Service (bytes) [Filebeat Netflow]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "Bytes",
+                "field": "network.bytes"
+              },
+              "schema": "metric",
+              "type": "sum"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customLabel": "Type of Service",
+                "field": "netflow.ip_class_of_service",
+                "order": "desc",
+                "orderBy": "1",
+                "size": 50
+              },
+              "schema": "segment",
+              "type": "terms"
+            }
+          ],
+          "listeners": {},
+          "params": {
+            "addLegend": true,
+            "addTooltip": true,
+            "isDonut": true,
+            "legendPosition": "right"
+          },
+          "title": "Types of Service (bytes) [Filebeat Netflow]",
+          "type": "pie"
+        }
+      },
+      "id": "1cf30eac-aae8-47fa-a156-37f6346d2d5a",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:38.685Z",
+      "version": "WzM0NzgsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "query_string": {
+                "analyze_wildcard": true,
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "Dashboard Navigation [Filebeat Netflow]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "listeners": {},
+          "params": {
+            "markdown": "[Overview](#/dashboard/34e26884-161a-4448-9556-43b5bf2f62a2) | [Conversation Partners](#/dashboard/acd7a630-0c71-4840-bc9e-4a3801374a32) | [Traffic Analysis](#/dashboard/38012abe-c611-4124-8497-381fcd85acc8) | [Top-N](#/dashboard/14387a13-53bc-43a4-b9cd-63977aa8d87c) | [Geo Location](#/dashboard/77326664-23be-4bf1-a126-6d7e60cfc024) | [Autonomous Systems](#/dashboard/c64665f9-d222-421e-90b0-c7310d944b8a) | [Flow Exporters](#/dashboard/feebb4e6-b13e-4e4e-b9fc-d3a178276425) | [Raw Flow Records](#/dashboard/94972700-de4a-4272-9143-2fa8d4981365)\n***"
+          },
+          "title": "Dashboard Navigation [Filebeat Netflow]",
+          "type": "markdown"
+        }
+      },
+      "id": "d4e6520a-9ced-47c9-a8f2-7246e8cbd2d3",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:38.685Z",
+      "version": "WzM0NjQsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "query_string": {
+                "analyze_wildcard": true,
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "VLANs (bytes) [Filebeat Netflow]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "Bytes",
+                "field": "network.bytes"
+              },
+              "schema": "metric",
+              "type": "sum"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customLabel": "VLAN",
+                "field": "netflow.vlan_id",
+                "order": "desc",
+                "orderBy": "1",
+                "size": 50
+              },
+              "schema": "segment",
+              "type": "terms"
+            }
+          ],
+          "listeners": {},
+          "params": {
+            "addLegend": true,
+            "addTooltip": true,
+            "isDonut": true,
+            "legendPosition": "right"
+          },
+          "title": "VLANs (bytes) [Filebeat Netflow]",
+          "type": "pie"
+        }
+      },
+      "id": "7fa6cb0a-518d-46e9-a228-15cd4253a957",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:38.685Z",
+      "version": "WzM0NzksMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "query_string": {
+                "analyze_wildcard": true,
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "Autonomous Systems (bytes) [Filebeat Netflow]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "Bytes",
+                "field": "network.bytes"
+              },
+              "schema": "metric",
+              "type": "sum"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customLabel": "Autonomous System",
+                "field": "destination.as.organization.name",
+                "order": "desc",
+                "orderBy": "1",
+                "size": 50
+              },
+              "schema": "segment",
+              "type": "terms"
+            }
+          ],
+          "listeners": {},
+          "params": {
+            "addLegend": true,
+            "addTooltip": true,
+            "isDonut": true,
+            "legendPosition": "right"
+          },
+          "title": "Autonomous Systems (bytes) [Filebeat Netflow]",
+          "type": "pie"
+        }
+      },
+      "id": "f772028b-d5a6-4d55-b441-493871981a60",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:38.685Z",
+      "version": "WzM0ODEsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "query_string": {
+                "analyze_wildcard": true,
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "TCP Flags (bytes) [Filebeat Netflow]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "Bytes",
+                "field": "network.bytes"
+              },
+              "schema": "metric",
+              "type": "sum"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customLabel": "TCP Flags",
+                "field": "netflow.tcp_control_bits",
+                "order": "desc",
+                "orderBy": "1",
+                "size": 255
+              },
+              "schema": "segment",
+              "type": "terms"
+            }
+          ],
+          "listeners": {},
+          "params": {
+            "addLegend": true,
+            "addTooltip": true,
+            "isDonut": true,
+            "legendPosition": "right"
+          },
+          "title": "TCP Flags (bytes) [Filebeat Netflow]",
+          "type": "pie"
+        }
+      },
+      "id": "57e13a20-e94f-4465-a942-42148634a1d2",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:38.685Z",
+      "version": "WzM0ODAsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "query_string": {
+                "analyze_wildcard": true,
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "Locality (bytes) [Filebeat Netflow]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "Bytes",
+                "field": "network.bytes"
+              },
+              "schema": "metric",
+              "type": "sum"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customLabel": "Locality",
+                "field": "flow.locality",
+                "order": "desc",
+                "orderBy": "1",
+                "size": 5
+              },
+              "schema": "segment",
+              "type": "terms"
+            }
+          ],
+          "listeners": {},
+          "params": {
+            "addLegend": true,
+            "addTooltip": true,
+            "isDonut": true,
+            "legendPosition": "right"
+          },
+          "title": "Locality (bytes) [Filebeat Netflow]",
+          "type": "pie"
+        }
+      },
+      "id": "b02c2713-17f0-41dd-88a3-ce33b446f19d",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:36.725Z",
+      "version": "WzM0NDcsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "query_string": {
+                "analyze_wildcard": true,
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "Countries and Cities (bytes) [Filebeat Netflow]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "Bytes",
+                "field": "network.bytes"
+              },
+              "schema": "metric",
+              "type": "sum"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customLabel": "Country",
+                "field": "destination.geo.country_name",
+                "order": "desc",
+                "orderBy": "1",
+                "size": 10
+              },
+              "schema": "segment",
+              "type": "terms"
+            },
+            {
+              "enabled": true,
+              "id": "3",
+              "params": {
+                "customLabel": "City",
+                "field": "destination.geo.city_name",
+                "order": "desc",
+                "orderBy": "1",
+                "size": 10
+              },
+              "schema": "segment",
+              "type": "terms"
+            }
+          ],
+          "listeners": {},
+          "params": {
+            "addLegend": true,
+            "addTooltip": true,
+            "isDonut": true,
+            "legendPosition": "right"
+          },
+          "title": "Countries and Cities (bytes) [Filebeat Netflow]",
+          "type": "pie"
+        }
+      },
+      "id": "5ccac452-e90a-4dde-ae9b-1be36ce3f761",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:36.725Z",
+      "version": "WzM0NDgsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "query_string": {
+                "analyze_wildcard": true,
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "Flow Exporters (bytes) [Filebeat Netflow]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "Bytes",
+                "field": "network.bytes"
+              },
+              "schema": "metric",
+              "type": "sum"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customLabel": "Flow Exporter",
+                "field": "agent.hostname",
+                "order": "desc",
+                "orderBy": "1",
+                "size": 50
+              },
+              "schema": "segment",
+              "type": "terms"
+            }
+          ],
+          "listeners": {},
+          "params": {
+            "addLegend": true,
+            "addTooltip": true,
+            "isDonut": true,
+            "legendPosition": "right"
+          },
+          "title": "Flow Exporters (bytes) [Filebeat Netflow]",
+          "type": "pie"
+        }
+      },
+      "id": "31708a70-4957-4a8a-8065-5c88a344ad02",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:36.725Z",
+      "version": "WzM0NDksMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "query_string": {
+                "analyze_wildcard": true,
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "Direction (bytes) [Filebeat Netflow]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "Bytes",
+                "field": "network.bytes"
+              },
+              "schema": "metric",
+              "type": "sum"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customLabel": "Direction",
+                "field": "network.direction",
+                "order": "desc",
+                "orderBy": "1",
+                "size": 5
+              },
+              "schema": "segment",
+              "type": "terms"
+            }
+          ],
+          "listeners": {},
+          "params": {
+            "addLegend": true,
+            "addTooltip": true,
+            "isDonut": true,
+            "legendPosition": "right"
+          },
+          "title": "Direction (bytes) [Filebeat Netflow]",
+          "type": "pie"
+        }
+      },
+      "id": "b677cd82-b33e-49b3-8b6e-0e110177b163",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:36.725Z",
+      "version": "WzM0NTAsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "query_string": {
+                "analyze_wildcard": true,
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "Version (bytes) [Filebeat Netflow]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "Bytes",
+                "field": "network.bytes"
+              },
+              "schema": "metric",
+              "type": "sum"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customLabel": "Version",
+                "field": "netflow.exporter.version",
+                "order": "desc",
+                "orderBy": "1",
+                "size": 5
+              },
+              "schema": "segment",
+              "type": "terms"
+            }
+          ],
+          "listeners": {},
+          "params": {
+            "addLegend": true,
+            "addTooltip": true,
+            "isDonut": true,
+            "legendPosition": "right"
+          },
+          "title": "Version (bytes) [Filebeat Netflow]",
+          "type": "pie"
+        }
+      },
+      "id": "3dec20c0-0d4f-43ef-8864-3779e1a1b33f",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:36.725Z",
+      "version": "WzM0NTEsMV0="
+    }
+  ],
+  "version": "7.2.0"
+}

--- a/dev/package-beats/netflow-module-1.0.0/kibana/dashboard/filebeat-netflow-top-n.json
+++ b/dev/package-beats/netflow-module-1.0.0/kibana/dashboard/filebeat-netflow-top-n.json
@@ -1,0 +1,1138 @@
+{
+  "objects": [
+    {
+      "attributes": {
+        "description": "Netflow Top N flows",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [
+              {
+                "$state": {
+                  "store": "globalState"
+                },
+                "meta": {
+                  "alias": null,
+                  "disabled": false,
+                  "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                  "key": "input.type",
+                  "negate": false,
+                  "params": {
+                    "query": "netflow"
+                  },
+                  "type": "phrase",
+                  "value": "netflow"
+                },
+                "query": {
+                  "match": {
+                    "input.type": {
+                      "query": "netflow",
+                      "type": "phrase"
+                    }
+                  }
+                }
+              }
+            ],
+            "highlightAll": true,
+            "version": true
+          }
+        },
+        "optionsJSON": {
+          "darkTheme": false
+        },
+        "panelsJSON": [
+          {
+            "col": 1,
+            "panelIndex": 1,
+            "panelRefName": "panel_0",
+            "row": 1,
+            "size_x": 12,
+            "size_y": 1
+          },
+          {
+            "col": 1,
+            "panelIndex": 2,
+            "panelRefName": "panel_1",
+            "row": 2,
+            "size_x": 6,
+            "size_y": 5
+          },
+          {
+            "col": 7,
+            "panelIndex": 3,
+            "panelRefName": "panel_2",
+            "row": 2,
+            "size_x": 6,
+            "size_y": 5
+          },
+          {
+            "col": 1,
+            "panelIndex": 4,
+            "panelRefName": "panel_3",
+            "row": 7,
+            "size_x": 6,
+            "size_y": 5
+          },
+          {
+            "col": 7,
+            "panelIndex": 5,
+            "panelRefName": "panel_4",
+            "row": 7,
+            "size_x": 6,
+            "size_y": 5
+          },
+          {
+            "col": 1,
+            "panelIndex": 6,
+            "panelRefName": "panel_5",
+            "row": 12,
+            "size_x": 6,
+            "size_y": 5
+          },
+          {
+            "col": 7,
+            "panelIndex": 7,
+            "panelRefName": "panel_6",
+            "row": 12,
+            "size_x": 6,
+            "size_y": 5
+          },
+          {
+            "col": 1,
+            "panelIndex": 8,
+            "panelRefName": "panel_7",
+            "row": 17,
+            "size_x": 6,
+            "size_y": 5
+          },
+          {
+            "col": 7,
+            "panelIndex": 9,
+            "panelRefName": "panel_8",
+            "row": 17,
+            "size_x": 6,
+            "size_y": 5
+          }
+        ],
+        "timeRestore": false,
+        "title": "[Filebeat Netflow] Top-N",
+        "uiStateJSON": {
+          "P-2": {
+            "vis": {
+              "params": {
+                "sort": {
+                  "columnIndex": null,
+                  "direction": null
+                }
+              }
+            }
+          },
+          "P-3": {
+            "vis": {
+              "params": {
+                "sort": {
+                  "columnIndex": null,
+                  "direction": null
+                }
+              }
+            }
+          },
+          "P-4": {
+            "vis": {
+              "params": {
+                "sort": {
+                  "columnIndex": null,
+                  "direction": null
+                }
+              }
+            }
+          },
+          "P-5": {
+            "vis": {
+              "params": {
+                "sort": {
+                  "columnIndex": null,
+                  "direction": null
+                }
+              }
+            }
+          },
+          "P-6": {
+            "vis": {
+              "params": {
+                "sort": {
+                  "columnIndex": null,
+                  "direction": null
+                }
+              }
+            }
+          },
+          "P-7": {
+            "vis": {
+              "params": {
+                "sort": {
+                  "columnIndex": null,
+                  "direction": null
+                }
+              }
+            }
+          },
+          "P-8": {
+            "vis": {
+              "params": {
+                "sort": {
+                  "columnIndex": 2,
+                  "direction": "desc"
+                }
+              }
+            }
+          },
+          "P-9": {
+            "vis": {
+              "params": {
+                "sort": {
+                  "columnIndex": null,
+                  "direction": null
+                }
+              }
+            }
+          }
+        },
+        "version": 1
+      },
+      "id": "14387a13-53bc-43a4-b9cd-63977aa8d87c",
+      "migrationVersion": {
+        "dashboard": "7.0.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+          "type": "index-pattern"
+        },
+        {
+          "id": "d4e6520a-9ced-47c9-a8f2-7246e8cbd2d3",
+          "name": "panel_0",
+          "type": "visualization"
+        },
+        {
+          "id": "15295ea6-ba84-47db-8ced-9312abbf495c",
+          "name": "panel_1",
+          "type": "visualization"
+        },
+        {
+          "id": "5303e99b-389c-47b7-ae7a-945c5a92ba49",
+          "name": "panel_2",
+          "type": "visualization"
+        },
+        {
+          "id": "e9ad835b-b2f2-42d3-a3e7-555a593deacf",
+          "name": "panel_3",
+          "type": "visualization"
+        },
+        {
+          "id": "31b5f6fd-eb9d-4e97-90fd-367062ef217f",
+          "name": "panel_4",
+          "type": "visualization"
+        },
+        {
+          "id": "2b3d4e86-2254-4033-8fe3-ce4753fafd03",
+          "name": "panel_5",
+          "type": "visualization"
+        },
+        {
+          "id": "036aef95-ec90-468d-ad7c-3cc4405e9e81",
+          "name": "panel_6",
+          "type": "visualization"
+        },
+        {
+          "id": "5292a65b-c532-422a-9008-1251a8073a3a",
+          "name": "panel_7",
+          "type": "visualization"
+        },
+        {
+          "id": "cccff92f-cb71-49a9-9caf-84867751d31e",
+          "name": "panel_8",
+          "type": "visualization"
+        }
+      ],
+      "type": "dashboard",
+      "updated_at": "2019-07-11T04:44:37.748Z",
+      "version": "WzM0NTIsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "query_string": {
+                "analyze_wildcard": true,
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "Dashboard Navigation [Filebeat Netflow]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "listeners": {},
+          "params": {
+            "markdown": "[Overview](#/dashboard/34e26884-161a-4448-9556-43b5bf2f62a2) | [Conversation Partners](#/dashboard/acd7a630-0c71-4840-bc9e-4a3801374a32) | [Traffic Analysis](#/dashboard/38012abe-c611-4124-8497-381fcd85acc8) | [Top-N](#/dashboard/14387a13-53bc-43a4-b9cd-63977aa8d87c) | [Geo Location](#/dashboard/77326664-23be-4bf1-a126-6d7e60cfc024) | [Autonomous Systems](#/dashboard/c64665f9-d222-421e-90b0-c7310d944b8a) | [Flow Exporters](#/dashboard/feebb4e6-b13e-4e4e-b9fc-d3a178276425) | [Raw Flow Records](#/dashboard/94972700-de4a-4272-9143-2fa8d4981365)\n***"
+          },
+          "title": "Dashboard Navigation [Filebeat Netflow]",
+          "type": "markdown"
+        }
+      },
+      "id": "d4e6520a-9ced-47c9-a8f2-7246e8cbd2d3",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:38.685Z",
+      "version": "WzM0NjQsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "query_string": {
+                "analyze_wildcard": true,
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "Top Sources [Filebeat Netflow]",
+        "uiStateJSON": {
+          "vis": {
+            "params": {
+              "sort": {
+                "columnIndex": null,
+                "direction": null
+              }
+            }
+          }
+        },
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customLabel": "Bytes",
+                "field": "network.bytes"
+              },
+              "schema": "metric",
+              "type": "sum"
+            },
+            {
+              "enabled": true,
+              "id": "3",
+              "params": {
+                "customLabel": "Packets",
+                "field": "network.packets"
+              },
+              "schema": "metric",
+              "type": "sum"
+            },
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "Flow Records"
+              },
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "4",
+              "params": {
+                "customLabel": "Source",
+                "field": "source.ip",
+                "order": "desc",
+                "orderBy": "2",
+                "size": 500
+              },
+              "schema": "bucket",
+              "type": "terms"
+            }
+          ],
+          "listeners": {},
+          "params": {
+            "perPage": 10,
+            "showMeticsAtAllLevels": false,
+            "showPartialRows": false,
+            "showTotal": true,
+            "sort": {
+              "columnIndex": null,
+              "direction": null
+            },
+            "totalFunc": "sum"
+          },
+          "title": "Top Sources [Filebeat Netflow]",
+          "type": "table"
+        }
+      },
+      "id": "15295ea6-ba84-47db-8ced-9312abbf495c",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:37.748Z",
+      "version": "WzM0NTQsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "query_string": {
+                "analyze_wildcard": true,
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "Top Destinations [Filebeat Netflow]",
+        "uiStateJSON": {
+          "vis": {
+            "params": {
+              "sort": {
+                "columnIndex": null,
+                "direction": null
+              }
+            }
+          }
+        },
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customLabel": "Bytes",
+                "field": "network.bytes"
+              },
+              "schema": "metric",
+              "type": "sum"
+            },
+            {
+              "enabled": true,
+              "id": "3",
+              "params": {
+                "customLabel": "Packets",
+                "field": "network.packets"
+              },
+              "schema": "metric",
+              "type": "sum"
+            },
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "Flow Records"
+              },
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "4",
+              "params": {
+                "customLabel": "Destination",
+                "field": "destination.ip",
+                "order": "desc",
+                "orderBy": "2",
+                "size": 500
+              },
+              "schema": "bucket",
+              "type": "terms"
+            }
+          ],
+          "listeners": {},
+          "params": {
+            "perPage": 10,
+            "showMeticsAtAllLevels": false,
+            "showPartialRows": false,
+            "showTotal": true,
+            "sort": {
+              "columnIndex": null,
+              "direction": null
+            },
+            "totalFunc": "sum"
+          },
+          "title": "Top Destinations [Filebeat Netflow]",
+          "type": "table"
+        }
+      },
+      "id": "5303e99b-389c-47b7-ae7a-945c5a92ba49",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:37.748Z",
+      "version": "WzM0NTUsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "query_string": {
+                "analyze_wildcard": true,
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "Top Source Ports [Filebeat Netflow]",
+        "uiStateJSON": {
+          "vis": {
+            "params": {
+              "sort": {
+                "columnIndex": null,
+                "direction": null
+              }
+            }
+          }
+        },
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customLabel": "Bytes",
+                "field": "network.bytes"
+              },
+              "schema": "metric",
+              "type": "sum"
+            },
+            {
+              "enabled": true,
+              "id": "3",
+              "params": {
+                "customLabel": "Packets",
+                "field": "network.packets"
+              },
+              "schema": "metric",
+              "type": "sum"
+            },
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "Flow Records"
+              },
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "4",
+              "params": {
+                "customLabel": "Source",
+                "field": "source.port",
+                "order": "desc",
+                "orderBy": "2",
+                "size": 500
+              },
+              "schema": "bucket",
+              "type": "terms"
+            }
+          ],
+          "listeners": {},
+          "params": {
+            "perPage": 10,
+            "showMeticsAtAllLevels": false,
+            "showPartialRows": false,
+            "showTotal": true,
+            "sort": {
+              "columnIndex": null,
+              "direction": null
+            },
+            "totalFunc": "sum"
+          },
+          "title": "Top Source Ports [Filebeat Netflow]",
+          "type": "table"
+        }
+      },
+      "id": "e9ad835b-b2f2-42d3-a3e7-555a593deacf",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:37.748Z",
+      "version": "WzM0NTYsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "query_string": {
+                "analyze_wildcard": true,
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "Top Destination Ports [Filebeat Netflow]",
+        "uiStateJSON": {
+          "vis": {
+            "params": {
+              "sort": {
+                "columnIndex": null,
+                "direction": null
+              }
+            }
+          }
+        },
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customLabel": "Bytes",
+                "field": "network.bytes"
+              },
+              "schema": "metric",
+              "type": "sum"
+            },
+            {
+              "enabled": true,
+              "id": "3",
+              "params": {
+                "customLabel": "Packets",
+                "field": "network.packets"
+              },
+              "schema": "metric",
+              "type": "sum"
+            },
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "Flow Records"
+              },
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "4",
+              "params": {
+                "customLabel": "Destination",
+                "field": "destination.port",
+                "order": "desc",
+                "orderBy": "2",
+                "size": 500
+              },
+              "schema": "bucket",
+              "type": "terms"
+            }
+          ],
+          "listeners": {},
+          "params": {
+            "perPage": 10,
+            "showMeticsAtAllLevels": false,
+            "showPartialRows": false,
+            "showTotal": true,
+            "sort": {
+              "columnIndex": null,
+              "direction": null
+            },
+            "totalFunc": "sum"
+          },
+          "title": "Top Destination Ports [Filebeat Netflow]",
+          "type": "table"
+        }
+      },
+      "id": "31b5f6fd-eb9d-4e97-90fd-367062ef217f",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:37.748Z",
+      "version": "WzM0NTcsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "query_string": {
+                "analyze_wildcard": true,
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "Top Protocols [Filebeat Netflow]",
+        "uiStateJSON": {
+          "vis": {
+            "params": {
+              "sort": {
+                "columnIndex": null,
+                "direction": null
+              }
+            }
+          }
+        },
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customLabel": "Bytes",
+                "field": "network.bytes"
+              },
+              "schema": "metric",
+              "type": "sum"
+            },
+            {
+              "enabled": true,
+              "id": "3",
+              "params": {
+                "customLabel": "Packets",
+                "field": "network.packets"
+              },
+              "schema": "metric",
+              "type": "sum"
+            },
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "Flow Records"
+              },
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "4",
+              "params": {
+                "customLabel": "Protocol",
+                "field": "network.transport",
+                "order": "desc",
+                "orderBy": "2",
+                "size": 500
+              },
+              "schema": "bucket",
+              "type": "terms"
+            }
+          ],
+          "listeners": {},
+          "params": {
+            "perPage": 10,
+            "showMeticsAtAllLevels": false,
+            "showPartialRows": false,
+            "showTotal": true,
+            "sort": {
+              "columnIndex": null,
+              "direction": null
+            },
+            "totalFunc": "sum"
+          },
+          "title": "Top Protocols [Filebeat Netflow]",
+          "type": "table"
+        }
+      },
+      "id": "2b3d4e86-2254-4033-8fe3-ce4753fafd03",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:37.748Z",
+      "version": "WzM0NTgsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "query_string": {
+                "analyze_wildcard": true,
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "Top Autonomous Systems [Filebeat Netflow]",
+        "uiStateJSON": {
+          "vis": {
+            "params": {
+              "sort": {
+                "columnIndex": null,
+                "direction": null
+              }
+            }
+          }
+        },
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customLabel": "Bytes",
+                "field": "network.bytes"
+              },
+              "schema": "metric",
+              "type": "sum"
+            },
+            {
+              "enabled": true,
+              "id": "3",
+              "params": {
+                "customLabel": "Packets",
+                "field": "network.packets"
+              },
+              "schema": "metric",
+              "type": "sum"
+            },
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "Flow Records"
+              },
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "4",
+              "params": {
+                "customLabel": "Autonomous System",
+                "field": "destination.as.organization.name",
+                "order": "desc",
+                "orderBy": "2",
+                "size": 500
+              },
+              "schema": "bucket",
+              "type": "terms"
+            }
+          ],
+          "listeners": {},
+          "params": {
+            "perPage": 10,
+            "showMeticsAtAllLevels": false,
+            "showPartialRows": false,
+            "showTotal": true,
+            "sort": {
+              "columnIndex": null,
+              "direction": null
+            },
+            "totalFunc": "sum"
+          },
+          "title": "Top Autonomous Systems [Filebeat Netflow]",
+          "type": "table"
+        }
+      },
+      "id": "036aef95-ec90-468d-ad7c-3cc4405e9e81",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:37.748Z",
+      "version": "WzM0NTksMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "query_string": {
+                "analyze_wildcard": true,
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "Top Cities [Filebeat Netflow]",
+        "uiStateJSON": {
+          "vis": {
+            "params": {
+              "sort": {
+                "columnIndex": 2,
+                "direction": "desc"
+              }
+            }
+          }
+        },
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customLabel": "Bytes",
+                "field": "network.bytes"
+              },
+              "schema": "metric",
+              "type": "sum"
+            },
+            {
+              "enabled": true,
+              "id": "3",
+              "params": {
+                "customLabel": "Packets",
+                "field": "network.packets"
+              },
+              "schema": "metric",
+              "type": "sum"
+            },
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "Flow Records"
+              },
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "4",
+              "params": {
+                "customLabel": "Country",
+                "field": "destination.geo.country_name",
+                "order": "desc",
+                "orderBy": "2",
+                "size": 500
+              },
+              "schema": "bucket",
+              "type": "terms"
+            },
+            {
+              "enabled": true,
+              "id": "5",
+              "params": {
+                "customLabel": "City",
+                "field": "destination.geo.city_name",
+                "order": "desc",
+                "orderBy": "2",
+                "size": 500
+              },
+              "schema": "bucket",
+              "type": "terms"
+            }
+          ],
+          "listeners": {},
+          "params": {
+            "perPage": 10,
+            "showMeticsAtAllLevels": false,
+            "showPartialRows": true,
+            "showTotal": true,
+            "sort": {
+              "columnIndex": null,
+              "direction": null
+            },
+            "totalFunc": "sum"
+          },
+          "title": "Top Cities [Filebeat Netflow]",
+          "type": "table"
+        }
+      },
+      "id": "5292a65b-c532-422a-9008-1251a8073a3a",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:37.748Z",
+      "version": "WzM0NjAsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "query_string": {
+                "analyze_wildcard": true,
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "Top Flow Exporters [Filebeat Netflow]",
+        "uiStateJSON": {
+          "vis": {
+            "params": {
+              "sort": {
+                "columnIndex": null,
+                "direction": null
+              }
+            }
+          }
+        },
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customLabel": "Bytes",
+                "field": "network.bytes"
+              },
+              "schema": "metric",
+              "type": "sum"
+            },
+            {
+              "enabled": true,
+              "id": "3",
+              "params": {
+                "customLabel": "Packets",
+                "field": "network.packets"
+              },
+              "schema": "metric",
+              "type": "sum"
+            },
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "Flow Records"
+              },
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "4",
+              "params": {
+                "customLabel": "Flow Exporter",
+                "field": "agent.hostname",
+                "order": "desc",
+                "orderBy": "2",
+                "size": 500
+              },
+              "schema": "bucket",
+              "type": "terms"
+            }
+          ],
+          "listeners": {},
+          "params": {
+            "perPage": 10,
+            "showMeticsAtAllLevels": false,
+            "showPartialRows": false,
+            "showTotal": true,
+            "sort": {
+              "columnIndex": null,
+              "direction": null
+            },
+            "totalFunc": "sum"
+          },
+          "title": "Top Flow Exporters [Filebeat Netflow]",
+          "type": "table"
+        }
+      },
+      "id": "cccff92f-cb71-49a9-9caf-84867751d31e",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:37.748Z",
+      "version": "WzM0NjEsMV0="
+    }
+  ],
+  "version": "7.2.0"
+}

--- a/dev/package-beats/netflow-module-1.0.0/kibana/dashboard/filebeat-netflow-traffic-analysis.json
+++ b/dev/package-beats/netflow-module-1.0.0/kibana/dashboard/filebeat-netflow-traffic-analysis.json
@@ -1,0 +1,3096 @@
+{
+  "objects": [
+    {
+      "attributes": {
+        "description": "Netflow traffic analysis",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [
+              {
+                "$state": {
+                  "store": "globalState"
+                },
+                "meta": {
+                  "alias": null,
+                  "disabled": false,
+                  "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                  "key": "input.type",
+                  "negate": false,
+                  "params": {
+                    "query": "netflow"
+                  },
+                  "type": "phrase",
+                  "value": "netflow"
+                },
+                "query": {
+                  "match": {
+                    "input.type": {
+                      "query": "netflow",
+                      "type": "phrase"
+                    }
+                  }
+                }
+              }
+            ],
+            "highlightAll": true,
+            "version": true
+          }
+        },
+        "optionsJSON": {
+          "darkTheme": false
+        },
+        "panelsJSON": [
+          {
+            "col": 7,
+            "panelIndex": 1,
+            "panelRefName": "panel_0",
+            "row": 22,
+            "size_x": 6,
+            "size_y": 2
+          },
+          {
+            "col": 1,
+            "panelIndex": 4,
+            "panelRefName": "panel_1",
+            "row": 1,
+            "size_x": 12,
+            "size_y": 1
+          },
+          {
+            "col": 7,
+            "panelIndex": 5,
+            "panelRefName": "panel_2",
+            "row": 28,
+            "size_x": 6,
+            "size_y": 2
+          },
+          {
+            "col": 1,
+            "panelIndex": 6,
+            "panelRefName": "panel_3",
+            "row": 28,
+            "size_x": 6,
+            "size_y": 2
+          },
+          {
+            "col": 7,
+            "panelIndex": 7,
+            "panelRefName": "panel_4",
+            "row": 10,
+            "size_x": 6,
+            "size_y": 2
+          },
+          {
+            "col": 1,
+            "panelIndex": 9,
+            "panelRefName": "panel_5",
+            "row": 22,
+            "size_x": 6,
+            "size_y": 2
+          },
+          {
+            "col": 7,
+            "panelIndex": 10,
+            "panelRefName": "panel_6",
+            "row": 16,
+            "size_x": 6,
+            "size_y": 2
+          },
+          {
+            "col": 1,
+            "panelIndex": 11,
+            "panelRefName": "panel_7",
+            "row": 16,
+            "size_x": 6,
+            "size_y": 2
+          },
+          {
+            "col": 1,
+            "panelIndex": 12,
+            "panelRefName": "panel_8",
+            "row": 10,
+            "size_x": 6,
+            "size_y": 2
+          },
+          {
+            "col": 1,
+            "panelIndex": 13,
+            "panelRefName": "panel_9",
+            "row": 4,
+            "size_x": 6,
+            "size_y": 2
+          },
+          {
+            "col": 7,
+            "panelIndex": 14,
+            "panelRefName": "panel_10",
+            "row": 4,
+            "size_x": 6,
+            "size_y": 2
+          },
+          {
+            "col": 1,
+            "panelIndex": 15,
+            "panelRefName": "panel_11",
+            "row": 2,
+            "size_x": 4,
+            "size_y": 2
+          },
+          {
+            "col": 1,
+            "panelIndex": 16,
+            "panelRefName": "panel_12",
+            "row": 8,
+            "size_x": 4,
+            "size_y": 2
+          },
+          {
+            "col": 7,
+            "panelIndex": 17,
+            "panelRefName": "panel_13",
+            "row": 2,
+            "size_x": 4,
+            "size_y": 2
+          },
+          {
+            "col": 7,
+            "panelIndex": 18,
+            "panelRefName": "panel_14",
+            "row": 8,
+            "size_x": 4,
+            "size_y": 2
+          },
+          {
+            "col": 1,
+            "panelIndex": 19,
+            "panelRefName": "panel_15",
+            "row": 14,
+            "size_x": 4,
+            "size_y": 2
+          },
+          {
+            "col": 7,
+            "panelIndex": 20,
+            "panelRefName": "panel_16",
+            "row": 14,
+            "size_x": 4,
+            "size_y": 2
+          },
+          {
+            "col": 1,
+            "panelIndex": 21,
+            "panelRefName": "panel_17",
+            "row": 20,
+            "size_x": 4,
+            "size_y": 2
+          },
+          {
+            "col": 7,
+            "panelIndex": 22,
+            "panelRefName": "panel_18",
+            "row": 20,
+            "size_x": 4,
+            "size_y": 2
+          },
+          {
+            "col": 1,
+            "panelIndex": 23,
+            "panelRefName": "panel_19",
+            "row": 26,
+            "size_x": 4,
+            "size_y": 2
+          },
+          {
+            "col": 7,
+            "panelIndex": 24,
+            "panelRefName": "panel_20",
+            "row": 26,
+            "size_x": 4,
+            "size_y": 2
+          },
+          {
+            "col": 1,
+            "panelIndex": 25,
+            "panelRefName": "panel_21",
+            "row": 6,
+            "size_x": 6,
+            "size_y": 2
+          },
+          {
+            "col": 11,
+            "panelIndex": 26,
+            "panelRefName": "panel_22",
+            "row": 2,
+            "size_x": 2,
+            "size_y": 2
+          },
+          {
+            "col": 5,
+            "panelIndex": 27,
+            "panelRefName": "panel_23",
+            "row": 2,
+            "size_x": 2,
+            "size_y": 2
+          },
+          {
+            "col": 7,
+            "panelIndex": 28,
+            "panelRefName": "panel_24",
+            "row": 6,
+            "size_x": 6,
+            "size_y": 2
+          },
+          {
+            "col": 11,
+            "panelIndex": 29,
+            "panelRefName": "panel_25",
+            "row": 8,
+            "size_x": 2,
+            "size_y": 2
+          },
+          {
+            "col": 5,
+            "panelIndex": 30,
+            "panelRefName": "panel_26",
+            "row": 8,
+            "size_x": 2,
+            "size_y": 2
+          },
+          {
+            "col": 7,
+            "panelIndex": 31,
+            "panelRefName": "panel_27",
+            "row": 24,
+            "size_x": 6,
+            "size_y": 2
+          },
+          {
+            "col": 7,
+            "panelIndex": 34,
+            "panelRefName": "panel_28",
+            "row": 30,
+            "size_x": 6,
+            "size_y": 2
+          },
+          {
+            "col": 1,
+            "panelIndex": 35,
+            "panelRefName": "panel_29",
+            "row": 30,
+            "size_x": 6,
+            "size_y": 2
+          },
+          {
+            "col": 7,
+            "panelIndex": 38,
+            "panelRefName": "panel_30",
+            "row": 12,
+            "size_x": 6,
+            "size_y": 2
+          },
+          {
+            "col": 1,
+            "panelIndex": 42,
+            "panelRefName": "panel_31",
+            "row": 12,
+            "size_x": 6,
+            "size_y": 2
+          },
+          {
+            "col": 1,
+            "panelIndex": 44,
+            "panelRefName": "panel_32",
+            "row": 24,
+            "size_x": 6,
+            "size_y": 2
+          },
+          {
+            "col": 1,
+            "panelIndex": 45,
+            "panelRefName": "panel_33",
+            "row": 18,
+            "size_x": 6,
+            "size_y": 2
+          },
+          {
+            "col": 7,
+            "panelIndex": 47,
+            "panelRefName": "panel_34",
+            "row": 18,
+            "size_x": 6,
+            "size_y": 2
+          },
+          {
+            "col": 5,
+            "panelIndex": 48,
+            "panelRefName": "panel_35",
+            "row": 14,
+            "size_x": 2,
+            "size_y": 2
+          },
+          {
+            "col": 11,
+            "panelIndex": 49,
+            "panelRefName": "panel_36",
+            "row": 14,
+            "size_x": 2,
+            "size_y": 2
+          },
+          {
+            "col": 11,
+            "panelIndex": 50,
+            "panelRefName": "panel_37",
+            "row": 20,
+            "size_x": 2,
+            "size_y": 2
+          },
+          {
+            "col": 11,
+            "panelIndex": 51,
+            "panelRefName": "panel_38",
+            "row": 26,
+            "size_x": 2,
+            "size_y": 2
+          },
+          {
+            "col": 5,
+            "panelIndex": 52,
+            "panelRefName": "panel_39",
+            "row": 26,
+            "size_x": 2,
+            "size_y": 2
+          },
+          {
+            "col": 5,
+            "panelIndex": 53,
+            "panelRefName": "panel_40",
+            "row": 20,
+            "size_x": 2,
+            "size_y": 2
+          }
+        ],
+        "timeRestore": false,
+        "title": "[Filebeat Netflow] Traffic Analysis",
+        "uiStateJSON": {
+          "P-15": {
+            "vis": {
+              "legendOpen": true
+            }
+          },
+          "P-26": {
+            "vis": {
+              "defaultColors": {
+                "0 - 100": "rgb(0,104,55)"
+              }
+            }
+          },
+          "P-27": {
+            "vis": {
+              "defaultColors": {
+                "0 - 100": "rgb(0,104,55)"
+              }
+            }
+          },
+          "P-29": {
+            "vis": {
+              "defaultColors": {
+                "0 - 100": "rgb(0,104,55)"
+              }
+            }
+          },
+          "P-30": {
+            "vis": {
+              "defaultColors": {
+                "0 - 100": "rgb(0,104,55)"
+              }
+            }
+          },
+          "P-48": {
+            "vis": {
+              "defaultColors": {
+                "0 - 100": "rgb(0,104,55)"
+              }
+            }
+          },
+          "P-49": {
+            "vis": {
+              "defaultColors": {
+                "0 - 100": "rgb(0,104,55)"
+              }
+            }
+          },
+          "P-50": {
+            "vis": {
+              "defaultColors": {
+                "0 - 100": "rgb(0,104,55)"
+              }
+            }
+          },
+          "P-51": {
+            "vis": {
+              "defaultColors": {
+                "0 - 100": "rgb(0,104,55)"
+              }
+            }
+          },
+          "P-52": {
+            "vis": {
+              "defaultColors": {
+                "0 - 100": "rgb(0,104,55)"
+              }
+            }
+          },
+          "P-53": {
+            "vis": {
+              "defaultColors": {
+                "0 - 100": "rgb(0,104,55)"
+              }
+            }
+          }
+        },
+        "version": 1
+      },
+      "id": "38012abe-c611-4124-8497-381fcd85acc8",
+      "migrationVersion": {
+        "dashboard": "7.0.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+          "type": "index-pattern"
+        },
+        {
+          "id": "abfa0b19-60cd-4984-9c3d-02ebf0aa1dfb",
+          "name": "panel_0",
+          "type": "visualization"
+        },
+        {
+          "id": "d4e6520a-9ced-47c9-a8f2-7246e8cbd2d3",
+          "name": "panel_1",
+          "type": "visualization"
+        },
+        {
+          "id": "1e74d5cb-556d-42ee-8042-88f6c1af47f0",
+          "name": "panel_2",
+          "type": "visualization"
+        },
+        {
+          "id": "5cfb2c9a-4815-4a25-9d7e-ab0ef55ffe63",
+          "name": "panel_3",
+          "type": "visualization"
+        },
+        {
+          "id": "3e27fb83-b3e3-4c15-b999-ed6da49b7a86",
+          "name": "panel_4",
+          "type": "visualization"
+        },
+        {
+          "id": "5d868836-c7b2-4812-bf47-4838aac281d9",
+          "name": "panel_5",
+          "type": "visualization"
+        },
+        {
+          "id": "a5efa3dd-f53a-4d14-9d3f-ee73345fd93d",
+          "name": "panel_6",
+          "type": "visualization"
+        },
+        {
+          "id": "717cd7c7-bfca-435d-8ee7-38259927aade",
+          "name": "panel_7",
+          "type": "visualization"
+        },
+        {
+          "id": "f668ecdb-eec7-44c6-9060-26aaf9fc8404",
+          "name": "panel_8",
+          "type": "visualization"
+        },
+        {
+          "id": "6bbd6712-494a-4fd9-b3d3-757304681f0f",
+          "name": "panel_9",
+          "type": "visualization"
+        },
+        {
+          "id": "681f0ce4-d828-4a99-b643-0c0715530050",
+          "name": "panel_10",
+          "type": "visualization"
+        },
+        {
+          "id": "fd6c1144-5026-4795-b7af-a9aa3fc28c56",
+          "name": "panel_11",
+          "type": "visualization"
+        },
+        {
+          "id": "0b2818fd-aecc-4bef-b566-9466eb702ae4",
+          "name": "panel_12",
+          "type": "visualization"
+        },
+        {
+          "id": "248e00b4-8fc2-406f-8907-729d5380aaa7",
+          "name": "panel_13",
+          "type": "visualization"
+        },
+        {
+          "id": "cf399a85-e348-4ac1-a399-e8f5a44114c4",
+          "name": "panel_14",
+          "type": "visualization"
+        },
+        {
+          "id": "1cf30eac-aae8-47fa-a156-37f6346d2d5a",
+          "name": "panel_15",
+          "type": "visualization"
+        },
+        {
+          "id": "7fa6cb0a-518d-46e9-a228-15cd4253a957",
+          "name": "panel_16",
+          "type": "visualization"
+        },
+        {
+          "id": "57e13a20-e94f-4465-a942-42148634a1d2",
+          "name": "panel_17",
+          "type": "visualization"
+        },
+        {
+          "id": "f772028b-d5a6-4d55-b441-493871981a60",
+          "name": "panel_18",
+          "type": "visualization"
+        },
+        {
+          "id": "a14c3248-952d-42aa-bd7d-9b39157a776f",
+          "name": "panel_19",
+          "type": "visualization"
+        },
+        {
+          "id": "a685420e-c45f-4b62-932b-5b76ac8b8ca2",
+          "name": "panel_20",
+          "type": "visualization"
+        },
+        {
+          "id": "0528bc66-6981-400a-a02d-c1d221b38890",
+          "name": "panel_21",
+          "type": "visualization"
+        },
+        {
+          "id": "e99dc327-03de-4561-9e0c-f550710125c2",
+          "name": "panel_22",
+          "type": "visualization"
+        },
+        {
+          "id": "32e712ed-fa15-4db7-8575-8476e8d65b03",
+          "name": "panel_23",
+          "type": "visualization"
+        },
+        {
+          "id": "d59a031c-70d6-47d7-966d-7fcb805be9be",
+          "name": "panel_24",
+          "type": "visualization"
+        },
+        {
+          "id": "af707b01-29f1-462b-b279-6d2e803f3645",
+          "name": "panel_25",
+          "type": "visualization"
+        },
+        {
+          "id": "ddd27657-c3c8-4f82-8059-6d7763dd599b",
+          "name": "panel_26",
+          "type": "visualization"
+        },
+        {
+          "id": "30cd1009-2925-4c9b-820d-d689f5d1efda",
+          "name": "panel_27",
+          "type": "visualization"
+        },
+        {
+          "id": "7d447b22-89dc-4f32-b549-4b8620af4d76",
+          "name": "panel_28",
+          "type": "visualization"
+        },
+        {
+          "id": "d41a9663-e5ad-47a7-955e-3803ae4e23c0",
+          "name": "panel_29",
+          "type": "visualization"
+        },
+        {
+          "id": "3a4209e2-281c-467e-b5cb-315bf4a2661f",
+          "name": "panel_30",
+          "type": "visualization"
+        },
+        {
+          "id": "201d7dd1-a880-4a64-b631-db5629340db9",
+          "name": "panel_31",
+          "type": "visualization"
+        },
+        {
+          "id": "8f83cf97-4a48-421f-8db5-690297d1f4fb",
+          "name": "panel_32",
+          "type": "visualization"
+        },
+        {
+          "id": "a1704d46-15fc-41c2-851d-796ceb49877f",
+          "name": "panel_33",
+          "type": "visualization"
+        },
+        {
+          "id": "15e2a267-2495-4df2-a121-abe410d2f18c",
+          "name": "panel_34",
+          "type": "visualization"
+        },
+        {
+          "id": "f27c1479-0625-4cdc-92de-672e47db0f87",
+          "name": "panel_35",
+          "type": "visualization"
+        },
+        {
+          "id": "0177bf1a-cba8-4ba6-a1d7-73caed86ffc2",
+          "name": "panel_36",
+          "type": "visualization"
+        },
+        {
+          "id": "d5568704-e30b-4108-bb49-06a9b8dce6a6",
+          "name": "panel_37",
+          "type": "visualization"
+        },
+        {
+          "id": "16262df9-a979-4136-935e-d883c7d373d7",
+          "name": "panel_38",
+          "type": "visualization"
+        },
+        {
+          "id": "63ef5338-fdf2-488e-b78a-f0e98daccc95",
+          "name": "panel_39",
+          "type": "visualization"
+        },
+        {
+          "id": "2dca3025-692c-4876-8bcc-e0b248dc9819",
+          "name": "panel_40",
+          "type": "visualization"
+        }
+      ],
+      "type": "dashboard",
+      "updated_at": "2019-07-11T04:44:38.685Z",
+      "version": "WzM0NjIsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "query_string": {
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "Autonomous Systems (bytes) [Filebeat Netflow]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "listeners": {},
+          "params": {
+            "expression": ".es(index=\"filebeat-*\", metric=\"sum:network.bytes\", split=\"destination.as.organization.name:10\", kibana=true).scale_interval(1s).fit(mode=scale).if(operator=\"lt\", if=0, then=0).trim(start=2,end=1).label(regex=\"^.* destination.as.organization.name:(.+) \u003e .*$\", label=\"$1\").lines(width=1, stack=true, fill=1).yaxis(label=\"bytes / sec\", min=0)",
+            "interval": "auto"
+          },
+          "title": "Autonomous Systems (bytes) [Filebeat Netflow]",
+          "type": "timelion"
+        }
+      },
+      "id": "abfa0b19-60cd-4984-9c3d-02ebf0aa1dfb",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:38.685Z",
+      "version": "WzM0NjMsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "query_string": {
+                "analyze_wildcard": true,
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "Dashboard Navigation [Filebeat Netflow]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "listeners": {},
+          "params": {
+            "markdown": "[Overview](#/dashboard/34e26884-161a-4448-9556-43b5bf2f62a2) | [Conversation Partners](#/dashboard/acd7a630-0c71-4840-bc9e-4a3801374a32) | [Traffic Analysis](#/dashboard/38012abe-c611-4124-8497-381fcd85acc8) | [Top-N](#/dashboard/14387a13-53bc-43a4-b9cd-63977aa8d87c) | [Geo Location](#/dashboard/77326664-23be-4bf1-a126-6d7e60cfc024) | [Autonomous Systems](#/dashboard/c64665f9-d222-421e-90b0-c7310d944b8a) | [Flow Exporters](#/dashboard/feebb4e6-b13e-4e4e-b9fc-d3a178276425) | [Raw Flow Records](#/dashboard/94972700-de4a-4272-9143-2fa8d4981365)\n***"
+          },
+          "title": "Dashboard Navigation [Filebeat Netflow]",
+          "type": "markdown"
+        }
+      },
+      "id": "d4e6520a-9ced-47c9-a8f2-7246e8cbd2d3",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:38.685Z",
+      "version": "WzM0NjQsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "query_string": {
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "Cities (bytes) [Filebeat Netflow]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "listeners": {},
+          "params": {
+            "expression": ".es(index=\"filebeat-*\", metric=\"sum:network.bytes\", split=\"destination.geo.city_name:10\", kibana=true).scale_interval(1s).fit(mode=scale).if(operator=\"lt\", if=0, then=0).trim(start=2,end=1).label(regex=\"^.* destination.geo.city_name:(.+) \u003e .*$\", label=\"$1\").lines(width=1, stack=true, fill=1).yaxis(label=\"bytes / sec\", min=0)",
+            "interval": "auto"
+          },
+          "title": "Cities (bytes) [Filebeat Netflow]",
+          "type": "timelion"
+        }
+      },
+      "id": "1e74d5cb-556d-42ee-8042-88f6c1af47f0",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:38.685Z",
+      "version": "WzM0NjUsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "query_string": {
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "Countries (bytes) [Filebeat Netflow]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "listeners": {},
+          "params": {
+            "expression": ".es(index=\"filebeat-*\", metric=\"sum:network.bytes\", split=\"destination.geo.country_name:10\", kibana=true).scale_interval(1s).fit(mode=scale).if(operator=\"lt\", if=0, then=0).trim(start=2,end=1).label(regex=\"^.* destination.geo.country_name:(.+) \u003e .*$\", label=\"$1\").lines(width=1, stack=true, fill=1).yaxis(label=\"bytes / sec\", min=0)",
+            "interval": "auto"
+          },
+          "title": "Countries (bytes) [Filebeat Netflow]",
+          "type": "timelion"
+        }
+      },
+      "id": "5cfb2c9a-4815-4a25-9d7e-ab0ef55ffe63",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:38.685Z",
+      "version": "WzM0NjYsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "query_string": {
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "Destination Ports (bytes) [Filebeat Netflow]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "listeners": {},
+          "params": {
+            "expression": ".es(index=\"filebeat-*\", metric=\"sum:network.bytes\", split=\"destination.port:10\", kibana=true).scale_interval(1s).fit(mode=scale).if(operator=\"lt\", if=0, then=0).trim(start=2,end=1).label(regex=\"^.* destination.port:(.+) \u003e .*$\", label=\"$1\").lines(width=1, stack=true, fill=1).yaxis(label=\"bytes / sec\", min=0)",
+            "interval": "auto"
+          },
+          "title": "Destination Ports (bytes) [Filebeat Netflow]",
+          "type": "timelion"
+        }
+      },
+      "id": "3e27fb83-b3e3-4c15-b999-ed6da49b7a86",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:38.685Z",
+      "version": "WzM0NjcsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "query_string": {
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "TCP Flags (bytes) [Filebeat Netflow]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "listeners": {},
+          "params": {
+            "expression": ".es(index=\"filebeat-*\", metric=\"sum:network.bytes\", split=\"netflow.tcp_control_bits:10\", kibana=true).scale_interval(1s).fit(mode=scale).if(operator=\"lt\", if=0, then=0).trim(start=2,end=1).label(regex=\"^.* netflow.tcp_control_bits:(.+) \u003e .*$\", label=\"$1\").lines(width=1, stack=true, fill=1).yaxis(label=\"bytes / sec\", min=0)",
+            "interval": "auto"
+          },
+          "title": "TCP Flags (bytes) [Filebeat Netflow]",
+          "type": "timelion"
+        }
+      },
+      "id": "5d868836-c7b2-4812-bf47-4838aac281d9",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:38.685Z",
+      "version": "WzM0NjgsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "query_string": {
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "VLANs (bytes) [Filebeat Netflow]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "listeners": {},
+          "params": {
+            "expression": ".es(index=\"filebeat-*\", metric=\"sum:network.bytes\", split=\"netflow.vlan_id:10\", kibana=true).scale_interval(1s).fit(mode=scale).if(operator=\"lt\", if=0, then=0).trim(start=2,end=1).label(regex=\"^.* netflow.vlan_id:(.+) \u003e .*$\", label=\"$1\").lines(width=1, stack=true, fill=1).yaxis(label=\"bytes / sec\", min=0)",
+            "interval": "auto"
+          },
+          "title": "VLANs (bytes) [Filebeat Netflow]",
+          "type": "timelion"
+        }
+      },
+      "id": "a5efa3dd-f53a-4d14-9d3f-ee73345fd93d",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:38.685Z",
+      "version": "WzM0NjksMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "query_string": {
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "Types of Service (bytes) [Filebeat Netflow]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "listeners": {},
+          "params": {
+            "expression": ".es(index=\"filebeat-*\", metric=\"sum:network.bytes\", split=\"netflow.ip_class_of_service:10\", kibana=true).scale_interval(1s).fit(mode=scale).if(operator=\"lt\", if=0, then=0).trim(start=2,end=1).label(regex=\"^.* netflow.ip_class_of_service:(.+) \u003e .*$\", label=\"$1\").lines(width=1, stack=true, fill=1).yaxis(label=\"bytes / sec\", min=0)",
+            "interval": "auto"
+          },
+          "title": "Types of Service (bytes) [Filebeat Netflow]",
+          "type": "timelion"
+        }
+      },
+      "id": "717cd7c7-bfca-435d-8ee7-38259927aade",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:38.685Z",
+      "version": "WzM0NzAsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "query_string": {
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "Source Ports (bytes) [Filebeat Netflow]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "listeners": {},
+          "params": {
+            "expression": ".es(index=\"filebeat-*\", metric=\"sum:network.bytes\", split=\"source.port:10\", kibana=true).scale_interval(1s).fit(mode=scale).if(operator=\"lt\", if=0, then=0).trim(start=2,end=1).label(regex=\"^.* source.port:(.+) \u003e .*$\", label=\"$1\").lines(width=1, stack=true, fill=1).yaxis(label=\"bytes / sec\", min=0)",
+            "interval": "auto"
+          },
+          "title": "Source Ports (bytes) [Filebeat Netflow]",
+          "type": "timelion"
+        }
+      },
+      "id": "f668ecdb-eec7-44c6-9060-26aaf9fc8404",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:38.685Z",
+      "version": "WzM0NzEsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "query_string": {
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "Sources (bytes) [Filebeat Netflow]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "listeners": {},
+          "params": {
+            "expression": ".es(index=\"filebeat-*\", metric=\"sum:network.bytes\", split=\"source.ip:10\", kibana=true).scale_interval(1s).fit(mode=scale).if(operator=\"lt\", if=0, then=0).trim(start=2,end=1).label(regex=\"^.* source.ip:(.+) \u003e .*$\", label=\"$1\").lines(width=1, stack=true, fill=1).yaxis(label=\"bytes / sec\", min=0)",
+            "interval": "auto"
+          },
+          "title": "Sources (bytes) [Filebeat Netflow]",
+          "type": "timelion"
+        }
+      },
+      "id": "6bbd6712-494a-4fd9-b3d3-757304681f0f",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:38.685Z",
+      "version": "WzM0NzIsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "query_string": {
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "Destinations (bytes) [Filebeat Netflow]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "listeners": {},
+          "params": {
+            "expression": ".es(index=\"filebeat-*\", metric=\"sum:network.bytes\", split=\"destination.ip:10\", kibana=true).scale_interval(1s).fit(mode=scale).if(operator=\"lt\", if=0, then=0).trim(start=2,end=1).label(regex=\"^.* destination.ip:(.+) \u003e .*$\", label=\"$1\").lines(width=1, stack=true, fill=1).yaxis(label=\"bytes / sec\", min=0)",
+            "interval": "auto"
+          },
+          "title": "Destinations (bytes) [Filebeat Netflow]",
+          "type": "timelion"
+        }
+      },
+      "id": "681f0ce4-d828-4a99-b643-0c0715530050",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:38.685Z",
+      "version": "WzM0NzMsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "query_string": {
+                "analyze_wildcard": true,
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "Sources (bytes) [Filebeat Netflow]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "Bytes",
+                "field": "network.bytes"
+              },
+              "schema": "metric",
+              "type": "sum"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customLabel": "Source",
+                "field": "source.ip",
+                "order": "desc",
+                "orderBy": "1",
+                "size": 50
+              },
+              "schema": "segment",
+              "type": "terms"
+            }
+          ],
+          "listeners": {},
+          "params": {
+            "addLegend": true,
+            "addTooltip": true,
+            "isDonut": true,
+            "legendPosition": "right"
+          },
+          "title": "Sources (bytes) [Filebeat Netflow]",
+          "type": "pie"
+        }
+      },
+      "id": "fd6c1144-5026-4795-b7af-a9aa3fc28c56",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:38.685Z",
+      "version": "WzM0NzQsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "query_string": {
+                "analyze_wildcard": true,
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "Source Ports (bytes) [Filebeat Netflow]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "Bytes",
+                "field": "network.bytes"
+              },
+              "schema": "metric",
+              "type": "sum"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customLabel": "Source Port",
+                "field": "source.port",
+                "order": "desc",
+                "orderBy": "1",
+                "size": 50
+              },
+              "schema": "segment",
+              "type": "terms"
+            }
+          ],
+          "listeners": {},
+          "params": {
+            "addLegend": true,
+            "addTooltip": true,
+            "isDonut": true,
+            "legendPosition": "right"
+          },
+          "title": "Source Ports (bytes) [Filebeat Netflow]",
+          "type": "pie"
+        }
+      },
+      "id": "0b2818fd-aecc-4bef-b566-9466eb702ae4",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:38.685Z",
+      "version": "WzM0NzUsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "query_string": {
+                "analyze_wildcard": true,
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "Destinations (bytes) [Filebeat Netflow]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "Bytes",
+                "field": "network.bytes"
+              },
+              "schema": "metric",
+              "type": "sum"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customLabel": "Destination",
+                "field": "destination.ip",
+                "order": "desc",
+                "orderBy": "1",
+                "size": 50
+              },
+              "schema": "segment",
+              "type": "terms"
+            }
+          ],
+          "listeners": {},
+          "params": {
+            "addLegend": true,
+            "addTooltip": true,
+            "isDonut": true,
+            "legendPosition": "right"
+          },
+          "title": "Destinations (bytes) [Filebeat Netflow]",
+          "type": "pie"
+        }
+      },
+      "id": "248e00b4-8fc2-406f-8907-729d5380aaa7",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:38.685Z",
+      "version": "WzM0NzYsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "query_string": {
+                "analyze_wildcard": true,
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "Destination Ports (bytes) [Filebeat Netflow]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "Bytes",
+                "field": "network.bytes"
+              },
+              "schema": "metric",
+              "type": "sum"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customLabel": "Destination Port",
+                "field": "destination.port",
+                "order": "desc",
+                "orderBy": "1",
+                "size": 50
+              },
+              "schema": "segment",
+              "type": "terms"
+            }
+          ],
+          "listeners": {},
+          "params": {
+            "addLegend": true,
+            "addTooltip": true,
+            "isDonut": true,
+            "legendPosition": "right"
+          },
+          "title": "Destination Ports (bytes) [Filebeat Netflow]",
+          "type": "pie"
+        }
+      },
+      "id": "cf399a85-e348-4ac1-a399-e8f5a44114c4",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:38.685Z",
+      "version": "WzM0NzcsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "query_string": {
+                "analyze_wildcard": true,
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "Types of Service (bytes) [Filebeat Netflow]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "Bytes",
+                "field": "network.bytes"
+              },
+              "schema": "metric",
+              "type": "sum"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customLabel": "Type of Service",
+                "field": "netflow.ip_class_of_service",
+                "order": "desc",
+                "orderBy": "1",
+                "size": 50
+              },
+              "schema": "segment",
+              "type": "terms"
+            }
+          ],
+          "listeners": {},
+          "params": {
+            "addLegend": true,
+            "addTooltip": true,
+            "isDonut": true,
+            "legendPosition": "right"
+          },
+          "title": "Types of Service (bytes) [Filebeat Netflow]",
+          "type": "pie"
+        }
+      },
+      "id": "1cf30eac-aae8-47fa-a156-37f6346d2d5a",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:38.685Z",
+      "version": "WzM0NzgsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "query_string": {
+                "analyze_wildcard": true,
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "VLANs (bytes) [Filebeat Netflow]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "Bytes",
+                "field": "network.bytes"
+              },
+              "schema": "metric",
+              "type": "sum"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customLabel": "VLAN",
+                "field": "netflow.vlan_id",
+                "order": "desc",
+                "orderBy": "1",
+                "size": 50
+              },
+              "schema": "segment",
+              "type": "terms"
+            }
+          ],
+          "listeners": {},
+          "params": {
+            "addLegend": true,
+            "addTooltip": true,
+            "isDonut": true,
+            "legendPosition": "right"
+          },
+          "title": "VLANs (bytes) [Filebeat Netflow]",
+          "type": "pie"
+        }
+      },
+      "id": "7fa6cb0a-518d-46e9-a228-15cd4253a957",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:38.685Z",
+      "version": "WzM0NzksMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "query_string": {
+                "analyze_wildcard": true,
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "TCP Flags (bytes) [Filebeat Netflow]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "Bytes",
+                "field": "network.bytes"
+              },
+              "schema": "metric",
+              "type": "sum"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customLabel": "TCP Flags",
+                "field": "netflow.tcp_control_bits",
+                "order": "desc",
+                "orderBy": "1",
+                "size": 255
+              },
+              "schema": "segment",
+              "type": "terms"
+            }
+          ],
+          "listeners": {},
+          "params": {
+            "addLegend": true,
+            "addTooltip": true,
+            "isDonut": true,
+            "legendPosition": "right"
+          },
+          "title": "TCP Flags (bytes) [Filebeat Netflow]",
+          "type": "pie"
+        }
+      },
+      "id": "57e13a20-e94f-4465-a942-42148634a1d2",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:38.685Z",
+      "version": "WzM0ODAsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "query_string": {
+                "analyze_wildcard": true,
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "Autonomous Systems (bytes) [Filebeat Netflow]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "Bytes",
+                "field": "network.bytes"
+              },
+              "schema": "metric",
+              "type": "sum"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customLabel": "Autonomous System",
+                "field": "destination.as.organization.name",
+                "order": "desc",
+                "orderBy": "1",
+                "size": 50
+              },
+              "schema": "segment",
+              "type": "terms"
+            }
+          ],
+          "listeners": {},
+          "params": {
+            "addLegend": true,
+            "addTooltip": true,
+            "isDonut": true,
+            "legendPosition": "right"
+          },
+          "title": "Autonomous Systems (bytes) [Filebeat Netflow]",
+          "type": "pie"
+        }
+      },
+      "id": "f772028b-d5a6-4d55-b441-493871981a60",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:38.685Z",
+      "version": "WzM0ODEsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "query_string": {
+                "analyze_wildcard": true,
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "Countries (bytes) [Filebeat Netflow]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "Bytes",
+                "field": "network.bytes"
+              },
+              "schema": "metric",
+              "type": "sum"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customLabel": "Country",
+                "field": "destination.geo.country_name",
+                "order": "desc",
+                "orderBy": "1",
+                "size": 50
+              },
+              "schema": "segment",
+              "type": "terms"
+            }
+          ],
+          "listeners": {},
+          "params": {
+            "addLegend": true,
+            "addTooltip": true,
+            "isDonut": true,
+            "legendPosition": "right"
+          },
+          "title": "Countries (bytes) [Filebeat Netflow]",
+          "type": "pie"
+        }
+      },
+      "id": "a14c3248-952d-42aa-bd7d-9b39157a776f",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:38.685Z",
+      "version": "WzM0ODIsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "query_string": {
+                "analyze_wildcard": true,
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "Cities (bytes) [Filebeat Netflow]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "Bytes",
+                "field": "network.bytes"
+              },
+              "schema": "metric",
+              "type": "sum"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customLabel": "City",
+                "field": "destination.geo.city_name",
+                "order": "desc",
+                "orderBy": "1",
+                "size": 50
+              },
+              "schema": "segment",
+              "type": "terms"
+            }
+          ],
+          "listeners": {},
+          "params": {
+            "addLegend": true,
+            "addTooltip": true,
+            "isDonut": true,
+            "legendPosition": "right"
+          },
+          "title": "Cities (bytes) [Filebeat Netflow]",
+          "type": "pie"
+        }
+      },
+      "id": "a685420e-c45f-4b62-932b-5b76ac8b8ca2",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:38.685Z",
+      "version": "WzM0ODMsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "query_string": {
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "Sources (packets) [Filebeat Netflow]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "listeners": {},
+          "params": {
+            "expression": ".es(index=\"filebeat-*\", metric=\"sum:network.packets\", split=\"source.ip:10\", kibana=true).scale_interval(1s).fit(mode=scale).if(operator=\"lt\", if=0, then=0).trim(start=2,end=1).label(regex=\"^.* source.ip:(.+) \u003e .*$\", label=\"$1\").lines(width=1, stack=true, fill=1).yaxis(label=\"packets / sec\", min=0)",
+            "interval": "auto"
+          },
+          "title": "Sources (packets) [Filebeat Netflow]",
+          "type": "timelion"
+        }
+      },
+      "id": "0528bc66-6981-400a-a02d-c1d221b38890",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:38.685Z",
+      "version": "WzM0ODQsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "query_string": {
+                "analyze_wildcard": true,
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "Destination Count [Filebeat Netflow]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "Destinations",
+                "field": "destination.ip"
+              },
+              "schema": "metric",
+              "type": "cardinality"
+            }
+          ],
+          "listeners": {},
+          "params": {
+            "fontSize": "32",
+            "handleNoResults": true
+          },
+          "title": "Destination Count [Filebeat Netflow]",
+          "type": "metric"
+        }
+      },
+      "id": "e99dc327-03de-4561-9e0c-f550710125c2",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:38.685Z",
+      "version": "WzM0ODUsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "query_string": {
+                "analyze_wildcard": true,
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "Source Count [Filebeat Netflow]",
+        "uiStateJSON": {
+          "vis": {
+            "defaultColors": {
+              "0 - 100": "rgb(0,104,55)"
+            }
+          }
+        },
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "Sources",
+                "field": "source.ip"
+              },
+              "schema": "metric",
+              "type": "cardinality"
+            }
+          ],
+          "listeners": {},
+          "params": {
+            "addLegend": false,
+            "addTooltip": true,
+            "fontSize": "32",
+            "gauge": {
+              "autoExtend": false,
+              "backStyle": "Full",
+              "colorSchema": "Green to Red",
+              "colorsRange": [
+                {
+                  "from": 0,
+                  "to": 100
+                }
+              ],
+              "gaugeColorMode": "None",
+              "gaugeStyle": "Full",
+              "gaugeType": "Metric",
+              "invertColors": false,
+              "labels": {
+                "color": "black",
+                "show": true
+              },
+              "orientation": "vertical",
+              "percentageMode": false,
+              "scale": {
+                "color": "#333",
+                "labels": false,
+                "show": false,
+                "width": 2
+              },
+              "style": {
+                "bgColor": false,
+                "bgFill": "#000",
+                "fontSize": "36",
+                "labelColor": false,
+                "subText": ""
+              },
+              "type": "simple",
+              "useRange": false,
+              "verticalSplit": false
+            },
+            "handleNoResults": true,
+            "type": "gauge"
+          },
+          "title": "Source Count [Filebeat Netflow]",
+          "type": "metric"
+        }
+      },
+      "id": "32e712ed-fa15-4db7-8575-8476e8d65b03",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:38.685Z",
+      "version": "WzM0ODYsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "query_string": {
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "Destinations (packets) [Filebeat Netflow]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "listeners": {},
+          "params": {
+            "expression": ".es(index=\"filebeat-*\", metric=\"sum:network.packets\", split=\"destination.ip:10\", kibana=true).scale_interval(1s).fit(mode=scale).if(operator=\"lt\", if=0, then=0).trim(start=2,end=1).label(regex=\"^.* destination.ip:(.+) \u003e .*$\", label=\"$1\").lines(width=1, stack=true, fill=1).yaxis(label=\"packets / sec\", min=0)",
+            "interval": "auto"
+          },
+          "title": "Destinations (packets) [Filebeat Netflow]",
+          "type": "timelion"
+        }
+      },
+      "id": "d59a031c-70d6-47d7-966d-7fcb805be9be",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:38.685Z",
+      "version": "WzM0ODcsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "query_string": {
+                "analyze_wildcard": true,
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "Destination Port Count [Filebeat Netflow]",
+        "uiStateJSON": {
+          "vis": {
+            "defaultColors": {
+              "0 - 100": "rgb(0,104,55)"
+            }
+          }
+        },
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "Destination Ports",
+                "field": "destination.port"
+              },
+              "schema": "metric",
+              "type": "cardinality"
+            }
+          ],
+          "listeners": {},
+          "params": {
+            "addLegend": false,
+            "addTooltip": true,
+            "fontSize": "32",
+            "gauge": {
+              "autoExtend": false,
+              "backStyle": "Full",
+              "colorSchema": "Green to Red",
+              "colorsRange": [
+                {
+                  "from": 0,
+                  "to": 100
+                }
+              ],
+              "gaugeColorMode": "None",
+              "gaugeStyle": "Full",
+              "gaugeType": "Metric",
+              "invertColors": false,
+              "labels": {
+                "color": "black",
+                "show": true
+              },
+              "orientation": "vertical",
+              "percentageMode": false,
+              "scale": {
+                "color": "#333",
+                "labels": false,
+                "show": false,
+                "width": 2
+              },
+              "style": {
+                "bgColor": false,
+                "bgFill": "#000",
+                "fontSize": "36",
+                "labelColor": false,
+                "subText": ""
+              },
+              "type": "simple",
+              "useRange": false,
+              "verticalSplit": false
+            },
+            "handleNoResults": true,
+            "type": "gauge"
+          },
+          "title": "Destination Port Count [Filebeat Netflow]",
+          "type": "metric"
+        }
+      },
+      "id": "af707b01-29f1-462b-b279-6d2e803f3645",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:38.685Z",
+      "version": "WzM0ODgsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "query_string": {
+                "analyze_wildcard": true,
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "Source Port Count [Filebeat Netflow]",
+        "uiStateJSON": {
+          "vis": {
+            "defaultColors": {
+              "0 - 100": "rgb(0,104,55)"
+            }
+          }
+        },
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "Source Ports",
+                "field": "source.port"
+              },
+              "schema": "metric",
+              "type": "cardinality"
+            }
+          ],
+          "listeners": {},
+          "params": {
+            "addLegend": false,
+            "addTooltip": true,
+            "fontSize": "32",
+            "gauge": {
+              "autoExtend": false,
+              "backStyle": "Full",
+              "colorSchema": "Green to Red",
+              "colorsRange": [
+                {
+                  "from": 0,
+                  "to": 100
+                }
+              ],
+              "gaugeColorMode": "None",
+              "gaugeStyle": "Full",
+              "gaugeType": "Metric",
+              "invertColors": false,
+              "labels": {
+                "color": "black",
+                "show": true
+              },
+              "orientation": "vertical",
+              "percentageMode": false,
+              "scale": {
+                "color": "#333",
+                "labels": false,
+                "show": false,
+                "width": 2
+              },
+              "style": {
+                "bgColor": false,
+                "bgFill": "#000",
+                "fontSize": "36",
+                "labelColor": false,
+                "subText": ""
+              },
+              "type": "simple",
+              "useRange": false,
+              "verticalSplit": false
+            },
+            "handleNoResults": true,
+            "type": "gauge"
+          },
+          "title": "Source Port Count [Filebeat Netflow]",
+          "type": "metric"
+        }
+      },
+      "id": "ddd27657-c3c8-4f82-8059-6d7763dd599b",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:38.685Z",
+      "version": "WzM0ODksMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "query_string": {
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "Autonomous Systems (packets) [Filebeat Netflow]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "listeners": {},
+          "params": {
+            "expression": ".es(index=\"filebeat-*\", metric=\"sum:network.packets\", split=\"destination.as.organization.name:10\", kibana=true).scale_interval(1s).fit(mode=scale).if(operator=\"lt\", if=0, then=0).trim(start=2,end=1).label(regex=\"^.* destination.as.organization.name:(.+) \u003e .*$\", label=\"$1\").lines(width=1, stack=true, fill=1).yaxis(label=\"packets / sec\", min=0)",
+            "interval": "auto"
+          },
+          "title": "Autonomous Systems (packets) [Filebeat Netflow]",
+          "type": "timelion"
+        }
+      },
+      "id": "30cd1009-2925-4c9b-820d-d689f5d1efda",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:38.685Z",
+      "version": "WzM0OTAsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "query_string": {
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "Cities (packets) [Filebeat Netflow]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "listeners": {},
+          "params": {
+            "expression": ".es(index=\"filebeat-*\", metric=\"sum:network.packets\", split=\"destination.geo.city_name:10\", kibana=true).scale_interval(1s).fit(mode=scale).if(operator=\"lt\", if=0, then=0).trim(start=2,end=1).label(regex=\"^.* destination.geo.city_name:(.+) \u003e .*$\", label=\"$1\").lines(width=1, stack=true, fill=1).yaxis(label=\"packets / sec\", min=0)",
+            "interval": "auto"
+          },
+          "title": "Cities (packets) [Filebeat Netflow]",
+          "type": "timelion"
+        }
+      },
+      "id": "7d447b22-89dc-4f32-b549-4b8620af4d76",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:38.685Z",
+      "version": "WzM0OTEsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "query_string": {
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "Countries (packets) [Filebeat Netflow]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "listeners": {},
+          "params": {
+            "expression": ".es(index=\"filebeat-*\", metric=\"sum:network.packets\", split=\"destination.geo.country_name:10\", kibana=true).scale_interval(1s).fit(mode=scale).if(operator=\"lt\", if=0, then=0).trim(start=2,end=1).label(regex=\"^.* destination.geo.country_name:(.+) \u003e .*$\", label=\"$1\").lines(width=1, stack=true, fill=1).yaxis(label=\"packets / sec\", min=0)",
+            "interval": "auto"
+          },
+          "title": "Countries (packets) [Filebeat Netflow]",
+          "type": "timelion"
+        }
+      },
+      "id": "d41a9663-e5ad-47a7-955e-3803ae4e23c0",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:38.685Z",
+      "version": "WzM0OTIsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "query_string": {
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "Destination Ports (packets) [Filebeat Netflow]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "listeners": {},
+          "params": {
+            "expression": ".es(index=\"filebeat-*\", metric=\"sum:network.packets\", split=\"destination.port:10\", kibana=true).scale_interval(1s).fit(mode=scale).if(operator=\"lt\", if=0, then=0).trim(start=2,end=1).label(regex=\"^.* destination.port:(.+) \u003e .*$\", label=\"$1\").lines(width=1, stack=true, fill=1).yaxis(label=\"packets / sec\", min=0)",
+            "interval": "auto"
+          },
+          "title": "Destination Ports (packets) [Filebeat Netflow]",
+          "type": "timelion"
+        }
+      },
+      "id": "3a4209e2-281c-467e-b5cb-315bf4a2661f",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:38.685Z",
+      "version": "WzM0OTMsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "query_string": {
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "Source Ports (packets) [Filebeat Netflow]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "listeners": {},
+          "params": {
+            "expression": ".es(index=\"filebeat-*\", metric=\"sum:network.packets\", split=\"source.port:10\", kibana=true).scale_interval(1s).fit(mode=scale).if(operator=\"lt\", if=0, then=0).trim(start=2,end=1).label(regex=\"^.* source.port:(.+) \u003e .*$\", label=\"$1\").lines(width=1, stack=true, fill=1).yaxis(label=\"packets / sec\", min=0)",
+            "interval": "auto"
+          },
+          "title": "Source Ports (packets) [Filebeat Netflow]",
+          "type": "timelion"
+        }
+      },
+      "id": "201d7dd1-a880-4a64-b631-db5629340db9",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:38.685Z",
+      "version": "WzM0OTQsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "query_string": {
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "TCP Flags (packets) [Filebeat Netflow]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "listeners": {},
+          "params": {
+            "expression": ".es(index=\"filebeat-*\", metric=\"sum:network.packets\", split=\"netflow.tcp_control_bits:10\", kibana=true).scale_interval(1s).fit(mode=scale).if(operator=\"lt\", if=0, then=0).trim(start=2,end=1).label(regex=\"^.* netflow.tcp_control_bits:(.+) \u003e .*$\", label=\"$1\").lines(width=1, stack=true, fill=1).yaxis(label=\"packets / sec\", min=0)",
+            "interval": "auto"
+          },
+          "title": "TCP Flags (packets) [Filebeat Netflow]",
+          "type": "timelion"
+        }
+      },
+      "id": "8f83cf97-4a48-421f-8db5-690297d1f4fb",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:38.685Z",
+      "version": "WzM0OTUsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "query_string": {
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "Types of Service (packets) [Filebeat Netflow]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "listeners": {},
+          "params": {
+            "expression": ".es(index=\"filebeat-*\", metric=\"sum:network.packets\", split=\"netflow.ip_class_of_service:10\", kibana=true).scale_interval(1s).fit(mode=scale).if(operator=\"lt\", if=0, then=0).trim(start=2,end=1).label(regex=\"^.* netflow.ip_class_of_service:(.+) \u003e .*$\", label=\"$1\").lines(width=1, stack=true, fill=1).yaxis(label=\"packets / sec\", min=0)",
+            "interval": "auto"
+          },
+          "title": "Types of Service (packets) [Filebeat Netflow]",
+          "type": "timelion"
+        }
+      },
+      "id": "a1704d46-15fc-41c2-851d-796ceb49877f",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:38.685Z",
+      "version": "WzM0OTYsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "query_string": {
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "VLANs (packets) [Filebeat Netflow]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "listeners": {},
+          "params": {
+            "expression": ".es(index=\"filebeat-*\", metric=\"sum:network.packets\", split=\"netflow.vlan_id:10\", kibana=true).scale_interval(1s).fit(mode=scale).if(operator=\"lt\", if=0, then=0).trim(start=2,end=1).label(regex=\"^.* netflow.vlan_id:(.+) \u003e .*$\", label=\"$1\").lines(width=1, stack=true, fill=1).yaxis(label=\"packets / sec\", min=0)",
+            "interval": "auto"
+          },
+          "title": "VLANs (packets) [Filebeat Netflow]",
+          "type": "timelion"
+        }
+      },
+      "id": "15e2a267-2495-4df2-a121-abe410d2f18c",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:38.685Z",
+      "version": "WzM0OTcsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "query_string": {
+                "analyze_wildcard": true,
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "ToS Count [Filebeat Netflow]",
+        "uiStateJSON": {
+          "vis": {
+            "defaultColors": {
+              "0 - 100": "rgb(0,104,55)"
+            }
+          }
+        },
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "Types of Service",
+                "field": "netflow.ip_class_of_service"
+              },
+              "schema": "metric",
+              "type": "cardinality"
+            }
+          ],
+          "listeners": {},
+          "params": {
+            "addLegend": false,
+            "addTooltip": true,
+            "fontSize": "32",
+            "gauge": {
+              "autoExtend": false,
+              "backStyle": "Full",
+              "colorSchema": "Green to Red",
+              "colorsRange": [
+                {
+                  "from": 0,
+                  "to": 100
+                }
+              ],
+              "gaugeColorMode": "None",
+              "gaugeStyle": "Full",
+              "gaugeType": "Metric",
+              "invertColors": false,
+              "labels": {
+                "color": "black",
+                "show": true
+              },
+              "orientation": "vertical",
+              "percentageMode": false,
+              "scale": {
+                "color": "#333",
+                "labels": false,
+                "show": false,
+                "width": 2
+              },
+              "style": {
+                "bgColor": false,
+                "bgFill": "#000",
+                "fontSize": "36",
+                "labelColor": false,
+                "subText": ""
+              },
+              "type": "simple",
+              "useRange": false,
+              "verticalSplit": false
+            },
+            "handleNoResults": true,
+            "type": "gauge"
+          },
+          "title": "ToS Count [Filebeat Netflow]",
+          "type": "metric"
+        }
+      },
+      "id": "f27c1479-0625-4cdc-92de-672e47db0f87",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:38.685Z",
+      "version": "WzM0OTgsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "query_string": {
+                "analyze_wildcard": true,
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "VLAN Count [Filebeat Netflow]",
+        "uiStateJSON": {
+          "vis": {
+            "defaultColors": {
+              "0 - 100": "rgb(0,104,55)"
+            }
+          }
+        },
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "VLANs",
+                "field": "netflow.vlan_id"
+              },
+              "schema": "metric",
+              "type": "cardinality"
+            }
+          ],
+          "listeners": {},
+          "params": {
+            "addLegend": false,
+            "addTooltip": true,
+            "fontSize": "32",
+            "gauge": {
+              "autoExtend": false,
+              "backStyle": "Full",
+              "colorSchema": "Green to Red",
+              "colorsRange": [
+                {
+                  "from": 0,
+                  "to": 100
+                }
+              ],
+              "gaugeColorMode": "None",
+              "gaugeStyle": "Full",
+              "gaugeType": "Metric",
+              "invertColors": false,
+              "labels": {
+                "color": "black",
+                "show": true
+              },
+              "orientation": "vertical",
+              "percentageMode": false,
+              "scale": {
+                "color": "#333",
+                "labels": false,
+                "show": false,
+                "width": 2
+              },
+              "style": {
+                "bgColor": false,
+                "bgFill": "#000",
+                "fontSize": "36",
+                "labelColor": false,
+                "subText": ""
+              },
+              "type": "simple",
+              "useRange": false,
+              "verticalSplit": false
+            },
+            "handleNoResults": true,
+            "type": "gauge"
+          },
+          "title": "VLAN Count [Filebeat Netflow]",
+          "type": "metric"
+        }
+      },
+      "id": "0177bf1a-cba8-4ba6-a1d7-73caed86ffc2",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:38.685Z",
+      "version": "WzM0OTksMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "query_string": {
+                "analyze_wildcard": true,
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "Autonomous System Count [Filebeat Netflow]",
+        "uiStateJSON": {
+          "vis": {
+            "defaultColors": {
+              "0 - 100": "rgb(0,104,55)"
+            }
+          }
+        },
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "Autonomous Systems",
+                "field": "destination.as.organization.name"
+              },
+              "schema": "metric",
+              "type": "cardinality"
+            }
+          ],
+          "listeners": {},
+          "params": {
+            "addLegend": false,
+            "addTooltip": true,
+            "fontSize": "32",
+            "gauge": {
+              "autoExtend": false,
+              "backStyle": "Full",
+              "colorSchema": "Green to Red",
+              "colorsRange": [
+                {
+                  "from": 0,
+                  "to": 100
+                }
+              ],
+              "gaugeColorMode": "None",
+              "gaugeStyle": "Full",
+              "gaugeType": "Metric",
+              "invertColors": false,
+              "labels": {
+                "color": "black",
+                "show": true
+              },
+              "orientation": "vertical",
+              "percentageMode": false,
+              "scale": {
+                "color": "#333",
+                "labels": false,
+                "show": false,
+                "width": 2
+              },
+              "style": {
+                "bgColor": false,
+                "bgFill": "#000",
+                "fontSize": "36",
+                "labelColor": false,
+                "subText": ""
+              },
+              "type": "simple",
+              "useRange": false,
+              "verticalSplit": false
+            },
+            "handleNoResults": true,
+            "type": "gauge"
+          },
+          "title": "Autonomous System Count [Filebeat Netflow]",
+          "type": "metric"
+        }
+      },
+      "id": "d5568704-e30b-4108-bb49-06a9b8dce6a6",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:38.685Z",
+      "version": "WzM1MDAsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "query_string": {
+                "analyze_wildcard": true,
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "City Count [Filebeat Netflow]",
+        "uiStateJSON": {
+          "vis": {
+            "defaultColors": {
+              "0 - 100": "rgb(0,104,55)"
+            }
+          }
+        },
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "Cities",
+                "field": "destination.geo.city_name"
+              },
+              "schema": "metric",
+              "type": "cardinality"
+            }
+          ],
+          "listeners": {},
+          "params": {
+            "addLegend": false,
+            "addTooltip": true,
+            "fontSize": "32",
+            "gauge": {
+              "autoExtend": false,
+              "backStyle": "Full",
+              "colorSchema": "Green to Red",
+              "colorsRange": [
+                {
+                  "from": 0,
+                  "to": 100
+                }
+              ],
+              "gaugeColorMode": "None",
+              "gaugeStyle": "Full",
+              "gaugeType": "Metric",
+              "invertColors": false,
+              "labels": {
+                "color": "black",
+                "show": true
+              },
+              "orientation": "vertical",
+              "percentageMode": false,
+              "scale": {
+                "color": "#333",
+                "labels": false,
+                "show": false,
+                "width": 2
+              },
+              "style": {
+                "bgColor": false,
+                "bgFill": "#000",
+                "fontSize": "36",
+                "labelColor": false,
+                "subText": ""
+              },
+              "type": "simple",
+              "useRange": false,
+              "verticalSplit": false
+            },
+            "handleNoResults": true,
+            "type": "gauge"
+          },
+          "title": "City Count [Filebeat Netflow]",
+          "type": "metric"
+        }
+      },
+      "id": "16262df9-a979-4136-935e-d883c7d373d7",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:38.685Z",
+      "version": "WzM1MDEsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "query_string": {
+                "analyze_wildcard": true,
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "Country Count [Filebeat Netflow]",
+        "uiStateJSON": {
+          "vis": {
+            "defaultColors": {
+              "0 - 100": "rgb(0,104,55)"
+            }
+          }
+        },
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "Countries",
+                "field": "destination.geo.country_name"
+              },
+              "schema": "metric",
+              "type": "cardinality"
+            }
+          ],
+          "listeners": {},
+          "params": {
+            "addLegend": false,
+            "addTooltip": true,
+            "fontSize": "32",
+            "gauge": {
+              "autoExtend": false,
+              "backStyle": "Full",
+              "colorSchema": "Green to Red",
+              "colorsRange": [
+                {
+                  "from": 0,
+                  "to": 100
+                }
+              ],
+              "gaugeColorMode": "None",
+              "gaugeStyle": "Full",
+              "gaugeType": "Metric",
+              "invertColors": false,
+              "labels": {
+                "color": "black",
+                "show": true
+              },
+              "orientation": "vertical",
+              "percentageMode": false,
+              "scale": {
+                "color": "#333",
+                "labels": false,
+                "show": false,
+                "width": 2
+              },
+              "style": {
+                "bgColor": false,
+                "bgFill": "#000",
+                "fontSize": "36",
+                "labelColor": false,
+                "subText": ""
+              },
+              "type": "simple",
+              "useRange": false,
+              "verticalSplit": false
+            },
+            "handleNoResults": true,
+            "type": "gauge"
+          },
+          "title": "Country Count [Filebeat Netflow]",
+          "type": "metric"
+        }
+      },
+      "id": "63ef5338-fdf2-488e-b78a-f0e98daccc95",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:38.685Z",
+      "version": "WzM1MDIsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "query_string": {
+                "analyze_wildcard": true,
+                "query": "*"
+              }
+            }
+          }
+        },
+        "title": "TCP Flags Count [Filebeat Netflow]",
+        "uiStateJSON": {
+          "vis": {
+            "defaultColors": {
+              "0 - 100": "rgb(0,104,55)"
+            }
+          }
+        },
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "TCP Flag States",
+                "field": "netflow.tcp_control_bits"
+              },
+              "schema": "metric",
+              "type": "cardinality"
+            }
+          ],
+          "listeners": {},
+          "params": {
+            "addLegend": false,
+            "addTooltip": true,
+            "fontSize": "32",
+            "gauge": {
+              "autoExtend": false,
+              "backStyle": "Full",
+              "colorSchema": "Green to Red",
+              "colorsRange": [
+                {
+                  "from": 0,
+                  "to": 100
+                }
+              ],
+              "gaugeColorMode": "None",
+              "gaugeStyle": "Full",
+              "gaugeType": "Metric",
+              "invertColors": false,
+              "labels": {
+                "color": "black",
+                "show": true
+              },
+              "orientation": "vertical",
+              "percentageMode": false,
+              "scale": {
+                "color": "#333",
+                "labels": false,
+                "show": false,
+                "width": 2
+              },
+              "style": {
+                "bgColor": false,
+                "bgFill": "#000",
+                "fontSize": "36",
+                "labelColor": false,
+                "subText": ""
+              },
+              "type": "simple",
+              "useRange": false,
+              "verticalSplit": false
+            },
+            "handleNoResults": true,
+            "type": "gauge"
+          },
+          "title": "TCP Flags Count [Filebeat Netflow]",
+          "type": "metric"
+        }
+      },
+      "id": "2dca3025-692c-4876-8bcc-e0b248dc9819",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-07-11T04:44:38.685Z",
+      "version": "WzM1MDMsMV0="
+    }
+  ],
+  "version": "7.2.0"
+}

--- a/dev/package-beats/netflow-module-1.0.0/manifest.yml
+++ b/dev/package-beats/netflow-module-1.0.0/manifest.yml
@@ -1,0 +1,13 @@
+name: netflow-module
+title: NetFlow
+version: 1.0.0
+description: |
+  Module for receiving NetFlow and IPFIX flow records over UDP. The module does not add fields beyond what the netflow input provides.
+type: ""
+categories:
+- logs
+requirement:
+  kibana:
+    version:
+      min: 6.7.0
+      max: 7.6.0

--- a/dev/package-beats/nginx-1.0.0/kibana/dashboard/Filebeat-nginx-logs.json
+++ b/dev/package-beats/nginx-1.0.0/kibana/dashboard/Filebeat-nginx-logs.json
@@ -1,0 +1,279 @@
+{
+    "objects": [
+        {
+            "attributes": {
+                "columns": [
+                    "log.level", 
+                    "message"
+                ], 
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlight": {
+                            "fields": {
+                                "*": {}
+                            }, 
+                            "fragment_size": 2147483647, 
+                            "post_tags": [
+                                "@/kibana-highlighted-field@"
+                            ], 
+                            "pre_tags": [
+                                "@kibana-highlighted-field@"
+                            ], 
+                            "require_field_match": false
+                        }, 
+                        "highlightAll": true, 
+                        "index": "filebeat-*", 
+                        "query": {
+                            "language": "kuery",
+                            "query": "event.module:nginx AND message:*"
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "sort": [
+                    "@timestamp", 
+                    "desc"
+                ], 
+                "title": "Nginx error logs [Filebeat Nginx] ECS", 
+                "version": 1
+            }, 
+            "id": "9eb25600-a1f0-11e7-928f-5dbe6f6f5519-ecs", 
+            "type": "search", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "columns": [
+                    "url.original", 
+                    "http.request.method", 
+                    "http.response.status_code", 
+                    "http.response.body.bytes"
+                ], 
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlight": {
+                            "fields": {
+                                "*": {}
+                            }, 
+                            "fragment_size": 2147483647, 
+                            "post_tags": [
+                                "@/kibana-highlighted-field@"
+                            ], 
+                            "pre_tags": [
+                                "@kibana-highlighted-field@"
+                            ], 
+                            "require_field_match": false
+                        }, 
+                        "highlightAll": true, 
+                        "index": "filebeat-*", 
+                        "query": {
+                            "language": "kuery",
+                            "query": "event.module:nginx AND url.original:*"
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "sort": [
+                    "@timestamp", 
+                    "desc"
+                ], 
+                "title": "Nginx access logs [Filebeat Nginx] ECS", 
+                "version": 1
+            }, 
+            "id": "6d9e66d0-a1f0-11e7-928f-5dbe6f6f5519-ecs", 
+            "type": "search", 
+            "version": 4
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "Access logs over time [Filebeat Nginx] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "annotations": [
+                            {
+                                "color": "#F00", 
+                                "icon": "fa-tag", 
+                                "id": "970b1420-a1f3-11e7-a062-a1c3587f4874", 
+                                "ignore_global_filters": 1, 
+                                "ignore_panel_filters": 1, 
+                                "index_pattern": "filebeat-*", 
+                                "time_field": "@timestamp"
+                            }
+                        ], 
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "background_color_rules": [
+                            {
+                                "id": "3189aa80-a1f3-11e7-a062-a1c3587f4874"
+                            }
+                        ], 
+                        "filter": "event.module:nginx AND fileset.name:access", 
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417", 
+                        "index_pattern": "filebeat-*", 
+                        "interval": "auto", 
+                        "legend_position": "bottom", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": 0.5, 
+                                "formatter": "number", 
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417", 
+                                "label": "Access logs", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "type": "count"
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_filters": [
+                                    {
+                                        "color": "#68BC00", 
+                                        "id": "1db649a0-a1f3-11e7-a062-a1c3587f4874"
+                                    }
+                                ], 
+                                "split_mode": "everything", 
+                                "stacked": "none", 
+                                "terms_field": "url.original", 
+                                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "timeseries"
+                    }, 
+                    "title": "Access logs over time [Filebeat Nginx] ECS", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "1cfb1a80-a1f4-11e7-928f-5dbe6f6f5519-ecs", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "Dashboards [Filebeat Nginx] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "fontSize": 12, 
+                        "markdown": "[Nginx logs overview](#/dashboard/55a9e6e0-a29e-11e7-928f-5dbe6f6f5519-ecs) | [Nginx access and error logs](#/dashboard/046212a0-a2a1-11e7-928f-5dbe6f6f5519-ecs)"
+                    }, 
+                    "title": "Dashboards [Filebeat Nginx] ECS", 
+                    "type": "markdown"
+                }
+            }, 
+            "id": "97109780-a2a5-11e7-928f-5dbe6f6f5519-ecs", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "Dashboard for the Filebeat Nginx module", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlightAll": true, 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "optionsJSON": {
+                    "darkTheme": false
+                }, 
+                "panelsJSON": [
+                    {
+                        "col": 1, 
+                        "columns": [
+                            "log.level", 
+                            "message"
+                        ], 
+                        "id": "9eb25600-a1f0-11e7-928f-5dbe6f6f5519-ecs", 
+                        "panelIndex": 11, 
+                        "row": 5, 
+                        "size_x": 12, 
+                        "size_y": 3, 
+                        "sort": [
+                            "@timestamp", 
+                            "desc"
+                        ], 
+                        "type": "search"
+                    }, 
+                    {
+                        "col": 1, 
+                        "columns": [
+                            "url.original", 
+                            "http.request.method", 
+                            "http.response.status_code", 
+                            "http.response.body.bytes"
+                        ], 
+                        "id": "6d9e66d0-a1f0-11e7-928f-5dbe6f6f5519-ecs", 
+                        "panelIndex": 16, 
+                        "row": 8, 
+                        "size_x": 12, 
+                        "size_y": 7, 
+                        "sort": [
+                            "@timestamp", 
+                            "desc"
+                        ], 
+                        "type": "search"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "1cfb1a80-a1f4-11e7-928f-5dbe6f6f5519-ecs", 
+                        "panelIndex": 18, 
+                        "row": 2, 
+                        "size_x": 12, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "97109780-a2a5-11e7-928f-5dbe6f6f5519-ecs", 
+                        "panelIndex": 19, 
+                        "row": 1, 
+                        "size_x": 12, 
+                        "size_y": 1, 
+                        "type": "visualization"
+                    }
+                ], 
+                "timeRestore": false, 
+                "title": "[Filebeat Nginx] Access and error logs ECS", 
+                "uiStateJSON": {}, 
+                "version": 1
+            }, 
+            "id": "046212a0-a2a1-11e7-928f-5dbe6f6f5519-ecs", 
+            "type": "dashboard", 
+            "version": 2
+        }
+    ], 
+    "version": "6.0.0-beta2"
+}

--- a/dev/package-beats/nginx-1.0.0/kibana/dashboard/Filebeat-nginx-overview.json
+++ b/dev/package-beats/nginx-1.0.0/kibana/dashboard/Filebeat-nginx-overview.json
@@ -1,0 +1,677 @@
+{
+    "objects": [
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "index": "filebeat-*",
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                },
+                "title": "Browsers breakdown [Filebeat Nginx] ECS",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true,
+                            "id": "1",
+                            "params": {},
+                            "schema": "metric",
+                            "type": "count"
+                        },
+                        {
+                            "enabled": true,
+                            "id": "2",
+                            "params": {
+                                "field": "user_agent.name",
+                                "order": "desc",
+                                "orderBy": "1",
+                                "size": 5
+                            },
+                            "schema": "segment",
+                            "type": "terms"
+                        },
+                        {
+                            "enabled": true,
+                            "id": "3",
+                            "params": {
+                                "field": "user_agent.version", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            },
+                            "schema": "segment",
+                            "type": "terms"
+                        }
+                    ],
+                    "listeners": {},
+                    "params": {
+                        "addLegend": true,
+                        "addTooltip": true,
+                        "isDonut": true,
+                        "legendPosition": "bottom",
+                        "shareYAxis": true
+                    },
+                    "title": "Nginx Access Browsers ECS",
+                    "type": "pie"
+                }
+            },
+            "id": "Nginx-Access-Browsers-ecs",
+            "type": "visualization",
+            "version": 1
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "index": "filebeat-*",
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                },
+                "title": "Operating systems breakdown [Filebeat Nginx] ECS",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true,
+                            "id": "1",
+                            "params": {},
+                            "schema": "metric",
+                            "type": "count"
+                        },
+                        {
+                            "enabled": true,
+                            "id": "2",
+                            "params": {
+                                "field": "user_agent.os.name",
+                                "order": "desc",
+                                "orderBy": "1",
+                                "size": 5
+                            },
+                            "schema": "segment",
+                            "type": "terms"
+                        },
+                        {
+                            "enabled": true,
+                            "id": "3",
+                            "params": {
+                                "field": "user_agent.os.version", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            },
+                            "schema": "segment",
+                            "type": "terms"
+                        }
+                    ],
+                    "listeners": {},
+                    "params": {
+                        "addLegend": true,
+                        "addTooltip": true,
+                        "isDonut": true,
+                        "legendPosition": "bottom",
+                        "shareYAxis": true
+                    },
+                    "title": "Nginx Access OSes ECS",
+                    "type": "pie"
+                }
+            },
+            "id": "Nginx-Access-OSes-ecs",
+            "type": "visualization",
+            "version": 1
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                },
+                "savedSearchId": "Filebeat-Nginx-module-ecs",
+                "title": "Access Map [Filebeat Nginx] ECS",
+                "uiStateJSON": {
+                    "mapCenter": [
+                        12.039320557540572,
+                        -0.17578125
+                    ]
+                },
+                "version": 1,
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true,
+                            "id": "1",
+                            "params": {},
+                            "schema": "metric",
+                            "type": "count"
+                        },
+                        {
+                            "enabled": true,
+                            "id": "2",
+                            "params": {
+                                "autoPrecision": true,
+                                "field": "source.geo.location"
+                            },
+                            "schema": "segment",
+                            "type": "geohash_grid"
+                        }
+                    ],
+                    "listeners": {},
+                    "params": {
+                        "addTooltip": true,
+                        "heatBlur": 15,
+                        "heatMaxZoom": 16,
+                        "heatMinOpacity": 0.1,
+                        "heatNormalizeData": true,
+                        "heatRadius": 25,
+                        "isDesaturated": true,
+                        "legendPosition": "bottomright",
+                        "mapCenter": [
+                            15,
+                            5
+                        ],
+                        "mapType": "Scaled Circle Markers",
+                        "mapZoom": 2,
+                        "wms": {
+                            "enabled": false,
+                            "options": {
+                                "attribution": "Maps provided by USGS",
+                                "format": "image/png",
+                                "layers": "0",
+                                "styles": "",
+                                "transparent": true,
+                                "version": "1.3.0"
+                            },
+                            "url": "https://basemap.nationalmap.gov/arcgis/services/USGSTopo/MapServer/WMSServer"
+                        }
+                    },
+                    "title": "Nginx Access Map ECS",
+                    "type": "tile_map"
+                }
+            },
+            "id": "Nginx-Access-Map-ecs",
+            "type": "visualization",
+            "version": 1
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                },
+                "title": "Response codes over time [Filebeat Nginx] ECS",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "params": {
+                        "axis_formatter": "number",
+                        "axis_position": "left",
+                        "filter": "event.module:nginx AND fileset.name:access",
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+                        "index_pattern": "filebeat-*",
+                        "interval": "auto",
+                        "legend_position": "bottom",
+                        "series": [
+                            {
+                                "axis_position": "right",
+                                "chart_type": "bar",
+                                "color": "#68BC00",
+                                "fill": 0.5,
+                                "formatter": "number",
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                                "label": "",
+                                "line_width": 1,
+                                "metrics": [
+                                    {
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                                        "type": "count"
+                                    }
+                                ],
+                                "point_size": 1,
+                                "seperate_axis": 0,
+                                "split_filters": [
+                                    {
+                                        "color": "#68BC00",
+                                        "filter": "http.response.status_code:[200 TO 299]",
+                                        "id": "5acdc750-a29d-11e7-a062-a1c3587f4874",
+                                        "label": "200s"
+                                    },
+                                    {
+                                        "color": "rgba(252,196,0,1)",
+                                        "filter": "http.response.status_code:[300 TO 399]",
+                                        "id": "6efd2ae0-a29d-11e7-a062-a1c3587f4874",
+                                        "label": "300s"
+                                    },
+                                    {
+                                        "color": "rgba(211,49,21,1)",
+                                        "filter": "http.response.status_code:[400 TO 499]",
+                                        "id": "76089a90-a29d-11e7-a062-a1c3587f4874",
+                                        "label": "400s"
+                                    },
+                                    {
+                                        "color": "rgba(171,20,158,1)",
+                                        "filter": "http.response.status_code:[500 TO 599]",
+                                        "id": "7c7929d0-a29d-11e7-a062-a1c3587f4874",
+                                        "label": "500s"
+                                    }
+                                ],
+                                "split_mode": "filters",
+                                "stacked": "stacked",
+                                "terms_field": "http.response.status_code",
+                                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417"
+                            }
+                        ],
+                        "show_grid": 1,
+                        "show_legend": 1,
+                        "time_field": "@timestamp",
+                        "type": "timeseries"
+                    },
+                    "title": "Response codes over time [Filebeat Nginx] ECS",
+                    "type": "metrics"
+                }
+            },
+            "id": "b70b1b20-a1f4-11e7-928f-5dbe6f6f5519-ecs",
+            "type": "visualization",
+            "version": 7
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                },
+                "title": "Top pages [Filebeat Nginx] ECS",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "params": {
+                        "axis_formatter": "number",
+                        "axis_position": "left",
+                        "bar_color_rules": [
+                            {
+                                "id": "6252c320-a1f5-11e7-92ba-5d0b8663aece"
+                            }
+                        ],
+                        "filter": "event.module:nginx AND fileset.name:access",
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+                        "index_pattern": "filebeat-*",
+                        "interval": "auto",
+                        "series": [
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "#68BC00",
+                                "fill": 0.5,
+                                "formatter": "number",
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                                "line_width": 1,
+                                "metrics": [
+                                    {
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                                        "type": "count"
+                                    }
+                                ],
+                                "point_size": 1,
+                                "seperate_axis": 0,
+                                "split_mode": "terms",
+                                "stacked": "none",
+                                "terms_field": "url.original",
+                                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417",
+                                "value_template": ""
+                            }
+                        ],
+                        "show_grid": 1,
+                        "show_legend": 1,
+                        "time_field": "@timestamp",
+                        "type": "top_n"
+                    },
+                    "title": "Top pages [Filebeat Nginx] ECS",
+                    "type": "metrics"
+                }
+            },
+            "id": "9184fa00-a1f5-11e7-928f-5dbe6f6f5519-ecs",
+            "type": "visualization",
+            "version": 3
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                },
+                "title": "Errors over time [Filebeat Nginx] ECS",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "params": {
+                        "axis_formatter": "number",
+                        "axis_position": "left",
+                        "filter": "event.module:nginx AND fileset.name:error",
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+                        "index_pattern": "filebeat-*",
+                        "interval": "auto",
+                        "legend_position": "bottom",
+                        "series": [
+                            {
+                                "axis_position": "right",
+                                "chart_type": "bar",
+                                "color": "rgba(211,49,21,1)",
+                                "fill": 0.5,
+                                "formatter": "number",
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                                "line_width": 1,
+                                "metrics": [
+                                    {
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                                        "type": "count"
+                                    }
+                                ],
+                                "point_size": 1,
+                                "seperate_axis": 0,
+                                "split_mode": "terms",
+                                "stacked": "none",
+                                "terms_field": "log.level",
+                                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417"
+                            }
+                        ],
+                        "show_grid": 1,
+                        "show_legend": 1,
+                        "time_field": "@timestamp",
+                        "type": "timeseries"
+                    },
+                    "title": "Errors over time [Filebeat Nginx] ECS",
+                    "type": "metrics"
+                }
+            },
+            "id": "46322e50-a1f6-11e7-928f-5dbe6f6f5519-ecs",
+            "type": "visualization",
+            "version": 5
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                },
+                "title": "Data Volume [Filebeat Nginx] ECS",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "params": {
+                        "axis_formatter": "number",
+                        "axis_position": "left",
+                        "filter": "event.module: nginx AND fileset.name: access",
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+                        "index_pattern": "filebeat-*",
+                        "interval": "auto",
+                        "legend_position": "bottom",
+                        "series": [
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "#68BC00",
+                                "fill": 0.5,
+                                "formatter": "bytes",
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                                "label": "",
+                                "line_width": 1,
+                                "metrics": [
+                                    {
+                                        "field": "http.response.body.bytes",
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                                        "type": "sum"
+                                    }
+                                ],
+                                "point_size": 1,
+                                "seperate_axis": 0,
+                                "split_filters": [
+                                    {
+                                        "color": "#68BC00",
+                                        "filter": "http.response.status_code:[200 TO 299]",
+                                        "id": "7c343c20-a29e-11e7-a062-a1c3587f4874",
+                                        "label": "200s"
+                                    }
+                                ],
+                                "split_mode": "everything",
+                                "stacked": "none",
+                                "terms_field": null
+                            }
+                        ],
+                        "show_grid": 1,
+                        "show_legend": 1,
+                        "time_field": "@timestamp",
+                        "type": "timeseries"
+                    },
+                    "title": "Data Volume [Filebeat Nginx] ECS",
+                    "type": "metrics"
+                }
+            },
+            "id": "0dd6f320-a29f-11e7-928f-5dbe6f6f5519-ecs",
+            "type": "visualization",
+            "version": 2
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                },
+                "title": "Dashboards [Filebeat Nginx] ECS",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "params": {
+                        "fontSize": 12,
+                        "markdown": "[Nginx logs overview](#/dashboard/55a9e6e0-a29e-11e7-928f-5dbe6f6f5519-ecs) | [Nginx access and error logs](#/dashboard/046212a0-a2a1-11e7-928f-5dbe6f6f5519-ecs)"
+                    },
+                    "title": "Dashboards [Filebeat Nginx] ECS",
+                    "type": "markdown"
+                }
+            },
+            "id": "97109780-a2a5-11e7-928f-5dbe6f6f5519-ecs",
+            "type": "visualization",
+            "version": 1
+        },
+        {
+            "attributes": {
+                "columns": [
+                    "url.original",
+                    "http.request.method",
+                    "http.response.status_code",
+                    "http.request.referrer",
+                    "http.response.body.bytes"
+                ],
+                "description": "",
+                "hits": 0,
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "highlight": {
+                            "fields": {
+                                "*": {}
+                            },
+                            "fragment_size": 2147483647,
+                            "post_tags": [
+                                "@/kibana-highlighted-field@"
+                            ],
+                            "pre_tags": [
+                                "@kibana-highlighted-field@"
+                            ],
+                            "require_field_match": false
+                        },
+                        "highlightAll": true,
+                        "index": "filebeat-*",
+                        "query": {
+                            "language": "kuery",
+                            "query": "event.module:nginx"
+                        },
+                        "version": true
+                    }
+                },
+                "sort": [
+                    "@timestamp",
+                    "desc"
+                ],
+                "title": "Nginx logs [Filebeat Nginx] ECS",
+                "version": 1
+            },
+            "id": "Filebeat-Nginx-module-ecs",
+            "type": "search",
+            "version": 2
+        },
+        {
+            "attributes": {
+                "description": "Dashboard for the Filebeat Nginx module",
+                "hits": 0,
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "highlightAll": true,
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        },
+                        "version": true
+                    }
+                },
+                "optionsJSON": {
+                    "darkTheme": false
+                },
+                "panelsJSON": [
+                    {
+                        "col": 10,
+                        "id": "Nginx-Access-Browsers-ecs",
+                        "panelIndex": 3,
+                        "row": 12,
+                        "size_x": 3,
+                        "size_y": 3,
+                        "type": "visualization"
+                    },
+                    {
+                        "col": 7,
+                        "id": "Nginx-Access-OSes-ecs",
+                        "panelIndex": 4,
+                        "row": 12,
+                        "size_x": 3,
+                        "size_y": 3,
+                        "type": "visualization"
+                    },
+                    {
+                        "col": 1,
+                        "id": "Nginx-Access-Map-ecs",
+                        "panelIndex": 8,
+                        "row": 2,
+                        "size_x": 12,
+                        "size_y": 4,
+                        "type": "visualization"
+                    },
+                    {
+                        "col": 1,
+                        "id": "b70b1b20-a1f4-11e7-928f-5dbe6f6f5519-ecs",
+                        "panelIndex": 13,
+                        "row": 6,
+                        "size_x": 12,
+                        "size_y": 3,
+                        "type": "visualization"
+                    },
+                    {
+                        "col": 7,
+                        "id": "9184fa00-a1f5-11e7-928f-5dbe6f6f5519-ecs",
+                        "panelIndex": 14,
+                        "row": 9,
+                        "size_x": 6,
+                        "size_y": 3,
+                        "type": "visualization"
+                    },
+                    {
+                        "col": 1,
+                        "id": "46322e50-a1f6-11e7-928f-5dbe6f6f5519-ecs",
+                        "panelIndex": 15,
+                        "row": 9,
+                        "size_x": 6,
+                        "size_y": 3,
+                        "type": "visualization"
+                    },
+                    {
+                        "col": 1,
+                        "id": "0dd6f320-a29f-11e7-928f-5dbe6f6f5519-ecs",
+                        "panelIndex": 16,
+                        "row": 12,
+                        "size_x": 6,
+                        "size_y": 3,
+                        "type": "visualization"
+                    },
+                    {
+                        "col": 1,
+                        "id": "97109780-a2a5-11e7-928f-5dbe6f6f5519-ecs",
+                        "panelIndex": 17,
+                        "row": 1,
+                        "size_x": 12,
+                        "size_y": 1,
+                        "type": "visualization"
+                    }
+                ],
+                "timeRestore": false,
+                "title": "[Filebeat Nginx] Overview ECS",
+                "uiStateJSON": {
+                    "P-4": {
+                        "vis": {
+                            "legendOpen": true
+                        }
+                    },
+                    "P-8": {
+                        "mapBounds": {
+                            "bottom_right": {
+                                "lat": -7.362466865535738,
+                                "lon": 245.39062500000003
+                            },
+                            "top_left": {
+                                "lat": 77.07878389624943,
+                                "lon": -245.74218750000003
+                            }
+                        },
+                        "mapCenter": [
+                            50.51342652633956,
+                            -0.17578125
+                        ],
+                        "mapCollar": {
+                            "bottom_right": {
+                                "lat": -49.583095,
+                                "lon": 180
+                            },
+                            "top_left": {
+                                "lat": 90,
+                                "lon": -180
+                            },
+                            "zoom": 2
+                        },
+                        "mapZoom": 2
+                    }
+                },
+                "version": 1
+            },
+            "id": "55a9e6e0-a29e-11e7-928f-5dbe6f6f5519-ecs",
+            "type": "dashboard",
+            "version": 6
+        }
+    ],
+    "version": "6.0.0-beta2"
+}

--- a/dev/package-beats/nginx-1.0.0/kibana/dashboard/metricbeat-nginx-overview.json
+++ b/dev/package-beats/nginx-1.0.0/kibana/dashboard/metricbeat-nginx-overview.json
@@ -1,0 +1,474 @@
+{
+    "objects": [
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "Request Rate [Metricbeat Nginx] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "legend_position": "bottom", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": 0.5, 
+                                "formatter": "number", 
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417", 
+                                "label": "Request rate", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "nginx.stubstatus.requests", 
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "type": "avg"
+                                    }, 
+                                    {
+                                        "field": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "id": "396ec980-f1a1-11e7-95d0-8ddf041d42a2", 
+                                        "type": "derivative", 
+                                        "unit": ""
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "timeseries"
+                    }, 
+                    "title": "Request Rate [Metricbeat Nginx] ECS", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "555df8a0-f1a1-11e7-a9ef-93c69af7b129-ecs", 
+            "type": "visualization", 
+            "updated_at": "2018-01-04T22:48:58.542Z", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "Accepts and Handled Rate [Metricbeat Nginx] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "annotations": [
+                            {
+                                "color": "#F00", 
+                                "icon": "fa-tag", 
+                                "id": "8644f980-f1a3-11e7-95d0-8ddf041d42a2", 
+                                "ignore_global_filters": 1, 
+                                "ignore_panel_filters": 1, 
+                                "index_pattern": "*", 
+                                "time_field": "@timestamp"
+                            }
+                        ], 
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "legend_position": "bottom", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": "0.5", 
+                                "formatter": "number", 
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417", 
+                                "label": "Accepts rate", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "nginx.stubstatus.accepts", 
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "type": "avg"
+                                    }, 
+                                    {
+                                        "field": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "id": "396ec980-f1a1-11e7-95d0-8ddf041d42a2", 
+                                        "type": "derivative", 
+                                        "unit": ""
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_color_mode": "gradient", 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }, 
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "rgba(0,156,224,1)", 
+                                "fill": "0.9", 
+                                "formatter": "number", 
+                                "id": "56dd33b0-f1a3-11e7-95d0-8ddf041d42a2", 
+                                "label": "Handled rate", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "nginx.stubstatus.handled", 
+                                        "id": "56dd33b1-f1a3-11e7-95d0-8ddf041d42a2", 
+                                        "type": "avg"
+                                    }, 
+                                    {
+                                        "field": "56dd33b1-f1a3-11e7-95d0-8ddf041d42a2", 
+                                        "id": "56dd33b2-f1a3-11e7-95d0-8ddf041d42a2", 
+                                        "type": "derivative", 
+                                        "unit": ""
+                                    }
+                                ], 
+                                "point_size": "3", 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "timeseries"
+                    }, 
+                    "title": "Accepts and Handled Rate [Metricbeat Nginx] ECS", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "a1d92240-f1a1-11e7-a9ef-93c69af7b129-ecs", 
+            "type": "visualization", 
+            "updated_at": "2018-01-04T23:07:23.056Z", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "Drops Rate [Metricbeat Nginx] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "legend_position": "bottom", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "rgba(188,0,65,1)", 
+                                "fill": 0.5, 
+                                "formatter": "number", 
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417", 
+                                "label": "Drops rate", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "nginx.stubstatus.dropped", 
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "type": "avg"
+                                    }, 
+                                    {
+                                        "field": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "id": "396ec980-f1a1-11e7-95d0-8ddf041d42a2", 
+                                        "type": "derivative", 
+                                        "unit": ""
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "timeseries"
+                    }, 
+                    "title": "Drops Rate [Metricbeat Nginx] ECS", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "d763a570-f1a1-11e7-a9ef-93c69af7b129-ecs", 
+            "type": "visualization", 
+            "updated_at": "2018-01-04T22:51:46.375Z", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "Active connections [Metricbeat Nginx] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "legend_position": "bottom", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": 0.5, 
+                                "formatter": "number", 
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "nginx.stubstatus.active", 
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "type": "avg"
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "timeseries"
+                    }, 
+                    "title": "Active connections [Metricbeat Nginx] ECS", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "47a8e0f0-f1a4-11e7-a9ef-93c69af7b129-ecs", 
+            "type": "visualization", 
+            "updated_at": "2018-01-04T23:09:55.944Z", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "Reading / Writing / Waiting Rates [Metricbeat Nginx] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "legend_position": "bottom", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": 0.5, 
+                                "formatter": "number", 
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417", 
+                                "label": "Reading", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "nginx.stubstatus.reading", 
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417", 
+                                        "type": "avg"
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }, 
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "rgba(0,156,224,1)", 
+                                "fill": 0.5, 
+                                "formatter": "number", 
+                                "id": "b1773680-f1a4-11e7-95d0-8ddf041d42a2", 
+                                "label": "Writing", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "nginx.stubstatus.writing", 
+                                        "id": "b1773681-f1a4-11e7-95d0-8ddf041d42a2", 
+                                        "type": "avg"
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }, 
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "rgba(252,220,0,1)", 
+                                "fill": 0.5, 
+                                "formatter": "number", 
+                                "id": "b68aa6c0-f1a4-11e7-95d0-8ddf041d42a2", 
+                                "label": "Waiting", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "nginx.stubstatus.waiting", 
+                                        "id": "b68aa6c1-f1a4-11e7-95d0-8ddf041d42a2", 
+                                        "type": "avg"
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "timeseries"
+                    }, 
+                    "title": "Reading / Writing / Waiting Rates [Metricbeat Nginx] ECS", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "dcbffe30-f1a4-11e7-a9ef-93c69af7b129-ecs", 
+            "type": "visualization", 
+            "updated_at": "2018-01-04T23:13:23.859Z", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "Overview dashboard for the Nginx module in Metricbeat",
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlightAll": true, 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "optionsJSON": {
+                    "darkTheme": false, 
+                    "hidePanelTitles": false, 
+                    "useMargins": true
+                }, 
+                "panelsJSON": [
+                    {
+                        "gridData": {
+                            "h": 3, 
+                            "i": "1", 
+                            "w": 6, 
+                            "x": 6, 
+                            "y": 0
+                        }, 
+                        "id": "555df8a0-f1a1-11e7-a9ef-93c69af7b129-ecs", 
+                        "panelIndex": "1", 
+                        "type": "visualization", 
+                        "version": "6.2.4"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 3, 
+                            "i": "2", 
+                            "w": 6, 
+                            "x": 6, 
+                            "y": 3
+                        }, 
+                        "id": "a1d92240-f1a1-11e7-a9ef-93c69af7b129-ecs", 
+                        "panelIndex": "2", 
+                        "type": "visualization", 
+                        "version": "6.2.4"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 3, 
+                            "i": "3", 
+                            "w": 6, 
+                            "x": 0, 
+                            "y": 3
+                        }, 
+                        "id": "d763a570-f1a1-11e7-a9ef-93c69af7b129-ecs", 
+                        "panelIndex": "3", 
+                        "type": "visualization", 
+                        "version": "6.2.4"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 3, 
+                            "i": "4", 
+                            "w": 6, 
+                            "x": 0, 
+                            "y": 0
+                        }, 
+                        "id": "47a8e0f0-f1a4-11e7-a9ef-93c69af7b129-ecs", 
+                        "panelIndex": "4", 
+                        "type": "visualization", 
+                        "version": "6.2.4"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 3, 
+                            "i": "5", 
+                            "w": 12, 
+                            "x": 0, 
+                            "y": 6
+                        }, 
+                        "id": "dcbffe30-f1a4-11e7-a9ef-93c69af7b129-ecs", 
+                        "panelIndex": "5", 
+                        "type": "visualization", 
+                        "version": "6.2.4"
+                    }
+                ], 
+                "timeRestore": false, 
+                "title": "[Metricbeat Nginx] Overview ECS", 
+                "version": 1
+            }, 
+            "id": "023d2930-f1a5-11e7-a9ef-93c69af7b129-ecs", 
+            "type": "dashboard", 
+            "updated_at": "2018-01-04T23:14:26.755Z", 
+            "version": 1
+        }
+    ], 
+    "version": "6.2.4"
+}

--- a/dev/package-beats/nginx-1.0.0/manifest.yml
+++ b/dev/package-beats/nginx-1.0.0/manifest.yml
@@ -1,0 +1,14 @@
+name: nginx
+title: Nginx
+version: 1.0.0
+description: |
+  Nginx server status metrics collected from various modules.
+type: ""
+categories:
+- logs
+- metrics
+requirement:
+  kibana:
+    version:
+      min: 6.7.0
+      max: 7.6.0

--- a/dev/package-beats/oracle-1.0.0/kibana/dashboard/Metricbeat-Oracle-overview.json
+++ b/dev/package-beats/oracle-1.0.0/kibana/dashboard/Metricbeat-Oracle-overview.json
@@ -1,0 +1,1520 @@
+{
+  "objects": [
+    {
+      "attributes": {
+        "description": "An overview of key metrics from all Metricsets in the Oracle database Metricbeat module",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "optionsJSON": {
+          "hidePanelTitles": false,
+          "useMargins": true
+        },
+        "panelsJSON": [
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 8,
+              "i": "1",
+              "w": 17,
+              "x": 18,
+              "y": 31
+            },
+            "panelIndex": "1",
+            "panelRefName": "panel_0",
+            "title": "Tablespace Total Size",
+            "version": "8.0.0-SNAPSHOT"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 8,
+              "i": "2",
+              "w": 12,
+              "x": 28,
+              "y": 0
+            },
+            "panelIndex": "2",
+            "panelRefName": "panel_1",
+            "title": "Ratio of used space in Tablespaces",
+            "version": "8.0.0-SNAPSHOT"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 13,
+              "i": "3",
+              "w": 28,
+              "x": 20,
+              "y": 18
+            },
+            "panelIndex": "3",
+            "panelRefName": "panel_2",
+            "title": "Avg data file size by filename",
+            "version": "8.0.0-SNAPSHOT"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 7,
+              "i": "5",
+              "w": 20,
+              "x": 0,
+              "y": 8
+            },
+            "panelIndex": "5",
+            "panelRefName": "panel_3",
+            "title": "Total Cursors by machine (Top 10)",
+            "version": "8.0.0-SNAPSHOT"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 8,
+              "i": "6",
+              "w": 8,
+              "x": 20,
+              "y": 0
+            },
+            "panelIndex": "6",
+            "panelRefName": "panel_4",
+            "title": "Cache Buffer Hit Ratio gauge",
+            "version": "8.0.0-SNAPSHOT"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 8,
+              "i": "9",
+              "w": 20,
+              "x": 0,
+              "y": 15
+            },
+            "panelIndex": "9",
+            "panelRefName": "panel_5",
+            "title": "Current opened cursors",
+            "version": "8.0.0-SNAPSHOT"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 8,
+              "i": "10",
+              "w": 13,
+              "x": 35,
+              "y": 31
+            },
+            "panelIndex": "10",
+            "panelRefName": "panel_6",
+            "title": "Session cache hits",
+            "version": "8.0.0-SNAPSHOT"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 8,
+              "i": "11",
+              "w": 20,
+              "x": 0,
+              "y": 0
+            },
+            "panelIndex": "11",
+            "panelRefName": "panel_7",
+            "title": "Average Cursors by machine (Top 10)",
+            "version": "8.0.0-SNAPSHOT"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 8,
+              "i": "12",
+              "w": 18,
+              "x": 0,
+              "y": 31
+            },
+            "panelIndex": "12",
+            "panelRefName": "panel_8",
+            "title": "Max Cursors by machine (Top 10)",
+            "version": "8.0.0-SNAPSHOT"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 8,
+              "i": "13",
+              "w": 20,
+              "x": 0,
+              "y": 23
+            },
+            "panelIndex": "13",
+            "panelRefName": "panel_9",
+            "title": "DB Blocks Gets by buffer pool (Top 10)",
+            "version": "8.0.0-SNAPSHOT"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 10,
+              "i": "14",
+              "w": 30,
+              "x": 18,
+              "y": 39
+            },
+            "panelIndex": "14",
+            "panelRefName": "panel_10",
+            "title": "Consistent Gets by buffer pool (Top 10)",
+            "version": "8.0.0-SNAPSHOT"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 10,
+              "i": "15",
+              "w": 18,
+              "x": 0,
+              "y": 39
+            },
+            "panelIndex": "15",
+            "panelRefName": "panel_11",
+            "title": "Total / Real parsed cursors",
+            "version": "8.0.0-SNAPSHOT"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 10,
+              "i": "16",
+              "w": 28,
+              "x": 20,
+              "y": 8
+            },
+            "panelIndex": "16",
+            "panelRefName": "panel_12",
+            "title": "Lock/Pin requests and IO reloads ratios",
+            "version": "8.0.0-SNAPSHOT"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 8,
+              "i": "17",
+              "w": 8,
+              "x": 40,
+              "y": 0
+            },
+            "panelIndex": "17",
+            "panelRefName": "panel_13",
+            "title": "Cursors cache hit ratio gauge",
+            "version": "8.0.0-SNAPSHOT"
+          }
+        ],
+        "timeRestore": false,
+        "title": "[Metricbeat Oracle] Overview",
+        "version": 1
+      },
+      "id": "3f018af0-ec08-11e9-a4bb-7b5324058fcc",
+      "migrationVersion": {
+        "dashboard": "7.3.0"
+      },
+      "references": [
+        {
+          "id": "05acae50-9bf0-11e9-a61b-f742ed613c57",
+          "name": "panel_0",
+          "type": "visualization"
+        },
+        {
+          "id": "981779d0-9bfc-11e9-a61b-f742ed613c57",
+          "name": "panel_1",
+          "type": "visualization"
+        },
+        {
+          "id": "c92efe60-9bef-11e9-a61b-f742ed613c57",
+          "name": "panel_2",
+          "type": "visualization"
+        },
+        {
+          "id": "62fb9430-ec0f-11e9-a4bb-7b5324058fcc",
+          "name": "panel_3",
+          "type": "visualization"
+        },
+        {
+          "id": "ec2b2010-ec0d-11e9-a4bb-7b5324058fcc",
+          "name": "panel_4",
+          "type": "visualization"
+        },
+        {
+          "id": "43369a60-ec0e-11e9-a4bb-7b5324058fcc",
+          "name": "panel_5",
+          "type": "visualization"
+        },
+        {
+          "id": "234013d0-ec0e-11e9-a4bb-7b5324058fcc",
+          "name": "panel_6",
+          "type": "visualization"
+        },
+        {
+          "id": "5a422660-ec0f-11e9-a4bb-7b5324058fcc",
+          "name": "panel_7",
+          "type": "visualization"
+        },
+        {
+          "id": "4f569650-ec0f-11e9-a4bb-7b5324058fcc",
+          "name": "panel_8",
+          "type": "visualization"
+        },
+        {
+          "id": "68ce1940-ec10-11e9-a4bb-7b5324058fcc",
+          "name": "panel_9",
+          "type": "visualization"
+        },
+        {
+          "id": "3ae419d0-ec10-11e9-a4bb-7b5324058fcc",
+          "name": "panel_10",
+          "type": "visualization"
+        },
+        {
+          "id": "c46de8c0-ec10-11e9-a4bb-7b5324058fcc",
+          "name": "panel_11",
+          "type": "visualization"
+        },
+        {
+          "id": "0b1da750-ec12-11e9-a4bb-7b5324058fcc",
+          "name": "panel_12",
+          "type": "visualization"
+        },
+        {
+          "id": "bc977600-ec12-11e9-a4bb-7b5324058fcc",
+          "name": "panel_13",
+          "type": "visualization"
+        }
+      ],
+      "type": "dashboard",
+      "updated_at": "2019-10-11T13:24:58.324Z",
+      "version": "WzQ1MiwzXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Tablespace Total Size [Metricbeat Oracle]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(115,216,255,1)",
+                "fill": 0.5,
+                "formatter": "bytes",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Tablespace total size",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "oracle.tablespace.space.total.bytes",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "terms",
+                "stacked": "stacked",
+                "terms_field": "oracle.tablespace.name",
+                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Tablespace Total Size [Metricbeat Oracle]",
+          "type": "metrics"
+        }
+      },
+      "id": "05acae50-9bf0-11e9-a61b-f742ed613c57",
+      "migrationVersion": {
+        "visualization": "7.3.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-10-11T09:17:37.972Z",
+      "version": "WzM4OSwzXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Ratio of used space in Tablespaces [Metricbeat Oracle]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "bar_color_rules": [
+              {
+                "id": "70de46f0-9bfc-11e9-baad-815beb8da1b5"
+              }
+            ],
+            "default_index_pattern": "metricbeat-*",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "percent",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "oracle.tablespace.space.used.bytes",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  },
+                  {
+                    "field": "oracle.tablespace.space.total.bytes",
+                    "id": "37c93d70-9bfc-11e9-baad-815beb8da1b5",
+                    "type": "avg"
+                  },
+                  {
+                    "denominator": "2",
+                    "field": "oracle.tablespace.space.total.bytes",
+                    "id": "0d474830-9bfc-11e9-baad-815beb8da1b5",
+                    "numerator": "1",
+                    "script": "params.used / params.total",
+                    "type": "math",
+                    "variables": [
+                      {
+                        "field": "61ca57f2-469d-11e7-af02-69e470af7417",
+                        "id": "34e8d9d0-9bfc-11e9-baad-815beb8da1b5",
+                        "name": "used"
+                      },
+                      {
+                        "field": "37c93d70-9bfc-11e9-baad-815beb8da1b5",
+                        "id": "467fdf40-9bfc-11e9-baad-815beb8da1b5",
+                        "name": "total"
+                      }
+                    ]
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "oracle.tablespace.name",
+                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "top_n"
+          },
+          "title": "Ratio of used space in Tablespaces [Metricbeat Oracle]",
+          "type": "metrics"
+        }
+      },
+      "id": "981779d0-9bfc-11e9-a61b-f742ed613c57",
+      "migrationVersion": {
+        "visualization": "7.3.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-10-11T09:17:37.972Z",
+      "version": "WzM5MSwzXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Avg data file size by filename [Metricbeat Oracle]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "",
+            "interval": "auto",
+            "legend_position": "bottom",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "bytes",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Data file size by filename",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "agg_with": "noop",
+                    "field": "oracle.tablespace.data_file.size.bytes",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "order": "desc",
+                    "size": 1,
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "terms",
+                "stacked": "stacked",
+                "terms_field": "oracle.tablespace.data_file.name",
+                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Avg data file size by filename [Metricbeat Oracle]",
+          "type": "metrics"
+        }
+      },
+      "id": "c92efe60-9bef-11e9-a61b-f742ed613c57",
+      "migrationVersion": {
+        "visualization": "7.3.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-10-11T09:17:37.972Z",
+      "version": "WzM4OCwzXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Total Cursors by machine (Top 10) [Metricbeat Oracle]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "",
+            "interval": "",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(104,188,0,1)",
+                "fill": 0.5,
+                "formatter": "number",
+                "id": "78091830-ec0e-11e9-bea4-bdae5d622976",
+                "label": "Top 10 Total cursors",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "oracle.performance.cursors.total",
+                    "id": "78091831-ec0e-11e9-bea4-bdae5d622976",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "terms",
+                "stacked": "stacked_within_series",
+                "steps": 0,
+                "terms_field": "oracle.performance.machine"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "",
+            "type": "timeseries"
+          },
+          "title": "Total Cursors by machine (Top 10) [Metricbeat Oracle]",
+          "type": "metrics"
+        }
+      },
+      "id": "62fb9430-ec0f-11e9-a4bb-7b5324058fcc",
+      "migrationVersion": {
+        "visualization": "7.3.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-10-11T10:12:28.094Z",
+      "version": "WzQyNywzXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Cache Buffer Hit Ratio gauge [Metricbeat Oracle]",
+        "uiStateJSON": {
+          "vis": {
+            "defaultColors": {
+              "0 - 50": "rgb(165,0,38)",
+              "50 - 75": "rgb(255,255,190)",
+              "75 - 100": "rgb(0,104,55)"
+            }
+          }
+        },
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "Cache Buffer Hit Ratio",
+                "field": "oracle.performance.cache.buffer.hit.pct"
+              },
+              "schema": "metric",
+              "type": "avg"
+            }
+          ],
+          "params": {
+            "addLegend": false,
+            "addTooltip": true,
+            "dimensions": {
+              "x": null,
+              "y": [
+                {
+                  "accessor": 0,
+                  "aggType": "avg",
+                  "format": {
+                    "id": "number"
+                  },
+                  "params": {}
+                }
+              ]
+            },
+            "gauge": {
+              "alignment": "automatic",
+              "backStyle": "Full",
+              "colorSchema": "Green to Red",
+              "colorsRange": [
+                {
+                  "from": 0,
+                  "to": 0.5
+                },
+                {
+                  "from": 0.5,
+                  "to": 0.75
+                },
+                {
+                  "from": 0.75,
+                  "to": 1
+                }
+              ],
+              "extendRange": true,
+              "gaugeColorMode": "Labels",
+              "gaugeStyle": "Full",
+              "gaugeType": "Arc",
+              "invertColors": true,
+              "labels": {
+                "color": "black",
+                "show": true
+              },
+              "orientation": "vertical",
+              "percentageMode": true,
+              "scale": {
+                "color": "rgba(105,112,125,0.2)",
+                "labels": false,
+                "show": true
+              },
+              "style": {
+                "bgColor": true,
+                "bgFill": "rgba(105,112,125,0.2)",
+                "bgMask": false,
+                "bgWidth": 0.9,
+                "fontSize": 60,
+                "labelColor": true,
+                "mask": false,
+                "maskBars": 50,
+                "subText": "",
+                "width": 0.9
+              },
+              "type": "meter"
+            },
+            "isDisplayWarning": false,
+            "type": "gauge"
+          },
+          "title": "Cache Buffer Hit Ratio gauge [Metricbeat Oracle]",
+          "type": "gauge"
+        }
+      },
+      "id": "ec2b2010-ec0d-11e9-a4bb-7b5324058fcc",
+      "migrationVersion": {
+        "visualization": "7.3.0"
+      },
+      "references": [
+        {
+          "id": "metricbeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-10-11T10:32:03.372Z",
+      "version": "WzQ0MywzXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Current opened cursors [Metricbeat Oracle]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "",
+            "interval": "",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(104,204,202,1)",
+                "fill": 0.5,
+                "formatter": "number",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Current opened cursors",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "oracle.performance.cursors.opened.current",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 0,
+            "time_field": "",
+            "type": "timeseries"
+          },
+          "title": "Current opened cursors [Metricbeat Oracle]",
+          "type": "metrics"
+        }
+      },
+      "id": "43369a60-ec0e-11e9-a4bb-7b5324058fcc",
+      "migrationVersion": {
+        "visualization": "7.3.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-10-11T10:43:29.383Z",
+      "version": "WzQ0OSwzXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Session cache hits [Metricbeat Oracle]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "",
+            "interval": "",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(219,223,0,1)",
+                "fill": 0.5,
+                "formatter": "number",
+                "hide_in_legend": 0,
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Session cache hits",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "oracle.performance.cursors.session.cache_hits",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 0,
+            "time_field": "",
+            "type": "timeseries"
+          },
+          "title": "Session cache hits [Metricbeat Oracle]",
+          "type": "metrics"
+        }
+      },
+      "id": "234013d0-ec0e-11e9-a4bb-7b5324058fcc",
+      "migrationVersion": {
+        "visualization": "7.3.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-10-11T10:35:45.888Z",
+      "version": "WzQ0NiwzXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Average Cursors by machine (Top 10) [Metricbeat Oracle]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "",
+            "interval": "",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(115,216,255,1)",
+                "fill": 0.5,
+                "formatter": "number",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Average cursors",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "oracle.performance.cursors.avg",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_color_mode": "gradient",
+                "split_filters": [
+                  {
+                    "color": "rgba(254,146,0,1)",
+                    "filter": {
+                      "language": "kuery",
+                      "query": ""
+                    },
+                    "id": "15889d10-ec0f-11e9-bea4-bdae5d622976"
+                  }
+                ],
+                "split_mode": "terms",
+                "stacked": "stacked",
+                "terms_field": "oracle.performance.machine"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "",
+            "type": "timeseries"
+          },
+          "title": "Average Cursors by machine (Top 10) [Metricbeat Oracle]",
+          "type": "metrics"
+        }
+      },
+      "id": "5a422660-ec0f-11e9-a4bb-7b5324058fcc",
+      "migrationVersion": {
+        "visualization": "7.3.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-10-11T10:14:31.128Z",
+      "version": "WzQzMCwzXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Max Cursors by machine (Top 10) [Metricbeat Oracle]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "",
+            "interval": "",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(104,204,202,1)",
+                "fill": 0.5,
+                "formatter": "number",
+                "id": "6e3a42c0-ec0e-11e9-bea4-bdae5d622976",
+                "label": "Top 10 Max cursors",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "oracle.performance.cursors.max",
+                    "id": "6e3a42c1-ec0e-11e9-bea4-bdae5d622976",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "terms",
+                "stacked": "stacked",
+                "terms_field": "oracle.performance.machine"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "",
+            "type": "timeseries"
+          },
+          "title": "Max Cursors by machine (Top 10) [Metricbeat Oracle]",
+          "type": "metrics"
+        }
+      },
+      "id": "4f569650-ec0f-11e9-a4bb-7b5324058fcc",
+      "migrationVersion": {
+        "visualization": "7.3.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-10-11T10:13:39.343Z",
+      "version": "WzQyOSwzXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "DB Blocks Gets by buffer pool (Top 10) [Metricbeat Oracle]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "",
+            "interval": "",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(115,216,255,1)",
+                "fill": 0.5,
+                "formatter": "number",
+                "id": "1547f520-ec10-11e9-bea4-bdae5d622976",
+                "label": "DB Blocks gets",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "oracle.performance.cache.get.db_blocks",
+                    "id": "1547f521-ec10-11e9-bea4-bdae5d622976",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "oracle.performance.buffer_pool"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "",
+            "type": "timeseries"
+          },
+          "title": "DB Blocks Gets by buffer pool (Top 10) [Metricbeat Oracle]",
+          "type": "metrics"
+        }
+      },
+      "id": "68ce1940-ec10-11e9-a4bb-7b5324058fcc",
+      "migrationVersion": {
+        "visualization": "7.3.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-10-11T10:18:28.007Z",
+      "version": "WzQzOCwzXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Consistent Gets by buffer pool (Top 10) [Metricbeat Oracle]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "",
+            "interval": "",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "number",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Consistent Gets",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "oracle.performance.cache.get.consistent",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "oracle.performance.buffer_pool"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "",
+            "type": "timeseries"
+          },
+          "title": "Consistent Gets by buffer pool (Top 10) [Metricbeat Oracle]",
+          "type": "metrics"
+        }
+      },
+      "id": "3ae419d0-ec10-11e9-a4bb-7b5324058fcc",
+      "migrationVersion": {
+        "visualization": "7.3.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-10-11T10:18:51.246Z",
+      "version": "WzQzOSwzXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Total / Real parsed cursors [Metricbeat Oracle]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "",
+            "interval": "",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "number",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Real parsed cursors",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "oracle.performance.cursors.parse.real",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(115,216,255,1)",
+                "fill": 0.5,
+                "formatter": "number",
+                "id": "a1dae560-ec10-11e9-bea4-bdae5d622976",
+                "label": "Total parsed cursors",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "oracle.performance.cursors.parse.total",
+                    "id": "a1dae561-ec10-11e9-bea4-bdae5d622976",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "",
+            "type": "timeseries"
+          },
+          "title": "Total / Real parsed cursors [Metricbeat Oracle]",
+          "type": "metrics"
+        }
+      },
+      "id": "c46de8c0-ec10-11e9-a4bb-7b5324058fcc",
+      "migrationVersion": {
+        "visualization": "7.3.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-10-11T10:20:37.067Z",
+      "version": "WzQ0MCwzXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Lock/Pin requests and IO reloads ratios [Metricbeat Oracle]",
+        "uiStateJSON": {
+          "vis": {
+            "defaultColors": {
+              "0 - 50": "rgb(247,251,255)",
+              "50 - 75": "rgb(107,174,214)",
+              "75 - 100": "rgb(8,48,107)"
+            }
+          }
+        },
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "IO Reloads",
+                "field": "oracle.performance.io_reloads"
+              },
+              "schema": "metric",
+              "type": "avg"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customLabel": "Lock requests",
+                "field": "oracle.performance.lock_requests"
+              },
+              "schema": "metric",
+              "type": "avg"
+            },
+            {
+              "enabled": true,
+              "id": "3",
+              "params": {
+                "customLabel": "Pin requests",
+                "field": "oracle.performance.pin_requests"
+              },
+              "schema": "metric",
+              "type": "avg"
+            }
+          ],
+          "params": {
+            "addLegend": false,
+            "addTooltip": true,
+            "dimensions": {
+              "x": null,
+              "y": [
+                {
+                  "accessor": 0,
+                  "aggType": "avg",
+                  "format": {
+                    "id": "number"
+                  },
+                  "params": {}
+                },
+                {
+                  "accessor": 1,
+                  "aggType": "avg",
+                  "format": {
+                    "id": "number"
+                  },
+                  "params": {}
+                },
+                {
+                  "accessor": 2,
+                  "aggType": "avg",
+                  "format": {
+                    "id": "number"
+                  },
+                  "params": {}
+                }
+              ]
+            },
+            "gauge": {
+              "alignment": "automatic",
+              "backStyle": "Full",
+              "colorSchema": "Blues",
+              "colorsRange": [
+                {
+                  "from": 0,
+                  "to": 0.5
+                },
+                {
+                  "from": 0.5,
+                  "to": 0.75
+                },
+                {
+                  "from": 0.75,
+                  "to": 1
+                }
+              ],
+              "extendRange": true,
+              "gaugeColorMode": "Labels",
+              "gaugeStyle": "Full",
+              "gaugeType": "Arc",
+              "invertColors": false,
+              "labels": {
+                "color": "black",
+                "show": true
+              },
+              "orientation": "vertical",
+              "percentageMode": true,
+              "scale": {
+                "color": "rgba(105,112,125,0.2)",
+                "labels": false,
+                "show": true
+              },
+              "style": {
+                "bgColor": true,
+                "bgFill": "rgba(105,112,125,0.2)",
+                "bgMask": false,
+                "bgWidth": 0.9,
+                "fontSize": 60,
+                "mask": false,
+                "maskBars": 50,
+                "subText": "",
+                "width": 0.9
+              },
+              "type": "meter"
+            },
+            "isDisplayWarning": false,
+            "type": "gauge"
+          },
+          "title": "Lock/Pin requests and IO reloads ratios [Metricbeat Oracle]",
+          "type": "gauge"
+        }
+      },
+      "id": "0b1da750-ec12-11e9-a4bb-7b5324058fcc",
+      "migrationVersion": {
+        "visualization": "7.3.0"
+      },
+      "references": [
+        {
+          "id": "metricbeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-10-11T10:29:45.157Z",
+      "version": "WzQ0MSwzXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Cursors cache hit ratio gauge [Metricbeat Oracle]",
+        "uiStateJSON": {
+          "vis": {
+            "defaultColors": {
+              "0 - 50": "rgb(0,104,55)",
+              "50 - 75": "rgb(255,255,190)",
+              "75 - 100": "rgb(165,0,38)"
+            }
+          }
+        },
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "Cursors cache hit ratio",
+                "field": "oracle.performance.cursors.cache_hit.pct"
+              },
+              "schema": "metric",
+              "type": "avg"
+            }
+          ],
+          "params": {
+            "addLegend": false,
+            "addTooltip": true,
+            "dimensions": {
+              "x": null,
+              "y": [
+                {
+                  "accessor": 0,
+                  "aggType": "avg",
+                  "format": {
+                    "id": "number"
+                  },
+                  "params": {}
+                }
+              ]
+            },
+            "gauge": {
+              "alignment": "automatic",
+              "backStyle": "Full",
+              "colorSchema": "Green to Red",
+              "colorsRange": [
+                {
+                  "from": 0,
+                  "to": 0.5
+                },
+                {
+                  "from": 0.5,
+                  "to": 0.75
+                },
+                {
+                  "from": 0.75,
+                  "to": 1
+                }
+              ],
+              "extendRange": true,
+              "gaugeColorMode": "Labels",
+              "gaugeStyle": "Full",
+              "gaugeType": "Arc",
+              "invertColors": false,
+              "labels": {
+                "color": "black",
+                "show": false
+              },
+              "orientation": "vertical",
+              "percentageMode": true,
+              "scale": {
+                "color": "rgba(105,112,125,0.2)",
+                "labels": false,
+                "show": true
+              },
+              "style": {
+                "bgColor": true,
+                "bgFill": "rgba(105,112,125,0.2)",
+                "bgMask": false,
+                "bgWidth": 0.9,
+                "fontSize": 60,
+                "mask": false,
+                "maskBars": 50,
+                "subText": "",
+                "width": 0.9
+              },
+              "type": "meter"
+            },
+            "isDisplayWarning": false,
+            "type": "gauge"
+          },
+          "title": "Cursors cache hit ratio gauge [Metricbeat Oracle]",
+          "type": "gauge"
+        }
+      },
+      "id": "bc977600-ec12-11e9-a4bb-7b5324058fcc",
+      "migrationVersion": {
+        "visualization": "7.3.0"
+      },
+      "references": [
+        {
+          "id": "metricbeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-10-11T10:34:42.911Z",
+      "version": "WzQ0NSwzXQ=="
+    }
+  ],
+  "version": "8.0.0-SNAPSHOT"
+}

--- a/dev/package-beats/oracle-1.0.0/kibana/dashboard/Metricbeat-Oracle-tablespaces.json
+++ b/dev/package-beats/oracle-1.0.0/kibana/dashboard/Metricbeat-Oracle-tablespaces.json
@@ -1,0 +1,536 @@
+{
+  "objects": [
+    {
+      "attributes": {
+        "description": "Overview of Oracle Tablespaces",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "optionsJSON": {
+          "hidePanelTitles": false,
+          "useMargins": true
+        },
+        "panelsJSON": [
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 15,
+              "i": "1",
+              "w": 19,
+              "x": 0,
+              "y": 0
+            },
+            "panelIndex": "1",
+            "panelRefName": "panel_0",
+            "title": "Avg data file size by filename",
+            "version": "8.0.0-SNAPSHOT"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 15,
+              "i": "2",
+              "w": 24,
+              "x": 0,
+              "y": 15
+            },
+            "panelIndex": "2",
+            "panelRefName": "panel_1",
+            "title": "Tablespace Total Size",
+            "version": "8.0.0-SNAPSHOT"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 15,
+              "i": "3",
+              "w": 19,
+              "x": 19,
+              "y": 0
+            },
+            "panelIndex": "3",
+            "panelRefName": "panel_2",
+            "title": "Maximum data file size",
+            "version": "8.0.0-SNAPSHOT"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 15,
+              "i": "4",
+              "w": 10,
+              "x": 38,
+              "y": 0
+            },
+            "panelIndex": "4",
+            "panelRefName": "panel_3",
+            "title": "Ratio of used space in Tablespaces",
+            "version": "8.0.0-SNAPSHOT"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 15,
+              "i": "5",
+              "w": 24,
+              "x": 24,
+              "y": 15
+            },
+            "panelIndex": "5",
+            "panelRefName": "panel_4",
+            "title": "Ratio of used space in data files",
+            "version": "8.0.0-SNAPSHOT"
+          }
+        ],
+        "timeRestore": false,
+        "title": "[Metricbeat Oracle] Tablespaces",
+        "version": 1
+      },
+      "id": "862e2c20-9bf0-11e9-a61b-f742ed613c57",
+      "migrationVersion": {
+        "dashboard": "7.0.0"
+      },
+      "references": [
+        {
+          "id": "c92efe60-9bef-11e9-a61b-f742ed613c57",
+          "name": "panel_0",
+          "type": "visualization"
+        },
+        {
+          "id": "05acae50-9bf0-11e9-a61b-f742ed613c57",
+          "name": "panel_1",
+          "type": "visualization"
+        },
+        {
+          "id": "4c051a90-9bf0-11e9-a61b-f742ed613c57",
+          "name": "panel_2",
+          "type": "visualization"
+        },
+        {
+          "id": "981779d0-9bfc-11e9-a61b-f742ed613c57",
+          "name": "panel_3",
+          "type": "visualization"
+        },
+        {
+          "id": "072de430-9bfd-11e9-a61b-f742ed613c57",
+          "name": "panel_4",
+          "type": "visualization"
+        }
+      ],
+      "type": "dashboard",
+      "updated_at": "2019-07-01T13:32:15.355Z",
+      "version": "Wzk0MywxNF0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Avg data file size by filename [Metricbeat Oracle]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "",
+            "interval": "auto",
+            "legend_position": "bottom",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "bytes",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Data file size by filename",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "agg_with": "noop",
+                    "field": "oracle.tablespace.data_file.size.bytes",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "order": "desc",
+                    "size": 1,
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "terms",
+                "stacked": "stacked",
+                "terms_field": "oracle.tablespace.data_file.name",
+                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Avg data file size by filename [Metricbeat Oracle]",
+          "type": "metrics"
+        }
+      },
+      "id": "c92efe60-9bef-11e9-a61b-f742ed613c57",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-07-01T12:24:40.028Z",
+      "version": "WzkzOCwxNF0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Tablespace Total Size [Metricbeat Oracle]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(115,216,255,1)",
+                "fill": 0.5,
+                "formatter": "bytes",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Tablespace total size",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "oracle.tablespace.space.total.bytes",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "terms",
+                "stacked": "stacked",
+                "terms_field": "oracle.tablespace.name",
+                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Tablespace Total Size [Metricbeat Oracle]",
+          "type": "metrics"
+        }
+      },
+      "id": "05acae50-9bf0-11e9-a61b-f742ed613c57",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-07-01T11:09:27.312Z",
+      "version": "WzkzNCwxNF0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Maximum data file size [Metricbeat Oracle]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "",
+            "interval": "auto",
+            "legend_position": "bottom",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(254,146,0,1)",
+                "fill": 0.5,
+                "formatter": "bytes",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Maximum data file size",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "oracle.tablespace.data_file.size.max.bytes",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "terms",
+                "stacked": "stacked",
+                "terms_field": "oracle.tablespace.data_file.name",
+                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Maximum data file size [Metricbeat Oracle]",
+          "type": "metrics"
+        }
+      },
+      "id": "4c051a90-9bf0-11e9-a61b-f742ed613c57",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-07-01T11:09:16.058Z",
+      "version": "WzkzMywxNF0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Ratio of used space in Tablespaces [Metricbeat Oracle]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "bar_color_rules": [
+              {
+                "id": "70de46f0-9bfc-11e9-baad-815beb8da1b5"
+              }
+            ],
+            "default_index_pattern": "metricbeat-*",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "percent",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "oracle.tablespace.space.used.bytes",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  },
+                  {
+                    "field": "oracle.tablespace.space.total.bytes",
+                    "id": "37c93d70-9bfc-11e9-baad-815beb8da1b5",
+                    "type": "avg"
+                  },
+                  {
+                    "denominator": "2",
+                    "field": "oracle.tablespace.space.total.bytes",
+                    "id": "0d474830-9bfc-11e9-baad-815beb8da1b5",
+                    "numerator": "1",
+                    "script": "params.used / params.total",
+                    "type": "math",
+                    "variables": [
+                      {
+                        "field": "61ca57f2-469d-11e7-af02-69e470af7417",
+                        "id": "34e8d9d0-9bfc-11e9-baad-815beb8da1b5",
+                        "name": "used"
+                      },
+                      {
+                        "field": "37c93d70-9bfc-11e9-baad-815beb8da1b5",
+                        "id": "467fdf40-9bfc-11e9-baad-815beb8da1b5",
+                        "name": "total"
+                      }
+                    ]
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "oracle.tablespace.name",
+                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "top_n"
+          },
+          "title": "Ratio of used space in Tablespaces [Metricbeat Oracle]",
+          "type": "metrics"
+        }
+      },
+      "id": "981779d0-9bfc-11e9-a61b-f742ed613c57",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-07-01T12:34:39.724Z",
+      "version": "WzkzOSwxNF0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Ratio of used space in data files [Metricbeat Oracle]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "bar_color_rules": [
+              {
+                "id": "da9fa430-9bfc-11e9-baad-815beb8da1b5"
+              }
+            ],
+            "default_index_pattern": "metricbeat-*",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "",
+            "interval": "auto",
+            "legend_position": "bottom",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(204,204,204,1)",
+                "fill": 0.5,
+                "formatter": "percent",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Ratio of used space in data files",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "oracle.tablespace.data_file.size.max.bytes",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  },
+                  {
+                    "field": "oracle.tablespace.data_file.size.bytes",
+                    "id": "c0f200a0-9bfc-11e9-baad-815beb8da1b5",
+                    "type": "avg"
+                  },
+                  {
+                    "id": "c8289f00-9bfc-11e9-baad-815beb8da1b5",
+                    "script": "params.used / params.max",
+                    "type": "math",
+                    "variables": [
+                      {
+                        "field": "61ca57f2-469d-11e7-af02-69e470af7417",
+                        "id": "c9a63e50-9bfc-11e9-baad-815beb8da1b5",
+                        "name": "max"
+                      },
+                      {
+                        "field": "c0f200a0-9bfc-11e9-baad-815beb8da1b5",
+                        "id": "cddc46e0-9bfc-11e9-baad-815beb8da1b5",
+                        "name": "used"
+                      }
+                    ]
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "terms",
+                "stacked": "stacked",
+                "terms_field": "oracle.tablespace.data_file.name",
+                "terms_order_by": "c0f200a0-9bfc-11e9-baad-815beb8da1b5"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "top_n"
+          },
+          "title": "Ratio of used space in data files [Metricbeat Oracle]",
+          "type": "metrics"
+        }
+      },
+      "id": "072de430-9bfd-11e9-a61b-f742ed613c57",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-07-01T12:37:59.842Z",
+      "version": "Wzk0MSwxNF0="
+    }
+  ],
+  "version": "8.0.0-SNAPSHOT"
+}

--- a/dev/package-beats/oracle-1.0.0/kibana/dashboard/Metricbet-Oracle-tablespaces.json
+++ b/dev/package-beats/oracle-1.0.0/kibana/dashboard/Metricbet-Oracle-tablespaces.json
@@ -1,0 +1,536 @@
+{
+  "objects": [
+    {
+      "attributes": {
+        "description": "Overview of Oracle Tablespaces",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "optionsJSON": {
+          "hidePanelTitles": false,
+          "useMargins": true
+        },
+        "panelsJSON": [
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 15,
+              "i": "1",
+              "w": 19,
+              "x": 0,
+              "y": 0
+            },
+            "panelIndex": "1",
+            "panelRefName": "panel_0",
+            "title": "Avg data file size by filename",
+            "version": "8.0.0-SNAPSHOT"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 15,
+              "i": "2",
+              "w": 24,
+              "x": 0,
+              "y": 15
+            },
+            "panelIndex": "2",
+            "panelRefName": "panel_1",
+            "title": "Tablespace Total Size",
+            "version": "8.0.0-SNAPSHOT"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 15,
+              "i": "3",
+              "w": 19,
+              "x": 19,
+              "y": 0
+            },
+            "panelIndex": "3",
+            "panelRefName": "panel_2",
+            "title": "Maximum data file size",
+            "version": "8.0.0-SNAPSHOT"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 15,
+              "i": "4",
+              "w": 10,
+              "x": 38,
+              "y": 0
+            },
+            "panelIndex": "4",
+            "panelRefName": "panel_3",
+            "title": "Ratio of used space in Tablespaces",
+            "version": "8.0.0-SNAPSHOT"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 15,
+              "i": "5",
+              "w": 24,
+              "x": 24,
+              "y": 15
+            },
+            "panelIndex": "5",
+            "panelRefName": "panel_4",
+            "title": "Ratio of used space in data files",
+            "version": "8.0.0-SNAPSHOT"
+          }
+        ],
+        "timeRestore": false,
+        "title": "[Metricbeat Oracle] Tablespaces",
+        "version": 1
+      },
+      "id": "862e2c20-9bf0-11e9-a61b-f742ed613c57",
+      "migrationVersion": {
+        "dashboard": "7.0.0"
+      },
+      "references": [
+        {
+          "id": "c92efe60-9bef-11e9-a61b-f742ed613c57",
+          "name": "panel_0",
+          "type": "visualization"
+        },
+        {
+          "id": "05acae50-9bf0-11e9-a61b-f742ed613c57",
+          "name": "panel_1",
+          "type": "visualization"
+        },
+        {
+          "id": "4c051a90-9bf0-11e9-a61b-f742ed613c57",
+          "name": "panel_2",
+          "type": "visualization"
+        },
+        {
+          "id": "981779d0-9bfc-11e9-a61b-f742ed613c57",
+          "name": "panel_3",
+          "type": "visualization"
+        },
+        {
+          "id": "072de430-9bfd-11e9-a61b-f742ed613c57",
+          "name": "panel_4",
+          "type": "visualization"
+        }
+      ],
+      "type": "dashboard",
+      "updated_at": "2019-07-01T13:32:15.355Z",
+      "version": "Wzk0MywxNF0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Avg data file size by filename [Metricbeat Oracle]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "",
+            "interval": "auto",
+            "legend_position": "bottom",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "bytes",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Data file size by filename",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "agg_with": "noop",
+                    "field": "oracle.tablespace.data_file.size.bytes",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "order": "desc",
+                    "size": 1,
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "terms",
+                "stacked": "stacked",
+                "terms_field": "oracle.tablespace.data_file.name",
+                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Avg data file size by filename [Metricbeat Oracle]",
+          "type": "metrics"
+        }
+      },
+      "id": "c92efe60-9bef-11e9-a61b-f742ed613c57",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-07-01T12:24:40.028Z",
+      "version": "WzkzOCwxNF0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Tablespace Total Size [Metricbeat Oracle]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(115,216,255,1)",
+                "fill": 0.5,
+                "formatter": "bytes",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Tablespace total size",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "oracle.tablespace.space.total.bytes",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "terms",
+                "stacked": "stacked",
+                "terms_field": "oracle.tablespace.name",
+                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Tablespace Total Size [Metricbeat Oracle]",
+          "type": "metrics"
+        }
+      },
+      "id": "05acae50-9bf0-11e9-a61b-f742ed613c57",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-07-01T11:09:27.312Z",
+      "version": "WzkzNCwxNF0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Maximum data file size [Metricbeat Oracle]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "",
+            "interval": "auto",
+            "legend_position": "bottom",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(254,146,0,1)",
+                "fill": 0.5,
+                "formatter": "bytes",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Maximum data file size",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "oracle.tablespace.data_file.size.max.bytes",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "terms",
+                "stacked": "stacked",
+                "terms_field": "oracle.tablespace.data_file.name",
+                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Maximum data file size [Metricbeat Oracle]",
+          "type": "metrics"
+        }
+      },
+      "id": "4c051a90-9bf0-11e9-a61b-f742ed613c57",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-07-01T11:09:16.058Z",
+      "version": "WzkzMywxNF0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Ratio of used space in Tablespaces [Metricbeat Oracle]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "bar_color_rules": [
+              {
+                "id": "70de46f0-9bfc-11e9-baad-815beb8da1b5"
+              }
+            ],
+            "default_index_pattern": "metricbeat-*",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "percent",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "oracle.tablespace.space.used.bytes",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  },
+                  {
+                    "field": "oracle.tablespace.space.total.bytes",
+                    "id": "37c93d70-9bfc-11e9-baad-815beb8da1b5",
+                    "type": "avg"
+                  },
+                  {
+                    "denominator": "2",
+                    "field": "oracle.tablespace.space.total.bytes",
+                    "id": "0d474830-9bfc-11e9-baad-815beb8da1b5",
+                    "numerator": "1",
+                    "script": "params.used / params.total",
+                    "type": "math",
+                    "variables": [
+                      {
+                        "field": "61ca57f2-469d-11e7-af02-69e470af7417",
+                        "id": "34e8d9d0-9bfc-11e9-baad-815beb8da1b5",
+                        "name": "used"
+                      },
+                      {
+                        "field": "37c93d70-9bfc-11e9-baad-815beb8da1b5",
+                        "id": "467fdf40-9bfc-11e9-baad-815beb8da1b5",
+                        "name": "total"
+                      }
+                    ]
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "oracle.tablespace.name",
+                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "top_n"
+          },
+          "title": "Ratio of used space in Tablespaces [Metricbeat Oracle]",
+          "type": "metrics"
+        }
+      },
+      "id": "981779d0-9bfc-11e9-a61b-f742ed613c57",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-07-01T12:34:39.724Z",
+      "version": "WzkzOSwxNF0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Ratio of used space in data files [Metricbeat Oracle]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "bar_color_rules": [
+              {
+                "id": "da9fa430-9bfc-11e9-baad-815beb8da1b5"
+              }
+            ],
+            "default_index_pattern": "metricbeat-*",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "",
+            "interval": "auto",
+            "legend_position": "bottom",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(204,204,204,1)",
+                "fill": 0.5,
+                "formatter": "percent",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Ratio of used space in data files",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "oracle.tablespace.data_file.size.max.bytes",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  },
+                  {
+                    "field": "oracle.tablespace.data_file.size.bytes",
+                    "id": "c0f200a0-9bfc-11e9-baad-815beb8da1b5",
+                    "type": "avg"
+                  },
+                  {
+                    "id": "c8289f00-9bfc-11e9-baad-815beb8da1b5",
+                    "script": "params.used / params.max",
+                    "type": "math",
+                    "variables": [
+                      {
+                        "field": "61ca57f2-469d-11e7-af02-69e470af7417",
+                        "id": "c9a63e50-9bfc-11e9-baad-815beb8da1b5",
+                        "name": "max"
+                      },
+                      {
+                        "field": "c0f200a0-9bfc-11e9-baad-815beb8da1b5",
+                        "id": "cddc46e0-9bfc-11e9-baad-815beb8da1b5",
+                        "name": "used"
+                      }
+                    ]
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "terms",
+                "stacked": "stacked",
+                "terms_field": "oracle.tablespace.data_file.name",
+                "terms_order_by": "c0f200a0-9bfc-11e9-baad-815beb8da1b5"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "top_n"
+          },
+          "title": "Ratio of used space in data files [Metricbeat Oracle]",
+          "type": "metrics"
+        }
+      },
+      "id": "072de430-9bfd-11e9-a61b-f742ed613c57",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-07-01T12:37:59.842Z",
+      "version": "Wzk0MSwxNF0="
+    }
+  ],
+  "version": "8.0.0-SNAPSHOT"
+}

--- a/dev/package-beats/oracle-1.0.0/manifest.yml
+++ b/dev/package-beats/oracle-1.0.0/manifest.yml
@@ -1,0 +1,12 @@
+name: oracle
+title: Oracle
+version: 1.0.0
+description: Oracle database module
+type: ""
+categories:
+- metrics
+requirement:
+  kibana:
+    version:
+      min: 6.7.0
+      max: 7.6.0

--- a/dev/package-beats/osquery-1.0.0/kibana/dashboard/osquery-compliance.json
+++ b/dev/package-beats/osquery-1.0.0/kibana/dashboard/osquery-compliance.json
@@ -1,0 +1,668 @@
+{
+    "objects": [
+        {
+            "attributes": {
+                "columns": [
+                    "osquery.result.columns.path", 
+                    "osquery.result.columns.type", 
+                    "osquery.result.columns.flags"
+                ], 
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [
+                            {
+                                "$state": {
+                                    "store": "appState"
+                                }, 
+                                "meta": {
+                                    "alias": null, 
+                                    "disabled": false, 
+                                    "index": "filebeat-*", 
+                                    "key": "osquery.result.name", 
+                                    "negate": false, 
+                                    "params": {
+                                        "query": "pack_it-compliance_mounts", 
+                                        "type": "phrase"
+                                    }, 
+                                    "type": "phrase", 
+                                    "value": "pack_it-compliance_mounts"
+                                }, 
+                                "query": {
+                                    "match": {
+                                        "osquery.result.name": {
+                                            "query": "pack_it-compliance_mounts", 
+                                            "type": "phrase"
+                                        }
+                                    }
+                                }
+                            }
+                        ], 
+                        "highlightAll": true, 
+                        "index": "filebeat-*", 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "sort": [
+                    "@timestamp", 
+                    "desc"
+                ], 
+                "title": "Mounts [Filebeat Osquery] ECS", 
+                "version": 1
+            }, 
+            "id": "7a9482d0-eb00-11e7-8f04-51231daa5b05-ecs", 
+            "type": "search", 
+            "updated_at": "2018-01-08T17:35:32.102Z", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                }, 
+                "savedSearchId": "7a9482d0-eb00-11e7-8f04-51231daa5b05-ecs", 
+                "title": "Mounts by type [Filebeat Osquery] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "field": "osquery.result.columns.path", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 10
+                            }, 
+                            "schema": "segment", 
+                            "type": "terms"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "field": "osquery.result.columns.type", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "segment", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "params": {
+                        "addLegend": true, 
+                        "addTooltip": true, 
+                        "isDonut": true, 
+                        "labels": {
+                            "last_level": true, 
+                            "show": false, 
+                            "truncate": 100, 
+                            "values": true
+                        }, 
+                        "legendPosition": "right", 
+                        "type": "pie"
+                    }, 
+                    "title": "Mounts by type [Filebeat Osquery] ECS", 
+                    "type": "pie"
+                }
+            }, 
+            "id": "a9fd8bb0-eb01-11e7-8f04-51231daa5b05-ecs", 
+            "type": "visualization", 
+            "updated_at": "2018-01-08T17:35:32.102Z", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "columns": [
+                    "osquery.result.columns.name", 
+                    "osquery.result.columns.version", 
+                    "osquery.result.columns.revision"
+                ], 
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [
+                            {
+                                "$state": {
+                                    "store": "appState"
+                                }, 
+                                "meta": {
+                                    "alias": null, 
+                                    "disabled": false, 
+                                    "index": "filebeat-*", 
+                                    "key": "osquery.result.name", 
+                                    "negate": false, 
+                                    "params": {
+                                        "query": "pack_it-compliance_deb_packages", 
+                                        "type": "phrase"
+                                    }, 
+                                    "type": "phrase", 
+                                    "value": "pack_it-compliance_deb_packages"
+                                }, 
+                                "query": {
+                                    "match": {
+                                        "osquery.result.name": {
+                                            "query": "pack_it-compliance_deb_packages", 
+                                            "type": "phrase"
+                                        }
+                                    }
+                                }
+                            }
+                        ], 
+                        "highlightAll": true, 
+                        "index": "filebeat-*", 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "sort": [
+                    "@timestamp", 
+                    "desc"
+                ], 
+                "title": "DEB packages installed [Filebeat Osquery] ECS", 
+                "version": 1
+            }, 
+            "id": "3824b080-eb02-11e7-8f04-51231daa5b05-ecs", 
+            "type": "search", 
+            "updated_at": "2018-01-08T17:35:32.102Z", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                }, 
+                "savedSearchId": "b5d6baa0-eb02-11e7-8f04-51231daa5b05-ecs", 
+                "title": "OS versions [Filebeat Osquery] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "field": "osquery.result.host_identifier"
+                            }, 
+                            "schema": "metric", 
+                            "type": "cardinality"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "4", 
+                            "params": {
+                                "field": "osquery.result.columns.platform_like", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "segment", 
+                            "type": "terms"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "field": "osquery.result.columns.name", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "segment", 
+                            "type": "terms"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "field": "osquery.result.columns.version", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "segment", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "params": {
+                        "addLegend": true, 
+                        "addTooltip": true, 
+                        "isDonut": true, 
+                        "labels": {
+                            "last_level": true, 
+                            "show": false, 
+                            "truncate": 100, 
+                            "values": true
+                        }, 
+                        "legendPosition": "right", 
+                        "type": "pie"
+                    }, 
+                    "title": "OS versions [Filebeat Osquery] ECS", 
+                    "type": "pie"
+                }
+            }, 
+            "id": "1da1ed30-eb03-11e7-8f04-51231daa5b05-ecs", 
+            "type": "visualization", 
+            "updated_at": "2018-01-08T17:35:32.102Z", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [
+                            {
+                                "$state": {
+                                    "store": "appState"
+                                }, 
+                                "meta": {
+                                    "alias": null, 
+                                    "disabled": false, 
+                                    "index": "filebeat-*", 
+                                    "key": "osquery.result.columns.status", 
+                                    "negate": false, 
+                                    "params": {
+                                        "query": "Live", 
+                                        "type": "phrase"
+                                    }, 
+                                    "type": "phrase", 
+                                    "value": "Live"
+                                }, 
+                                "query": {
+                                    "match": {
+                                        "osquery.result.columns.status": {
+                                            "query": "Live", 
+                                            "type": "phrase"
+                                        }
+                                    }
+                                }
+                            }
+                        ], 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                }, 
+                "savedSearchId": "f59e21e0-eb03-11e7-8f04-51231daa5b05-ecs", 
+                "title": "Number of Kernel modules [Filebeat Osquery] ECS", 
+                "uiStateJSON": {
+                    "vis": {
+                        "defaultColors": {
+                            "0 - 100": "rgb(0,104,55)"
+                        }
+                    }
+                }, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "Live Kernel modules", 
+                                "field": "osquery.result.columns.name"
+                            }, 
+                            "schema": "metric", 
+                            "type": "cardinality"
+                        }
+                    ], 
+                    "params": {
+                        "addLegend": true, 
+                        "addTooltip": true, 
+                        "gauge": {
+                            "backStyle": "Full", 
+                            "colorSchema": "Green to Red", 
+                            "colorsRange": [
+                                {
+                                    "from": 0, 
+                                    "to": 100
+                                }
+                            ], 
+                            "extendRange": true, 
+                            "gaugeColorMode": "Labels", 
+                            "gaugeStyle": "Full", 
+                            "gaugeType": "Arc", 
+                            "invertColors": false, 
+                            "labels": {
+                                "color": "black", 
+                                "show": true
+                            }, 
+                            "orientation": "vertical", 
+                            "percentageMode": false, 
+                            "scale": {
+                                "color": "#333", 
+                                "labels": false, 
+                                "show": true
+                            }, 
+                            "style": {
+                                "bgColor": false, 
+                                "bgFill": "#eee", 
+                                "bgMask": false, 
+                                "bgWidth": 0.9, 
+                                "fontSize": 60, 
+                                "labelColor": true, 
+                                "mask": false, 
+                                "maskBars": 50, 
+                                "subText": "", 
+                                "width": 0.9
+                            }, 
+                            "type": "meter", 
+                            "verticalSplit": false
+                        }, 
+                        "isDisplayWarning": false, 
+                        "type": "gauge"
+                    }, 
+                    "title": "Number of Kernel modules [Filebeat Osquery] ECS", 
+                    "type": "gauge"
+                }
+            }, 
+            "id": "240f3630-eb05-11e7-8f04-51231daa5b05-ecs", 
+            "type": "visualization", 
+            "updated_at": "2018-01-08T17:35:32.102Z", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "Navigation [Filebeat Osquery] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "fontSize": 10, 
+                        "markdown": "[Compilance](#/dashboard/69f5ae20-eb02-11e7-8f04-51231daa5b05-ecs) | [OSSEC Rootkit](#/dashboard/c0a7ce90-f4aa-11e7-8647-534bb4c21040-ecs)"
+                    }, 
+                    "title": "Navigation [Filebeat Osquery] ECS", 
+                    "type": "markdown"
+                }
+            }, 
+            "id": "2d6e0760-f4ab-11e7-8647-534bb4c21040-ecs", 
+            "type": "visualization", 
+            "updated_at": "2018-01-08T19:41:10.264Z", 
+            "version": 3
+        }, 
+        {
+            "attributes": {
+                "columns": [
+                    "osquery.result.name"
+                ], 
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [
+                            {
+                                "$state": {
+                                    "store": "appState"
+                                }, 
+                                "meta": {
+                                    "alias": null, 
+                                    "disabled": false, 
+                                    "index": "filebeat-*", 
+                                    "key": "osquery.result.name", 
+                                    "negate": false, 
+                                    "params": {
+                                        "query": "pack_it-compliance_os_version", 
+                                        "type": "phrase"
+                                    }, 
+                                    "type": "phrase", 
+                                    "value": "pack_it-compliance_os_version"
+                                }, 
+                                "query": {
+                                    "match": {
+                                        "osquery.result.name": {
+                                            "query": "pack_it-compliance_os_version", 
+                                            "type": "phrase"
+                                        }
+                                    }
+                                }
+                            }
+                        ], 
+                        "highlightAll": true, 
+                        "index": "filebeat-*", 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "sort": [
+                    "@timestamp", 
+                    "desc"
+                ], 
+                "title": "OS versions [Filebeat Osquery] ECS", 
+                "version": 1
+            }, 
+            "id": "b5d6baa0-eb02-11e7-8f04-51231daa5b05-ecs", 
+            "type": "search", 
+            "updated_at": "2018-01-08T17:35:32.102Z", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "columns": [
+                    "osquery.result.name", 
+                    "osquery.result.columns.name", 
+                    "osquery.result.columns.status"
+                ], 
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [
+                            {
+                                "$state": {
+                                    "store": "appState"
+                                }, 
+                                "meta": {
+                                    "alias": null, 
+                                    "disabled": false, 
+                                    "index": "filebeat-*", 
+                                    "key": "osquery.result.name", 
+                                    "negate": false, 
+                                    "params": {
+                                        "query": "pack_it-compliance_kernel_modules", 
+                                        "type": "phrase"
+                                    }, 
+                                    "type": "phrase", 
+                                    "value": "pack_it-compliance_kernel_modules"
+                                }, 
+                                "query": {
+                                    "match": {
+                                        "osquery.result.name": {
+                                            "query": "pack_it-compliance_kernel_modules", 
+                                            "type": "phrase"
+                                        }
+                                    }
+                                }
+                            }
+                        ], 
+                        "highlightAll": true, 
+                        "index": "filebeat-*", 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "sort": [
+                    "@timestamp", 
+                    "desc"
+                ], 
+                "title": "Kernel modules [Filebeat Osquery] ECS", 
+                "version": 1
+            }, 
+            "id": "f59e21e0-eb03-11e7-8f04-51231daa5b05-ecs", 
+            "type": "search", 
+            "updated_at": "2018-01-08T17:35:32.102Z", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "Dashboard for visualizing the data collected by the Osquery compliance pack.", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlightAll": true, 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "optionsJSON": {
+                    "darkTheme": false, 
+                    "hidePanelTitles": false, 
+                    "useMargins": true
+                }, 
+                "panelsJSON": [
+                    {
+                        "gridData": {
+                            "h": 4, 
+                            "i": "1", 
+                            "w": 6, 
+                            "x": 6, 
+                            "y": 6
+                        }, 
+                        "id": "7a9482d0-eb00-11e7-8f04-51231daa5b05-ecs", 
+                        "panelIndex": "1", 
+                        "type": "search", 
+                        "version": "6.2.4"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 5, 
+                            "i": "2", 
+                            "w": 7, 
+                            "x": 5, 
+                            "y": 1
+                        }, 
+                        "id": "a9fd8bb0-eb01-11e7-8f04-51231daa5b05-ecs", 
+                        "panelIndex": "2", 
+                        "type": "visualization", 
+                        "version": "6.2.4"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 4, 
+                            "i": "3", 
+                            "w": 6, 
+                            "x": 0, 
+                            "y": 6
+                        }, 
+                        "id": "3824b080-eb02-11e7-8f04-51231daa5b05-ecs", 
+                        "panelIndex": "3", 
+                        "type": "search", 
+                        "version": "6.2.4"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 3, 
+                            "i": "4", 
+                            "w": 5, 
+                            "x": 0, 
+                            "y": 1
+                        }, 
+                        "id": "1da1ed30-eb03-11e7-8f04-51231daa5b05-ecs", 
+                        "panelIndex": "4", 
+                        "type": "visualization", 
+                        "version": "6.2.4"
+                    }, 
+                    {
+                        "embeddableConfig": {
+                            "vis": {
+                                "defaultColors": {
+                                    "0 - 100": "rgb(0,104,55)"
+                                }, 
+                                "legendOpen": false
+                            }
+                        }, 
+                        "gridData": {
+                            "h": 2, 
+                            "i": "5", 
+                            "w": 5, 
+                            "x": 0, 
+                            "y": 4
+                        }, 
+                        "id": "240f3630-eb05-11e7-8f04-51231daa5b05-ecs", 
+                        "panelIndex": "5", 
+                        "type": "visualization", 
+                        "version": "6.2.4"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 1, 
+                            "i": "6", 
+                            "w": 12, 
+                            "x": 0, 
+                            "y": 0
+                        }, 
+                        "id": "2d6e0760-f4ab-11e7-8647-534bb4c21040-ecs", 
+                        "panelIndex": "6", 
+                        "type": "visualization", 
+                        "version": "6.1.0-SNAPSHOT"
+                    }
+                ], 
+                "timeRestore": false, 
+                "title": "[Filebeat Osquery] Compliance pack ECS", 
+                "uiStateJSON": {
+                    "P-5": {
+                        "vis": {
+                            "defaultColors": {
+                                "0 - 100": "rgb(0,104,55)"
+                            }
+                        }
+                    }
+                }, 
+                "version": 1
+            }, 
+            "id": "69f5ae20-eb02-11e7-8f04-51231daa5b05-ecs", 
+            "type": "dashboard", 
+            "updated_at": "2018-01-08T19:42:15.406Z", 
+            "version": 2
+        }
+    ], 
+    "version": "6.1.0-SNAPSHOT"
+}

--- a/dev/package-beats/osquery-1.0.0/kibana/dashboard/osquery-rootkit.json
+++ b/dev/package-beats/osquery-1.0.0/kibana/dashboard/osquery-rootkit.json
@@ -1,0 +1,387 @@
+{
+    "objects": [
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "Info OSSEC rootkit [Filebeat Osquery] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "fontSize": 12, 
+                        "markdown": "This dashboard shows data collected by the ossec-rootkit pack from osquery."
+                    }, 
+                    "title": "Info OSSEC rootkit [Filebeat Osquery] ECS", 
+                    "type": "markdown"
+                }
+            }, 
+            "id": "6ec10290-f4aa-11e7-8647-534bb4c21040-ecs", 
+            "type": "visualization", 
+            "updated_at": "2018-01-08T19:30:49.785Z", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                }, 
+                "savedSearchId": "0fe5dc00-f49b-11e7-8647-534bb4c21040-ecs", 
+                "title": "Number of rootkits found [Filebeat Osquery] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "Rootkits", 
+                                "field": "osquery.result.name"
+                            }, 
+                            "schema": "metric", 
+                            "type": "cardinality"
+                        }
+                    ], 
+                    "params": {
+                        "addLegend": false, 
+                        "addTooltip": true, 
+                        "metric": {
+                            "colorSchema": "Green to Red", 
+                            "colorsRange": [
+                                {
+                                    "from": 0, 
+                                    "to": 10000
+                                }
+                            ], 
+                            "invertColors": false, 
+                            "labels": {
+                                "show": true
+                            }, 
+                            "metricColorMode": "None", 
+                            "percentageMode": false, 
+                            "style": {
+                                "bgColor": false, 
+                                "bgFill": "#000", 
+                                "fontSize": 40, 
+                                "labelColor": false, 
+                                "subText": ""
+                            }, 
+                            "useRanges": false
+                        }, 
+                        "type": "metric"
+                    }, 
+                    "title": "Number of rootkits found [Filebeat Osquery] ECS", 
+                    "type": "metric"
+                }
+            }, 
+            "id": "ffdbba50-f4a9-11e7-8647-534bb4c21040-ecs", 
+            "type": "visualization", 
+            "updated_at": "2018-01-08T19:40:05.060Z", 
+            "version": 3
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                }, 
+                "savedSearchId": "0fe5dc00-f49b-11e7-8647-534bb4c21040-ecs", 
+                "title": "Number of hosts infected [Filebeat Osquery] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "Hosts", 
+                                "field": "agent.hostname"
+                            }, 
+                            "schema": "metric", 
+                            "type": "cardinality"
+                        }
+                    ], 
+                    "params": {
+                        "addLegend": false, 
+                        "addTooltip": true, 
+                        "metric": {
+                            "colorSchema": "Green to Red", 
+                            "colorsRange": [
+                                {
+                                    "from": 0, 
+                                    "to": 10000
+                                }
+                            ], 
+                            "invertColors": false, 
+                            "labels": {
+                                "show": true
+                            }, 
+                            "metricColorMode": "None", 
+                            "percentageMode": false, 
+                            "style": {
+                                "bgColor": false, 
+                                "bgFill": "#000", 
+                                "fontSize": 40, 
+                                "labelColor": false, 
+                                "subText": ""
+                            }, 
+                            "useRanges": false
+                        }, 
+                        "type": "metric"
+                    }, 
+                    "title": "Number of hosts infected [Filebeat Osquery] ECS", 
+                    "type": "metric"
+                }
+            }, 
+            "id": "ab587180-f4a9-11e7-8647-534bb4c21040-ecs", 
+            "type": "visualization", 
+            "updated_at": "2018-01-08T19:39:45.085Z", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "Navigation [Filebeat Osquery] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "fontSize": 10, 
+                        "markdown": "[Compilance](#/dashboard/69f5ae20-eb02-11e7-8f04-51231daa5b05-ecs) | [OSSEC Rootkit](#/dashboard/c0a7ce90-f4aa-11e7-8647-534bb4c21040-ecs)"
+                    }, 
+                    "title": "Navigation [Filebeat Osquery] ECS", 
+                    "type": "markdown"
+                }
+            }, 
+            "id": "2d6e0760-f4ab-11e7-8647-534bb4c21040-ecs", 
+            "type": "visualization", 
+            "updated_at": "2018-01-08T19:41:10.264Z", 
+            "version": 3
+        }, 
+        {
+            "attributes": {
+                "columns": [
+                    "osquery.result.name", 
+                    "osquery.result.columns.path", 
+                    "agent.hostname"
+                ], 
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [
+                            {
+                                "$state": {
+                                    "store": "appState"
+                                }, 
+                                "meta": {
+                                    "alias": null, 
+                                    "disabled": false, 
+                                    "index": "filebeat-*", 
+                                    "key": "query", 
+                                    "negate": false, 
+                                    "type": "custom", 
+                                    "value": "{\"prefix\":{\"osquery.result.name\":\"pack_ossec-rootkit\"}}"
+                                }, 
+                                "query": {
+                                    "prefix": {
+                                        "osquery.result.name": "pack_ossec-rootkit"
+                                    }
+                                }
+                            }, 
+                            {
+                                "$state": {
+                                    "store": "appState"
+                                }, 
+                                "meta": {
+                                    "alias": null, 
+                                    "disabled": false, 
+                                    "index": "filebeat-*", 
+                                    "key": "event.module", 
+                                    "negate": false, 
+                                    "params": {
+                                        "query": "osquery", 
+                                        "type": "phrase"
+                                    }, 
+                                    "type": "phrase", 
+                                    "value": "osquery"
+                                }, 
+                                "query": {
+                                    "match": {
+                                        "event.module": {
+                                            "query": "osquery", 
+                                            "type": "phrase"
+                                        }
+                                    }
+                                }
+                            }, 
+                            {
+                                "$state": {
+                                    "store": "appState"
+                                }, 
+                                "meta": {
+                                    "alias": null, 
+                                    "disabled": false, 
+                                    "index": "filebeat-*", 
+                                    "key": "fileset.name", 
+                                    "negate": false, 
+                                    "params": {
+                                        "query": "result", 
+                                        "type": "phrase"
+                                    }, 
+                                    "type": "phrase", 
+                                    "value": "result"
+                                }, 
+                                "query": {
+                                    "match": {
+                                        "fileset.name": {
+                                            "query": "result", 
+                                            "type": "phrase"
+                                        }
+                                    }
+                                }
+                            }
+                        ], 
+                        "highlightAll": true, 
+                        "index": "filebeat-*", 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "sort": [
+                    "@timestamp", 
+                    "desc"
+                ], 
+                "title": "OSSEC Rootkits [Filebeat Osquery] ECS", 
+                "version": 1
+            }, 
+            "id": "0fe5dc00-f49b-11e7-8647-534bb4c21040-ecs", 
+            "type": "search", 
+            "updated_at": "2018-01-08T19:38:24.483Z", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "This dashboard shows data collected by the OSSEC rootkit pack from osquery", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlightAll": true, 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "optionsJSON": {
+                    "darkTheme": false, 
+                    "hidePanelTitles": false, 
+                    "useMargins": true
+                }, 
+                "panelsJSON": [
+                    {
+                        "gridData": {
+                            "h": 2, 
+                            "i": "1", 
+                            "w": 4, 
+                            "x": 8, 
+                            "y": 1
+                        }, 
+                        "id": "6ec10290-f4aa-11e7-8647-534bb4c21040-ecs", 
+                        "panelIndex": "1", 
+                        "type": "visualization", 
+                        "version": "6.1.0-SNAPSHOT"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 2, 
+                            "i": "2", 
+                            "w": 4, 
+                            "x": 4, 
+                            "y": 1
+                        }, 
+                        "id": "ffdbba50-f4a9-11e7-8647-534bb4c21040-ecs", 
+                        "panelIndex": "2", 
+                        "type": "visualization", 
+                        "version": "6.1.0-SNAPSHOT"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 2, 
+                            "i": "3", 
+                            "w": 4, 
+                            "x": 0, 
+                            "y": 1
+                        }, 
+                        "id": "ab587180-f4a9-11e7-8647-534bb4c21040-ecs", 
+                        "panelIndex": "3", 
+                        "type": "visualization", 
+                        "version": "6.1.0-SNAPSHOT"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 1, 
+                            "i": "4", 
+                            "w": 12, 
+                            "x": 0, 
+                            "y": 0
+                        }, 
+                        "id": "2d6e0760-f4ab-11e7-8647-534bb4c21040-ecs", 
+                        "panelIndex": "4", 
+                        "type": "visualization", 
+                        "version": "6.1.0-SNAPSHOT"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 4, 
+                            "i": "5", 
+                            "w": 12, 
+                            "x": 0, 
+                            "y": 3
+                        }, 
+                        "id": "0fe5dc00-f49b-11e7-8647-534bb4c21040-ecs", 
+                        "panelIndex": "5", 
+                        "type": "search", 
+                        "version": "6.1.0-SNAPSHOT"
+                    }
+                ], 
+                "timeRestore": false, 
+                "title": "[Filebeat Osquery] OSSEC rootkit pack ECS", 
+                "uiStateJSON": {}, 
+                "version": 1
+            }, 
+            "id": "c0a7ce90-f4aa-11e7-8647-534bb4c21040-ecs", 
+            "type": "dashboard", 
+            "updated_at": "2018-01-08T19:40:16.304Z", 
+            "version": 6
+        }
+    ], 
+    "version": "6.1.0-SNAPSHOT"
+}

--- a/dev/package-beats/osquery-1.0.0/manifest.yml
+++ b/dev/package-beats/osquery-1.0.0/manifest.yml
@@ -1,0 +1,13 @@
+name: osquery
+title: Osquery
+version: 1.0.0
+description: |
+  Fields exported by the `osquery` module
+type: ""
+categories:
+- logs
+requirement:
+  kibana:
+    version:
+      min: 6.7.0
+      max: 7.6.0

--- a/dev/package-beats/panw-1.0.0/kibana/dashboard/Filebeat-panw-network-overview.json
+++ b/dev/package-beats/panw-1.0.0/kibana/dashboard/Filebeat-panw-network-overview.json
@@ -1,0 +1,1107 @@
+{
+  "objects": [
+    {
+      "attributes": {
+        "description": "Palo Alto Networks PAN-OS Networks Overview",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "optionsJSON": {
+          "hidePanelTitles": false,
+          "useMargins": true
+        },
+        "panelsJSON": [
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 15,
+              "i": "1",
+              "w": 24,
+              "x": 24,
+              "y": 0
+            },
+            "panelIndex": "1",
+            "panelRefName": "panel_0",
+            "version": "7.1.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 15,
+              "i": "2",
+              "w": 24,
+              "x": 0,
+              "y": 0
+            },
+            "panelIndex": "2",
+            "panelRefName": "panel_1",
+            "version": "7.1.0"
+          },
+          {
+            "embeddableConfig": {
+              "vis": {
+                "legendOpen": false
+              }
+            },
+            "gridData": {
+              "h": 15,
+              "i": "3",
+              "w": 24,
+              "x": 0,
+              "y": 15
+            },
+            "panelIndex": "3",
+            "panelRefName": "panel_2",
+            "version": "7.1.0"
+          },
+          {
+            "embeddableConfig": {
+              "vis": {
+                "legendOpen": false
+              }
+            },
+            "gridData": {
+              "h": 15,
+              "i": "4",
+              "w": 12,
+              "x": 24,
+              "y": 15
+            },
+            "panelIndex": "4",
+            "panelRefName": "panel_3",
+            "version": "7.1.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 15,
+              "i": "5",
+              "w": 12,
+              "x": 36,
+              "y": 15
+            },
+            "panelIndex": "5",
+            "panelRefName": "panel_4",
+            "version": "7.1.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 15,
+              "i": "6",
+              "w": 24,
+              "x": 0,
+              "y": 30
+            },
+            "panelIndex": "6",
+            "panelRefName": "panel_5",
+            "version": "7.1.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 15,
+              "i": "7",
+              "w": 24,
+              "x": 24,
+              "y": 30
+            },
+            "panelIndex": "7",
+            "panelRefName": "panel_6",
+            "version": "7.1.0"
+          }
+        ],
+        "timeRestore": false,
+        "title": "[Filebeat PANW] Network Flows ECS",
+        "version": 1
+      },
+      "id": "e40ba240-7572-11e9-976e-65a8f47cc4c1",
+      "migrationVersion": {
+        "dashboard": "7.0.0"
+      },
+      "references": [
+        {
+          "id": "091fe860-756a-11e9-976e-65a8f47cc4c1",
+          "name": "panel_0",
+          "type": "visualization"
+        },
+        {
+          "id": "87f30f60-7569-11e9-976e-65a8f47cc4c1",
+          "name": "panel_1",
+          "type": "visualization"
+        },
+        {
+          "id": "78e7e820-756d-11e9-976e-65a8f47cc4c1",
+          "name": "panel_2",
+          "type": "visualization"
+        },
+        {
+          "id": "d9cab170-756f-11e9-976e-65a8f47cc4c1",
+          "name": "panel_3",
+          "type": "visualization"
+        },
+        {
+          "id": "135930b0-7570-11e9-976e-65a8f47cc4c1",
+          "name": "panel_4",
+          "type": "visualization"
+        },
+        {
+          "id": "e46331c0-756a-11e9-976e-65a8f47cc4c1",
+          "name": "panel_5",
+          "type": "visualization"
+        },
+        {
+          "id": "0407a3e0-756f-11e9-976e-65a8f47cc4c1",
+          "name": "panel_6",
+          "type": "visualization"
+        }
+      ],
+      "type": "dashboard",
+      "updated_at": "2019-05-13T11:33:12.420Z",
+      "version": "WzI0NSwxXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "savedSearchRefName": "search_0",
+        "title": "Destination Flows Map [Filebeat PANW] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "autoPrecision": true,
+                "field": "destination.geo.location",
+                "isFilteredByCollar": true,
+                "mapCenter": [
+                  0,
+                  0
+                ],
+                "mapZoom": 2,
+                "precision": 2,
+                "useGeocentroid": true
+              },
+              "schema": "segment",
+              "type": "geohash_grid"
+            }
+          ],
+          "params": {
+            "addTooltip": true,
+            "colorSchema": "Yellow to Red",
+            "heatClusterSize": 1.5,
+            "isDesaturated": true,
+            "legendPosition": "bottomright",
+            "mapCenter": [
+              0,
+              0
+            ],
+            "mapType": "Scaled Circle Markers",
+            "mapZoom": 2,
+            "wms": {
+              "enabled": false,
+              "options": {
+                "format": "image/png",
+                "transparent": true
+              }
+            }
+          },
+          "title": "Destination Flows Map [Filebeat PANW] ECS",
+          "type": "tile_map"
+        }
+      },
+      "id": "091fe860-756a-11e9-976e-65a8f47cc4c1",
+      "migrationVersion": {
+        "visualization": "7.0.1"
+      },
+      "references": [
+        {
+          "id": "290685e0-7569-11e9-976e-65a8f47cc4c1",
+          "name": "search_0",
+          "type": "search"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-05-13T10:29:49.158Z",
+      "version": "WzIzOCwxXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "savedSearchRefName": "search_0",
+        "title": "Source Flows Map [Filebeat PANW] ECS",
+        "uiStateJSON": {
+          "mapCenter": [
+            -0.17578097424708533,
+            0.17578125
+          ],
+          "mapZoom": 1
+        },
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "autoPrecision": true,
+                "field": "source.geo.location",
+                "isFilteredByCollar": true,
+                "mapCenter": [
+                  0,
+                  0
+                ],
+                "mapZoom": 2,
+                "precision": 2,
+                "useGeocentroid": true
+              },
+              "schema": "segment",
+              "type": "geohash_grid"
+            }
+          ],
+          "params": {
+            "addTooltip": true,
+            "colorSchema": "Yellow to Red",
+            "heatClusterSize": 1.5,
+            "isDesaturated": true,
+            "legendPosition": "bottomright",
+            "mapCenter": [
+              0,
+              0
+            ],
+            "mapType": "Scaled Circle Markers",
+            "mapZoom": 2,
+            "wms": {
+              "enabled": false,
+              "options": {
+                "format": "image/png",
+                "transparent": true
+              }
+            }
+          },
+          "title": "Source Flows Map [Filebeat PANW] ECS",
+          "type": "tile_map"
+        }
+      },
+      "id": "87f30f60-7569-11e9-976e-65a8f47cc4c1",
+      "migrationVersion": {
+        "visualization": "7.0.1"
+      },
+      "references": [
+        {
+          "id": "290685e0-7569-11e9-976e-65a8f47cc4c1",
+          "name": "search_0",
+          "type": "search"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-05-13T10:26:12.438Z",
+      "version": "WzIzNywxXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [
+              {
+                "$state": {
+                  "store": "appState"
+                },
+                "meta": {
+                  "alias": null,
+                  "disabled": false,
+                  "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                  "key": "event.action",
+                  "negate": true,
+                  "params": {
+                    "query": "flow_terminated"
+                  },
+                  "type": "phrase",
+                  "value": "flow_terminated"
+                },
+                "query": {
+                  "match": {
+                    "event.action": {
+                      "query": "flow_terminated",
+                      "type": "phrase"
+                    }
+                  }
+                }
+              }
+            ],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "savedSearchRefName": "search_0",
+        "title": "Flow Creation Histogram [Filebeat PANW] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customInterval": "2h",
+                "drop_partials": false,
+                "extended_bounds": {},
+                "field": "@timestamp",
+                "interval": "auto",
+                "min_doc_count": 1,
+                "timeRange": {
+                  "from": "2018-04-10T04:36:19.586Z",
+                  "to": "2018-04-10T04:39:56.264Z"
+                },
+                "useNormalizedEsInterval": true
+              },
+              "schema": "segment",
+              "type": "date_histogram"
+            },
+            {
+              "enabled": true,
+              "id": "3",
+              "params": {
+                "field": "event.outcome",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 5
+              },
+              "schema": "group",
+              "type": "terms"
+            }
+          ],
+          "params": {
+            "addLegend": true,
+            "addTimeMarker": false,
+            "addTooltip": true,
+            "categoryAxes": [
+              {
+                "id": "CategoryAxis-1",
+                "labels": {
+                  "show": true,
+                  "truncate": 100
+                },
+                "position": "bottom",
+                "scale": {
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {},
+                "type": "category"
+              }
+            ],
+            "grid": {
+              "categoryLines": false
+            },
+            "legendPosition": "right",
+            "seriesParams": [
+              {
+                "data": {
+                  "id": "1",
+                  "label": "Count"
+                },
+                "drawLinesBetweenPoints": true,
+                "mode": "stacked",
+                "show": "true",
+                "showCircles": true,
+                "type": "histogram",
+                "valueAxis": "ValueAxis-1"
+              }
+            ],
+            "times": [],
+            "type": "histogram",
+            "valueAxes": [
+              {
+                "id": "ValueAxis-1",
+                "labels": {
+                  "filter": false,
+                  "rotate": 0,
+                  "show": true,
+                  "truncate": 100
+                },
+                "name": "LeftAxis-1",
+                "position": "left",
+                "scale": {
+                  "mode": "normal",
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {
+                  "text": "Count"
+                },
+                "type": "value"
+              }
+            ]
+          },
+          "title": "Flow Creation Histogram [Filebeat PANW] ECS",
+          "type": "histogram"
+        }
+      },
+      "id": "78e7e820-756d-11e9-976e-65a8f47cc4c1",
+      "migrationVersion": {
+        "visualization": "7.0.1"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+          "type": "index-pattern"
+        },
+        {
+          "id": "290685e0-7569-11e9-976e-65a8f47cc4c1",
+          "name": "search_0",
+          "type": "search"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-05-13T10:54:25.186Z",
+      "version": "WzI0MCwxXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [
+              {
+                "$state": {
+                  "store": "appState"
+                },
+                "meta": {
+                  "alias": null,
+                  "disabled": false,
+                  "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                  "key": "event.action",
+                  "negate": true,
+                  "params": {
+                    "query": "flow_started"
+                  },
+                  "type": "phrase",
+                  "value": "flow_started"
+                },
+                "query": {
+                  "match": {
+                    "event.action": {
+                      "query": "flow_started",
+                      "type": "phrase"
+                    }
+                  }
+                }
+              }
+            ],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "savedSearchRefName": "search_0",
+        "title": "Source Zone breakout [Filebeat PANW] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "field": "panw.panos.source.zone",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 5
+              },
+              "schema": "segment",
+              "type": "terms"
+            },
+            {
+              "enabled": true,
+              "id": "3",
+              "params": {
+                "field": "event.outcome",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 5
+              },
+              "schema": "group",
+              "type": "terms"
+            }
+          ],
+          "params": {
+            "addLegend": true,
+            "addTimeMarker": false,
+            "addTooltip": true,
+            "categoryAxes": [
+              {
+                "id": "CategoryAxis-1",
+                "labels": {
+                  "filter": false,
+                  "rotate": 0,
+                  "show": true,
+                  "truncate": 200
+                },
+                "position": "left",
+                "scale": {
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {},
+                "type": "category"
+              }
+            ],
+            "grid": {
+              "categoryLines": false
+            },
+            "legendPosition": "right",
+            "seriesParams": [
+              {
+                "data": {
+                  "id": "1",
+                  "label": "Count"
+                },
+                "drawLinesBetweenPoints": true,
+                "mode": "normal",
+                "show": true,
+                "showCircles": true,
+                "type": "histogram",
+                "valueAxis": "ValueAxis-1"
+              }
+            ],
+            "times": [],
+            "type": "histogram",
+            "valueAxes": [
+              {
+                "id": "ValueAxis-1",
+                "labels": {
+                  "filter": true,
+                  "rotate": 75,
+                  "show": true,
+                  "truncate": 100
+                },
+                "name": "LeftAxis-1",
+                "position": "bottom",
+                "scale": {
+                  "mode": "normal",
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {
+                  "text": "Count"
+                },
+                "type": "value"
+              }
+            ]
+          },
+          "title": "Source Zone breakout [Filebeat PANW] ECS",
+          "type": "horizontal_bar"
+        }
+      },
+      "id": "d9cab170-756f-11e9-976e-65a8f47cc4c1",
+      "migrationVersion": {
+        "visualization": "7.0.1"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+          "type": "index-pattern"
+        },
+        {
+          "id": "290685e0-7569-11e9-976e-65a8f47cc4c1",
+          "name": "search_0",
+          "type": "search"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-05-13T11:12:26.462Z",
+      "version": "WzI0MywxXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [
+              {
+                "$state": {
+                  "store": "appState"
+                },
+                "meta": {
+                  "alias": null,
+                  "disabled": false,
+                  "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                  "key": "event.action",
+                  "negate": true,
+                  "params": {
+                    "query": "flow_started"
+                  },
+                  "type": "phrase",
+                  "value": "flow_started"
+                },
+                "query": {
+                  "match": {
+                    "event.action": {
+                      "query": "flow_started",
+                      "type": "phrase"
+                    }
+                  }
+                }
+              }
+            ],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "savedSearchRefName": "search_0",
+        "title": "Destination Zone breakout [Filebeat PANW] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "field": "panw.panos.destination.zone",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 5
+              },
+              "schema": "segment",
+              "type": "terms"
+            },
+            {
+              "enabled": true,
+              "id": "3",
+              "params": {
+                "field": "event.outcome",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 5
+              },
+              "schema": "group",
+              "type": "terms"
+            }
+          ],
+          "params": {
+            "addLegend": true,
+            "addTimeMarker": false,
+            "addTooltip": true,
+            "categoryAxes": [
+              {
+                "id": "CategoryAxis-1",
+                "labels": {
+                  "filter": false,
+                  "rotate": 0,
+                  "show": true,
+                  "truncate": 200
+                },
+                "position": "left",
+                "scale": {
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {},
+                "type": "category"
+              }
+            ],
+            "grid": {
+              "categoryLines": false
+            },
+            "legendPosition": "right",
+            "seriesParams": [
+              {
+                "data": {
+                  "id": "1",
+                  "label": "Count"
+                },
+                "drawLinesBetweenPoints": true,
+                "mode": "normal",
+                "show": true,
+                "showCircles": true,
+                "type": "histogram",
+                "valueAxis": "ValueAxis-1"
+              }
+            ],
+            "times": [],
+            "type": "histogram",
+            "valueAxes": [
+              {
+                "id": "ValueAxis-1",
+                "labels": {
+                  "filter": true,
+                  "rotate": 75,
+                  "show": true,
+                  "truncate": 100
+                },
+                "name": "LeftAxis-1",
+                "position": "bottom",
+                "scale": {
+                  "mode": "normal",
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {
+                  "text": "Count"
+                },
+                "type": "value"
+              }
+            ]
+          },
+          "title": "Destination Zone breakout [Filebeat PANW] ECS",
+          "type": "horizontal_bar"
+        }
+      },
+      "id": "135930b0-7570-11e9-976e-65a8f47cc4c1",
+      "migrationVersion": {
+        "visualization": "7.0.1"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+          "type": "index-pattern"
+        },
+        {
+          "id": "290685e0-7569-11e9-976e-65a8f47cc4c1",
+          "name": "search_0",
+          "type": "search"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-05-13T11:13:03.291Z",
+      "version": "WzI0NCwxXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "savedSearchRefName": "search_0",
+        "title": "Event Outcome by Transport and Destination Port [Filebeat PANW] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "field": "event.outcome",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 5
+              },
+              "schema": "segment",
+              "type": "terms"
+            },
+            {
+              "enabled": true,
+              "id": "3",
+              "params": {
+                "field": "network.transport",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 5
+              },
+              "schema": "segment",
+              "type": "terms"
+            },
+            {
+              "enabled": true,
+              "id": "4",
+              "params": {
+                "field": "destination.port",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 5
+              },
+              "schema": "segment",
+              "type": "terms"
+            }
+          ],
+          "params": {
+            "addLegend": true,
+            "addTooltip": true,
+            "isDonut": true,
+            "labels": {
+              "last_level": true,
+              "show": false,
+              "truncate": 100,
+              "values": true
+            },
+            "legendPosition": "right",
+            "type": "pie"
+          },
+          "title": "Event Outcome by Transport and Destination Port [Filebeat PANW] ECS",
+          "type": "pie"
+        }
+      },
+      "id": "e46331c0-756a-11e9-976e-65a8f47cc4c1",
+      "migrationVersion": {
+        "visualization": "7.0.1"
+      },
+      "references": [
+        {
+          "id": "290685e0-7569-11e9-976e-65a8f47cc4c1",
+          "name": "search_0",
+          "type": "search"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-05-13T10:35:57.020Z",
+      "version": "WzIzOSwxXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "savedSearchRefName": "search_0",
+        "title": "Network Application breakout [Filebeat PANW] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "field": "event.outcome",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 5
+              },
+              "schema": "segment",
+              "type": "terms"
+            },
+            {
+              "enabled": true,
+              "id": "3",
+              "params": {
+                "field": "network.application",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 5
+              },
+              "schema": "segment",
+              "type": "terms"
+            }
+          ],
+          "params": {
+            "addLegend": true,
+            "addTooltip": true,
+            "isDonut": true,
+            "labels": {
+              "last_level": true,
+              "show": false,
+              "truncate": 100,
+              "values": true
+            },
+            "legendPosition": "right",
+            "type": "pie"
+          },
+          "title": "Network Application breakout [Filebeat PANW] ECS",
+          "type": "pie"
+        }
+      },
+      "id": "0407a3e0-756f-11e9-976e-65a8f47cc4c1",
+      "migrationVersion": {
+        "visualization": "7.0.1"
+      },
+      "references": [
+        {
+          "id": "290685e0-7569-11e9-976e-65a8f47cc4c1",
+          "name": "search_0",
+          "type": "search"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-05-13T11:05:28.094Z",
+      "version": "WzI0MSwxXQ=="
+    },
+    {
+      "attributes": {
+        "columns": [
+          "_source"
+        ],
+        "description": "",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "highlightAll": true,
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "language": "kuery",
+              "query": "panw.panos:* and event.category: \"network_traffic\""
+            },
+            "version": true
+          }
+        },
+        "sort": [
+          "@timestamp",
+          "desc"
+        ],
+        "title": "PAN-OS Flows [Filebeat PANW] ECS",
+        "version": 1
+      },
+      "id": "290685e0-7569-11e9-976e-65a8f47cc4c1",
+      "migrationVersion": {
+        "search": "7.0.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "search",
+      "updated_at": "2019-05-13T10:23:33.182Z",
+      "version": "WzIzNSwxXQ=="
+    }
+  ],
+  "version": "7.1.0"
+}

--- a/dev/package-beats/panw-1.0.0/kibana/dashboard/Filebeat-panw-threat-overview.json
+++ b/dev/package-beats/panw-1.0.0/kibana/dashboard/Filebeat-panw-threat-overview.json
@@ -1,0 +1,796 @@
+{
+  "objects": [
+    {
+      "attributes": {
+        "description": "Palo Alto Networks PAN-OS Threats Overview",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "optionsJSON": {
+          "hidePanelTitles": false,
+          "useMargins": true
+        },
+        "panelsJSON": [
+          {
+            "embeddableConfig": {
+              "vis": {
+                "legendOpen": false
+              }
+            },
+            "gridData": {
+              "h": 15,
+              "i": "1",
+              "w": 31,
+              "x": 0,
+              "y": 0
+            },
+            "panelIndex": "1",
+            "panelRefName": "panel_0",
+            "title": "Threat outcome histogram",
+            "version": "7.1.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 15,
+              "i": "2",
+              "w": 24,
+              "x": 0,
+              "y": 15
+            },
+            "panelIndex": "2",
+            "panelRefName": "panel_1",
+            "title": "Top threats by name",
+            "version": "7.1.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 15,
+              "i": "3",
+              "w": 24,
+              "x": 24,
+              "y": 15
+            },
+            "panelIndex": "3",
+            "panelRefName": "panel_2",
+            "title": "Top threats by resource",
+            "version": "7.1.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 8,
+              "i": "4",
+              "w": 24,
+              "x": 0,
+              "y": 30
+            },
+            "panelIndex": "4",
+            "panelRefName": "panel_3",
+            "title": "Top attackers (clients)",
+            "version": "7.1.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 8,
+              "i": "5",
+              "w": 24,
+              "x": 24,
+              "y": 30
+            },
+            "panelIndex": "5",
+            "panelRefName": "panel_4",
+            "title": "Top attackers (servers)",
+            "version": "7.1.0"
+          },
+          {
+            "embeddableConfig": {
+              "vis": {
+                "legendOpen": true
+              }
+            },
+            "gridData": {
+              "h": 15,
+              "i": "6",
+              "w": 17,
+              "x": 31,
+              "y": 0
+            },
+            "panelIndex": "6",
+            "panelRefName": "panel_5",
+            "title": "Outcome by threat type",
+            "version": "7.1.0"
+          }
+        ],
+        "timeRestore": false,
+        "title": "[Filebeat PANW] Threats Overview ECS",
+        "version": 1
+      },
+      "id": "772964e0-7591-11e9-aacf-79a3704914a0",
+      "migrationVersion": {
+        "dashboard": "7.0.0"
+      },
+      "references": [
+        {
+          "id": "0bd2a0c0-7574-11e9-976e-65a8f47cc4c1",
+          "name": "panel_0",
+          "type": "visualization"
+        },
+        {
+          "id": "3eca1070-7589-11e9-aacf-79a3704914a0",
+          "name": "panel_1",
+          "type": "visualization"
+        },
+        {
+          "id": "5bd32b20-7575-11e9-976e-65a8f47cc4c1",
+          "name": "panel_2",
+          "type": "visualization"
+        },
+        {
+          "id": "90ce3300-758a-11e9-aacf-79a3704914a0",
+          "name": "panel_3",
+          "type": "visualization"
+        },
+        {
+          "id": "a95aaf20-758a-11e9-aacf-79a3704914a0",
+          "name": "panel_4",
+          "type": "visualization"
+        },
+        {
+          "id": "6dce7930-758c-11e9-aacf-79a3704914a0",
+          "name": "panel_5",
+          "type": "visualization"
+        }
+      ],
+      "type": "dashboard",
+      "updated_at": "2019-05-13T15:12:04.141Z",
+      "version": "WzI1NiwyXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "savedSearchRefName": "search_0",
+        "title": "Threat outcome histogram [Filebeat PANW] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customInterval": "2h",
+                "drop_partials": false,
+                "extended_bounds": {},
+                "field": "@timestamp",
+                "interval": "auto",
+                "min_doc_count": 1,
+                "timeRange": {
+                  "from": "2018-04-10T04:36:19.586Z",
+                  "to": "2018-04-10T04:39:56.264Z"
+                },
+                "useNormalizedEsInterval": true
+              },
+              "schema": "segment",
+              "type": "date_histogram"
+            },
+            {
+              "enabled": true,
+              "id": "3",
+              "params": {
+                "field": "event.outcome",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 5
+              },
+              "schema": "group",
+              "type": "terms"
+            }
+          ],
+          "params": {
+            "addLegend": true,
+            "addTimeMarker": false,
+            "addTooltip": true,
+            "categoryAxes": [
+              {
+                "id": "CategoryAxis-1",
+                "labels": {
+                  "show": true,
+                  "truncate": 100
+                },
+                "position": "bottom",
+                "scale": {
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {},
+                "type": "category"
+              }
+            ],
+            "grid": {
+              "categoryLines": false
+            },
+            "legendPosition": "right",
+            "seriesParams": [
+              {
+                "data": {
+                  "id": "1",
+                  "label": "Count"
+                },
+                "drawLinesBetweenPoints": true,
+                "mode": "stacked",
+                "show": "true",
+                "showCircles": true,
+                "type": "histogram",
+                "valueAxis": "ValueAxis-1"
+              }
+            ],
+            "times": [],
+            "type": "histogram",
+            "valueAxes": [
+              {
+                "id": "ValueAxis-1",
+                "labels": {
+                  "filter": false,
+                  "rotate": 0,
+                  "show": true,
+                  "truncate": 100
+                },
+                "name": "LeftAxis-1",
+                "position": "left",
+                "scale": {
+                  "mode": "normal",
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {
+                  "text": "Count"
+                },
+                "type": "value"
+              }
+            ]
+          },
+          "title": "Threat outcome histogram [Filebeat PANW] ECS",
+          "type": "histogram"
+        }
+      },
+      "id": "0bd2a0c0-7574-11e9-976e-65a8f47cc4c1",
+      "migrationVersion": {
+        "visualization": "7.0.1"
+      },
+      "references": [
+        {
+          "id": "3cea1360-7569-11e9-976e-65a8f47cc4c1",
+          "name": "search_0",
+          "type": "search"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-05-13T11:41:28.652Z",
+      "version": "WzI0NiwxXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "savedSearchRefName": "search_0",
+        "title": "Threat ID Cloud [Filebeat PANW] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "field": "panw.panos.threat.name",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 5
+              },
+              "schema": "segment",
+              "type": "terms"
+            }
+          ],
+          "params": {
+            "maxFontSize": 72,
+            "minFontSize": 18,
+            "orientation": "single",
+            "scale": "linear",
+            "showLabel": true
+          },
+          "title": "Threat ID Cloud [Filebeat PANW] ECS",
+          "type": "tagcloud"
+        }
+      },
+      "id": "3eca1070-7589-11e9-aacf-79a3704914a0",
+      "migrationVersion": {
+        "visualization": "7.0.1"
+      },
+      "references": [
+        {
+          "id": "3cea1360-7569-11e9-976e-65a8f47cc4c1",
+          "name": "search_0",
+          "type": "search"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-05-13T15:06:36.839Z",
+      "version": "WzI1NSwyXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "savedSearchRefName": "search_0",
+        "title": "Threat Resource Cloud [Filebeat PANW] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "field": "url.original",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 5
+              },
+              "schema": "segment",
+              "type": "terms"
+            }
+          ],
+          "params": {
+            "maxFontSize": 72,
+            "minFontSize": 18,
+            "orientation": "single",
+            "scale": "linear",
+            "showLabel": true
+          },
+          "title": "Threat Resource Cloud [Filebeat PANW] ECS",
+          "type": "tagcloud"
+        }
+      },
+      "id": "5bd32b20-7575-11e9-976e-65a8f47cc4c1",
+      "migrationVersion": {
+        "visualization": "7.0.1"
+      },
+      "references": [
+        {
+          "id": "3cea1360-7569-11e9-976e-65a8f47cc4c1",
+          "name": "search_0",
+          "type": "search"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-05-13T11:50:52.370Z",
+      "version": "WzI0NywxXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [
+              {
+                "$state": {
+                  "store": "appState"
+                },
+                "meta": {
+                  "alias": null,
+                  "disabled": false,
+                  "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                  "key": "network.direction",
+                  "negate": false,
+                  "params": {
+                    "query": "inbound"
+                  },
+                  "type": "phrase",
+                  "value": "inbound"
+                },
+                "query": {
+                  "match": {
+                    "network.direction": {
+                      "query": "inbound",
+                      "type": "phrase"
+                    }
+                  }
+                }
+              }
+            ],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "savedSearchRefName": "search_0",
+        "title": "Top attackers (clients) [Filebeat PANW] ECS",
+        "uiStateJSON": {
+          "vis": {
+            "params": {
+              "sort": {
+                "columnIndex": null,
+                "direction": null
+              }
+            }
+          }
+        },
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "field": "client.ip",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 5
+              },
+              "schema": "bucket",
+              "type": "terms"
+            }
+          ],
+          "params": {
+            "perPage": 10,
+            "showMetricsAtAllLevels": false,
+            "showPartialRows": false,
+            "showTotal": false,
+            "sort": {
+              "columnIndex": null,
+              "direction": null
+            },
+            "totalFunc": "sum"
+          },
+          "title": "Top attackers (clients) [Filebeat PANW] ECS",
+          "type": "table"
+        }
+      },
+      "id": "90ce3300-758a-11e9-aacf-79a3704914a0",
+      "migrationVersion": {
+        "visualization": "7.0.1"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+          "type": "index-pattern"
+        },
+        {
+          "id": "3cea1360-7569-11e9-976e-65a8f47cc4c1",
+          "name": "search_0",
+          "type": "search"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-05-13T14:22:40.688Z",
+      "version": "WzI1MSwyXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [
+              {
+                "$state": {
+                  "store": "appState"
+                },
+                "meta": {
+                  "alias": null,
+                  "disabled": false,
+                  "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                  "key": "network.direction",
+                  "negate": false,
+                  "params": {
+                    "query": "outbound"
+                  },
+                  "type": "phrase",
+                  "value": "outbound"
+                },
+                "query": {
+                  "match": {
+                    "network.direction": {
+                      "query": "outbound",
+                      "type": "phrase"
+                    }
+                  }
+                }
+              }
+            ],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "savedSearchRefName": "search_0",
+        "title": "Top attackers (servers) [Filebeat PANW] ECS",
+        "uiStateJSON": {
+          "vis": {
+            "params": {
+              "sort": {
+                "columnIndex": null,
+                "direction": null
+              }
+            }
+          }
+        },
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "field": "server.ip",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 5
+              },
+              "schema": "bucket",
+              "type": "terms"
+            }
+          ],
+          "params": {
+            "perPage": 10,
+            "showMetricsAtAllLevels": false,
+            "showPartialRows": false,
+            "showTotal": false,
+            "sort": {
+              "columnIndex": null,
+              "direction": null
+            },
+            "totalFunc": "sum"
+          },
+          "title": "Top attackers (servers) [Filebeat PANW] ECS",
+          "type": "table"
+        }
+      },
+      "id": "a95aaf20-758a-11e9-aacf-79a3704914a0",
+      "migrationVersion": {
+        "visualization": "7.0.1"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+          "type": "index-pattern"
+        },
+        {
+          "id": "3cea1360-7569-11e9-976e-65a8f47cc4c1",
+          "name": "search_0",
+          "type": "search"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-05-13T14:23:21.874Z",
+      "version": "WzI1MiwyXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "savedSearchRefName": "search_0",
+        "title": "Outcome by Threat Type [Filebeat PANW] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "3",
+              "params": {
+                "field": "event.action",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 5
+              },
+              "schema": "segment",
+              "type": "terms"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "field": "event.outcome",
+                "missingBucket": true,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 5
+              },
+              "schema": "segment",
+              "type": "terms"
+            }
+          ],
+          "params": {
+            "addLegend": true,
+            "addTooltip": true,
+            "isDonut": true,
+            "labels": {
+              "last_level": true,
+              "show": false,
+              "truncate": 100,
+              "values": true
+            },
+            "legendPosition": "right",
+            "type": "pie"
+          },
+          "title": "Outcome by Threat Type [Filebeat PANW] ECS",
+          "type": "pie"
+        }
+      },
+      "id": "6dce7930-758c-11e9-aacf-79a3704914a0",
+      "migrationVersion": {
+        "visualization": "7.0.1"
+      },
+      "references": [
+        {
+          "id": "3cea1360-7569-11e9-976e-65a8f47cc4c1",
+          "name": "search_0",
+          "type": "search"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-05-13T14:36:00.962Z",
+      "version": "WzI1MywyXQ=="
+    },
+    {
+      "attributes": {
+        "columns": [
+          "_source"
+        ],
+        "description": "",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "highlightAll": true,
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "language": "kuery",
+              "query": "panw.panos:* and event.category: \"security_threat\""
+            },
+            "version": true
+          }
+        },
+        "sort": [
+          "@timestamp",
+          "desc"
+        ],
+        "title": "PAN-OS Threats [Filebeat PANW] ECS",
+        "version": 1
+      },
+      "id": "3cea1360-7569-11e9-976e-65a8f47cc4c1",
+      "migrationVersion": {
+        "search": "7.0.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "search",
+      "updated_at": "2019-05-13T10:24:06.550Z",
+      "version": "WzIzNiwxXQ=="
+    }
+  ],
+  "version": "7.1.0"
+}

--- a/dev/package-beats/panw-1.0.0/manifest.yml
+++ b/dev/package-beats/panw-1.0.0/manifest.yml
@@ -1,0 +1,13 @@
+name: panw
+title: panw
+version: 1.0.0
+description: |
+  Module for Palo Alto Networks (PAN-OS)
+type: ""
+categories:
+- logs
+requirement:
+  kibana:
+    version:
+      min: 6.7.0
+      max: 7.6.0

--- a/dev/package-beats/php_fpm-1.0.0/manifest.yml
+++ b/dev/package-beats/php_fpm-1.0.0/manifest.yml
@@ -1,0 +1,13 @@
+name: php_fpm
+title: PHP_FPM
+version: 1.0.0
+description: |
+  PHP-FPM server status metrics collected from PHP-FPM.
+type: ""
+categories:
+- metrics
+requirement:
+  kibana:
+    version:
+      min: 6.7.0
+      max: 7.6.0

--- a/dev/package-beats/postgresql-1.0.0/kibana/dashboard/Filebeat-Postgresql-overview.json
+++ b/dev/package-beats/postgresql-1.0.0/kibana/dashboard/Filebeat-Postgresql-overview.json
@@ -1,0 +1,331 @@
+{
+    "objects": [
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "PostgreSQL All Logs-ecs", 
+                "title": "Log Level Count [Filebeat PostgreSQL] ECS", 
+                "uiStateJSON": {
+                    "vis": {
+                        "params": {
+                            "sort": {
+                                "columnIndex": null, 
+                                "direction": null
+                            }
+                        }
+                    }
+                }, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "field": "log.level", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 12
+                            }, 
+                            "schema": "bucket", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "params": {
+                        "perPage": 10, 
+                        "showMeticsAtAllLevels": false, 
+                        "showPartialRows": false, 
+                        "showTotal": false, 
+                        "sort": {
+                            "columnIndex": null, 
+                            "direction": null
+                        }, 
+                        "totalFunc": "sum"
+                    }, 
+                    "title": "Log Level Count [Filebeat PostgreSQL] ECS", 
+                    "type": "table"
+                }
+            }, 
+            "id": "PostgreSQL Log Level Count-ecs", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "columns": [
+                    "user.name", 
+                    "postgresql.log.database", 
+                    "log.level", 
+                    "message", 
+                    "postgresql.log.query"
+                ], 
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [
+                            {
+                                "$state": {
+                                    "store": "appState"
+                                }, 
+                                "meta": {
+                                    "alias": null, 
+                                    "disabled": false, 
+                                    "index": "filebeat-*", 
+                                    "key": "event.module", 
+                                    "negate": false, 
+                                    "params": {
+                                        "query": "postgresql", 
+                                        "type": "phrase"
+                                    }, 
+                                    "type": "phrase", 
+                                    "value": "postgresql"
+                                }, 
+                                "query": {
+                                    "match": {
+                                        "event.module": {
+                                            "query": "postgresql", 
+                                            "type": "phrase"
+                                        }
+                                    }
+                                }
+                            }
+                        ], 
+                        "highlightAll": true, 
+                        "index": "filebeat-*", 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "sort": [
+                    "@timestamp", 
+                    "desc"
+                ], 
+                "title": "All Logs [Filebeat PostgreSQL] ECS", 
+                "version": 1
+            }, 
+            "id": "PostgreSQL All Logs-ecs", 
+            "type": "search", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "PostgreSQL All Logs-ecs", 
+                "title": "Logs by level over time [Filebeat PostgreSQL] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "field": "log.level", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "group", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "categoryAxes": [
+                            {
+                                "id": "CategoryAxis-1", 
+                                "labels": {
+                                    "show": true, 
+                                    "truncate": 100
+                                }, 
+                                "position": "bottom", 
+                                "scale": {
+                                    "type": "linear"
+                                }, 
+                                "show": true, 
+                                "style": {}, 
+                                "title": {
+                                    "text": "@timestamp per month"
+                                }, 
+                                "type": "category"
+                            }
+                        ], 
+                        "grid": {
+                            "categoryLines": false, 
+                            "style": {
+                                "color": "#eee"
+                            }
+                        }, 
+                        "legendPosition": "right", 
+                        "seriesParams": [
+                            {
+                                "data": {
+                                    "id": "1", 
+                                    "label": "Count"
+                                }, 
+                                "drawLinesBetweenPoints": true, 
+                                "mode": "stacked", 
+                                "show": "true", 
+                                "showCircles": true, 
+                                "type": "histogram", 
+                                "valueAxis": "ValueAxis-1"
+                            }
+                        ], 
+                        "times": [], 
+                        "type": "histogram", 
+                        "valueAxes": [
+                            {
+                                "id": "ValueAxis-1", 
+                                "labels": {
+                                    "filter": false, 
+                                    "rotate": 0, 
+                                    "show": true, 
+                                    "truncate": 100
+                                }, 
+                                "name": "LeftAxis-1", 
+                                "position": "left", 
+                                "scale": {
+                                    "mode": "normal", 
+                                    "type": "linear"
+                                }, 
+                                "show": true, 
+                                "style": {}, 
+                                "title": {
+                                    "text": "Count"
+                                }, 
+                                "type": "value"
+                            }
+                        ]
+                    }, 
+                    "title": "Logs by level over time [Filebeat PostgreSQL] ECS", 
+                    "type": "histogram"
+                }
+            }, 
+            "id": "3dbd5370-87f3-11e7-ad9c-db80de0bf8d3-ecs", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "Overview dashboard for the Filebeat PostgreSQL module", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlightAll": true, 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "optionsJSON": {
+                    "darkTheme": false
+                }, 
+                "panelsJSON": [
+                    {
+                        "col": 1, 
+                        "id": "PostgreSQL Log Level Count-ecs", 
+                        "panelIndex": 1, 
+                        "row": 1, 
+                        "size_x": 3, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "columns": [
+                            "user.name", 
+                            "postgresql.log.database", 
+                            "log.level", 
+                            "message", 
+                            "postgresql.log.query"
+                        ], 
+                        "id": "PostgreSQL All Logs-ecs", 
+                        "panelIndex": 2, 
+                        "row": 4, 
+                        "size_x": 12, 
+                        "size_y": 6, 
+                        "sort": [
+                            "@timestamp", 
+                            "desc"
+                        ], 
+                        "type": "search"
+                    }, 
+                    {
+                        "col": 4, 
+                        "id": "3dbd5370-87f3-11e7-ad9c-db80de0bf8d3-ecs", 
+                        "panelIndex": 3, 
+                        "row": 1, 
+                        "size_x": 9, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }
+                ], 
+                "timeRestore": false, 
+                "title": "[Filebeat PostgreSQL] Overview ECS", 
+                "uiStateJSON": {
+                    "P-1": {
+                        "vis": {
+                            "params": {
+                                "sort": {
+                                    "columnIndex": null, 
+                                    "direction": null
+                                }
+                            }
+                        }
+                    }
+                }, 
+                "version": 1
+            }, 
+            "id": "158be870-87f4-11e7-ad9c-db80de0bf8d3-ecs", 
+            "type": "dashboard", 
+            "version": 1
+        }
+    ], 
+    "version": "6.0.0-beta1-SNAPSHOT"
+}

--- a/dev/package-beats/postgresql-1.0.0/kibana/dashboard/Filebeat-Postgresql-slowlogs.json
+++ b/dev/package-beats/postgresql-1.0.0/kibana/dashboard/Filebeat-Postgresql-slowlogs.json
@@ -1,0 +1,300 @@
+{
+    "objects": [
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                }, 
+                "savedSearchId": "PostgreSQL Query Durations-ecs", 
+                "title": "Query count and cumulated duration [Filebeat PostgreSQL] ECS", 
+                "uiStateJSON": {
+                    "vis": {
+                        "colors": {
+                            "Number of queries": "#0A437C", 
+                            "Sum of query duration": "#6ED0E0"
+                        }, 
+                        "legendOpen": true
+                    }
+                }, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "4", 
+                            "params": {
+                                "customLabel": "Number of queries"
+                            }, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customLabel": "Sum of query duration", 
+                                "field": "event.duration"
+                            }, 
+                            "schema": "metric", 
+                            "type": "sum"
+                        }
+                    ], 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "categoryAxes": [
+                            {
+                                "id": "CategoryAxis-1", 
+                                "labels": {
+                                    "show": true, 
+                                    "truncate": 100
+                                }, 
+                                "position": "bottom", 
+                                "scale": {
+                                    "type": "linear"
+                                }, 
+                                "show": true, 
+                                "style": {}, 
+                                "title": {
+                                    "text": "@timestamp per 3 hours"
+                                }, 
+                                "type": "category"
+                            }
+                        ], 
+                        "grid": {
+                            "categoryLines": false, 
+                            "style": {
+                                "color": "#eee"
+                            }
+                        }, 
+                        "legendPosition": "right", 
+                        "seriesParams": [
+                            {
+                                "data": {
+                                    "id": "4", 
+                                    "label": "Number of queries"
+                                }, 
+                                "drawLinesBetweenPoints": true, 
+                                "interpolate": "linear", 
+                                "lineWidth": 2, 
+                                "mode": "normal", 
+                                "show": true, 
+                                "showCircles": true, 
+                                "type": "histogram", 
+                                "valueAxis": "ValueAxis-1"
+                            }, 
+                            {
+                                "data": {
+                                    "id": "2", 
+                                    "label": "Sum of query duration"
+                                }, 
+                                "drawLinesBetweenPoints": true, 
+                                "interpolate": "linear", 
+                                "lineWidth": 2, 
+                                "mode": "normal", 
+                                "show": true, 
+                                "showCircles": true, 
+                                "type": "histogram", 
+                                "valueAxis": "ValueAxis-1"
+                            }
+                        ], 
+                        "times": [], 
+                        "type": "histogram", 
+                        "valueAxes": [
+                            {
+                                "id": "ValueAxis-1", 
+                                "labels": {
+                                    "filter": false, 
+                                    "rotate": 0, 
+                                    "show": true, 
+                                    "truncate": 100
+                                }, 
+                                "name": "LeftAxis-1", 
+                                "position": "left", 
+                                "scale": {
+                                    "mode": "normal", 
+                                    "type": "linear"
+                                }, 
+                                "show": true, 
+                                "style": {}, 
+                                "title": {
+                                    "text": ""
+                                }, 
+                                "type": "value"
+                            }
+                        ]
+                    }, 
+                    "title": "Query count and cumulated duration [Filebeat PostgreSQL] ECS", 
+                    "type": "histogram"
+                }
+            }, 
+            "id": "PostgreSQL Query Count and Duration-ecs", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "columns": [
+                    "user.name", 
+                    "postgresql.log.database", 
+                    "event.duration",
+                    "postgresql.log.query"
+                ], 
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlightAll": true, 
+                        "index": "filebeat-*", 
+                        "query": {
+                            "language": "kuery",
+                            "query": "event.duration>30000000"
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "sort": [
+                    "@timestamp", 
+                    "desc"
+                ], 
+                "title": "Slow Queries [Filebeat PostgreSQL] ECS", 
+                "version": 1
+            }, 
+            "id": "Slow PostgreSQL Queries-ecs", 
+            "type": "search", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "columns": [
+                    "user.name", 
+                    "postgresql.log.database", 
+                    "event.duration",
+                    "postgresql.log.query"
+                ], 
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlightAll": true, 
+                        "index": "filebeat-*", 
+                        "query": {
+                            "language": "kuery",
+                            "query": "event.duration:*"
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "sort": [
+                    "@timestamp", 
+                    "desc"
+                ], 
+                "title": "Query Durations [Filebeat PostgreSQL] ECS", 
+                "version": 1
+            }, 
+            "id": "PostgreSQL Query Durations-ecs", 
+            "type": "search", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "Dashboard for analyzing the query durations of the Filebeat PostgreSQL module", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlightAll": true, 
+                        "query": {
+                            "language": "kuery",
+                            "query": "postgresql.log.query:*"
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "optionsJSON": {
+                    "darkTheme": false
+                }, 
+                "panelsJSON": [
+                    {
+                        "col": 1, 
+                        "id": "PostgreSQL Query Count and Duration-ecs", 
+                        "panelIndex": 1, 
+                        "row": 1, 
+                        "size_x": 6, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 7, 
+                        "columns": [
+                            "user.name", 
+                            "postgresql.log.database", 
+                            "event.duration",
+                            "postgresql.log.query"
+                        ], 
+                        "id": "Slow PostgreSQL Queries-ecs", 
+                        "panelIndex": 2, 
+                        "row": 1, 
+                        "size_x": 6, 
+                        "size_y": 3, 
+                        "sort": [
+                            "@timestamp", 
+                            "desc"
+                        ], 
+                        "type": "search"
+                    }, 
+                    {
+                        "col": 1, 
+                        "columns": [
+                            "user.name", 
+                            "postgresql.log.database", 
+                            "event.duration",
+                            "postgresql.log.query"
+                        ], 
+                        "id": "PostgreSQL Query Durations-ecs", 
+                        "panelIndex": 3, 
+                        "row": 4, 
+                        "size_x": 12, 
+                        "size_y": 5, 
+                        "sort": [
+                            "@timestamp", 
+                            "desc"
+                        ], 
+                        "type": "search"
+                    }
+                ], 
+                "timeRestore": false, 
+                "title": "[Filebeat PostgreSQL] Query Duration Overview ECS", 
+                "uiStateJSON": {}, 
+                "version": 1
+            }, 
+            "id": "e4c5f230-87f3-11e7-ad9c-db80de0bf8d3-ecs", 
+            "type": "dashboard", 
+            "version": 1
+        }
+    ], 
+    "version": "6.0.0-beta1-SNAPSHOT"
+}

--- a/dev/package-beats/postgresql-1.0.0/kibana/dashboard/Metricbeat-postgresql-overview.json
+++ b/dev/package-beats/postgresql-1.0.0/kibana/dashboard/Metricbeat-postgresql-overview.json
@@ -1,0 +1,1334 @@
+{
+  "objects": [
+    {
+      "attributes": {
+        "description": "This PostgreSQL dashboard shows the most important database related metrics.\n\n",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "optionsJSON": {
+          "hidePanelTitles": false,
+          "useMargins": true
+        },
+        "panelsJSON": [
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 12,
+              "i": "1",
+              "w": 24,
+              "x": 0,
+              "y": 6
+            },
+            "panelIndex": "1",
+            "panelRefName": "panel_0",
+            "title": "Query Latency",
+            "version": "7.3.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 12,
+              "i": "2",
+              "w": 24,
+              "x": 24,
+              "y": 0
+            },
+            "panelIndex": "2",
+            "panelRefName": "panel_1",
+            "title": "Database Transactions",
+            "version": "7.3.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 10,
+              "i": "3",
+              "w": 24,
+              "x": 0,
+              "y": 18
+            },
+            "panelIndex": "3",
+            "panelRefName": "panel_2",
+            "title": "Fileblock IO",
+            "version": "7.3.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 6,
+              "i": "4",
+              "w": 14,
+              "x": 10,
+              "y": 0
+            },
+            "panelIndex": "4",
+            "panelRefName": "panel_3",
+            "title": "Rows Fetched/Returned",
+            "version": "7.3.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 9,
+              "i": "5",
+              "w": 24,
+              "x": 24,
+              "y": 22
+            },
+            "panelIndex": "5",
+            "panelRefName": "panel_4",
+            "title": "Rows Inserted/Deleted/Updated",
+            "version": "7.3.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 11,
+              "i": "6",
+              "w": 24,
+              "x": 0,
+              "y": 28
+            },
+            "panelIndex": "6",
+            "panelRefName": "panel_5",
+            "title": "Conflict/Deadlock Rates",
+            "version": "7.3.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 6,
+              "i": "7",
+              "w": 10,
+              "x": 0,
+              "y": 0
+            },
+            "panelIndex": "7",
+            "panelRefName": "panel_6",
+            "title": "Database Filter",
+            "version": "7.3.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 10,
+              "i": "8",
+              "w": 24,
+              "x": 24,
+              "y": 12
+            },
+            "panelIndex": "8",
+            "panelRefName": "panel_7",
+            "title": "Query Calls Count",
+            "version": "7.3.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 8,
+              "i": "9",
+              "w": 12,
+              "x": 24,
+              "y": 31
+            },
+            "panelIndex": "9",
+            "panelRefName": "panel_8",
+            "title": "Local block cache stats",
+            "version": "7.3.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 8,
+              "i": "10",
+              "w": 12,
+              "x": 36,
+              "y": 31
+            },
+            "panelIndex": "10",
+            "panelRefName": "panel_9",
+            "title": "Shared block cache stats",
+            "version": "7.3.0"
+          }
+        ],
+        "timeRestore": false,
+        "title": "[Metricbeat PostgreSQL] Database Overview",
+        "version": 1
+      },
+      "id": "4288b790-b79f-11e9-a579-f5c0a5d81340",
+      "migrationVersion": {
+        "dashboard": "7.3.0"
+      },
+      "references": [
+        {
+          "id": "fbfa67e0-b796-11e9-a579-f5c0a5d81340",
+          "name": "panel_0",
+          "type": "visualization"
+        },
+        {
+          "id": "d733c630-b797-11e9-a579-f5c0a5d81340",
+          "name": "panel_1",
+          "type": "visualization"
+        },
+        {
+          "id": "570973a0-b798-11e9-a579-f5c0a5d81340",
+          "name": "panel_2",
+          "type": "visualization"
+        },
+        {
+          "id": "66d67200-b799-11e9-a579-f5c0a5d81340",
+          "name": "panel_3",
+          "type": "visualization"
+        },
+        {
+          "id": "20931ef0-b79a-11e9-a579-f5c0a5d81340",
+          "name": "panel_4",
+          "type": "visualization"
+        },
+        {
+          "id": "960ecdf0-b79a-11e9-a579-f5c0a5d81340",
+          "name": "panel_5",
+          "type": "visualization"
+        },
+        {
+          "id": "98e6b0a0-b79b-11e9-a579-f5c0a5d81340",
+          "name": "panel_6",
+          "type": "visualization"
+        },
+        {
+          "id": "147875b0-b903-11e9-a579-f5c0a5d81340",
+          "name": "panel_7",
+          "type": "visualization"
+        },
+        {
+          "id": "0cb65170-b909-11e9-a579-f5c0a5d81340",
+          "name": "panel_8",
+          "type": "visualization"
+        },
+        {
+          "id": "e2b28ce0-b908-11e9-a579-f5c0a5d81340",
+          "name": "panel_9",
+          "type": "visualization"
+        }
+      ],
+      "type": "dashboard",
+      "updated_at": "2019-08-19T14:53:17.203Z",
+      "version": "WzE1NjQsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Query Latency [Metricbeat PostgreSQL] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "kuery",
+              "query": ""
+            },
+            "id": "919c5570-b796-11e9-8ed3-ef1959e6b366",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(0,156,224,1)",
+                "fill": 0,
+                "formatter": "number",
+                "id": "919c5571-b796-11e9-8ed3-ef1959e6b366",
+                "label": "Query Latency",
+                "line_width": 2,
+                "metrics": [
+                  {
+                    "field": "postgresql.statement.query.time.total.ms",
+                    "id": "919c7c80-b796-11e9-8ed3-ef1959e6b366",
+                    "type": "max"
+                  },
+                  {
+                    "field": "919c7c80-b796-11e9-8ed3-ef1959e6b366",
+                    "id": "9e553c60-b79f-11e9-9029-a9d302b79ec2",
+                    "type": "derivative",
+                    "unit": "1s"
+                  },
+                  {
+                    "field": "9e553c60-b79f-11e9-9029-a9d302b79ec2",
+                    "id": "a58b6590-b79f-11e9-9029-a9d302b79ec2",
+                    "type": "positive_only",
+                    "unit": ""
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "postgresql.statement.query.text",
+                "terms_order_by": "919c7c80-b796-11e9-8ed3-ef1959e6b366",
+                "terms_size": "10",
+                "value_template": "{{value}}"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Query Latency [Metricbeat PostgreSQL] ECS",
+          "type": "metrics"
+        }
+      },
+      "id": "fbfa67e0-b796-11e9-a579-f5c0a5d81340",
+      "migrationVersion": {
+        "visualization": "7.3.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-08-09T11:40:30.561Z",
+      "version": "WzExNjcsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Database Transactions [Metricbeat PostgreSQL] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "kuery",
+              "query": ""
+            },
+            "id": "7af01590-b797-11e9-8816-2992f1df7a62",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(104,188,0,1)",
+                "fill": 0,
+                "formatter": "number",
+                "id": "7af01591-b797-11e9-8816-2992f1df7a62",
+                "label": "committed",
+                "line_width": 2,
+                "metrics": [
+                  {
+                    "field": "postgresql.database.transactions.commit",
+                    "id": "7af01592-b797-11e9-8816-2992f1df7a62",
+                    "type": "max"
+                  },
+                  {
+                    "field": "7af01592-b797-11e9-8816-2992f1df7a62",
+                    "id": "7af01594-b797-11e9-8816-2992f1df7a62",
+                    "type": "derivative",
+                    "unit": "1s"
+                  },
+                  {
+                    "field": "7af01594-b797-11e9-8816-2992f1df7a62",
+                    "id": "7af01593-b797-11e9-8816-2992f1df7a62",
+                    "type": "positive_only"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(254,146,0,1)",
+                "fill": 0,
+                "formatter": "number",
+                "id": "7af01595-b797-11e9-8816-2992f1df7a62",
+                "label": "rolled back",
+                "line_width": 2,
+                "metrics": [
+                  {
+                    "field": "postgresql.database.transactions.rollback",
+                    "id": "7af01596-b797-11e9-8816-2992f1df7a62",
+                    "type": "max"
+                  },
+                  {
+                    "field": "7af01596-b797-11e9-8816-2992f1df7a62",
+                    "id": "7af01598-b797-11e9-8816-2992f1df7a62",
+                    "type": "derivative",
+                    "unit": "1s"
+                  },
+                  {
+                    "field": "7af01598-b797-11e9-8816-2992f1df7a62",
+                    "id": "7af01597-b797-11e9-8816-2992f1df7a62",
+                    "type": "positive_only"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Database Transactions [Metricbeat PostgreSQL] ECS",
+          "type": "metrics"
+        }
+      },
+      "id": "d733c630-b797-11e9-a579-f5c0a5d81340",
+      "migrationVersion": {
+        "visualization": "7.3.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-08-09T11:40:44.158Z",
+      "version": "WzExNzMsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Fileblock IO [Metricbeat PostgreSQL] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "kuery",
+              "query": ""
+            },
+            "id": "fbc27280-b797-11e9-b46b-4f80f005c4a5",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(252,196,0,1)",
+                "fill": 0,
+                "formatter": "number",
+                "id": "fbc27281-b797-11e9-b46b-4f80f005c4a5",
+                "label": "read",
+                "line_width": 2,
+                "metrics": [
+                  {
+                    "field": "postgresql.database.blocks.time.read.ms",
+                    "id": "fbc27282-b797-11e9-b46b-4f80f005c4a5",
+                    "type": "max"
+                  },
+                  {
+                    "field": "fbc27282-b797-11e9-b46b-4f80f005c4a5",
+                    "id": "fbc27284-b797-11e9-b46b-4f80f005c4a5",
+                    "type": "derivative",
+                    "unit": "1s"
+                  },
+                  {
+                    "field": "fbc27284-b797-11e9-b46b-4f80f005c4a5",
+                    "id": "fbc27283-b797-11e9-b46b-4f80f005c4a5",
+                    "type": "positive_only"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}} ms"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(123,100,255,1)",
+                "fill": 0,
+                "formatter": "number",
+                "id": "fbc27285-b797-11e9-b46b-4f80f005c4a5",
+                "label": "write",
+                "line_width": 2,
+                "metrics": [
+                  {
+                    "field": "postgresql.database.blocks.time.write.ms",
+                    "id": "fbc27286-b797-11e9-b46b-4f80f005c4a5",
+                    "type": "max"
+                  },
+                  {
+                    "field": "fbc27286-b797-11e9-b46b-4f80f005c4a5",
+                    "id": "fbc27288-b797-11e9-b46b-4f80f005c4a5",
+                    "type": "derivative",
+                    "unit": "1s"
+                  },
+                  {
+                    "field": "fbc27288-b797-11e9-b46b-4f80f005c4a5",
+                    "id": "fbc27287-b797-11e9-b46b-4f80f005c4a5",
+                    "type": "positive_only"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}} ms"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Fileblock IO [Metricbeat PostgreSQL] ECS",
+          "type": "metrics"
+        }
+      },
+      "id": "570973a0-b798-11e9-a579-f5c0a5d81340",
+      "migrationVersion": {
+        "visualization": "7.3.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-08-09T11:41:16.761Z",
+      "version": "WzExODgsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Rows Fetched/Returned [Metricbeat PostgreSQL] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "background_color_rules": [
+              {
+                "id": "bec42b70-b798-11e9-af2f-3be5a91b64a6"
+              }
+            ],
+            "bar_color_rules": [
+              {
+                "id": "cc80b5d0-b798-11e9-af2f-3be5a91b64a6"
+              }
+            ],
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "kuery",
+              "query": ""
+            },
+            "gauge_color_rules": [
+              {
+                "id": "ada89790-b798-11e9-af2f-3be5a91b64a6"
+              }
+            ],
+            "gauge_inner_width": 10,
+            "gauge_style": "half",
+            "gauge_width": 10,
+            "id": "a6981ed0-b798-11e9-a598-8baa89257193",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(164,221,0,1)",
+                "fill": 0,
+                "filter": {
+                  "language": "kuery",
+                  "query": ""
+                },
+                "formatter": "number",
+                "id": "a6981ed1-b798-11e9-a598-8baa89257193",
+                "label": "Rows Returned",
+                "line_width": 2,
+                "metrics": [
+                  {
+                    "field": "postgresql.database.rows.returned",
+                    "id": "a6981ed2-b798-11e9-a598-8baa89257193",
+                    "percentiles": [
+                      {
+                        "id": "b507cc90-b798-11e9-af2f-3be5a91b64a6",
+                        "mode": "line",
+                        "shade": 0.2,
+                        "value": 50
+                      }
+                    ],
+                    "type": "max"
+                  },
+                  {
+                    "field": "a6981ed2-b798-11e9-a598-8baa89257193",
+                    "id": "ed6f33d0-b8ff-11e9-8645-31d6a6d28728",
+                    "type": "derivative",
+                    "unit": "1"
+                  },
+                  {
+                    "field": "ed6f33d0-b8ff-11e9-8645-31d6a6d28728",
+                    "id": "f58b9e50-b8ff-11e9-8645-31d6a6d28728",
+                    "type": "positive_only",
+                    "unit": ""
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(0,156,224,1)",
+                "fill": 0,
+                "formatter": "number",
+                "id": "a6981ed3-b798-11e9-a598-8baa89257193",
+                "label": "Rows Fetched",
+                "line_width": 2,
+                "metrics": [
+                  {
+                    "field": "postgresql.database.rows.fetched",
+                    "id": "a6981ed4-b798-11e9-a598-8baa89257193",
+                    "type": "max"
+                  },
+                  {
+                    "field": "a6981ed4-b798-11e9-a598-8baa89257193",
+                    "id": "064737e0-b900-11e9-8645-31d6a6d28728",
+                    "type": "derivative",
+                    "unit": "1s"
+                  },
+                  {
+                    "field": "064737e0-b900-11e9-8645-31d6a6d28728",
+                    "id": "0fea1b50-b900-11e9-8645-31d6a6d28728",
+                    "type": "positive_only",
+                    "unit": ""
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Rows Fetched/Returned [Metricbeat PostgreSQL] ECS",
+          "type": "metrics"
+        }
+      },
+      "id": "66d67200-b799-11e9-a579-f5c0a5d81340",
+      "migrationVersion": {
+        "visualization": "7.3.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-08-09T11:40:15.889Z",
+      "version": "WzExNTgsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Rows Inserted/Deleted/Updated [Metricbeat PostgreSQL] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "kuery",
+              "query": ""
+            },
+            "id": "fc474800-b799-11e9-bfa6-bd2fe13c0445",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#3185FC",
+                "fill": 0,
+                "formatter": "number",
+                "id": "fc474801-b799-11e9-bfa6-bd2fe13c0445",
+                "label": "inserted",
+                "line_width": 2,
+                "metrics": [
+                  {
+                    "field": "postgresql.database.rows.inserted",
+                    "id": "fc474802-b799-11e9-bfa6-bd2fe13c0445",
+                    "type": "max"
+                  },
+                  {
+                    "field": "fc474802-b799-11e9-bfa6-bd2fe13c0445",
+                    "id": "fc474804-b799-11e9-bfa6-bd2fe13c0445",
+                    "type": "derivative",
+                    "unit": "1s"
+                  },
+                  {
+                    "field": "fc474804-b799-11e9-bfa6-bd2fe13c0445",
+                    "id": "fc474803-b799-11e9-bfa6-bd2fe13c0445",
+                    "type": "positive_only"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}/s"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#DB1374",
+                "fill": 0,
+                "formatter": "number",
+                "id": "fc474805-b799-11e9-bfa6-bd2fe13c0445",
+                "label": "deleted",
+                "line_width": 2,
+                "metrics": [
+                  {
+                    "field": "postgresql.database.rows.deleted",
+                    "id": "fc474806-b799-11e9-bfa6-bd2fe13c0445",
+                    "type": "max"
+                  },
+                  {
+                    "field": "fc474806-b799-11e9-bfa6-bd2fe13c0445",
+                    "id": "fc474808-b799-11e9-bfa6-bd2fe13c0445",
+                    "type": "derivative",
+                    "unit": "1s"
+                  },
+                  {
+                    "field": "fc474808-b799-11e9-bfa6-bd2fe13c0445",
+                    "id": "fc474807-b799-11e9-bfa6-bd2fe13c0445",
+                    "type": "positive_only"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}/s"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#00B3A4",
+                "fill": 0,
+                "formatter": "number",
+                "id": "fc476f10-b799-11e9-bfa6-bd2fe13c0445",
+                "label": "updated",
+                "line_width": 2,
+                "metrics": [
+                  {
+                    "field": "postgresql.database.rows.updated",
+                    "id": "fc476f11-b799-11e9-bfa6-bd2fe13c0445",
+                    "type": "max"
+                  },
+                  {
+                    "field": "fc476f11-b799-11e9-bfa6-bd2fe13c0445",
+                    "id": "fc476f13-b799-11e9-bfa6-bd2fe13c0445",
+                    "type": "derivative",
+                    "unit": "1s"
+                  },
+                  {
+                    "field": "fc476f13-b799-11e9-bfa6-bd2fe13c0445",
+                    "id": "fc476f12-b799-11e9-bfa6-bd2fe13c0445",
+                    "type": "positive_only"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}/s"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Rows Inserted/Deleted/Updated [Metricbeat PostgreSQL] ECS",
+          "type": "metrics"
+        }
+      },
+      "id": "20931ef0-b79a-11e9-a579-f5c0a5d81340",
+      "migrationVersion": {
+        "visualization": "7.3.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-08-09T11:41:36.559Z",
+      "version": "WzExOTYsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Conflict/Deadlock Rates [Metricbeat PostgreSQL] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "kuery",
+              "query": ""
+            },
+            "id": "6c90db30-b79a-11e9-a8f0-d7983cd3d871",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(12,121,125,1)",
+                "fill": 0,
+                "formatter": "number",
+                "id": "6c90db31-b79a-11e9-a8f0-d7983cd3d871",
+                "label": "conflicts",
+                "line_width": 2,
+                "metrics": [
+                  {
+                    "field": "postgresql.database.conflicts",
+                    "id": "6c90db32-b79a-11e9-a8f0-d7983cd3d871",
+                    "type": "max"
+                  },
+                  {
+                    "field": "6c90db32-b79a-11e9-a8f0-d7983cd3d871",
+                    "id": "6c90db34-b79a-11e9-a8f0-d7983cd3d871",
+                    "type": "derivative",
+                    "unit": "1s"
+                  },
+                  {
+                    "field": "6c90db34-b79a-11e9-a8f0-d7983cd3d871",
+                    "id": "6c90db33-b79a-11e9-a8f0-d7983cd3d871",
+                    "type": "positive_only"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(244,78,59,1)",
+                "fill": 0,
+                "formatter": "number",
+                "id": "6c90db35-b79a-11e9-a8f0-d7983cd3d871",
+                "label": "deadlocks",
+                "line_width": 2,
+                "metrics": [
+                  {
+                    "field": "postgresql.database.deadlocks",
+                    "id": "6c90db36-b79a-11e9-a8f0-d7983cd3d871",
+                    "type": "max"
+                  },
+                  {
+                    "field": "6c90db36-b79a-11e9-a8f0-d7983cd3d871",
+                    "id": "6c90db38-b79a-11e9-a8f0-d7983cd3d871",
+                    "type": "derivative",
+                    "unit": "1s"
+                  },
+                  {
+                    "field": "6c90db38-b79a-11e9-a8f0-d7983cd3d871",
+                    "id": "6c90db37-b79a-11e9-a8f0-d7983cd3d871",
+                    "type": "positive_only"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Conflict/Deadlock Rates [Metricbeat PostgreSQL] ECS",
+          "type": "metrics"
+        }
+      },
+      "id": "960ecdf0-b79a-11e9-a579-f5c0a5d81340",
+      "migrationVersion": {
+        "visualization": "7.3.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-08-09T11:42:02.764Z",
+      "version": "WzEyMDQsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Database Filter [Metricbeat PostgreSQL] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "controls": [
+              {
+                "fieldName": "postgresql.database.name",
+                "id": "1549397251041",
+                "indexPatternRefName": "control_0_index_pattern",
+                "label": "database",
+                "options": {
+                  "dynamicOptions": true,
+                  "multiselect": false,
+                  "order": "desc",
+                  "size": 5,
+                  "type": "terms"
+                },
+                "parent": "",
+                "type": "list"
+              }
+            ],
+            "pinFilters": false,
+            "updateFiltersOnChange": true,
+            "useTimeFilter": true
+          },
+          "title": "Database Filter [Metricbeat PostgreSQL] ECS",
+          "type": "input_control_vis"
+        }
+      },
+      "id": "98e6b0a0-b79b-11e9-a579-f5c0a5d81340",
+      "migrationVersion": {
+        "visualization": "7.3.0"
+      },
+      "references": [
+        {
+          "id": "metricbeat-*",
+          "name": "control_0_index_pattern",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-08-09T11:39:56.460Z",
+      "version": "WzExNTEsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Query Calls Count [Metricbeat PostgreSQL] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "bar_color_rules": [
+              {
+                "id": "6da7d6e0-b902-11e9-9f00-7b1f283b2282"
+              }
+            ],
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "kuery",
+              "query": ""
+            },
+            "id": "2bc5fea0-b902-11e9-8b8c-f99be54b4271",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "pivot_id": "postgresql.statement.query.text",
+            "pivot_type": "string",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(22,165,165,1)",
+                "fill": 0,
+                "formatter": "number",
+                "id": "2bc5fea1-b902-11e9-8b8c-f99be54b4271",
+                "label": "Number of times the query has been run",
+                "line_width": 2,
+                "metrics": [
+                  {
+                    "field": "postgresql.statement.query.calls",
+                    "id": "2bc5fea2-b902-11e9-8b8c-f99be54b4271",
+                    "type": "max"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "postgresql.statement.query.text",
+                "terms_order_by": "2bc5fea2-b902-11e9-8b8c-f99be54b4271",
+                "terms_size": "10",
+                "value_template": "{{value}}"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "top_n"
+          },
+          "title": "Query Calls Count [Metricbeat PostgreSQL] ECS",
+          "type": "metrics"
+        }
+      },
+      "id": "147875b0-b903-11e9-a579-f5c0a5d81340",
+      "migrationVersion": {
+        "visualization": "7.3.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-08-09T11:40:59.993Z",
+      "version": "WzExODAsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Local block cache stats [Metricbeat PostgreSQL] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "kuery",
+              "query": ""
+            },
+            "id": "8f49dbd0-b908-11e9-a256-6d0ec934f3f9",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#3185FC",
+                "fill": 0,
+                "formatter": "number",
+                "id": "8f49dbd1-b908-11e9-a256-6d0ec934f3f9",
+                "label": "cache hits",
+                "line_width": 2,
+                "metrics": [
+                  {
+                    "field": "postgresql.statement.query.memory.local.hit",
+                    "id": "8f49dbd2-b908-11e9-a256-6d0ec934f3f9",
+                    "type": "max"
+                  },
+                  {
+                    "field": "8f49dbd2-b908-11e9-a256-6d0ec934f3f9",
+                    "id": "8f49dbd4-b908-11e9-a256-6d0ec934f3f9",
+                    "type": "derivative",
+                    "unit": "1s"
+                  },
+                  {
+                    "field": "8f49dbd2-b908-11e9-a256-6d0ec934f3f9",
+                    "id": "8f49dbd3-b908-11e9-a256-6d0ec934f3f9",
+                    "type": "positive_only",
+                    "unit": ""
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#DB1374",
+                "fill": 0,
+                "formatter": "number",
+                "id": "8f49dbd5-b908-11e9-a256-6d0ec934f3f9",
+                "label": "cache read",
+                "line_width": 2,
+                "metrics": [
+                  {
+                    "field": "postgresql.statement.query.memory.local.read",
+                    "id": "8f49dbd6-b908-11e9-a256-6d0ec934f3f9",
+                    "type": "max"
+                  },
+                  {
+                    "field": "8f49dbd6-b908-11e9-a256-6d0ec934f3f9",
+                    "id": "8f49dbd8-b908-11e9-a256-6d0ec934f3f9",
+                    "type": "derivative",
+                    "unit": "1s"
+                  },
+                  {
+                    "field": "8f49dbd6-b908-11e9-a256-6d0ec934f3f9",
+                    "id": "8f49dbd7-b908-11e9-a256-6d0ec934f3f9",
+                    "type": "positive_only",
+                    "unit": ""
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Local block cache stats [Metricbeat PostgreSQL] ECS",
+          "type": "metrics"
+        }
+      },
+      "id": "0cb65170-b909-11e9-a579-f5c0a5d81340",
+      "migrationVersion": {
+        "visualization": "7.3.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-08-09T11:42:18.557Z",
+      "version": "WzEyMTAsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Shared block cache stats [Metricbeat PostgreSQL] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "kuery",
+              "query": ""
+            },
+            "id": "8f49dbd0-b908-11e9-a256-6d0ec934f3f9",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#3185FC",
+                "fill": 0,
+                "formatter": "number",
+                "id": "8f49dbd1-b908-11e9-a256-6d0ec934f3f9",
+                "label": "cache hits",
+                "line_width": 2,
+                "metrics": [
+                  {
+                    "field": "postgresql.statement.query.memory.shared.hit",
+                    "id": "8f49dbd2-b908-11e9-a256-6d0ec934f3f9",
+                    "type": "max"
+                  },
+                  {
+                    "field": "8f49dbd2-b908-11e9-a256-6d0ec934f3f9",
+                    "id": "8f49dbd4-b908-11e9-a256-6d0ec934f3f9",
+                    "type": "derivative",
+                    "unit": "1s"
+                  },
+                  {
+                    "field": "8f49dbd4-b908-11e9-a256-6d0ec934f3f9",
+                    "id": "8f49dbd3-b908-11e9-a256-6d0ec934f3f9",
+                    "type": "positive_only"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#DB1374",
+                "fill": 0,
+                "formatter": "number",
+                "id": "8f49dbd5-b908-11e9-a256-6d0ec934f3f9",
+                "label": "cache read",
+                "line_width": 2,
+                "metrics": [
+                  {
+                    "field": "postgresql.statement.query.memory.shared.read",
+                    "id": "8f49dbd6-b908-11e9-a256-6d0ec934f3f9",
+                    "type": "max"
+                  },
+                  {
+                    "field": "8f49dbd6-b908-11e9-a256-6d0ec934f3f9",
+                    "id": "8f49dbd8-b908-11e9-a256-6d0ec934f3f9",
+                    "type": "derivative",
+                    "unit": "1s"
+                  },
+                  {
+                    "field": "8f49dbd8-b908-11e9-a256-6d0ec934f3f9",
+                    "id": "8f49dbd7-b908-11e9-a256-6d0ec934f3f9",
+                    "type": "positive_only"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Shared block cache stats [Metricbeat PostgreSQL] ECS",
+          "type": "metrics"
+        }
+      },
+      "id": "e2b28ce0-b908-11e9-a579-f5c0a5d81340",
+      "migrationVersion": {
+        "visualization": "7.3.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-08-09T11:42:42.659Z",
+      "version": "WzEyMTksMV0="
+    }
+  ],
+  "version": "7.3.0"
+}

--- a/dev/package-beats/postgresql-1.0.0/manifest.yml
+++ b/dev/package-beats/postgresql-1.0.0/manifest.yml
@@ -1,0 +1,14 @@
+name: postgresql
+title: PostgreSQL
+version: 1.0.0
+description: |
+  Metrics collected from PostgreSQL servers.
+type: ""
+categories:
+- logs
+- metrics
+requirement:
+  kibana:
+    version:
+      min: 6.7.0
+      max: 7.6.0

--- a/dev/package-beats/prometheus-1.0.0/kibana/dashboard/Metricbeat-prometheus-overview.json
+++ b/dev/package-beats/prometheus-1.0.0/kibana/dashboard/Metricbeat-prometheus-overview.json
@@ -1,0 +1,905 @@
+{
+  "objects": [
+    {
+      "attributes": {
+        "description": "Various stats for Prometheus Server",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "optionsJSON": {
+          "hidePanelTitles": false,
+          "useMargins": true
+        },
+        "panelsJSON": [
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 15,
+              "i": "1",
+              "w": 24,
+              "x": 0,
+              "y": 0
+            },
+            "panelIndex": "1",
+            "panelRefName": "panel_0",
+            "title": "HTTP Requests",
+            "version": "7.3.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 15,
+              "i": "2",
+              "w": 24,
+              "x": 24,
+              "y": 0
+            },
+            "panelIndex": "2",
+            "panelRefName": "panel_1",
+            "title": "Query Durations",
+            "version": "7.3.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 7,
+              "i": "3",
+              "w": 24,
+              "x": 24,
+              "y": 15
+            },
+            "panelIndex": "3",
+            "panelRefName": "panel_2",
+            "title": "Number of Targets",
+            "version": "7.3.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 15,
+              "i": "4",
+              "w": 24,
+              "x": 0,
+              "y": 22
+            },
+            "panelIndex": "4",
+            "panelRefName": "panel_3",
+            "title": "Head Chunks",
+            "version": "7.3.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 7,
+              "i": "5",
+              "w": 11,
+              "x": 0,
+              "y": 15
+            },
+            "panelIndex": "5",
+            "panelRefName": "panel_4",
+            "title": "WAL Stats",
+            "version": "7.3.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 7,
+              "i": "6",
+              "w": 13,
+              "x": 11,
+              "y": 15
+            },
+            "panelIndex": "6",
+            "panelRefName": "panel_5",
+            "title": "Reload Count",
+            "version": "7.3.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 15,
+              "i": "7",
+              "w": 10,
+              "x": 24,
+              "y": 22
+            },
+            "panelIndex": "7",
+            "panelRefName": "panel_6",
+            "title": "Remote API Reads",
+            "version": "7.3.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 15,
+              "i": "8",
+              "w": 14,
+              "x": 34,
+              "y": 22
+            },
+            "panelIndex": "8",
+            "panelRefName": "panel_7",
+            "title": "Alert Notifications",
+            "version": "7.3.0"
+          }
+        ],
+        "timeRestore": false,
+        "title": "[Metricbeat Prometheus] Overview",
+        "version": 1
+      },
+      "id": "6a9b80c0-b2ed-11e9-9a23-67ee28886a4b",
+      "migrationVersion": {
+        "dashboard": "7.3.0"
+      },
+      "references": [
+        {
+          "id": "19886730-b2e7-11e9-9a23-67ee28886a4b",
+          "name": "panel_0",
+          "type": "visualization"
+        },
+        {
+          "id": "f77c5900-b2e4-11e9-9a23-67ee28886a4b",
+          "name": "panel_1",
+          "type": "visualization"
+        },
+        {
+          "id": "ffb70040-b2ec-11e9-9a23-67ee28886a4b",
+          "name": "panel_2",
+          "type": "visualization"
+        },
+        {
+          "id": "79345b00-b2e5-11e9-9a23-67ee28886a4b",
+          "name": "panel_3",
+          "type": "visualization"
+        },
+        {
+          "id": "138704c0-b2f8-11e9-9a23-67ee28886a4b",
+          "name": "panel_4",
+          "type": "visualization"
+        },
+        {
+          "id": "d7740b40-b2fc-11e9-9a23-67ee28886a4b",
+          "name": "panel_5",
+          "type": "visualization"
+        },
+        {
+          "id": "edd33100-b305-11e9-9a23-67ee28886a4b",
+          "name": "panel_6",
+          "type": "visualization"
+        },
+        {
+          "id": "0b356630-b308-11e9-9a23-67ee28886a4b",
+          "name": "panel_7",
+          "type": "visualization"
+        }
+      ],
+      "type": "dashboard",
+      "updated_at": "2019-08-02T10:59:13.474Z",
+      "version": "WzYxMCwxXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "HTTP Requests [Metricbeat Prometheus]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "kuery",
+              "query": ""
+            },
+            "id": "b2579fe0-b2e6-11e9-96a9-535735f478e7",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(219,223,0,1)",
+                "fill": 0,
+                "formatter": "number",
+                "id": "b2579fe1-b2e6-11e9-96a9-535735f478e7",
+                "label": "HTTP Requests",
+                "line_width": 2,
+                "metrics": [
+                  {
+                    "field": "prometheus.metrics.prometheus_http_requests_total",
+                    "id": "b2579fe2-b2e6-11e9-96a9-535735f478e7",
+                    "type": "max"
+                  },
+                  {
+                    "field": "b2579fe2-b2e6-11e9-96a9-535735f478e7",
+                    "id": "4ff83340-b445-11e9-88c2-81f27aea5920",
+                    "type": "derivative",
+                    "unit": "1s"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "prometheus.labels.handler",
+                "terms_size": "5",
+                "value_template": "{{value}}"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "HTTP Requests [Metricbeat Prometheus]",
+          "type": "metrics"
+        }
+      },
+      "id": "19886730-b2e7-11e9-9a23-67ee28886a4b",
+      "migrationVersion": {
+        "visualization": "7.3.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-08-01T10:16:22.004Z",
+      "version": "WzUwMCwxXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Query Durations [Metricbeat Prometheus]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "kuery",
+              "query": "prometheus.labels.quantile : \"0.99\""
+            },
+            "id": "0fa40ac0-b2e3-11e9-9d48-591d2f459020",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(0,156,224,1)",
+                "fill": 0,
+                "filter": {
+                  "language": "kuery",
+                  "query": "prometheus.labels.quantile : \"0.99\" "
+                },
+                "formatter": "'0.0[0000]'",
+                "id": "0fa40ac1-b2e3-11e9-9d48-591d2f459020",
+                "label": "Query Durations p99",
+                "line_width": 2,
+                "metrics": [
+                  {
+                    "field": "prometheus.metrics.prometheus_engine_query_duration_seconds",
+                    "id": "0fa40ac2-b2e3-11e9-9d48-591d2f459020",
+                    "type": "max"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_filters": [
+                  {
+                    "color": "#3185FC",
+                    "filter": {
+                      "language": "kuery",
+                      "query": "prometheus.labels.slice : \"inner_eval\" "
+                    },
+                    "id": "5089a8b0-b2e3-11e9-a478-1744b9617108",
+                    "label": "Inner"
+                  }
+                ],
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "prometheus.labels.slice",
+                "terms_order_by": "_count",
+                "value_template": "{{value}}"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Query Durations [Metricbeat Prometheus]",
+          "type": "metrics"
+        }
+      },
+      "id": "f77c5900-b2e4-11e9-9a23-67ee28886a4b",
+      "migrationVersion": {
+        "visualization": "7.3.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-07-31T12:29:35.301Z",
+      "version": "WzQ0MSwxXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Number of Targets [Metricbeat Prometheus]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "kuery",
+              "query": ""
+            },
+            "id": "08298160-b2ea-11e9-a1e3-dd90a90fb461",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(0,156,224,1)",
+                "fill": "0.2",
+                "filter": {
+                  "language": "kuery",
+                  "query": ""
+                },
+                "formatter": "number",
+                "id": "08298161-b2ea-11e9-a1e3-dd90a90fb461",
+                "label": "Total Number of Discovered Targets",
+                "line_width": "1",
+                "metrics": [
+                  {
+                    "field": "prometheus.metrics.prometheus_sd_discovered_targets",
+                    "id": "08298162-b2ea-11e9-a1e3-dd90a90fb461",
+                    "type": "max"
+                  }
+                ],
+                "point_size": "0",
+                "separate_axis": 0,
+                "split_mode": "terms",
+                "stacked": "none",
+                "steps": 1,
+                "terms_direction": "desc",
+                "terms_field": "prometheus.labels.name",
+                "terms_order_by": "08298162-b2ea-11e9-a1e3-dd90a90fb461",
+                "value_template": "{{value}}"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Number of Targets [Metricbeat Prometheus]",
+          "type": "metrics"
+        }
+      },
+      "id": "ffb70040-b2ec-11e9-9a23-67ee28886a4b",
+      "migrationVersion": {
+        "visualization": "7.3.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-07-31T12:34:36.214Z",
+      "version": "WzQ2MiwxXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Head Chunks [Metricbeat Prometheus]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "kuery",
+              "query": ""
+            },
+            "id": "2f5a6920-b2e5-11e9-b248-0162f01eb4ee",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(101,50,148,1)",
+                "fill": 0,
+                "formatter": "number",
+                "id": "2f5a9030-b2e5-11e9-b248-0162f01eb4ee",
+                "label": "Head Chunks",
+                "line_width": 2,
+                "metrics": [
+                  {
+                    "field": "prometheus.metrics.prometheus_tsdb_head_chunks",
+                    "id": "2f5a9031-b2e5-11e9-b248-0162f01eb4ee",
+                    "type": "max"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Head Chunks [Metricbeat Prometheus]",
+          "type": "metrics"
+        }
+      },
+      "id": "79345b00-b2e5-11e9-9a23-67ee28886a4b",
+      "migrationVersion": {
+        "visualization": "7.3.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-07-31T12:35:36.349Z",
+      "version": "WzQ2OSwxXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "WAL [Metricbeat Prometheus]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "bar_color_rules": [
+              {
+                "id": "f4985140-b2f7-11e9-8481-37d39feabbb2"
+              }
+            ],
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "kuery",
+              "query": ""
+            },
+            "id": "ce91d200-b2f7-11e9-9e3f-5b12e64d4361",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(247,75,56,1)",
+                "fill": 0,
+                "formatter": "number",
+                "id": "ce91f910-b2f7-11e9-9e3f-5b12e64d4361",
+                "label": "Failed WAL Truncations",
+                "line_width": 2,
+                "metrics": [
+                  {
+                    "field": "prometheus.metrics.prometheus_tsdb_wal_truncations_failed_total",
+                    "id": "ce91f911-b2f7-11e9-9e3f-5b12e64d4361",
+                    "type": "max"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(251,158,0,1)",
+                "fill": 0,
+                "formatter": "number",
+                "id": "ce91f912-b2f7-11e9-9e3f-5b12e64d4361",
+                "label": "WAL Corruptions Total",
+                "line_width": 2,
+                "metrics": [
+                  {
+                    "field": "prometheus.metrics.prometheus_tsdb_wal_corruptions_total",
+                    "id": "ce91f913-b2f7-11e9-9e3f-5b12e64d4361",
+                    "type": "max"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "top_n"
+          },
+          "title": "WAL [Metricbeat Prometheus]",
+          "type": "metrics"
+        }
+      },
+      "id": "138704c0-b2f8-11e9-9a23-67ee28886a4b",
+      "migrationVersion": {
+        "visualization": "7.3.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-07-31T12:31:29.355Z",
+      "version": "WzQ0NywxXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Reload Count [Metricbeat Prometheus]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "kuery",
+              "query": ""
+            },
+            "id": "6acaf760-b2fc-11e9-86ff-9300d5a00260",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(12,121,125,1)",
+                "fill": "0.2",
+                "formatter": "'0.0[0000]'",
+                "id": "6acaf761-b2fc-11e9-86ff-9300d5a00260",
+                "label": "reloads",
+                "line_width": "1",
+                "metrics": [
+                  {
+                    "field": "prometheus.metrics.prometheus_tsdb_reloads_total",
+                    "id": "6acaf762-b2fc-11e9-86ff-9300d5a00260",
+                    "type": "max"
+                  },
+                  {
+                    "field": "6acaf762-b2fc-11e9-86ff-9300d5a00260",
+                    "id": "6acaf764-b2fc-11e9-86ff-9300d5a00260",
+                    "type": "derivative",
+                    "unit": "1s"
+                  },
+                  {
+                    "field": "6acaf764-b2fc-11e9-86ff-9300d5a00260",
+                    "id": "6acaf763-b2fc-11e9-86ff-9300d5a00260",
+                    "type": "positive_only"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "steps": 1,
+                "value_template": "{{value}}"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#DB1374",
+                "fill": "0.2",
+                "formatter": "'0.0[0000]'",
+                "id": "6acaf765-b2fc-11e9-86ff-9300d5a00260",
+                "label": "failures",
+                "line_width": "1",
+                "metrics": [
+                  {
+                    "field": "prometheus.metrics.prometheus_tsdb_reloads_failures_total",
+                    "id": "6acaf766-b2fc-11e9-86ff-9300d5a00260",
+                    "type": "max"
+                  },
+                  {
+                    "field": "6acaf766-b2fc-11e9-86ff-9300d5a00260",
+                    "id": "6acaf768-b2fc-11e9-86ff-9300d5a00260",
+                    "type": "derivative",
+                    "unit": "1s"
+                  },
+                  {
+                    "field": "6acaf768-b2fc-11e9-86ff-9300d5a00260",
+                    "id": "6acaf767-b2fc-11e9-86ff-9300d5a00260",
+                    "type": "positive_only"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "steps": 1,
+                "value_template": "{{value}}"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Reload Count [Metricbeat Prometheus]",
+          "type": "metrics"
+        }
+      },
+      "id": "d7740b40-b2fc-11e9-9a23-67ee28886a4b",
+      "migrationVersion": {
+        "visualization": "7.3.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-07-30T19:05:35.833Z",
+      "version": "WzM3OSwxXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Remote API Reads [Metricbeat Prometheus]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "kuery",
+              "query": ""
+            },
+            "id": "a3dbf320-b305-11e9-a86d-99bede5bfcc3",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(219,223,0,1)",
+                "fill": 0,
+                "formatter": "number",
+                "id": "a3dbf321-b305-11e9-a86d-99bede5bfcc3",
+                "label": "# of remote read queries",
+                "line_width": 2,
+                "metrics": [
+                  {
+                    "field": "prometheus.metrics.prometheus_api_remote_read_queries",
+                    "id": "a3dbf322-b305-11e9-a86d-99bede5bfcc3",
+                    "type": "max"
+                  },
+                  {
+                    "field": "a3dbf322-b305-11e9-a86d-99bede5bfcc3",
+                    "id": "a3dbf324-b305-11e9-a86d-99bede5bfcc3",
+                    "type": "derivative",
+                    "unit": "1s"
+                  },
+                  {
+                    "field": "a3dbf324-b305-11e9-a86d-99bede5bfcc3",
+                    "id": "a3dbf323-b305-11e9-a86d-99bede5bfcc3",
+                    "type": "positive_only"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Remote API Reads [Metricbeat Prometheus]",
+          "type": "metrics"
+        }
+      },
+      "id": "edd33100-b305-11e9-9a23-67ee28886a4b",
+      "migrationVersion": {
+        "visualization": "7.3.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-07-30T20:09:25.775Z",
+      "version": "WzM5NCwxXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Alert Notifications [Metricbeat Prometheus]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "filter": {
+              "language": "kuery",
+              "query": ""
+            },
+            "id": "b1741ab0-b307-11e9-95cd-c3f5589dc7d2",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(211,49,21,1)",
+                "fill": 0,
+                "formatter": "number",
+                "id": "b1741ab1-b307-11e9-95cd-c3f5589dc7d2",
+                "label": "Capacity of the alert notifications queue",
+                "line_width": 2,
+                "metrics": [
+                  {
+                    "field": "prometheus.metrics.prometheus_notifications_queue_capacity",
+                    "id": "b1741ab2-b307-11e9-95cd-c3f5589dc7d2",
+                    "type": "max"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(176,188,0,1)",
+                "fill": "0.2",
+                "formatter": "number",
+                "id": "b1741ab3-b307-11e9-95cd-c3f5589dc7d2",
+                "label": "Alert notifications in the queue",
+                "line_width": "1",
+                "metrics": [
+                  {
+                    "field": "prometheus.metrics.prometheus_notifications_queue_length",
+                    "id": "b1741ab4-b307-11e9-95cd-c3f5589dc7d2",
+                    "type": "max"
+                  }
+                ],
+                "point_size": 0,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Alert Notifications [Metricbeat Prometheus]",
+          "type": "metrics"
+        }
+      },
+      "id": "0b356630-b308-11e9-9a23-67ee28886a4b",
+      "migrationVersion": {
+        "visualization": "7.3.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-07-30T20:24:34.067Z",
+      "version": "WzQwMiwxXQ=="
+    }
+  ],
+  "version": "7.3.0"
+}

--- a/dev/package-beats/prometheus-1.0.0/manifest.yml
+++ b/dev/package-beats/prometheus-1.0.0/manifest.yml
@@ -1,0 +1,13 @@
+name: prometheus
+title: Prometheus
+version: 1.0.0
+description: |
+  Stats scraped from a Prometheus endpoint.
+type: ""
+categories:
+- metrics
+requirement:
+  kibana:
+    version:
+      min: 6.7.0
+      max: 7.6.0

--- a/dev/package-beats/rabbitmq-1.0.0/kibana/dashboard/Metricbeat-rabbitmq-overview.json
+++ b/dev/package-beats/rabbitmq-1.0.0/kibana/dashboard/Metricbeat-rabbitmq-overview.json
@@ -1,0 +1,453 @@
+{
+    "objects": [
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "Metricbeat-Rabbitmq-ecs", 
+                "title": "Memory Usage [Metricbeat RabbitMQ] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "Used memory", 
+                                "field": "rabbitmq.node.mem.used.bytes", 
+                                "json": ""
+                            }, 
+                            "schema": "metric", 
+                            "type": "max"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "customInterval": "30s", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "custom", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "4", 
+                            "params": {
+                                "customLabel": "Node name", 
+                                "field": "rabbitmq.node.name", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "group", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "defaultYExtents": true, 
+                        "drawLinesBetweenPoints": true, 
+                        "interpolate": "linear", 
+                        "legendPosition": "top", 
+                        "radiusRatio": 9, 
+                        "scale": "linear", 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "showCircles": false, 
+                        "smoothLines": true, 
+                        "times": [], 
+                        "yAxis": {}
+                    }, 
+                    "title": "RabbitMQ Memory Usage ECS", 
+                    "type": "line"
+                }
+            }, 
+            "id": "RabbitMQ-Memory-Usage-ecs", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "Metricbeat-Rabbitmq-ecs", 
+                "title": "Number of Nodes [Metricbeat RabbitMQ] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "RabbitMQ Nodes", 
+                                "field": "rabbitmq.node.name"
+                            }, 
+                            "schema": "metric", 
+                            "type": "cardinality"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "fontSize": 60, 
+                        "handleNoResults": true
+                    }, 
+                    "title": "Rabbitmq Number of Nodes ECS",
+                    "type": "metric"
+                }
+            }, 
+            "id": "Rabbitmq-Number-of-Nodes-ecs", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "Metricbeat-Rabbitmq-ecs", 
+                "title": "Erlang Process Usage [Metricbeat RabbitMQ] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "Used Process", 
+                                "field": "rabbitmq.node.proc.used"
+                            }, 
+                            "schema": "metric", 
+                            "type": "max"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "customInterval": "30s", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "custom", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "4", 
+                            "params": {
+                                "customLabel": "Node name", 
+                                "field": "rabbitmq.node.name", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "group", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "defaultYExtents": false, 
+                        "drawLinesBetweenPoints": true, 
+                        "interpolate": "linear", 
+                        "legendPosition": "top", 
+                        "radiusRatio": 9, 
+                        "scale": "linear", 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "showCircles": false, 
+                        "smoothLines": true, 
+                        "times": [], 
+                        "yAxis": {}
+                    }, 
+                    "title": "RabbitMQ Erlang Process Usage ECS", 
+                    "type": "line"
+                }
+            }, 
+            "id": "RabbitMQ-Erlang-Process-Usage-ecs", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "Metricbeat-Rabbitmq-ecs", 
+                "title": "Queue Index Operations [Metricbeat RabbitMQ] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "Queue Index Read", 
+                                "field": "rabbitmq.node.queue.index.read.count"
+                            }, 
+                            "schema": "metric", 
+                            "type": "max"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "30s", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "custom", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "customLabel": "Queue Index Jornal Write", 
+                                "field": "rabbitmq.node.queue.index.journal_write.count"
+                            }, 
+                            "schema": "metric", 
+                            "type": "max"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "4", 
+                            "params": {
+                                "customLabel": "Queue Index Write", 
+                                "field": "rabbitmq.node.queue.index.write.count"
+                            }, 
+                            "schema": "metric", 
+                            "type": "max"
+                        }
+                    ], 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "categoryAxes": [
+                            {
+                                "id": "CategoryAxis-1", 
+                                "labels": {
+                                    "show": true, 
+                                    "truncate": 100
+                                }, 
+                                "position": "bottom", 
+                                "scale": {
+                                    "type": "linear"
+                                }, 
+                                "show": true, 
+                                "style": {}, 
+                                "title": {}, 
+                                "type": "category"
+                            }
+                        ], 
+                        "defaultYExtents": false, 
+                        "drawLinesBetweenPoints": true, 
+                        "grid": {
+                            "categoryLines": false, 
+                            "style": {
+                                "color": "#eee"
+                            }
+                        }, 
+                        "interpolate": "linear", 
+                        "legendPosition": "top", 
+                        "radiusRatio": 9, 
+                        "scale": "linear", 
+                        "seriesParams": [
+                            {
+                                "data": {
+                                    "id": "1", 
+                                    "label": "Count"
+                                }, 
+                                "drawLinesBetweenPoints": true, 
+                                "mode": "normal", 
+                                "show": "true", 
+                                "showCircles": true, 
+                                "type": "line", 
+                                "valueAxis": "ValueAxis-1"
+                            }
+                        ], 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "showCircles": false, 
+                        "smoothLines": false, 
+                        "times": [], 
+                        "type": "line", 
+                        "valueAxes": [
+                            {
+                                "id": "ValueAxis-1", 
+                                "labels": {
+                                    "filter": false, 
+                                    "rotate": 0, 
+                                    "show": true, 
+                                    "truncate": 100
+                                }, 
+                                "name": "LeftAxis-1", 
+                                "position": "left", 
+                                "scale": {
+                                    "mode": "normal", 
+                                    "type": "linear"
+                                }, 
+                                "show": true, 
+                                "style": {}, 
+                                "title": {
+                                    "text": "Count"
+                                }, 
+                                "type": "value"
+                            }
+                        ], 
+                        "yAxis": {}
+                    }, 
+                    "title": "Queue Index Operations [Metricbeat RabbitMQ] ECS", 
+                    "type": "line"
+                }
+            }, 
+            "id": "RabbitMQ-Queue-Index-Operations-ecs", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlight": {
+                            "fields": {
+                                "*": {}
+                            }, 
+                            "fragment_size": 2147483647, 
+                            "post_tags": [
+                                "@/kibana-highlighted-field@"
+                            ], 
+                            "pre_tags": [
+                                "@kibana-highlighted-field@"
+                            ], 
+                            "require_field_match": false
+                        }, 
+                        "index": "metricbeat-*", 
+                        "query": {
+                            "language": "kuery",
+                                "query": "event.module:rabbitmq"
+                            }
+                    }
+                }, 
+                "sort": [
+                    "@timestamp", 
+                    "desc"
+                ], 
+                "title": "Metricbeat Rabbitmq ECS",
+                "version": 1
+            }, 
+            "id": "Metricbeat-Rabbitmq-ecs", 
+            "type": "search", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "Overview of RabbitMQ status",
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlightAll": true, 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "optionsJSON": {
+                    "darkTheme": false
+                }, 
+                "panelsJSON": [
+                    {
+                        "col": 1, 
+                        "id": "RabbitMQ-Memory-Usage-ecs", 
+                        "panelIndex": 8, 
+                        "row": 1, 
+                        "size_x": 6, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 8, 
+                        "id": "Rabbitmq-Number-of-Nodes-ecs", 
+                        "panelIndex": 2, 
+                        "row": 1, 
+                        "size_x": 3, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "RabbitMQ-Erlang-Process-Usage-ecs", 
+                        "panelIndex": 10, 
+                        "row": 4, 
+                        "size_x": 6, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 7, 
+                        "id": "RabbitMQ-Queue-Index-Operations-ecs", 
+                        "panelIndex": 9, 
+                        "row": 4, 
+                        "size_x": 6, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }
+                ], 
+                "timeRestore": false, 
+                "title": "[Metricbeat RabbitMQ] Overview ECS", 
+                "uiStateJSON": {
+                    "P-2": {
+                        "vis": {
+                            "defaultColors": {
+                                "0 - 100": "rgb(0,104,55)"
+                            }
+                        }
+                    }
+                }, 
+                "version": 1
+            }, 
+            "id": "AV4YobKIge1VCbKU_qVo-ecs", 
+            "type": "dashboard", 
+            "version": 2
+        }
+    ], 
+    "version": "6.0.0-beta1-SNAPSHOT"
+}

--- a/dev/package-beats/rabbitmq-1.0.0/manifest.yml
+++ b/dev/package-beats/rabbitmq-1.0.0/manifest.yml
@@ -1,0 +1,14 @@
+name: rabbitmq
+title: RabbitMQ
+version: 1.0.0
+description: |
+  RabbitMQ module
+type: ""
+categories:
+- logs
+- metrics
+requirement:
+  kibana:
+    version:
+      min: 6.7.0
+      max: 7.6.0

--- a/dev/package-beats/redis-1.0.0/kibana/dashboard/Filebeat-redis.json
+++ b/dev/package-beats/redis-1.0.0/kibana/dashboard/Filebeat-redis.json
@@ -1,0 +1,562 @@
+{
+    "objects": [
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlightAll": true, 
+                        "index": "filebeat-*", 
+                        "query": {
+                            "language": "kuery",
+                                    "query": "event.dataset:redis.log"
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "title": "Log levels and roles breakdown [Filebeat Redis] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "field": "redis.log.role", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "segment", 
+                            "type": "terms"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customLabel": "Log level", 
+                                "field": "log.level", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "segment", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "params": {
+                        "addLegend": true, 
+                        "addTooltip": true, 
+                        "isDonut": false, 
+                        "legendPosition": "bottom", 
+                        "type": "pie"
+                    }, 
+                    "title": "Log levels and roles breakdown [Filebeat Redis] ECS", 
+                    "type": "pie"
+                }
+            }, 
+            "id": "78b9afe0-478f-11e7-b1f0-cb29bac6bf8b-ecs", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlightAll": true, 
+                        "index": "filebeat-*", 
+                        "query": {
+                            "language": "kuery",
+                                    "query": "event.dataset:redis.log"
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "title": "Logs over time [Filebeat Redis] ECS", 
+                "uiStateJSON": {
+                    "vis": {
+                        "colors": {
+                            "notice": "#629E51", 
+                            "warning": "#EF843C"
+                        }
+                    }
+                }, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "field": "log.level", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "group", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "categoryAxes": [
+                            {
+                                "id": "CategoryAxis-1", 
+                                "labels": {
+                                    "show": true, 
+                                    "truncate": 100
+                                }, 
+                                "position": "bottom", 
+                                "scale": {
+                                    "type": "linear"
+                                }, 
+                                "show": true, 
+                                "style": {}, 
+                                "title": {
+                                    "text": "@timestamp per month"
+                                }, 
+                                "type": "category"
+                            }
+                        ], 
+                        "defaultYExtents": false, 
+                        "drawLinesBetweenPoints": true, 
+                        "grid": {
+                            "categoryLines": false, 
+                            "style": {
+                                "color": "#eee"
+                            }
+                        }, 
+                        "interpolate": "linear", 
+                        "legendPosition": "right", 
+                        "radiusRatio": 9, 
+                        "scale": "linear", 
+                        "seriesParams": [
+                            {
+                                "data": {
+                                    "id": "1", 
+                                    "label": "Count"
+                                }, 
+                                "drawLinesBetweenPoints": true, 
+                                "mode": "stacked", 
+                                "show": "true", 
+                                "showCircles": true, 
+                                "type": "histogram", 
+                                "valueAxis": "ValueAxis-1"
+                            }
+                        ], 
+                        "setYExtents": false, 
+                        "showCircles": true, 
+                        "times": [], 
+                        "type": "histogram", 
+                        "valueAxes": [
+                            {
+                                "id": "ValueAxis-1", 
+                                "labels": {
+                                    "filter": false, 
+                                    "rotate": 0, 
+                                    "show": true, 
+                                    "truncate": 100
+                                }, 
+                                "name": "LeftAxis-1", 
+                                "position": "left", 
+                                "scale": {
+                                    "mode": "normal", 
+                                    "type": "linear"
+                                }, 
+                                "show": true, 
+                                "style": {}, 
+                                "title": {
+                                    "text": "Count"
+                                }, 
+                                "type": "value"
+                            }
+                        ]
+                    }, 
+                    "title": "Logs over time [Filebeat Redis] ECS", 
+                    "type": "histogram"
+                }
+            }, 
+            "id": "d2864600-478f-11e7-be88-2ddb32f3df97-ecs", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "columns": [
+                    "host.name", 
+                    "log.level", 
+                    "redis.log.role", 
+                    "message"
+                ], 
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [
+                            {
+                                "$state": {
+                                    "store": "appState"
+                                }, 
+                                "meta": {
+                                    "alias": null, 
+                                    "disabled": false, 
+                                    "index": "filebeat-*", 
+                                    "key": "event.module", 
+                                    "negate": false, 
+                                    "params": {
+                                        "query": "redis", 
+                                        "type": "phrase"
+                                    }, 
+                                    "type": "phrase", 
+                                    "value": "redis"
+                                }, 
+                                "query": {
+                                    "match": {
+                                        "event.module": {
+                                            "query": "redis", 
+                                            "type": "phrase"
+                                        }
+                                    }
+                                }
+                            }, 
+                            {
+                                "$state": {
+                                    "store": "appState"
+                                }, 
+                                "meta": {
+                                    "alias": null, 
+                                    "disabled": false, 
+                                    "index": "filebeat-*", 
+                                    "key": "fileset.name", 
+                                    "negate": false, 
+                                    "params": {
+                                        "query": "log", 
+                                        "type": "phrase"
+                                    }, 
+                                    "type": "phrase", 
+                                    "value": "log"
+                                }, 
+                                "query": {
+                                    "match": {
+                                        "fileset.name": {
+                                            "query": "log", 
+                                            "type": "phrase"
+                                        }
+                                    }
+                                }
+                            }
+                        ], 
+                        "highlightAll": true, 
+                        "index": "filebeat-*", 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "sort": [
+                    "@timestamp", 
+                    "desc"
+                ], 
+                "title": "Logs [Filebeat Redis] ECS", 
+                "version": 1
+            }, 
+            "id": "73613570-4791-11e7-be88-2ddb32f3df97-ecs", 
+            "type": "search", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "0ab87b80-478e-11e7-b1f0-cb29bac6bf8b-ecs", 
+                "title": "Top slowest commands [Filebeat Redis] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "Command", 
+                                "field": "redis.slowlog.duration.us"
+                            }, 
+                            "schema": "metric", 
+                            "type": "max"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customLabel": "Duration (microseconds)", 
+                                "field": "redis.slowlog.cmd", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "segment", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "categoryAxes": [
+                            {
+                                "id": "CategoryAxis-1", 
+                                "labels": {
+                                    "filter": false, 
+                                    "rotate": 0, 
+                                    "show": true, 
+                                    "truncate": 200
+                                }, 
+                                "position": "left", 
+                                "scale": {
+                                    "type": "linear"
+                                }, 
+                                "show": true, 
+                                "style": {}, 
+                                "title": {
+                                    "text": "Duration (microseconds)"
+                                }, 
+                                "type": "category"
+                            }
+                        ], 
+                        "defaultYExtents": false, 
+                        "drawLinesBetweenPoints": true, 
+                        "grid": {
+                            "categoryLines": false, 
+                            "style": {
+                                "color": "#eee"
+                            }
+                        }, 
+                        "interpolate": "linear", 
+                        "legendPosition": "right", 
+                        "radiusRatio": 9, 
+                        "scale": "linear", 
+                        "seriesParams": [
+                            {
+                                "data": {
+                                    "id": "1", 
+                                    "label": "Command"
+                                }, 
+                                "drawLinesBetweenPoints": true, 
+                                "mode": "normal", 
+                                "show": true, 
+                                "showCircles": true, 
+                                "type": "histogram", 
+                                "valueAxis": "ValueAxis-1"
+                            }
+                        ], 
+                        "setYExtents": false, 
+                        "showCircles": true, 
+                        "times": [], 
+                        "type": "histogram", 
+                        "valueAxes": [
+                            {
+                                "id": "ValueAxis-1", 
+                                "labels": {
+                                    "filter": true, 
+                                    "rotate": 75, 
+                                    "show": true, 
+                                    "truncate": 100
+                                }, 
+                                "name": "LeftAxis-1", 
+                                "position": "bottom", 
+                                "scale": {
+                                    "mode": "normal", 
+                                    "type": "linear"
+                                }, 
+                                "show": true, 
+                                "style": {}, 
+                                "title": {
+                                    "text": "Command"
+                                }, 
+                                "type": "value"
+                            }
+                        ]
+                    }, 
+                    "title": "Top slowest commands [Filebeat Redis] ECS", 
+                    "type": "histogram"
+                }
+            }, 
+            "id": "dcccaa80-4791-11e7-be88-2ddb32f3df97-ecs", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "columns": [
+                    "host.name", 
+                    "message", 
+                    "redis.slowlog.duration.us", 
+                    "redis.slowlog.key"
+                ], 
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlightAll": true, 
+                        "index": "filebeat-*", 
+                        "query": {
+                            "language": "kuery",
+                                    "query": "event.dataset:redis.slowlog"
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "sort": [
+                    "@timestamp", 
+                    "desc"
+                ], 
+                "title": "Slow logs [Filebeat Redis] ECS", 
+                "version": 1
+            }, 
+            "id": "0ab87b80-478e-11e7-b1f0-cb29bac6bf8b-ecs", 
+            "type": "search", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "Overview dashboard for the FIlebeat Redis module", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlightAll": true, 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "optionsJSON": {
+                    "darkTheme": false
+                }, 
+                "panelsJSON": [
+                    {
+                        "col": 1, 
+                        "id": "78b9afe0-478f-11e7-b1f0-cb29bac6bf8b-ecs", 
+                        "panelIndex": 2, 
+                        "row": 5, 
+                        "size_x": 3, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 4, 
+                        "id": "d2864600-478f-11e7-be88-2ddb32f3df97-ecs", 
+                        "panelIndex": 3, 
+                        "row": 5, 
+                        "size_x": 9, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "columns": [
+                            "host.name", 
+                            "log.level", 
+                            "redis.log.role", 
+                            "message"
+                        ], 
+                        "id": "73613570-4791-11e7-be88-2ddb32f3df97-ecs", 
+                        "panelIndex": 4, 
+                        "row": 8, 
+                        "size_x": 12, 
+                        "size_y": 4, 
+                        "sort": [
+                            "@timestamp", 
+                            "desc"
+                        ], 
+                        "type": "search"
+                    }, 
+                    {
+                        "col": 7, 
+                        "id": "dcccaa80-4791-11e7-be88-2ddb32f3df97-ecs", 
+                        "panelIndex": 5, 
+                        "row": 1, 
+                        "size_x": 6, 
+                        "size_y": 4, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "columns": [
+                            "host.name", 
+                            "message", 
+                            "redis.slowlog.duration.us", 
+                            "redis.slowlog.key"
+                        ], 
+                        "id": "0ab87b80-478e-11e7-b1f0-cb29bac6bf8b-ecs", 
+                        "panelIndex": 6, 
+                        "row": 1, 
+                        "size_x": 6, 
+                        "size_y": 4, 
+                        "sort": [
+                            "@timestamp", 
+                            "desc"
+                        ], 
+                        "type": "search"
+                    }
+                ], 
+                "timeRestore": false, 
+                "title": "[Filebeat Redis] Overview ECS", 
+                "uiStateJSON": {
+                    "P-5": {
+                        "vis": {
+                            "legendOpen": false
+                        }
+                    }
+                }, 
+                "version": 1
+            }, 
+            "id": "7fea2930-478e-11e7-b1f0-cb29bac6bf8b-ecs", 
+            "type": "dashboard", 
+            "version": 4
+        }
+    ], 
+    "version": "6.0.0-beta1-SNAPSHOT"
+}

--- a/dev/package-beats/redis-1.0.0/kibana/dashboard/Metricbeat-redis-keys.json
+++ b/dev/package-beats/redis-1.0.0/kibana/dashboard/Metricbeat-redis-keys.json
@@ -1,0 +1,893 @@
+{
+  "objects": [
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Keyspace selector [Metricbeat Redis] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "controls": [
+              {
+                "fieldName": "redis.keyspace.id",
+                "id": "1545388837304",
+                "indexPattern": "metricbeat-*",
+                "label": "Keyspace",
+                "options": {
+                  "dynamicOptions": true,
+                  "multiselect": true,
+                  "order": "desc",
+                  "size": 5,
+                  "type": "terms"
+                },
+                "parent": "",
+                "type": "list"
+              }
+            ],
+            "pinFilters": false,
+            "updateFiltersOnChange": true,
+            "useTimeFilter": false
+          },
+          "title": "Keyspace selector [Metricbeat Redis] ECS",
+          "type": "input_control_vis"
+        }
+      },
+      "id": "00d39210-050d-11e9-9c60-d582a238e2c5-ecs",
+      "type": "visualization",
+      "updated_at": "2018-12-21T11:19:04.179Z",
+      "version": 5
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [
+              {
+                "$state": {
+                  "store": "appState"
+                },
+                "meta": {
+                  "alias": null,
+                  "disabled": false,
+                  "index": "metricbeat-*",
+                  "key": "redis.key.type",
+                  "negate": false,
+                  "params": {
+                    "query": "list",
+                    "type": "phrase"
+                  },
+                  "type": "phrase",
+                  "value": "list"
+                },
+                "query": {
+                  "match": {
+                    "redis.key.type": {
+                      "query": "list",
+                      "type": "phrase"
+                    }
+                  }
+                }
+              }
+            ],
+            "index": "metricbeat-*",
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Lists length [Metricbeat Redis] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "Number of elements",
+                "field": "redis.key.length"
+              },
+              "schema": "metric",
+              "type": "max"
+            },
+            {
+              "enabled": true,
+              "id": "3",
+              "params": {
+                "customLabel": "Keyspace",
+                "field": "redis.keyspace.id",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 16
+              },
+              "schema": "group",
+              "type": "terms"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customLabel": "Key name",
+                "field": "redis.key.name",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": true,
+                "otherBucketLabel": "Other",
+                "size": 20
+              },
+              "schema": "group",
+              "type": "terms"
+            },
+            {
+              "enabled": true,
+              "id": "4",
+              "params": {
+                "customInterval": "2h",
+                "drop_partials": false,
+                "extended_bounds": {},
+                "field": "@timestamp",
+                "interval": "auto",
+                "min_doc_count": 1,
+                "timeRange": {
+                  "from": "now-15m",
+                  "mode": "quick",
+                  "to": "now"
+                },
+                "time_zone": "Europe/Berlin",
+                "useNormalizedEsInterval": true
+              },
+              "schema": "segment",
+              "type": "date_histogram"
+            }
+          ],
+          "params": {
+            "addLegend": true,
+            "addTimeMarker": false,
+            "addTooltip": true,
+            "categoryAxes": [
+              {
+                "id": "CategoryAxis-1",
+                "labels": {
+                  "show": true,
+                  "truncate": 100
+                },
+                "position": "bottom",
+                "scale": {
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {},
+                "type": "category"
+              }
+            ],
+            "grid": {
+              "categoryLines": false,
+              "style": {
+                "color": "#eee"
+              }
+            },
+            "legendPosition": "right",
+            "seriesParams": [
+              {
+                "data": {
+                  "id": "1",
+                  "label": "Number of elements"
+                },
+                "drawLinesBetweenPoints": true,
+                "interpolate": "linear",
+                "mode": "normal",
+                "show": "true",
+                "showCircles": true,
+                "type": "line",
+                "valueAxis": "ValueAxis-1"
+              }
+            ],
+            "times": [],
+            "type": "line",
+            "valueAxes": [
+              {
+                "id": "ValueAxis-1",
+                "labels": {
+                  "filter": false,
+                  "rotate": 0,
+                  "show": true,
+                  "truncate": 100
+                },
+                "name": "LeftAxis-1",
+                "position": "left",
+                "scale": {
+                  "mode": "normal",
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {
+                  "text": "Number of elements"
+                },
+                "type": "value"
+              }
+            ]
+          },
+          "title": "Lists length [Metricbeat Redis] ECS",
+          "type": "line"
+        }
+      },
+      "id": "7f4bc7d0-050c-11e9-9c60-d582a238e2c5-ecs",
+      "type": "visualization",
+      "updated_at": "2018-12-21T11:22:12.807Z",
+      "version": 4
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "index": "metricbeat-*",
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Keys by type [Metricbeat Redis] ECS",
+        "uiStateJSON": {
+          "vis": {
+            "legendOpen": false
+          }
+        },
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "Number of keys",
+                "field": "redis.key.id"
+              },
+              "schema": "metric",
+              "type": "cardinality"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customLabel": "Key type",
+                "field": "redis.key.type",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 5
+              },
+              "schema": "group",
+              "type": "terms"
+            },
+            {
+              "enabled": true,
+              "id": "3",
+              "params": {
+                "customInterval": "2h",
+                "customLabel": "",
+                "drop_partials": false,
+                "extended_bounds": {},
+                "field": "@timestamp",
+                "interval": "auto",
+                "min_doc_count": 1,
+                "timeRange": {
+                  "from": "now-15m",
+                  "mode": "quick",
+                  "to": "now"
+                },
+                "time_zone": "Europe/Berlin",
+                "useNormalizedEsInterval": true
+              },
+              "schema": "segment",
+              "type": "date_histogram"
+            }
+          ],
+          "params": {
+            "addLegend": true,
+            "addTimeMarker": false,
+            "addTooltip": true,
+            "categoryAxes": [
+              {
+                "id": "CategoryAxis-1",
+                "labels": {
+                  "show": true,
+                  "truncate": 100
+                },
+                "position": "bottom",
+                "scale": {
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {},
+                "type": "category"
+              }
+            ],
+            "grid": {
+              "categoryLines": false,
+              "style": {
+                "color": "#eee"
+              }
+            },
+            "legendPosition": "right",
+            "seriesParams": [
+              {
+                "data": {
+                  "id": "1",
+                  "label": "Number of keys"
+                },
+                "drawLinesBetweenPoints": true,
+                "mode": "normal",
+                "show": "true",
+                "showCircles": true,
+                "type": "line",
+                "valueAxis": "ValueAxis-1"
+              }
+            ],
+            "times": [],
+            "type": "line",
+            "valueAxes": [
+              {
+                "id": "ValueAxis-1",
+                "labels": {
+                  "filter": false,
+                  "rotate": 0,
+                  "show": true,
+                  "truncate": 100
+                },
+                "name": "LeftAxis-1",
+                "position": "left",
+                "scale": {
+                  "mode": "normal",
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {
+                  "text": "Number of keys"
+                },
+                "type": "value"
+              }
+            ]
+          },
+          "title": "Keys by type [Metricbeat Redis] ECS",
+          "type": "line"
+        }
+      },
+      "id": "4435ac40-050e-11e9-9c60-d582a238e2c5-ecs",
+      "type": "visualization",
+      "updated_at": "2018-12-21T11:23:46.207Z",
+      "version": 5
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [
+              {
+                "$state": {
+                  "store": "appState"
+                },
+                "meta": {
+                  "alias": null,
+                  "disabled": false,
+                  "index": "metricbeat-*",
+                  "key": "redis.key.type",
+                  "negate": false,
+                  "params": {
+                    "query": "string",
+                    "type": "phrase"
+                  },
+                  "type": "phrase",
+                  "value": "string"
+                },
+                "query": {
+                  "match": {
+                    "redis.key.type": {
+                      "query": "string",
+                      "type": "phrase"
+                    }
+                  }
+                }
+              }
+            ],
+            "index": "metricbeat-*",
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Average string key size [Metricbeat Redis] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "Average key size",
+                "field": "redis.key.length"
+              },
+              "schema": "metric",
+              "type": "avg"
+            },
+            {
+              "enabled": true,
+              "id": "3",
+              "params": {
+                "customLabel": "Keyspace",
+                "field": "redis.keyspace.id",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 5
+              },
+              "schema": "group",
+              "type": "terms"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customInterval": "2h",
+                "drop_partials": false,
+                "extended_bounds": {},
+                "field": "@timestamp",
+                "interval": "auto",
+                "min_doc_count": 1,
+                "timeRange": {
+                  "from": "now-15m",
+                  "mode": "quick",
+                  "to": "now"
+                },
+                "time_zone": "Europe/Berlin",
+                "useNormalizedEsInterval": true
+              },
+              "schema": "segment",
+              "type": "date_histogram"
+            }
+          ],
+          "params": {
+            "addLegend": true,
+            "addTimeMarker": false,
+            "addTooltip": true,
+            "categoryAxes": [
+              {
+                "id": "CategoryAxis-1",
+                "labels": {
+                  "show": true,
+                  "truncate": 100
+                },
+                "position": "bottom",
+                "scale": {
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {},
+                "type": "category"
+              }
+            ],
+            "grid": {
+              "categoryLines": false,
+              "style": {
+                "color": "#eee"
+              }
+            },
+            "legendPosition": "right",
+            "seriesParams": [
+              {
+                "data": {
+                  "id": "1",
+                  "label": "Average key size"
+                },
+                "drawLinesBetweenPoints": true,
+                "mode": "normal",
+                "show": "true",
+                "showCircles": true,
+                "type": "line",
+                "valueAxis": "ValueAxis-1"
+              }
+            ],
+            "times": [],
+            "type": "line",
+            "valueAxes": [
+              {
+                "id": "ValueAxis-1",
+                "labels": {
+                  "filter": false,
+                  "rotate": 0,
+                  "show": true,
+                  "truncate": 100
+                },
+                "name": "LeftAxis-1",
+                "position": "left",
+                "scale": {
+                  "mode": "normal",
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {
+                  "text": "Average key size"
+                },
+                "type": "value"
+              }
+            ]
+          },
+          "title": "Average string key size [Metricbeat Redis] ECS",
+          "type": "line"
+        }
+      },
+      "id": "8541a4a0-0513-11e9-9c60-d582a238e2c5-ecs",
+      "type": "visualization",
+      "updated_at": "2018-12-21T11:28:20.970Z",
+      "version": 1
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [
+              {
+                "$state": {
+                  "store": "appState"
+                },
+                "meta": {
+                  "alias": null,
+                  "disabled": false,
+                  "index": "metricbeat-*",
+                  "key": "redis.key.expire.ttl",
+                  "negate": false,
+                  "params": {
+                    "gte": 0,
+                    "lt": null
+                  },
+                  "type": "range",
+                  "value": "0 to +∞"
+                },
+                "range": {
+                  "redis.key.expire.ttl": {
+                    "gte": 0,
+                    "lt": null
+                  }
+                }
+              }
+            ],
+            "index": "metricbeat-*",
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Average keys TTL [Metricbeat Redis] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "Average TTL",
+                "field": "redis.key.expire.ttl"
+              },
+              "schema": "metric",
+              "type": "avg"
+            },
+            {
+              "enabled": true,
+              "id": "4",
+              "params": {
+                "customLabel": "Keyspace",
+                "field": "redis.keyspace.id",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 5
+              },
+              "schema": "group",
+              "type": "terms"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customLabel": "Key type",
+                "field": "redis.key.type",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 5
+              },
+              "schema": "group",
+              "type": "terms"
+            },
+            {
+              "enabled": true,
+              "id": "3",
+              "params": {
+                "customInterval": "2h",
+                "drop_partials": false,
+                "extended_bounds": {},
+                "field": "@timestamp",
+                "interval": "auto",
+                "min_doc_count": 1,
+                "timeRange": {
+                  "from": "now-15m",
+                  "mode": "quick",
+                  "to": "now"
+                },
+                "time_zone": "Europe/Berlin",
+                "useNormalizedEsInterval": true
+              },
+              "schema": "segment",
+              "type": "date_histogram"
+            }
+          ],
+          "params": {
+            "addLegend": true,
+            "addTimeMarker": false,
+            "addTooltip": true,
+            "categoryAxes": [
+              {
+                "id": "CategoryAxis-1",
+                "labels": {
+                  "show": true,
+                  "truncate": 100
+                },
+                "position": "bottom",
+                "scale": {
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {},
+                "type": "category"
+              }
+            ],
+            "grid": {
+              "categoryLines": false,
+              "style": {
+                "color": "#eee"
+              }
+            },
+            "legendPosition": "right",
+            "seriesParams": [
+              {
+                "data": {
+                  "id": "1",
+                  "label": "Average TTL"
+                },
+                "drawLinesBetweenPoints": true,
+                "mode": "normal",
+                "show": "true",
+                "showCircles": true,
+                "type": "line",
+                "valueAxis": "ValueAxis-1"
+              }
+            ],
+            "times": [],
+            "type": "line",
+            "valueAxes": [
+              {
+                "id": "ValueAxis-1",
+                "labels": {
+                  "filter": false,
+                  "rotate": 0,
+                  "show": true,
+                  "truncate": 100
+                },
+                "name": "LeftAxis-1",
+                "position": "left",
+                "scale": {
+                  "mode": "normal",
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {
+                  "text": "Average TTL"
+                },
+                "type": "value"
+              }
+            ]
+          },
+          "title": "Average keys TTL [Metricbeat Redis] ECS",
+          "type": "line"
+        }
+      },
+      "id": "517a5fd0-0514-11e9-9c60-d582a238e2c5-ecs",
+      "type": "visualization",
+      "updated_at": "2018-12-21T11:34:03.597Z",
+      "version": 1
+    },
+    {
+      "attributes": {
+        "description": "Redis keys metrics",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [
+              {
+                "$state": {
+                  "store": "appState"
+                },
+                "meta": {
+                  "alias": null,
+                  "controlledBy": "1545388837304",
+                  "disabled": false,
+                  "index": "metricbeat-*",
+                  "key": "redis.keyspace.id",
+                  "negate": false,
+                  "params": [
+                    "db0",
+                    "db1"
+                  ],
+                  "type": "phrases",
+                  "value": "db0, db1"
+                },
+                "query": {
+                  "bool": {
+                    "minimum_should_match": 1,
+                    "should": [
+                      {
+                        "match_phrase": {
+                          "redis.keyspace.id": "db0"
+                        }
+                      },
+                      {
+                        "match_phrase": {
+                          "redis.keyspace.id": "db1"
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            ],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "optionsJSON": {
+          "darkTheme": false,
+          "hidePanelTitles": false,
+          "useMargins": true
+        },
+        "panelsJSON": [
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 5,
+              "i": "1",
+              "w": 12,
+              "x": 0,
+              "y": 0
+            },
+            "id": "00d39210-050d-11e9-9c60-d582a238e2c5-ecs",
+            "panelIndex": "1",
+            "title": "Keyspace selector",
+            "type": "visualization",
+            "version": "6.5.2"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 15,
+              "i": "2",
+              "w": 36,
+              "x": 12,
+              "y": 0
+            },
+            "id": "7f4bc7d0-050c-11e9-9c60-d582a238e2c5-ecs",
+            "panelIndex": "2",
+            "title": "Lists length",
+            "type": "visualization",
+            "version": "6.5.2"
+          },
+          {
+            "embeddableConfig": {
+              "vis": {
+                "legendOpen": false
+              }
+            },
+            "gridData": {
+              "h": 10,
+              "i": "3",
+              "w": 12,
+              "x": 0,
+              "y": 5
+            },
+            "id": "4435ac40-050e-11e9-9c60-d582a238e2c5-ecs",
+            "panelIndex": "3",
+            "title": "Keys by type",
+            "type": "visualization",
+            "version": "6.5.2"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 15,
+              "i": "4",
+              "w": 24,
+              "x": 0,
+              "y": 15
+            },
+            "id": "8541a4a0-0513-11e9-9c60-d582a238e2c5-ecs",
+            "panelIndex": "4",
+            "title": "Average size of string keys",
+            "type": "visualization",
+            "version": "6.5.2"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 15,
+              "i": "5",
+              "w": 24,
+              "x": 24,
+              "y": 15
+            },
+            "id": "517a5fd0-0514-11e9-9c60-d582a238e2c5-ecs",
+            "panelIndex": "5",
+            "title": "Average keys TTL",
+            "type": "visualization",
+            "version": "6.5.2"
+          }
+        ],
+        "timeRestore": false,
+        "title": "[Metricbeat Redis] Keys ECS",
+        "version": 1
+      },
+      "id": "28969190-0511-11e9-9c60-d582a238e2c5-ecs",
+      "type": "dashboard",
+      "updated_at": "2018-12-21T11:39:13.143Z",
+      "version": 4
+    }
+  ],
+  "version": "6.5.2"
+}

--- a/dev/package-beats/redis-1.0.0/kibana/dashboard/Metricbeat-redis-overview.json
+++ b/dev/package-beats/redis-1.0.0/kibana/dashboard/Metricbeat-redis-overview.json
@@ -1,0 +1,819 @@
+{
+    "objects": [
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "Metricbeat-Redis-ecs", 
+                "title": "Clients [Metricbeat Redis] ECS", 
+                "uiStateJSON": {
+                    "vis": {
+                        "defaultColors": {
+                            "0 - 100": "rgb(0,104,55)"
+                        }
+                    }
+                }, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "Connected clients", 
+                                "field": "redis.info.clients.connected"
+                            }, 
+                            "schema": "metric", 
+                            "type": "max"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": false, 
+                        "addTooltip": true, 
+                        "fontSize": 60, 
+                        "gauge": {
+                            "autoExtend": false, 
+                            "backStyle": "Full", 
+                            "colorSchema": "Green to Red", 
+                            "colorsRange": [
+                                {
+                                    "from": 0, 
+                                    "to": 100
+                                }
+                            ], 
+                            "gaugeColorMode": "None", 
+                            "gaugeStyle": "Full", 
+                            "gaugeType": "Metric", 
+                            "invertColors": false, 
+                            "labels": {
+                                "color": "black", 
+                                "show": true
+                            }, 
+                            "orientation": "vertical", 
+                            "percentageMode": false, 
+                            "scale": {
+                                "color": "#333", 
+                                "labels": false, 
+                                "show": false, 
+                                "width": 2
+                            }, 
+                            "style": {
+                                "bgColor": false, 
+                                "fontSize": 60, 
+                                "labelColor": false, 
+                                "subText": ""
+                            }, 
+                            "type": "simple", 
+                            "useRange": false, 
+                            "verticalSplit": false
+                        }, 
+                        "handleNoResults": true, 
+                        "type": "gauge"
+                    }, 
+                    "title": "Clients [Metricbeat Redis] ECS", 
+                    "type": "metric"
+                }
+            }, 
+            "col": 1, 
+            "id": "Redis-Clients-Metrics-ecs", 
+            "panelIndex": 2, 
+            "row": 1, 
+            "size_x": 3, 
+            "size_y": 3, 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "Metricbeat-Redis-ecs", 
+                "title": "Connected clients [Metricbeat Redis] ECS", 
+                "uiStateJSON": {
+                    "vis": {
+                        "colors": {
+                            "Blocked": "#C15C17"
+                        }
+                    }
+                }, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "Connected", 
+                                "field": "redis.info.clients.connected"
+                            }, 
+                            "schema": "metric", 
+                            "type": "max"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "customLabel": "Blocked", 
+                                "field": "redis.info.clients.blocked"
+                            }, 
+                            "schema": "metric", 
+                            "type": "max"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "categoryAxes": [
+                            {
+                                "id": "CategoryAxis-1", 
+                                "labels": {
+                                    "show": true, 
+                                    "truncate": 100
+                                }, 
+                                "position": "bottom", 
+                                "scale": {
+                                    "type": "linear"
+                                }, 
+                                "show": true, 
+                                "style": {}, 
+                                "title": {}, 
+                                "type": "category"
+                            }
+                        ], 
+                        "defaultYExtents": false, 
+                        "grid": {
+                            "categoryLines": false, 
+                            "style": {
+                                "color": "#eee"
+                            }
+                        }, 
+                        "legendPosition": "right", 
+                        "mode": "grouped", 
+                        "scale": "linear", 
+                        "seriesParams": [
+                            {
+                                "data": {
+                                    "id": "1", 
+                                    "label": "Count"
+                                }, 
+                                "drawLinesBetweenPoints": true, 
+                                "mode": "stacked", 
+                                "show": "true", 
+                                "showCircles": true, 
+                                "type": "histogram", 
+                                "valueAxis": "ValueAxis-1"
+                            }
+                        ], 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "times": [], 
+                        "valueAxes": [
+                            {
+                                "id": "ValueAxis-1", 
+                                "labels": {
+                                    "filter": false, 
+                                    "rotate": 0, 
+                                    "show": true, 
+                                    "truncate": 100
+                                }, 
+                                "name": "LeftAxis-1", 
+                                "position": "left", 
+                                "scale": {
+                                    "mode": "normal", 
+                                    "type": "linear"
+                                }, 
+                                "show": true, 
+                                "style": {}, 
+                                "title": {
+                                    "text": "Count"
+                                }, 
+                                "type": "value"
+                            }
+                        ], 
+                        "yAxis": {}
+                    }, 
+                    "title": "Connected clients [Metricbeat Redis] ECS", 
+                    "type": "histogram"
+                }
+            }, 
+            "col": 4, 
+            "id": "Redis-Connected-clients-ecs", 
+            "panelIndex": 1, 
+            "row": 1, 
+            "size_x": 5, 
+            "size_y": 3, 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "Metricbeat-Redis-ecs", 
+                "title": "Hosts [Metricbeat Redis] ECS", 
+                "uiStateJSON": {
+                    "vis": {
+                        "params": {
+                            "sort": {
+                                "columnIndex": null, 
+                                "direction": null
+                            }
+                        }
+                    }
+                }, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "field": "service.address", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "bucket", 
+                            "type": "terms"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "customLabel": "Uptime (s)", 
+                                "field": "redis.info.server.uptime"
+                            }, 
+                            "schema": "metric", 
+                            "type": "max"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "6", 
+                            "params": {
+                                "customLabel": "PID", 
+                                "field": "process.pid"
+                            }, 
+                            "schema": "metric", 
+                            "type": "max"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "Memory", 
+                                "field": "redis.info.memory.used.peak"
+                            }, 
+                            "schema": "metric", 
+                            "type": "max"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "4", 
+                            "params": {
+                                "customLabel": "CPU used (user)", 
+                                "field": "redis.info.cpu.used.user"
+                            }, 
+                            "schema": "metric", 
+                            "type": "max"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "5", 
+                            "params": {
+                                "customLabel": "CPU used (system)", 
+                                "field": "redis.info.cpu.used.sys"
+                            }, 
+                            "schema": "metric", 
+                            "type": "max"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "perPage": 10, 
+                        "showMeticsAtAllLevels": false, 
+                        "showPartialRows": false, 
+                        "showTotal": false, 
+                        "sort": {
+                            "columnIndex": null, 
+                            "direction": null
+                        }, 
+                        "totalFunc": "sum"
+                    }, 
+                    "title": "Hosts [Metricbeat Redis] ECS", 
+                    "type": "table"
+                }
+            }, 
+            "col": 1, 
+            "id": "Redis-hosts-ecs", 
+            "panelIndex": 3, 
+            "row": 4, 
+            "size_x": 12, 
+            "size_y": 2, 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "Metricbeat-Redis-ecs", 
+                "title": "Server Versions [Metricbeat Redis] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "Hosts", 
+                                "field": "service.address"
+                            }, 
+                            "schema": "metric", 
+                            "type": "cardinality"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customLabel": "Multiplexing API", 
+                                "field": "service.version", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "segment", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTooltip": true, 
+                        "isDonut": false, 
+                        "legendPosition": "right", 
+                        "shareYAxis": true
+                    }, 
+                    "title": "Server Versions [Metricbeat Redis] ECS", 
+                    "type": "pie"
+                }
+            }, 
+            "col": 1, 
+            "id": "Redis-Server-Versions-ecs", 
+            "panelIndex": 4, 
+            "row": 6, 
+            "size_x": 4, 
+            "size_y": 2, 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "Metricbeat-Redis-ecs", 
+                "title": "Server mode [Metricbeat Redis] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "Hosts", 
+                                "field": "service.address"
+                            }, 
+                            "schema": "metric", 
+                            "type": "cardinality"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customLabel": "Server mode", 
+                                "field": "redis.info.server.mode", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "segment", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTooltip": true, 
+                        "isDonut": false, 
+                        "legendPosition": "right", 
+                        "shareYAxis": true
+                    }, 
+                    "title": "Server mode [Metricbeat Redis] ECS", 
+                    "type": "pie"
+                }
+            }, 
+            "col": 5, 
+            "id": "Redis-server-mode-ecs", 
+            "panelIndex": 5, 
+            "row": 6, 
+            "size_x": 4, 
+            "size_y": 2, 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "Metricbeat-Redis-ecs", 
+                "title": "Multiplexing API [Metricbeat Redis] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "Hosts", 
+                                "field": "service.address"
+                            }, 
+                            "schema": "metric", 
+                            "type": "cardinality"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customLabel": "Multiplexing API", 
+                                "field": "redis.info.server.multiplexing_api", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "segment", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTooltip": true, 
+                        "isDonut": false, 
+                        "legendPosition": "right", 
+                        "shareYAxis": true
+                    }, 
+                    "title": "Multiplexing API [Metricbeat Redis] ECS", 
+                    "type": "pie"
+                }
+            }, 
+            "col": 9, 
+            "id": "Redis-multiplexing-API-ecs", 
+            "panelIndex": 6, 
+            "row": 6, 
+            "size_x": 3, 
+            "size_y": 2, 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "Metricbeat-Redis-ecs", 
+                "title": "Keyspaces [Metricbeat Redis] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "Number of keys", 
+                                "field": "redis.keyspace.keys"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "customLabel": "Keyspaces", 
+                                "field": "redis.keyspace.id", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "group", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "categoryAxes": [
+                            {
+                                "id": "CategoryAxis-1", 
+                                "labels": {
+                                    "show": true, 
+                                    "truncate": 100
+                                }, 
+                                "position": "bottom", 
+                                "scale": {
+                                    "type": "linear"
+                                }, 
+                                "show": true, 
+                                "style": {}, 
+                                "title": {}, 
+                                "type": "category"
+                            }
+                        ], 
+                        "defaultYExtents": false, 
+                        "grid": {
+                            "categoryLines": false, 
+                            "style": {
+                                "color": "#eee"
+                            }
+                        }, 
+                        "interpolate": "linear", 
+                        "legendPosition": "right", 
+                        "mode": "stacked", 
+                        "scale": "linear", 
+                        "seriesParams": [
+                            {
+                                "data": {
+                                    "id": "1", 
+                                    "label": "Count"
+                                }, 
+                                "drawLinesBetweenPoints": true, 
+                                "interpolate": "linear", 
+                                "mode": "stacked", 
+                                "show": "true", 
+                                "showCircles": true, 
+                                "type": "area", 
+                                "valueAxis": "ValueAxis-1"
+                            }
+                        ], 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "smoothLines": false, 
+                        "times": [], 
+                        "valueAxes": [
+                            {
+                                "id": "ValueAxis-1", 
+                                "labels": {
+                                    "filter": false, 
+                                    "rotate": 0, 
+                                    "show": true, 
+                                    "truncate": 100
+                                }, 
+                                "name": "LeftAxis-1", 
+                                "position": "left", 
+                                "scale": {
+                                    "mode": "normal", 
+                                    "type": "linear"
+                                }, 
+                                "show": true, 
+                                "style": {}, 
+                                "title": {
+                                    "text": "Count"
+                                }, 
+                                "type": "value"
+                            }
+                        ], 
+                        "yAxis": {}
+                    }, 
+                    "title": "Keyspaces [Metricbeat Redis] ECS", 
+                    "type": "area"
+                }
+            }, 
+            "col": 9, 
+            "id": "Redis-Keyspaces-ecs", 
+            "panelIndex": 7, 
+            "row": 1, 
+            "size_x": 4, 
+            "size_y": 3, 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "columns": [
+                    "_source"
+                ], 
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlight": {
+                            "fields": {
+                                "*": {}
+                            }, 
+                            "fragment_size": 2147483647, 
+                            "post_tags": [
+                                "@/kibana-highlighted-field@"
+                            ], 
+                            "pre_tags": [
+                                "@kibana-highlighted-field@"
+                            ], 
+                            "require_field_match": false
+                        }, 
+                        "index": "metricbeat-*", 
+                        "query": {
+                            "language": "kuery",
+                                "query": "event.module:redis"
+                            }
+                    }
+                }, 
+                "sort": [
+                    "@timestamp", 
+                    "desc"
+                ], 
+                "title": "Metricbeat Redis ECS", 
+                "version": 1
+            }, 
+            "id": "Metricbeat-Redis-ecs", 
+            "type": "search", 
+            "version": 7
+        }, 
+        {
+            "attributes": {
+                "description": "Overview of Redis server metrics",
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                                "query": {
+                            "language": "kuery",
+                            "query": ""
+                        },
+                        "highlightAll": true, 
+                        "version": true
+                    }
+                }, 
+                "optionsJSON": {
+                    "darkTheme": false
+                }, 
+                "panelsJSON": [
+                    {
+                        "col": 1, 
+                        "id": "Redis-Clients-Metrics-ecs", 
+                        "panelIndex": 2, 
+                        "row": 1, 
+                        "size_x": 3, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 4, 
+                        "id": "Redis-Connected-clients-ecs", 
+                        "panelIndex": 1, 
+                        "row": 1, 
+                        "size_x": 5, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "Redis-hosts-ecs", 
+                        "panelIndex": 3, 
+                        "row": 4, 
+                        "size_x": 12, 
+                        "size_y": 2, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "Redis-Server-Versions-ecs", 
+                        "panelIndex": 4, 
+                        "row": 6, 
+                        "size_x": 4, 
+                        "size_y": 2, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 5, 
+                        "id": "Redis-server-mode-ecs", 
+                        "panelIndex": 5, 
+                        "row": 6, 
+                        "size_x": 4, 
+                        "size_y": 2, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 9, 
+                        "id": "Redis-multiplexing-API-ecs", 
+                        "panelIndex": 6, 
+                        "row": 6, 
+                        "size_x": 3, 
+                        "size_y": 2, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 9, 
+                        "id": "Redis-Keyspaces-ecs", 
+                        "panelIndex": 7, 
+                        "row": 1, 
+                        "size_x": 4, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }
+                ], 
+                "timeRestore": false, 
+                "title": "[Metricbeat Redis] Overview ECS", 
+                "uiStateJSON": {
+                    "P-2": {
+                        "vis": {
+                            "defaultColors": {
+                                "0 - 100": "rgb(0,104,55)"
+                            }
+                        }
+                    }, 
+                    "P-3": {
+                        "vis": {
+                            "params": {
+                                "sort": {
+                                    "columnIndex": null, 
+                                    "direction": null
+                                }
+                            }
+                        }
+                    }, 
+                    "P-4": {
+                        "vis": {
+                            "legendOpen": true
+                        }
+                    }
+                }, 
+                "version": 1
+            }, 
+            "id": "AV4YjZ5pux-M-tCAunxK-ecs", 
+            "type": "dashboard", 
+            "version": 1
+        }
+    ], 
+    "version": "5.6.0-SNAPSHOT"
+}

--- a/dev/package-beats/redis-1.0.0/manifest.yml
+++ b/dev/package-beats/redis-1.0.0/manifest.yml
@@ -1,0 +1,14 @@
+name: redis
+title: Redis
+version: 1.0.0
+description: |
+  Redis metrics collected from Redis.
+type: ""
+categories:
+- logs
+- metrics
+requirement:
+  kibana:
+    version:
+      min: 6.7.0
+      max: 7.6.0

--- a/dev/package-beats/santa-1.0.0/kibana/dashboard/filebeat-santa-log-overview.json
+++ b/dev/package-beats/santa-1.0.0/kibana/dashboard/filebeat-santa-log-overview.json
@@ -1,0 +1,589 @@
+{
+    "objects": [
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                },
+                "title": "Description [Filebeat Santa] ECS",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "params": {
+                        "fontSize": 12,
+                        "markdown": "![Santa Icon](https://raw.githubusercontent.com/google/santa/master/Source/SantaGUI/Resources/Images.xcassets/AppIcon.appiconset/santa-hat-icon-128.png)\n\nGoogle Santa is a binary whitelisting/blacklisting system for macOS that monitors process executions.",
+                        "openLinksInNewTab": false
+                    },
+                    "title": "Description [Filebeat Santa] ECS",
+                    "type": "markdown"
+                }
+            },
+            "id": "dad521d0-ff69-11e8-93c5-d5ecd1b3e307-ecs",
+            "type": "visualization",
+            "updated_at": "2018-12-14T06:31:14.285Z",
+            "version": 1
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                },
+                "title": "Decisions [Filebeat Santa] ECS",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "params": {
+                        "axis_formatter": "number",
+                        "axis_position": "left",
+                        "axis_scale": "normal",
+                        "filter": "event.module:santa AND event.dataset:log",
+                        "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+                        "index_pattern": "filebeat-*",
+                        "interval": "auto",
+                        "series": [
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "#68BC00",
+                                "fill": 0.5,
+                                "formatter": "number",
+                                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                                "label": "Decision",
+                                "line_width": 1,
+                                "metrics": [
+                                    {
+                                        "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                                        "type": "count"
+                                    }
+                                ],
+                                "point_size": 1,
+                                "separate_axis": 0,
+                                "split_mode": "terms",
+                                "stacked": "none",
+                                "terms_field": "santa.decision"
+                            }
+                        ],
+                        "show_grid": 1,
+                        "show_legend": 1,
+                        "time_field": "@timestamp",
+                        "type": "timeseries"
+                    },
+                    "title": "Decisions [Filebeat Santa] ECS",
+                    "type": "metrics"
+                }
+            },
+            "id": "1579d690-ff6b-11e8-93c5-d5ecd1b3e307-ecs",
+            "type": "visualization",
+            "updated_at": "2018-12-14T06:40:02.169Z",
+            "version": 1
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                },
+                "savedSearchId": "6d56a010-ff6a-11e8-93c5-d5ecd1b3e307-ecs",
+                "title": "Total Events [Filebeat Santa] ECS",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true,
+                            "id": "1",
+                            "params": {
+                                "customLabel": "Total Events"
+                            },
+                            "schema": "metric",
+                            "type": "count"
+                        }
+                    ],
+                    "params": {
+                        "addLegend": false,
+                        "addTooltip": true,
+                        "metric": {
+                            "colorSchema": "Green to Red",
+                            "colorsRange": [
+                                {
+                                    "from": 0,
+                                    "to": 10000
+                                }
+                            ],
+                            "invertColors": false,
+                            "labels": {
+                                "show": true
+                            },
+                            "metricColorMode": "None",
+                            "percentageMode": false,
+                            "style": {
+                                "bgColor": false,
+                                "bgFill": "#000",
+                                "fontSize": 60,
+                                "labelColor": false,
+                                "subText": ""
+                            },
+                            "useRanges": false
+                        },
+                        "type": "metric"
+                    },
+                    "title": "Total Events [Filebeat Santa] ECS",
+                    "type": "metric"
+                }
+            },
+            "id": "51677b80-ff6b-11e8-93c5-d5ecd1b3e307-ecs",
+            "type": "visualization",
+            "updated_at": "2018-12-14T06:41:42.712Z",
+            "version": 1
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                },
+                "savedSearchId": "6d56a010-ff6a-11e8-93c5-d5ecd1b3e307-ecs",
+                "title": "Decision and Reason [Filebeat Santa] ECS",
+                "uiStateJSON": {
+                    "vis": {
+                        "colors": {
+                            "ALLOW": "#7EB26D"
+                        }
+                    }
+                },
+                "version": 1,
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true,
+                            "id": "1",
+                            "params": {},
+                            "schema": "metric",
+                            "type": "count"
+                        },
+                        {
+                            "enabled": true,
+                            "id": "2",
+                            "params": {
+                                "customLabel": "Decision",
+                                "field": "santa.decision",
+                                "missingBucket": false,
+                                "missingBucketLabel": "Missing",
+                                "order": "desc",
+                                "orderBy": "1",
+                                "otherBucket": false,
+                                "otherBucketLabel": "Other",
+                                "size": 5
+                            },
+                            "schema": "segment",
+                            "type": "terms"
+                        },
+                        {
+                            "enabled": true,
+                            "id": "3",
+                            "params": {
+                                "customLabel": "Reason",
+                                "field": "santa.reason",
+                                "missingBucket": false,
+                                "missingBucketLabel": "Missing",
+                                "order": "desc",
+                                "orderBy": "1",
+                                "otherBucket": false,
+                                "otherBucketLabel": "Other",
+                                "size": 5
+                            },
+                            "schema": "segment",
+                            "type": "terms"
+                        }
+                    ],
+                    "params": {
+                        "addLegend": true,
+                        "addTooltip": true,
+                        "isDonut": true,
+                        "labels": {
+                            "last_level": true,
+                            "show": false,
+                            "truncate": 100,
+                            "values": true
+                        },
+                        "legendPosition": "right",
+                        "type": "pie"
+                    },
+                    "title": "Decision and Reason [Filebeat Santa] ECS",
+                    "type": "pie"
+                }
+            },
+            "id": "30962fe0-ff6c-11e8-93c5-d5ecd1b3e307-ecs",
+            "type": "visualization",
+            "updated_at": "2018-12-14T06:47:57.150Z",
+            "version": 1
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                },
+                "savedSearchId": "6d56a010-ff6a-11e8-93c5-d5ecd1b3e307-ecs",
+                "title": "Num of Hosts Reporting [Filebeat Santa] ECS",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true,
+                            "id": "1",
+                            "params": {
+                                "customLabel": "Hosts Reporting",
+                                "field": "agent.hostname"
+                            },
+                            "schema": "metric",
+                            "type": "cardinality"
+                        }
+                    ],
+                    "params": {
+                        "addLegend": false,
+                        "addTooltip": true,
+                        "metric": {
+                            "colorSchema": "Green to Red",
+                            "colorsRange": [
+                                {
+                                    "from": 0,
+                                    "to": 10000
+                                }
+                            ],
+                            "invertColors": false,
+                            "labels": {
+                                "show": true
+                            },
+                            "metricColorMode": "None",
+                            "percentageMode": false,
+                            "style": {
+                                "bgColor": false,
+                                "bgFill": "#000",
+                                "fontSize": 60,
+                                "labelColor": false,
+                                "subText": ""
+                            },
+                            "useRanges": false
+                        },
+                        "type": "metric"
+                    },
+                    "title": "Num of Hosts Reporting [Filebeat Santa] ECS",
+                    "type": "metric"
+                }
+            },
+            "id": "b06c0460-ff6c-11e8-93c5-d5ecd1b3e307-ecs",
+            "type": "visualization",
+            "updated_at": "2018-12-14T06:51:31.622Z",
+            "version": 1
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                },
+                "savedSearchId": "6d56a010-ff6a-11e8-93c5-d5ecd1b3e307-ecs",
+                "title": "Code Signers [Filebeat Santa] ECS",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true,
+                            "id": "1",
+                            "params": {},
+                            "schema": "metric",
+                            "type": "count"
+                        },
+                        {
+                            "enabled": true,
+                            "id": "2",
+                            "params": {
+                                "field": "certificate.common_name",
+                                "missingBucket": false,
+                                "missingBucketLabel": "Missing",
+                                "order": "desc",
+                                "orderBy": "1",
+                                "otherBucket": false,
+                                "otherBucketLabel": "Other",
+                                "size": 5
+                            },
+                            "schema": "segment",
+                            "type": "terms"
+                        }
+                    ],
+                    "params": {
+                        "maxFontSize": 39,
+                        "minFontSize": 12,
+                        "orientation": "single",
+                        "scale": "linear",
+                        "showLabel": true
+                    },
+                    "title": "Code Signers [Filebeat Santa] ECS",
+                    "type": "tagcloud"
+                }
+            },
+            "id": "11858000-ff6d-11e8-93c5-d5ecd1b3e307-ecs",
+            "type": "visualization",
+            "updated_at": "2018-12-14T06:57:58.885Z",
+            "version": 2
+        },
+        {
+            "attributes": {
+                "columns": [
+                    "agent.hostname",
+                    "process.executable",
+                    "user.name",
+                    "certificate.common_name"
+                ],
+                "description": "",
+                "hits": 0,
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [
+                            {
+                                "$state": {
+                                    "store": "appState"
+                                },
+                                "meta": {
+                                    "alias": null,
+                                    "disabled": false,
+                                    "index": "filebeat-*",
+                                    "key": "event.module",
+                                    "negate": false,
+                                    "params": {
+                                        "query": "santa",
+                                        "type": "phrase"
+                                    },
+                                    "type": "phrase",
+                                    "value": "santa"
+                                },
+                                "query": {
+                                    "match": {
+                                        "event.module": {
+                                            "query": "santa",
+                                            "type": "phrase"
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "$state": {
+                                    "store": "appState"
+                                },
+                                "meta": {
+                                    "alias": null,
+                                    "disabled": false,
+                                    "index": "filebeat-*",
+                                    "key": "event.dataset",
+                                    "negate": false,
+                                    "params": {
+                                        "query": "log",
+                                        "type": "phrase"
+                                    },
+                                    "type": "phrase",
+                                    "value": "log"
+                                },
+                                "query": {
+                                    "match": {
+                                        "event.dataset": {
+                                            "query": "log",
+                                            "type": "phrase"
+                                        }
+                                    }
+                                }
+                            }
+                        ],
+                        "highlightAll": true,
+                        "index": "filebeat-*",
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        },
+                        "version": true
+                    }
+                },
+                "sort": [
+                    "@timestamp",
+                    "desc"
+                ],
+                "title": "Santa Logs Search [Filebeat Santa] ECS",
+                "version": 1
+            },
+            "id": "6d56a010-ff6a-11e8-93c5-d5ecd1b3e307-ecs",
+            "type": "search",
+            "updated_at": "2018-12-14T06:57:11.037Z",
+            "version": 2
+        },
+        {
+            "attributes": {
+                "description": "Process executions on macOS monitored by Google Santa.",
+                "hits": 0,
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                },
+                "optionsJSON": {
+                    "darkTheme": false,
+                    "hidePanelTitles": false,
+                    "useMargins": true
+                },
+                "panelsJSON": [
+                    {
+                        "embeddableConfig": {},
+                        "gridData": {
+                            "h": 12,
+                            "i": "1",
+                            "w": 10,
+                            "x": 0,
+                            "y": 0
+                        },
+                        "id": "dad521d0-ff69-11e8-93c5-d5ecd1b3e307-ecs",
+                        "panelIndex": "1",
+                        "type": "visualization",
+                        "version": "7.0.0-alpha1-SNAPSHOT"
+                    },
+                    {
+                        "embeddableConfig": {},
+                        "gridData": {
+                            "h": 12,
+                            "i": "2",
+                            "w": 38,
+                            "x": 10,
+                            "y": 0
+                        },
+                        "id": "1579d690-ff6b-11e8-93c5-d5ecd1b3e307-ecs",
+                        "panelIndex": "2",
+                        "type": "visualization",
+                        "version": "7.0.0-alpha1-SNAPSHOT"
+                    },
+                    {
+                        "embeddableConfig": {},
+                        "gridData": {
+                            "h": 10,
+                            "i": "3",
+                            "w": 10,
+                            "x": 8,
+                            "y": 12
+                        },
+                        "id": "51677b80-ff6b-11e8-93c5-d5ecd1b3e307-ecs",
+                        "panelIndex": "3",
+                        "type": "visualization",
+                        "version": "7.0.0-alpha1-SNAPSHOT"
+                    },
+                    {
+                        "embeddableConfig": {},
+                        "gridData": {
+                            "h": 10,
+                            "i": "4",
+                            "w": 12,
+                            "x": 36,
+                            "y": 12
+                        },
+                        "id": "30962fe0-ff6c-11e8-93c5-d5ecd1b3e307-ecs",
+                        "panelIndex": "4",
+                        "type": "visualization",
+                        "version": "7.0.0-alpha1-SNAPSHOT"
+                    },
+                    {
+                        "embeddableConfig": {},
+                        "gridData": {
+                            "h": 10,
+                            "i": "5",
+                            "w": 8,
+                            "x": 0,
+                            "y": 12
+                        },
+                        "id": "b06c0460-ff6c-11e8-93c5-d5ecd1b3e307-ecs",
+                        "panelIndex": "5",
+                        "type": "visualization",
+                        "version": "7.0.0-alpha1-SNAPSHOT"
+                    },
+                    {
+                        "embeddableConfig": {},
+                        "gridData": {
+                            "h": 10,
+                            "i": "6",
+                            "w": 18,
+                            "x": 18,
+                            "y": 12
+                        },
+                        "id": "11858000-ff6d-11e8-93c5-d5ecd1b3e307-ecs",
+                        "panelIndex": "6",
+                        "type": "visualization",
+                        "version": "7.0.0-alpha1-SNAPSHOT"
+                    },
+                    {
+                        "embeddableConfig": {},
+                        "gridData": {
+                            "h": 10,
+                            "i": "7",
+                            "w": 48,
+                            "x": 0,
+                            "y": 22
+                        },
+                        "id": "6d56a010-ff6a-11e8-93c5-d5ecd1b3e307-ecs",
+                        "panelIndex": "7",
+                        "type": "search",
+                        "version": "7.0.0-alpha1-SNAPSHOT"
+                    }
+                ],
+                "timeRestore": false,
+                "title": "[Filebeat Santa] Overview ECS",
+                "version": 1
+            },
+            "id": "161855f0-ff6a-11e8-93c5-d5ecd1b3e307-ecs",
+            "type": "dashboard",
+            "updated_at": "2018-12-14T06:58:23.367Z",
+            "version": 5
+        }
+    ],
+    "version": "7.0.0-alpha1-SNAPSHOT"
+}

--- a/dev/package-beats/santa-1.0.0/manifest.yml
+++ b/dev/package-beats/santa-1.0.0/manifest.yml
@@ -1,0 +1,13 @@
+name: santa
+title: Google Santa
+version: 1.0.0
+description: |
+  Santa Module
+type: ""
+categories:
+- logs
+requirement:
+  kibana:
+    version:
+      min: 6.7.0
+      max: 7.6.0

--- a/dev/package-beats/statsd-1.0.0/manifest.yml
+++ b/dev/package-beats/statsd-1.0.0/manifest.yml
@@ -1,0 +1,13 @@
+name: statsd
+title: Statsd
+version: 1.0.0
+description: |
+  Statsd module
+type: ""
+categories:
+- metrics
+requirement:
+  kibana:
+    version:
+      min: 6.7.0
+      max: 7.6.0

--- a/dev/package-beats/suricata-1.0.0/kibana/dashboard/Filebeat-Suricata-Alert-Overview.json
+++ b/dev/package-beats/suricata-1.0.0/kibana/dashboard/Filebeat-Suricata-Alert-Overview.json
@@ -1,0 +1,786 @@
+{
+  "objects": [
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "savedSearchId": "1c2bcec0-86d1-11e8-b59d-21efb914e65c-ecs",
+        "title": "Top Alerting Hosts [Filebeat Suricata] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customInterval": "2h",
+                "extended_bounds": {},
+                "field": "@timestamp",
+                "interval": "auto",
+                "min_doc_count": 1
+              },
+              "schema": "segment",
+              "type": "date_histogram"
+            },
+            {
+              "enabled": true,
+              "id": "3",
+              "params": {
+                "field": "host.name",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 10
+              },
+              "schema": "group",
+              "type": "terms"
+            }
+          ],
+          "params": {
+            "addLegend": true,
+            "addTimeMarker": false,
+            "addTooltip": true,
+            "categoryAxes": [
+              {
+                "id": "CategoryAxis-1",
+                "labels": {
+                  "show": true,
+                  "truncate": 100
+                },
+                "position": "bottom",
+                "scale": {
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {},
+                "type": "category"
+              }
+            ],
+            "grid": {
+              "categoryLines": false,
+              "style": {
+                "color": "#eee"
+              }
+            },
+            "legendPosition": "right",
+            "seriesParams": [
+              {
+                "data": {
+                  "id": "1",
+                  "label": "Count"
+                },
+                "drawLinesBetweenPoints": true,
+                "mode": "stacked",
+                "show": "true",
+                "showCircles": true,
+                "type": "histogram",
+                "valueAxis": "ValueAxis-1"
+              }
+            ],
+            "times": [],
+            "type": "histogram",
+            "valueAxes": [
+              {
+                "id": "ValueAxis-1",
+                "labels": {
+                  "filter": false,
+                  "rotate": 0,
+                  "show": true,
+                  "truncate": 100
+                },
+                "name": "LeftAxis-1",
+                "position": "left",
+                "scale": {
+                  "mode": "normal",
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {
+                  "text": "Count"
+                },
+                "type": "value"
+              }
+            ]
+          },
+          "title": "Top Alerting Hosts [Filebeat Suricata] ECS",
+          "type": "histogram"
+        }
+      },
+      "id": "494fa290-86d2-11e8-b59d-21efb914e65c-ecs",
+      "type": "visualization",
+      "updated_at": "2018-11-07T22:56:23.933Z",
+      "version": 1
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "savedSearchId": "1c2bcec0-86d1-11e8-b59d-21efb914e65c-ecs",
+        "title": "Top Alert Signatures [Filebeat Suricata] ECS",
+        "uiStateJSON": {
+          "vis": {
+            "params": {
+              "sort": {
+                "columnIndex": null,
+                "direction": null
+              }
+            }
+          }
+        },
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customLabel": "Alert Signature",
+                "field": "suricata.eve.alert.signature",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 10
+              },
+              "schema": "bucket",
+              "type": "terms"
+            },
+            {
+              "enabled": true,
+              "id": "3",
+              "params": {
+                "customLabel": "Alert Category",
+                "field": "suricata.eve.alert.category",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 5
+              },
+              "schema": "bucket",
+              "type": "terms"
+            }
+          ],
+          "params": {
+            "perPage": 10,
+            "showMetricsAtAllLevels": false,
+            "showPartialRows": false,
+            "showTotal": false,
+            "sort": {
+              "columnIndex": null,
+              "direction": null
+            },
+            "totalFunc": "sum"
+          },
+          "title": "Top Alert Signatures [Filebeat Suricata] ECS",
+          "type": "table"
+        }
+      },
+      "id": "16033310-86d3-11e8-b59d-21efb914e65c-ecs",
+      "type": "visualization",
+      "updated_at": "2018-11-07T22:56:23.933Z",
+      "version": 1
+    },
+    {
+      "attributes": {
+        "columns": [
+          "host.name",
+          "suricata.eve.flow_id",
+          "source.ip",
+          "source.port",
+          "destination.ip",
+          "destination.port",
+          "source.geo.country_iso_code",
+          "destination.geo.country_iso_code"
+        ],
+        "description": "",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [
+              {
+                "$state": {
+                  "store": "appState"
+                },
+                "meta": {
+                  "alias": null,
+                  "disabled": false,
+                  "index": "filebeat-*",
+                  "key": "suricata.eve.event_type",
+                  "negate": false,
+                  "params": {
+                    "query": "alert",
+                    "type": "phrase"
+                  },
+                  "type": "phrase",
+                  "value": "alert"
+                },
+                "query": {
+                  "match": {
+                    "suricata.eve.event_type": {
+                      "query": "alert",
+                      "type": "phrase"
+                    }
+                  }
+                }
+              },
+              {
+                "$state": {
+                  "store": "appState"
+                },
+                "meta": {
+                  "alias": null,
+                  "disabled": false,
+                  "index": "filebeat-*",
+                  "key": "event.module",
+                  "negate": false,
+                  "params": {
+                    "query": "suricata",
+                    "type": "phrase"
+                  },
+                  "type": "phrase",
+                  "value": "suricata"
+                },
+                "query": {
+                  "match": {
+                    "event.module": {
+                      "query": "suricata",
+                      "type": "phrase"
+                    }
+                  }
+                }
+              }
+            ],
+            "highlightAll": true,
+            "index": "filebeat-*",
+            "query": {
+              "language": "kuery",
+              "query": ""
+            },
+            "version": true
+          }
+        },
+        "sort": [
+          "@timestamp",
+          "desc"
+        ],
+        "title": "Alerts [Filebeat Suricata] ECS",
+        "version": 1
+      },
+      "id": "1c2bcec0-86d1-11e8-b59d-21efb914e65c-ecs",
+      "type": "search",
+      "updated_at": "2018-11-07T22:56:23.933Z",
+      "version": 1
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "savedSearchId": "1c2bcec0-86d1-11e8-b59d-21efb914e65c-ecs",
+        "title": "Alert - Source Location [Filebeat Suricata] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "autoPrecision": true,
+                "field": "source.geo.location",
+                "isFilteredByCollar": true,
+                "mapCenter": [
+                  0,
+                  0
+                ],
+                "mapZoom": 2,
+                "precision": 2,
+                "useGeocentroid": true
+              },
+              "schema": "segment",
+              "type": "geohash_grid"
+            }
+          ],
+          "params": {
+            "addTooltip": true,
+            "colorSchema": "Yellow to Red",
+            "heatClusterSize": 1.5,
+            "isDesaturated": true,
+            "legendPosition": "bottomright",
+            "mapCenter": [
+              0,
+              0
+            ],
+            "mapType": "Scaled Circle Markers",
+            "mapZoom": 2,
+            "wms": {
+              "baseLayersAreLoaded": {},
+              "enabled": false,
+              "options": {
+                "format": "image/png",
+                "transparent": true
+              },
+              "selectedTmsLayer": {
+                "attribution": "\u003cp\u003e\u0026#169; \u003ca href=\"http://www.openstreetmap.org/copyright\"\u003eOpenStreetMap\u003c/a\u003e contributors | \u003ca href=\"https://www.elastic.co/elastic-maps-service\"\u003eElastic Maps Service\u003c/a\u003e\u003c/p\u003e\u0026#10;",
+                "id": "road_map",
+                "maxZoom": 18,
+                "minZoom": 0,
+                "subdomains": [],
+                "url": "https://tiles.maps.elastic.co/v2/default/{z}/{x}/{y}.png?elastic_tile_service_tos=agree\u0026my_app_name=kibana\u0026my_app_version=6.3.0\u0026license=fc9de2c1-5f06-4080-8dd0-8a334171d89a"
+              },
+              "tmsLayers": [
+                {
+                  "attribution": "\u003cp\u003e\u0026#169; \u003ca href=\"http://www.openstreetmap.org/copyright\"\u003eOpenStreetMap\u003c/a\u003e contributors | \u003ca href=\"https://www.elastic.co/elastic-maps-service\"\u003eElastic Maps Service\u003c/a\u003e\u003c/p\u003e\u0026#10;",
+                  "id": "road_map",
+                  "maxZoom": 18,
+                  "minZoom": 0,
+                  "subdomains": [],
+                  "url": "https://tiles.maps.elastic.co/v2/default/{z}/{x}/{y}.png?elastic_tile_service_tos=agree\u0026my_app_name=kibana\u0026my_app_version=6.3.0\u0026license=fc9de2c1-5f06-4080-8dd0-8a334171d89a"
+                }
+              ]
+            }
+          },
+          "title": "Alert - Source Location [Filebeat Suricata] ECS",
+          "type": "tile_map"
+        }
+      },
+      "id": "85fed080-86d7-11e8-b59d-21efb914e65c-ecs",
+      "type": "visualization",
+      "updated_at": "2018-11-07T22:56:23.933Z",
+      "version": 1
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "savedSearchId": "1c2bcec0-86d1-11e8-b59d-21efb914e65c-ecs",
+        "title": "Alert - Destination Location [Filebeat Suricata] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "autoPrecision": true,
+                "field": "destination.geo.location",
+                "isFilteredByCollar": true,
+                "mapCenter": [
+                  0,
+                  0
+                ],
+                "mapZoom": 2,
+                "precision": 2,
+                "useGeocentroid": true
+              },
+              "schema": "segment",
+              "type": "geohash_grid"
+            }
+          ],
+          "params": {
+            "addTooltip": true,
+            "colorSchema": "Yellow to Red",
+            "heatClusterSize": 1.5,
+            "isDesaturated": true,
+            "legendPosition": "bottomright",
+            "mapCenter": [
+              0,
+              0
+            ],
+            "mapType": "Scaled Circle Markers",
+            "mapZoom": 2,
+            "wms": {
+              "baseLayersAreLoaded": {},
+              "enabled": false,
+              "options": {
+                "format": "image/png",
+                "transparent": true
+              },
+              "selectedTmsLayer": {
+                "attribution": "\u003cp\u003e\u0026#169; \u003ca href=\"http://www.openstreetmap.org/copyright\"\u003eOpenStreetMap\u003c/a\u003e contributors | \u003ca href=\"https://www.elastic.co/elastic-maps-service\"\u003eElastic Maps Service\u003c/a\u003e\u003c/p\u003e\u0026#10;",
+                "id": "road_map",
+                "maxZoom": 18,
+                "minZoom": 0,
+                "subdomains": [],
+                "url": "https://tiles.maps.elastic.co/v2/default/{z}/{x}/{y}.png?elastic_tile_service_tos=agree\u0026my_app_name=kibana\u0026my_app_version=6.3.0\u0026license=fc9de2c1-5f06-4080-8dd0-8a334171d89a"
+              },
+              "tmsLayers": [
+                {
+                  "attribution": "\u003cp\u003e\u0026#169; \u003ca href=\"http://www.openstreetmap.org/copyright\"\u003eOpenStreetMap\u003c/a\u003e contributors | \u003ca href=\"https://www.elastic.co/elastic-maps-service\"\u003eElastic Maps Service\u003c/a\u003e\u003c/p\u003e\u0026#10;",
+                  "id": "road_map",
+                  "maxZoom": 18,
+                  "minZoom": 0,
+                  "subdomains": [],
+                  "url": "https://tiles.maps.elastic.co/v2/default/{z}/{x}/{y}.png?elastic_tile_service_tos=agree\u0026my_app_name=kibana\u0026my_app_version=6.3.0\u0026license=fc9de2c1-5f06-4080-8dd0-8a334171d89a"
+                }
+              ]
+            }
+          },
+          "title": "Alert - Destination Location [Filebeat Suricata] ECS",
+          "type": "tile_map"
+        }
+      },
+      "id": "a09ca070-86d7-11e8-b59d-21efb914e65c-ecs",
+      "type": "visualization",
+      "updated_at": "2018-11-07T22:56:23.933Z",
+      "version": 1
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "savedSearchId": "1c2bcec0-86d1-11e8-b59d-21efb914e65c-ecs",
+        "title": "Alerts - Top Destination Countries [Filebeat Suricata] ECS",
+        "uiStateJSON": {
+          "vis": {
+            "params": {
+              "sort": {
+                "columnIndex": null,
+                "direction": null
+              }
+            }
+          }
+        },
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customLabel": "Source Country",
+                "field": "destination.geo.country_iso_code",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 10
+              },
+              "schema": "bucket",
+              "type": "terms"
+            }
+          ],
+          "params": {
+            "perPage": 5,
+            "showMetricsAtAllLevels": false,
+            "showPartialRows": false,
+            "showTotal": false,
+            "sort": {
+              "columnIndex": null,
+              "direction": null
+            },
+            "totalFunc": "sum"
+          },
+          "title": "Alerts - Top Destination Countries [Filebeat Suricata] ECS",
+          "type": "table"
+        }
+      },
+      "id": "2ccdc1a0-86d8-11e8-b59d-21efb914e65c-ecs",
+      "type": "visualization",
+      "updated_at": "2018-11-07T22:56:23.933Z",
+      "version": 1
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "savedSearchId": "1c2bcec0-86d1-11e8-b59d-21efb914e65c-ecs",
+        "title": "Alerts - Top Source Countries [Filebeat Suricata] ECS",
+        "uiStateJSON": {
+          "vis": {
+            "params": {
+              "sort": {
+                "columnIndex": null,
+                "direction": null
+              }
+            }
+          }
+        },
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customLabel": "Source Country",
+                "field": "source.geo.country_iso_code",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 10
+              },
+              "schema": "bucket",
+              "type": "terms"
+            }
+          ],
+          "params": {
+            "perPage": 5,
+            "showMetricsAtAllLevels": false,
+            "showPartialRows": false,
+            "showTotal": false,
+            "sort": {
+              "columnIndex": null,
+              "direction": null
+            },
+            "totalFunc": "sum"
+          },
+          "title": "Alerts - Top Source Countries [Filebeat Suricata] ECS",
+          "type": "table"
+        }
+      },
+      "id": "c7b8b8f0-86d8-11e8-b59d-21efb914e65c-ecs",
+      "type": "visualization",
+      "updated_at": "2018-11-07T22:56:23.933Z",
+      "version": 1
+    },
+    {
+      "attributes": {
+        "description": "Overview of the Suricata Alerts dashboard.",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "highlightAll": true,
+            "query": {
+              "language": "kuery",
+              "query": ""
+            },
+            "version": true
+          }
+        },
+        "optionsJSON": {
+          "darkTheme": false,
+          "hidePanelTitles": false,
+          "useMargins": true
+        },
+        "panelsJSON": [
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 10,
+              "i": "1",
+              "w": 23,
+              "x": 0,
+              "y": 0
+            },
+            "id": "494fa290-86d2-11e8-b59d-21efb914e65c-ecs",
+            "panelIndex": "1",
+            "type": "visualization",
+            "version": "6.3.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 22,
+              "i": "2",
+              "w": 25,
+              "x": 23,
+              "y": 0
+            },
+            "id": "16033310-86d3-11e8-b59d-21efb914e65c-ecs",
+            "panelIndex": "2",
+            "type": "visualization",
+            "version": "6.3.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 16,
+              "i": "3",
+              "w": 48,
+              "x": 0,
+              "y": 37
+            },
+            "id": "1c2bcec0-86d1-11e8-b59d-21efb914e65c-ecs",
+            "panelIndex": "3",
+            "type": "search",
+            "version": "6.3.0"
+          },
+          {
+            "embeddableConfig": {
+              "mapCenter": [
+                38.548165423046584,
+                -6.328125000000001
+              ],
+              "mapZoom": 2
+            },
+            "gridData": {
+              "h": 15,
+              "i": "4",
+              "w": 23,
+              "x": 0,
+              "y": 22
+            },
+            "id": "85fed080-86d7-11e8-b59d-21efb914e65c-ecs",
+            "panelIndex": "4",
+            "type": "visualization",
+            "version": "6.3.0"
+          },
+          {
+            "embeddableConfig": {
+              "mapCenter": [
+                41.77131167976407,
+                1.9335937500000002
+              ],
+              "mapZoom": 2
+            },
+            "gridData": {
+              "h": 15,
+              "i": "5",
+              "w": 25,
+              "x": 23,
+              "y": 22
+            },
+            "id": "a09ca070-86d7-11e8-b59d-21efb914e65c-ecs",
+            "panelIndex": "5",
+            "type": "visualization",
+            "version": "6.3.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 12,
+              "i": "7",
+              "w": 12,
+              "x": 11,
+              "y": 10
+            },
+            "id": "2ccdc1a0-86d8-11e8-b59d-21efb914e65c-ecs",
+            "panelIndex": "7",
+            "type": "visualization",
+            "version": "6.3.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 12,
+              "i": "8",
+              "w": 11,
+              "x": 0,
+              "y": 10
+            },
+            "id": "c7b8b8f0-86d8-11e8-b59d-21efb914e65c-ecs",
+            "panelIndex": "8",
+            "type": "visualization",
+            "version": "6.3.0"
+          }
+        ],
+        "timeRestore": false,
+        "title": "[Filebeat Suricata] Alert Overview ECS",
+        "version": 1
+      },
+      "id": "05268ee0-86d1-11e8-b59d-21efb914e65c-ecs",
+      "type": "dashboard",
+      "updated_at": "2018-11-07T22:56:23.933Z",
+      "version": 1
+    }
+  ],
+  "version": "6.4.3"
+}

--- a/dev/package-beats/suricata-1.0.0/kibana/dashboard/Filebeat-Suricata-Overview.json
+++ b/dev/package-beats/suricata-1.0.0/kibana/dashboard/Filebeat-Suricata-Overview.json
@@ -1,0 +1,919 @@
+{
+  "objects": [
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "savedSearchId": "13dd22f0-86cc-11e8-b59d-21efb914e65c-ecs",
+        "title": "Activity Types over Time [Filebeat Suricata] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customInterval": "2h",
+                "extended_bounds": {},
+                "field": "@timestamp",
+                "interval": "auto",
+                "min_doc_count": 1
+              },
+              "schema": "segment",
+              "type": "date_histogram"
+            },
+            {
+              "enabled": true,
+              "id": "3",
+              "params": {
+                "field": "suricata.eve.event_type",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 20
+              },
+              "schema": "group",
+              "type": "terms"
+            }
+          ],
+          "params": {
+            "addLegend": true,
+            "addTimeMarker": false,
+            "addTooltip": true,
+            "categoryAxes": [
+              {
+                "id": "CategoryAxis-1",
+                "labels": {
+                  "show": true,
+                  "truncate": 100
+                },
+                "position": "bottom",
+                "scale": {
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {},
+                "type": "category"
+              }
+            ],
+            "grid": {
+              "categoryLines": false,
+              "style": {
+                "color": "#eee"
+              }
+            },
+            "legendPosition": "right",
+            "seriesParams": [
+              {
+                "data": {
+                  "id": "1",
+                  "label": "Count"
+                },
+                "drawLinesBetweenPoints": true,
+                "mode": "stacked",
+                "show": "true",
+                "showCircles": true,
+                "type": "histogram",
+                "valueAxis": "ValueAxis-1"
+              }
+            ],
+            "times": [],
+            "type": "histogram",
+            "valueAxes": [
+              {
+                "id": "ValueAxis-1",
+                "labels": {
+                  "filter": false,
+                  "rotate": 0,
+                  "show": true,
+                  "truncate": 100
+                },
+                "name": "LeftAxis-1",
+                "position": "left",
+                "scale": {
+                  "mode": "normal",
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {
+                  "text": "Count"
+                },
+                "type": "value"
+              }
+            ]
+          },
+          "title": "Activity Types over Time [Filebeat Suricata] ECS",
+          "type": "histogram"
+        }
+      },
+      "id": "c7d46c60-86da-11e8-b59d-21efb914e65c-ecs",
+      "type": "visualization",
+      "updated_at": "2018-11-07T22:56:24.962Z",
+      "version": 1
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "savedSearchId": "13dd22f0-86cc-11e8-b59d-21efb914e65c-ecs",
+        "title": "Event Types [Filebeat Suricata] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "field": "suricata.eve.event_type",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 20
+              },
+              "schema": "segment",
+              "type": "terms"
+            }
+          ],
+          "params": {
+            "addLegend": true,
+            "addTooltip": true,
+            "isDonut": true,
+            "labels": {
+              "last_level": true,
+              "show": false,
+              "truncate": 100,
+              "values": true
+            },
+            "legendPosition": "bottom",
+            "type": "pie"
+          },
+          "title": "Event Types [Filebeat Suricata] ECS",
+          "type": "pie"
+        }
+      },
+      "id": "0a0aa630-86db-11e8-b59d-21efb914e65c-ecs",
+      "type": "visualization",
+      "updated_at": "2018-11-07T22:56:24.962Z",
+      "version": 1
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "savedSearchId": "13dd22f0-86cc-11e8-b59d-21efb914e65c-ecs",
+        "title": "Top Application Protocols [Filebeat Suricata] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "field": "network.protocol",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 10
+              },
+              "schema": "segment",
+              "type": "terms"
+            }
+          ],
+          "params": {
+            "addLegend": true,
+            "addTooltip": true,
+            "isDonut": true,
+            "labels": {
+              "last_level": true,
+              "show": false,
+              "truncate": 100,
+              "values": true
+            },
+            "legendPosition": "bottom",
+            "type": "pie"
+          },
+          "title": "Top Application Protocols [Filebeat Suricata] ECS",
+          "type": "pie"
+        }
+      },
+      "id": "728f64c0-86db-11e8-b59d-21efb914e65c-ecs",
+      "type": "visualization",
+      "updated_at": "2018-11-07T22:56:24.962Z",
+      "version": 1
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "savedSearchId": "13dd22f0-86cc-11e8-b59d-21efb914e65c-ecs",
+        "title": "Top Hosts Generating Events [Filebeat Suricata] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customInterval": "2h",
+                "extended_bounds": {},
+                "field": "@timestamp",
+                "interval": "auto",
+                "min_doc_count": 1
+              },
+              "schema": "segment",
+              "type": "date_histogram"
+            },
+            {
+              "enabled": true,
+              "id": "3",
+              "params": {
+                "field": "host.name",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 10
+              },
+              "schema": "group",
+              "type": "terms"
+            }
+          ],
+          "params": {
+            "addLegend": true,
+            "addTimeMarker": false,
+            "addTooltip": true,
+            "categoryAxes": [
+              {
+                "id": "CategoryAxis-1",
+                "labels": {
+                  "show": true,
+                  "truncate": 100
+                },
+                "position": "bottom",
+                "scale": {
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {},
+                "type": "category"
+              }
+            ],
+            "grid": {
+              "categoryLines": false,
+              "style": {
+                "color": "#eee"
+              }
+            },
+            "legendPosition": "right",
+            "seriesParams": [
+              {
+                "data": {
+                  "id": "1",
+                  "label": "Count"
+                },
+                "drawLinesBetweenPoints": true,
+                "mode": "stacked",
+                "show": "true",
+                "showCircles": true,
+                "type": "histogram",
+                "valueAxis": "ValueAxis-1"
+              }
+            ],
+            "times": [],
+            "type": "histogram",
+            "valueAxes": [
+              {
+                "id": "ValueAxis-1",
+                "labels": {
+                  "filter": false,
+                  "rotate": 0,
+                  "show": true,
+                  "truncate": 100
+                },
+                "name": "LeftAxis-1",
+                "position": "left",
+                "scale": {
+                  "mode": "normal",
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {
+                  "text": "Count"
+                },
+                "type": "value"
+              }
+            ]
+          },
+          "title": "Top Hosts Generating Events [Filebeat Suricata] ECS",
+          "type": "histogram"
+        }
+      },
+      "id": "9d5b5b50-86db-11e8-b59d-21efb914e65c-ecs",
+      "type": "visualization",
+      "updated_at": "2018-11-07T22:56:24.962Z",
+      "version": 1
+    },
+    {
+      "attributes": {
+        "columns": [
+          "host.name",
+          "suricata.eve.event_type",
+          "suricata.eve.flow_id",
+          "network.transport",
+          "source.ip",
+          "source.port",
+          "destination.ip",
+          "destination.port",
+          "destination.geo.region_name",
+          "destination.geo.country_iso_code"
+        ],
+        "description": "",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [
+              {
+                "$state": {
+                  "store": "appState"
+                },
+                "meta": {
+                  "alias": null,
+                  "disabled": false,
+                  "index": "filebeat-*",
+                  "key": "suricata.eve.event_type",
+                  "negate": true,
+                  "params": {
+                    "query": "stats",
+                    "type": "phrase"
+                  },
+                  "type": "phrase",
+                  "value": "stats"
+                },
+                "query": {
+                  "match": {
+                    "suricata.eve.event_type": {
+                      "query": "stats",
+                      "type": "phrase"
+                    }
+                  }
+                }
+              },
+              {
+                "$state": {
+                  "store": "appState"
+                },
+                "meta": {
+                  "alias": null,
+                  "disabled": false,
+                  "index": "filebeat-*",
+                  "key": "event.module",
+                  "negate": false,
+                  "params": {
+                    "query": "suricata",
+                    "type": "phrase"
+                  },
+                  "type": "phrase",
+                  "value": "suricata"
+                },
+                "query": {
+                  "match": {
+                    "event.module": {
+                      "query": "suricata",
+                      "type": "phrase"
+                    }
+                  }
+                }
+              }
+            ],
+            "highlightAll": true,
+            "index": "filebeat-*",
+            "query": {
+              "language": "kuery",
+              "query": ""
+            },
+            "version": true
+          }
+        },
+        "sort": [
+          "@timestamp",
+          "desc"
+        ],
+        "title": "Events [Filebeat Suricata] ECS",
+        "version": 1
+      },
+      "id": "13dd22f0-86cc-11e8-b59d-21efb914e65c-ecs",
+      "type": "search",
+      "updated_at": "2018-11-07T22:56:24.962Z",
+      "version": 1
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "savedSearchId": "13dd22f0-86cc-11e8-b59d-21efb914e65c-ecs",
+        "title": "Top Connection Source Countries [Filebeat Suricata] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customLabel": "Top Connection Source Countries",
+                "field": "source.geo.country_iso_code",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 10
+              },
+              "schema": "segment",
+              "type": "terms"
+            }
+          ],
+          "params": {
+            "maxFontSize": 72,
+            "minFontSize": 18,
+            "orientation": "single",
+            "scale": "linear",
+            "showLabel": true
+          },
+          "title": "Top Connection Source Countries [Filebeat Suricata] ECS",
+          "type": "tagcloud"
+        }
+      },
+      "id": "5f99eb50-86dc-11e8-b59d-21efb914e65c-ecs",
+      "type": "visualization",
+      "updated_at": "2018-11-07T22:56:24.962Z",
+      "version": 1
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "savedSearchId": "13dd22f0-86cc-11e8-b59d-21efb914e65c-ecs",
+        "title": "Top Connection Destination Countries [Filebeat Suricata] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customLabel": "Top Connection Destination Countries",
+                "field": "destination.geo.country_iso_code",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 10
+              },
+              "schema": "segment",
+              "type": "terms"
+            }
+          ],
+          "params": {
+            "maxFontSize": 72,
+            "minFontSize": 18,
+            "orientation": "single",
+            "scale": "linear",
+            "showLabel": true
+          },
+          "title": "Top Connection Destination Countries [Filebeat Suricata] ECS",
+          "type": "tagcloud"
+        }
+      },
+      "id": "8e7f88d0-86dc-11e8-b59d-21efb914e65c-ecs",
+      "type": "visualization",
+      "updated_at": "2018-11-07T22:56:24.962Z",
+      "version": 1
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "savedSearchId": "13dd22f0-86cc-11e8-b59d-21efb914e65c-ecs",
+        "title": "Top Network Protocols [Filebeat Suricata] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "field": "network.transport",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 10
+              },
+              "schema": "segment",
+              "type": "terms"
+            }
+          ],
+          "params": {
+            "addLegend": true,
+            "addTooltip": true,
+            "isDonut": true,
+            "labels": {
+              "last_level": true,
+              "show": false,
+              "truncate": 100,
+              "values": true
+            },
+            "legendPosition": "bottom",
+            "type": "pie"
+          },
+          "title": "Top Network Protocols [Filebeat Suricata] ECS",
+          "type": "pie"
+        }
+      },
+      "id": "0a363820-86dd-11e8-b59d-21efb914e65c-ecs",
+      "type": "visualization",
+      "updated_at": "2018-11-07T22:56:24.962Z",
+      "version": 1
+    },
+    {
+      "attributes": {
+        "columns": [
+          "host.name",
+          "suricata.eve.stats.detect.alert",
+          "suricata.eve.stats.app_layer.flow.dns_udp",
+          "suricata.eve.stats.app_layer.flow.tls",
+          "suricata.eve.stats.app_layer.flow.http",
+          "suricata.eve.stats.app_layer.flow.ssh",
+          "suricata.eve.stats.tcp.sessions"
+        ],
+        "description": "",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [
+              {
+                "$state": {
+                  "store": "appState"
+                },
+                "meta": {
+                  "alias": null,
+                  "disabled": false,
+                  "index": "filebeat-*",
+                  "key": "suricata.eve.event_type",
+                  "negate": false,
+                  "params": {
+                    "query": "stats",
+                    "type": "phrase"
+                  },
+                  "type": "phrase",
+                  "value": "stats"
+                },
+                "query": {
+                  "match": {
+                    "suricata.eve.event_type": {
+                      "query": "stats",
+                      "type": "phrase"
+                    }
+                  }
+                }
+              },
+              {
+                "$state": {
+                  "store": "appState"
+                },
+                "meta": {
+                  "alias": null,
+                  "disabled": false,
+                  "index": "filebeat-*",
+                  "key": "event.module",
+                  "negate": false,
+                  "params": {
+                    "query": "suricata",
+                    "type": "phrase"
+                  },
+                  "type": "phrase",
+                  "value": "suricata"
+                },
+                "query": {
+                  "match": {
+                    "event.module": {
+                      "query": "suricata",
+                      "type": "phrase"
+                    }
+                  }
+                }
+              }
+            ],
+            "highlightAll": true,
+            "index": "filebeat-*",
+            "query": {
+              "language": "kuery",
+              "query": ""
+            },
+            "version": true
+          }
+        },
+        "sort": [
+          "@timestamp",
+          "desc"
+        ],
+        "title": "Host Stats [Filebeat Suricata] ECS",
+        "version": 1
+      },
+      "id": "d57a2db0-86ca-11e8-b59d-21efb914e65c-ecs",
+      "type": "search",
+      "updated_at": "2018-11-07T22:56:24.962Z",
+      "version": 1
+    },
+    {
+      "attributes": {
+        "description": "Overview of the Surcata events dashboard.",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "highlightAll": true,
+            "query": {
+              "language": "kuery",
+              "query": ""
+            },
+            "version": true
+          }
+        },
+        "optionsJSON": {
+          "darkTheme": false,
+          "hidePanelTitles": false,
+          "useMargins": true
+        },
+        "panelsJSON": [
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 10,
+              "i": "1",
+              "w": 48,
+              "x": 0,
+              "y": 0
+            },
+            "id": "c7d46c60-86da-11e8-b59d-21efb914e65c-ecs",
+            "panelIndex": "1",
+            "type": "visualization",
+            "version": "6.3.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 14,
+              "i": "2",
+              "w": 9,
+              "x": 0,
+              "y": 20
+            },
+            "id": "0a0aa630-86db-11e8-b59d-21efb914e65c-ecs",
+            "panelIndex": "2",
+            "type": "visualization",
+            "version": "6.3.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 14,
+              "i": "3",
+              "w": 11,
+              "x": 19,
+              "y": 20
+            },
+            "id": "728f64c0-86db-11e8-b59d-21efb914e65c-ecs",
+            "panelIndex": "3",
+            "type": "visualization",
+            "version": "6.3.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 10,
+              "i": "4",
+              "w": 48,
+              "x": 0,
+              "y": 10
+            },
+            "id": "9d5b5b50-86db-11e8-b59d-21efb914e65c-ecs",
+            "panelIndex": "4",
+            "type": "visualization",
+            "version": "6.3.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 19,
+              "i": "5",
+              "w": 48,
+              "x": 0,
+              "y": 34
+            },
+            "id": "13dd22f0-86cc-11e8-b59d-21efb914e65c-ecs",
+            "panelIndex": "5",
+            "type": "search",
+            "version": "6.3.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 14,
+              "i": "6",
+              "w": 9,
+              "x": 30,
+              "y": 20
+            },
+            "id": "5f99eb50-86dc-11e8-b59d-21efb914e65c-ecs",
+            "panelIndex": "6",
+            "type": "visualization",
+            "version": "6.3.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 14,
+              "i": "7",
+              "w": 9,
+              "x": 39,
+              "y": 20
+            },
+            "id": "8e7f88d0-86dc-11e8-b59d-21efb914e65c-ecs",
+            "panelIndex": "7",
+            "type": "visualization",
+            "version": "6.3.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 14,
+              "i": "8",
+              "w": 10,
+              "x": 9,
+              "y": 20
+            },
+            "id": "0a363820-86dd-11e8-b59d-21efb914e65c-ecs",
+            "panelIndex": "8",
+            "type": "visualization",
+            "version": "6.3.0"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 16,
+              "i": "9",
+              "w": 48,
+              "x": 0,
+              "y": 53
+            },
+            "id": "d57a2db0-86ca-11e8-b59d-21efb914e65c-ecs",
+            "panelIndex": "9",
+            "type": "search",
+            "version": "6.3.0"
+          }
+        ],
+        "timeRestore": false,
+        "title": "[Filebeat Suricata] Events Overview ECS",
+        "version": 1
+      },
+      "id": "78289c40-86da-11e8-b59d-21efb914e65c-ecs",
+      "type": "dashboard",
+      "updated_at": "2018-11-07T22:56:24.962Z",
+      "version": 1
+    }
+  ],
+  "version": "6.4.3"
+}

--- a/dev/package-beats/suricata-1.0.0/manifest.yml
+++ b/dev/package-beats/suricata-1.0.0/manifest.yml
@@ -1,0 +1,13 @@
+name: suricata
+title: Suricata
+version: 1.0.0
+description: |
+  Module for handling the EVE JSON logs produced by Suricata.
+type: ""
+categories:
+- logs
+requirement:
+  kibana:
+    version:
+      min: 6.7.0
+      max: 7.6.0

--- a/dev/package-beats/system-1.0.0/kibana/dashboard/Filebeat-auth-sudo-commands.json
+++ b/dev/package-beats/system-1.0.0/kibana/dashboard/Filebeat-auth-sudo-commands.json
@@ -1,0 +1,350 @@
+{
+    "objects": [
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                },
+                "savedSearchId": "b6f321e0-fa25-11e6-bbd3-29c986c96e5a-ecs",
+                "title": "Sudo commands by user [Filebeat System] ECS",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true,
+                            "id": "1",
+                            "params": {},
+                            "schema": "metric",
+                            "type": "count"
+                        },
+                        {
+                            "enabled": true,
+                            "id": "2",
+                            "params": {
+                                "customInterval": "2h",
+                                "extended_bounds": {},
+                                "field": "@timestamp",
+                                "interval": "auto",
+                                "min_doc_count": 1
+                            },
+                            "schema": "segment",
+                            "type": "date_histogram"
+                        },
+                        {
+                            "enabled": true,
+                            "id": "3",
+                            "params": {
+                                "field": "user.name",
+                                "order": "desc",
+                                "orderBy": "1",
+                                "size": 5
+                            },
+                            "schema": "group",
+                            "type": "terms"
+                        }
+                    ],
+                    "listeners": {},
+                    "params": {
+                        "addLegend": true,
+                        "addTimeMarker": false,
+                        "addTooltip": true,
+                        "defaultYExtents": false,
+                        "legendPosition": "right",
+                        "mode": "stacked",
+                        "scale": "linear",
+                        "setYExtents": false,
+                        "times": []
+                    },
+                    "title": "Sudo commands by user ECS",
+                    "type": "histogram"
+                }
+            },
+            "id": "5c7af030-fa2a-11e6-bbd3-29c986c96e5a-ecs",
+            "type": "visualization",
+            "version": 2
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "highlightAll": true,
+                        "index": "filebeat-*",
+                        "query": {
+                            "language": "kuery",
+                            "query": "system.auth.sudo.error:*"
+                        }
+                    }
+                },
+                "title": "Sudo errors [Filebeat System] ECS",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true,
+                            "id": "1",
+                            "params": {},
+                            "schema": "metric",
+                            "type": "count"
+                        },
+                        {
+                            "enabled": true,
+                            "id": "2",
+                            "params": {
+                                "customInterval": "2h",
+                                "extended_bounds": {},
+                                "field": "@timestamp",
+                                "interval": "auto",
+                                "min_doc_count": 1
+                            },
+                            "schema": "segment",
+                            "type": "date_histogram"
+                        },
+                        {
+                            "enabled": true,
+                            "id": "3",
+                            "params": {
+                                "field": "system.auth.sudo.error",
+                                "order": "desc",
+                                "orderBy": "1",
+                                "size": 5
+                            },
+                            "schema": "group",
+                            "type": "terms"
+                        }
+                    ],
+                    "listeners": {},
+                    "params": {
+                        "addLegend": true,
+                        "addTimeMarker": false,
+                        "addTooltip": true,
+                        "defaultYExtents": false,
+                        "legendPosition": "right",
+                        "mode": "stacked",
+                        "scale": "linear",
+                        "setYExtents": false,
+                        "times": []
+                    },
+                    "title": "Sudo errors ECS",
+                    "type": "histogram"
+                }
+            },
+            "id": "51164310-fa2b-11e6-bbd3-29c986c96e5a-ecs",
+            "type": "visualization",
+            "version": 2
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                },
+                "savedSearchId": "b6f321e0-fa25-11e6-bbd3-29c986c96e5a-ecs",
+                "title": "Top sudo commands [Filebeat System] ECS",
+                "uiStateJSON": {
+                    "vis": {
+                        "params": {
+                            "sort": {
+                                "columnIndex": null,
+                                "direction": null
+                            }
+                        }
+                    }
+                },
+                "version": 1,
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true,
+                            "id": "1",
+                            "params": {},
+                            "schema": "metric",
+                            "type": "count"
+                        },
+                        {
+                            "enabled": true,
+                            "id": "2",
+                            "params": {
+                                "field": "system.auth.sudo.command",
+                                "order": "desc",
+                                "orderBy": "1",
+                                "size": 5
+                            },
+                            "schema": "bucket",
+                            "type": "terms"
+                        },
+                        {
+                            "enabled": true,
+                            "id": "3",
+                            "params": {
+                                "field": "user.name",
+                                "order": "desc",
+                                "orderBy": "1",
+                                "size": 5
+                            },
+                            "schema": "bucket",
+                            "type": "terms"
+                        }
+                    ],
+                    "listeners": {},
+                    "params": {
+                        "perPage": 10,
+                        "showMeticsAtAllLevels": false,
+                        "showPartialRows": false,
+                        "showTotal": false,
+                        "sort": {
+                            "columnIndex": null,
+                            "direction": null
+                        },
+                        "totalFunc": "sum"
+                    },
+                    "title": "Top sudo commands ECS",
+                    "type": "table"
+                }
+            },
+            "id": "dc589770-fa2b-11e6-bbd3-29c986c96e5a-ecs",
+            "type": "visualization",
+            "version": 2
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                },
+                "title": "Dashboards [Filebeat System] ECS",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "params": {
+                        "fontSize": 12,
+                        "markdown": "[Syslog](#/dashboard/Filebeat-syslog-dashboard-ecs) | [Sudo commands](#/dashboard/277876d0-fa2c-11e6-bbd3-29c986c96e5a-ecs) | [SSH logins](#/dashboard/5517a150-f9ce-11e6-8115-a7c18106d86a-ecs) | [New users and groups](#/dashboard/0d3f2380-fa78-11e6-ae9b-81e5311e8cab-ecs)"
+                    },
+                    "title": "Dashboards [Filebeat System] ECS",
+                    "type": "markdown"
+                }
+            },
+            "id": "327417e0-8462-11e7-bab8-bd2f0fb42c54-ecs",
+            "type": "visualization",
+            "version": 1
+        },
+        {
+            "attributes": {
+                "columns": [
+                    "user.name",
+                    "system.auth.sudo.user",
+                    "system.auth.sudo.pwd",
+                    "system.auth.sudo.command"
+                ],
+                "description": "",
+                "hits": 0,
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "highlightAll": true,
+                        "index": "filebeat-*",
+                        "query": {
+                            "language": "kuery",
+                            "query": "system.auth.sudo:*"
+                        }
+                    }
+                },
+                "sort": [
+                    "@timestamp",
+                    "desc"
+                ],
+                "title": "Sudo commands [Filebeat System] ECS",
+                "version": 1
+            },
+            "id": "b6f321e0-fa25-11e6-bbd3-29c986c96e5a-ecs",
+            "type": "search",
+            "version": 2
+        },
+        {
+            "attributes": {
+                "description": "Sudo commands dashboard from the Filebeat System module",
+                "hits": 0,
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "highlightAll": true,
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        },
+                        "version": true
+                    }
+                },
+                "optionsJSON": {
+                    "darkTheme": false
+                },
+                "panelsJSON": [
+                    {
+                        "col": 1,
+                        "id": "5c7af030-fa2a-11e6-bbd3-29c986c96e5a-ecs",
+                        "panelIndex": 1,
+                        "row": 6,
+                        "size_x": 12,
+                        "size_y": 4,
+                        "type": "visualization"
+                    },
+                    {
+                        "col": 1,
+                        "id": "51164310-fa2b-11e6-bbd3-29c986c96e5a-ecs",
+                        "panelIndex": 2,
+                        "row": 10,
+                        "size_x": 12,
+                        "size_y": 3,
+                        "type": "visualization"
+                    },
+                    {
+                        "col": 1,
+                        "id": "dc589770-fa2b-11e6-bbd3-29c986c96e5a-ecs",
+                        "panelIndex": 3,
+                        "row": 2,
+                        "size_x": 12,
+                        "size_y": 4,
+                        "type": "visualization"
+                    },
+                    {
+                        "col": 1,
+                        "id": "327417e0-8462-11e7-bab8-bd2f0fb42c54-ecs",
+                        "panelIndex": 4,
+                        "row": 1,
+                        "size_x": 12,
+                        "size_y": 1,
+                        "type": "visualization"
+                    }
+                ],
+                "timeRestore": false,
+                "title": "[Filebeat System] Sudo commands ECS",
+                "uiStateJSON": {
+                    "P-3": {
+                        "vis": {
+                            "params": {
+                                "sort": {
+                                    "columnIndex": null,
+                                    "direction": null
+                                }
+                            }
+                        }
+                    }
+                },
+                "version": 1
+            },
+            "id": "277876d0-fa2c-11e6-bbd3-29c986c96e5a-ecs",
+            "type": "dashboard",
+            "version": 6
+        }
+    ],
+    "version": "6.0.0-beta1-SNAPSHOT"
+}

--- a/dev/package-beats/system-1.0.0/kibana/dashboard/Filebeat-new-users-and-groups.json
+++ b/dev/package-beats/system-1.0.0/kibana/dashboard/Filebeat-new-users-and-groups.json
@@ -1,0 +1,683 @@
+{
+    "objects": [
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                },
+                "savedSearchId": "8030c1b0-fa77-11e6-ae9b-81e5311e8cab-ecs",
+                "title": "New users [Filebeat System] ECS",
+                "uiStateJSON": {
+                    "vis": {
+                        "params": {
+                            "sort": {
+                                "columnIndex": null,
+                                "direction": null
+                            }
+                        }
+                    }
+                },
+                "version": 1,
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true,
+                            "id": "1",
+                            "params": {},
+                            "schema": "metric",
+                            "type": "count"
+                        },
+                        {
+                            "enabled": true,
+                            "id": "2",
+                            "params": {
+                                "customLabel": "Host",
+                                "field": "host.hostname",
+                                "order": "desc",
+                                "orderBy": "1",
+                                "size": 5
+                            },
+                            "schema": "bucket",
+                            "type": "terms"
+                        },
+                        {
+                            "enabled": true,
+                            "id": "3",
+                            "params": {
+                                "customLabel": "User",
+                                "field": "user.name",
+                                "order": "desc",
+                                "orderBy": "1",
+                                "size": 5
+                            },
+                            "schema": "bucket",
+                            "type": "terms"
+                        },
+                        {
+                            "enabled": true,
+                            "id": "4",
+                            "params": {
+                                "customLabel": "UID",
+                                "field": "user.id",
+                                "order": "desc",
+                                "orderBy": "1",
+                                "size": 5
+                            },
+                            "schema": "bucket",
+                            "type": "terms"
+                        },
+                        {
+                            "enabled": true,
+                            "id": "5",
+                            "params": {
+                                "customLabel": "GID",
+                                "field": "group.id",
+                                "order": "desc",
+                                "orderBy": "1",
+                                "size": 5
+                            },
+                            "schema": "bucket",
+                            "type": "terms"
+                        },
+                        {
+                            "enabled": true,
+                            "id": "6",
+                            "params": {
+                                "customLabel": "Home",
+                                "field": "system.auth.useradd.home",
+                                "order": "desc",
+                                "orderBy": "1",
+                                "size": 5
+                            },
+                            "schema": "bucket",
+                            "type": "terms"
+                        },
+                        {
+                            "enabled": true,
+                            "id": "7",
+                            "params": {
+                                "customLabel": "Shell",
+                                "field": "system.auth.useradd.shell",
+                                "order": "desc",
+                                "orderBy": "1",
+                                "size": 5
+                            },
+                            "schema": "bucket",
+                            "type": "terms"
+                        }
+                    ],
+                    "listeners": {},
+                    "params": {
+                        "perPage": 10,
+                        "showMeticsAtAllLevels": false,
+                        "showPartialRows": false,
+                        "showTotal": false,
+                        "sort": {
+                            "columnIndex": null,
+                            "direction": null
+                        },
+                        "totalFunc": "sum"
+                    },
+                    "title": "New users ECS",
+                    "type": "table"
+                }
+            },
+            "id": "f398d2f0-fa77-11e6-ae9b-81e5311e8cab-ecs",
+            "type": "visualization",
+            "version": 2
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                },
+                "savedSearchId": "8030c1b0-fa77-11e6-ae9b-81e5311e8cab-ecs",
+                "title": "New users over time [Filebeat System] ECS",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true,
+                            "id": "1",
+                            "params": {},
+                            "schema": "metric",
+                            "type": "count"
+                        },
+                        {
+                            "enabled": true,
+                            "id": "2",
+                            "params": {
+                                "customInterval": "2h",
+                                "extended_bounds": {},
+                                "field": "@timestamp",
+                                "interval": "auto",
+                                "min_doc_count": 1
+                            },
+                            "schema": "segment",
+                            "type": "date_histogram"
+                        },
+                        {
+                            "enabled": true,
+                            "id": "3",
+                            "params": {
+                                "field": "user.name",
+                                "order": "desc",
+                                "orderBy": "1",
+                                "size": 5
+                            },
+                            "schema": "group",
+                            "type": "terms"
+                        }
+                    ],
+                    "listeners": {},
+                    "params": {
+                        "addLegend": true,
+                        "addTimeMarker": false,
+                        "addTooltip": true,
+                        "defaultYExtents": false,
+                        "legendPosition": "bottom",
+                        "mode": "stacked",
+                        "scale": "linear",
+                        "setYExtents": false,
+                        "times": []
+                    },
+                    "title": "New users over time ECS",
+                    "type": "histogram"
+                }
+            },
+            "id": "5dd15c00-fa78-11e6-ae9b-81e5311e8cab-ecs",
+            "type": "visualization",
+            "version": 2
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                },
+                "savedSearchId": "8030c1b0-fa77-11e6-ae9b-81e5311e8cab-ecs",
+                "title": "New users by shell [Filebeat System] ECS",
+                "uiStateJSON": {
+                    "vis": {
+                        "colors": {
+                            "/bin/bash": "#E24D42",
+                            "/bin/false": "#508642",
+                            "/sbin/nologin": "#7EB26D"
+                        },
+                        "legendOpen": true
+                    }
+                },
+                "version": 1,
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true,
+                            "id": "1",
+                            "params": {},
+                            "schema": "metric",
+                            "type": "count"
+                        },
+                        {
+                            "enabled": true,
+                            "id": "2",
+                            "params": {
+                                "field": "system.auth.useradd.shell",
+                                "order": "desc",
+                                "orderBy": "1",
+                                "size": 5
+                            },
+                            "schema": "segment",
+                            "type": "terms"
+                        },
+                        {
+                            "enabled": true,
+                            "id": "3",
+                            "params": {
+                                "field": "user.name",
+                                "order": "desc",
+                                "orderBy": "1",
+                                "size": 5
+                            },
+                            "schema": "segment",
+                            "type": "terms"
+                        }
+                    ],
+                    "listeners": {},
+                    "params": {
+                        "addLegend": true,
+                        "addTooltip": true,
+                        "isDonut": false,
+                        "legendPosition": "right"
+                    },
+                    "title": "New users by shell ECS",
+                    "type": "pie"
+                }
+            },
+            "id": "e121b140-fa78-11e6-a1df-a78bd7504d38-ecs",
+            "type": "visualization",
+            "version": 2
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                },
+                "savedSearchId": "8030c1b0-fa77-11e6-ae9b-81e5311e8cab-ecs",
+                "title": "New users by home directory [Filebeat System] ECS",
+                "uiStateJSON": {
+                    "vis": {
+                        "colors": {
+                            "/bin/bash": "#E24D42",
+                            "/bin/false": "#508642",
+                            "/nonexistent": "#629E51",
+                            "/sbin/nologin": "#7EB26D"
+                        },
+                        "legendOpen": true
+                    }
+                },
+                "version": 1,
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true,
+                            "id": "1",
+                            "params": {},
+                            "schema": "metric",
+                            "type": "count"
+                        },
+                        {
+                            "enabled": true,
+                            "id": "2",
+                            "params": {
+                                "field": "system.auth.useradd.home",
+                                "order": "desc",
+                                "orderBy": "1",
+                                "size": 5
+                            },
+                            "schema": "segment",
+                            "type": "terms"
+                        },
+                        {
+                            "enabled": true,
+                            "id": "3",
+                            "params": {
+                                "field": "user.name",
+                                "order": "desc",
+                                "orderBy": "1",
+                                "size": 5
+                            },
+                            "schema": "segment",
+                            "type": "terms"
+                        }
+                    ],
+                    "listeners": {},
+                    "params": {
+                        "addLegend": true,
+                        "addTooltip": true,
+                        "isDonut": false,
+                        "legendPosition": "right"
+                    },
+                    "title": "New users by home directory ECS",
+                    "type": "pie"
+                }
+            },
+            "id": "d56ee420-fa79-11e6-a1df-a78bd7504d38-ecs",
+            "type": "visualization",
+            "version": 2
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                },
+                "savedSearchId": "eb0039f0-fa7f-11e6-a1df-a78bd7504d38-ecs",
+                "title": "New groups [Filebeat System] ECS",
+                "uiStateJSON": {
+                    "vis": {
+                        "params": {
+                            "sort": {
+                                "columnIndex": null,
+                                "direction": null
+                            }
+                        }
+                    }
+                },
+                "version": 1,
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true,
+                            "id": "1",
+                            "params": {},
+                            "schema": "metric",
+                            "type": "count"
+                        },
+                        {
+                            "enabled": true,
+                            "id": "2",
+                            "params": {
+                                "field": "group.name",
+                                "order": "desc",
+                                "orderBy": "1",
+                                "size": 5
+                            },
+                            "schema": "bucket",
+                            "type": "terms"
+                        },
+                        {
+                            "enabled": true,
+                            "id": "3",
+                            "params": {
+                                "field": "group.id",
+                                "order": "desc",
+                                "orderBy": "1",
+                                "size": 5
+                            },
+                            "schema": "bucket",
+                            "type": "terms"
+                        }
+                    ],
+                    "listeners": {},
+                    "params": {
+                        "perPage": 10,
+                        "showMeticsAtAllLevels": false,
+                        "showPartialRows": false,
+                        "showTotal": false,
+                        "sort": {
+                            "columnIndex": null,
+                            "direction": null
+                        },
+                        "totalFunc": "sum"
+                    },
+                    "title": "New groups ECS",
+                    "type": "table"
+                }
+            },
+            "id": "12667040-fa80-11e6-a1df-a78bd7504d38-ecs",
+            "type": "visualization",
+            "version": 2
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                },
+                "savedSearchId": "eb0039f0-fa7f-11e6-a1df-a78bd7504d38-ecs",
+                "title": "New groups over time [Filebeat System] ECS",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true,
+                            "id": "1",
+                            "params": {},
+                            "schema": "metric",
+                            "type": "count"
+                        },
+                        {
+                            "enabled": true,
+                            "id": "2",
+                            "params": {
+                                "customInterval": "2h",
+                                "extended_bounds": {},
+                                "field": "@timestamp",
+                                "interval": "auto",
+                                "min_doc_count": 1
+                            },
+                            "schema": "segment",
+                            "type": "date_histogram"
+                        },
+                        {
+                            "enabled": true,
+                            "id": "3",
+                            "params": {
+                                "field": "group.name",
+                                "order": "desc",
+                                "orderBy": "1",
+                                "size": 5
+                            },
+                            "schema": "group",
+                            "type": "terms"
+                        }
+                    ],
+                    "listeners": {},
+                    "params": {
+                        "addLegend": true,
+                        "addTimeMarker": false,
+                        "addTooltip": true,
+                        "defaultYExtents": false,
+                        "legendPosition": "bottom",
+                        "mode": "stacked",
+                        "scale": "linear",
+                        "setYExtents": false,
+                        "times": []
+                    },
+                    "title": "New groups over time ECS",
+                    "type": "histogram"
+                }
+            },
+            "id": "346bb290-fa80-11e6-a1df-a78bd7504d38-ecs",
+            "type": "visualization",
+            "version": 2
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                },
+                "title": "Dashboards [Filebeat System] ECS",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "params": {
+                        "fontSize": 12,
+                        "markdown": "[Syslog](#/dashboard/Filebeat-syslog-dashboard-ecs) | [Sudo commands](#/dashboard/277876d0-fa2c-11e6-bbd3-29c986c96e5a-ecs) | [SSH logins](#/dashboard/5517a150-f9ce-11e6-8115-a7c18106d86a-ecs) | [New users and groups](#/dashboard/0d3f2380-fa78-11e6-ae9b-81e5311e8cab-ecs)"
+                    },
+                    "title": "Dashboards [Filebeat System] ECS",
+                    "type": "markdown"
+                }
+            },
+            "id": "327417e0-8462-11e7-bab8-bd2f0fb42c54-ecs",
+            "type": "visualization",
+            "version": 1
+        },
+        {
+            "attributes": {
+                "columns": [
+                    "user.name",
+                    "user.id",
+                    "group.id",
+                    "system.auth.useradd.home",
+                    "system.auth.useradd.shell"
+                ],
+                "description": "",
+                "hits": 0,
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "highlightAll": true,
+                        "index": "filebeat-*",
+                        "query": {
+                            "language": "kuery",
+                            "query": "system.auth.useradd:*"
+                        }
+                    }
+                },
+                "sort": [
+                    "@timestamp",
+                    "desc"
+                ],
+                "title": "useradd logs [Filebeat System] ECS",
+                "version": 1
+            },
+            "id": "8030c1b0-fa77-11e6-ae9b-81e5311e8cab-ecs",
+            "type": "search",
+            "version": 2
+        },
+        {
+            "attributes": {
+                "columns": [
+                    "group.name",
+                    "group.id"
+                ],
+                "description": "",
+                "hits": 0,
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "highlightAll": true,
+                        "index": "filebeat-*",
+                        "query": {
+                            "language": "kuery",
+                            "query": "system.auth.groupadd:*"
+                        }
+                    }
+                },
+                "sort": [
+                    "@timestamp",
+                    "desc"
+                ],
+                "title": "groupadd logs [Filebeat System] ECS",
+                "version": 1
+            },
+            "id": "eb0039f0-fa7f-11e6-a1df-a78bd7504d38-ecs",
+            "type": "search",
+            "version": 2
+        },
+        {
+            "attributes": {
+                "description": "New users and groups dashboard for the System module in Filebeat",
+                "hits": 0,
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "highlightAll": true,
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        },
+                        "version": true
+                    }
+                },
+                "optionsJSON": {
+                    "darkTheme": false
+                },
+                "panelsJSON": [
+                    {
+                        "col": 1,
+                        "id": "f398d2f0-fa77-11e6-ae9b-81e5311e8cab-ecs",
+                        "panelIndex": 1,
+                        "row": 2,
+                        "size_x": 6,
+                        "size_y": 3,
+                        "type": "visualization"
+                    },
+                    {
+                        "col": 7,
+                        "id": "5dd15c00-fa78-11e6-ae9b-81e5311e8cab-ecs",
+                        "panelIndex": 2,
+                        "row": 2,
+                        "size_x": 6,
+                        "size_y": 3,
+                        "type": "visualization"
+                    },
+                    {
+                        "col": 1,
+                        "id": "e121b140-fa78-11e6-a1df-a78bd7504d38-ecs",
+                        "panelIndex": 3,
+                        "row": 5,
+                        "size_x": 6,
+                        "size_y": 3,
+                        "type": "visualization"
+                    },
+                    {
+                        "col": 7,
+                        "id": "d56ee420-fa79-11e6-a1df-a78bd7504d38-ecs",
+                        "panelIndex": 4,
+                        "row": 5,
+                        "size_x": 6,
+                        "size_y": 3,
+                        "type": "visualization"
+                    },
+                    {
+                        "col": 1,
+                        "id": "12667040-fa80-11e6-a1df-a78bd7504d38-ecs",
+                        "panelIndex": 5,
+                        "row": 8,
+                        "size_x": 6,
+                        "size_y": 3,
+                        "type": "visualization"
+                    },
+                    {
+                        "col": 7,
+                        "id": "346bb290-fa80-11e6-a1df-a78bd7504d38-ecs",
+                        "panelIndex": 6,
+                        "row": 8,
+                        "size_x": 6,
+                        "size_y": 3,
+                        "type": "visualization"
+                    },
+                    {
+                        "col": 1,
+                        "id": "327417e0-8462-11e7-bab8-bd2f0fb42c54-ecs",
+                        "panelIndex": 7,
+                        "row": 1,
+                        "size_x": 12,
+                        "size_y": 1,
+                        "type": "visualization"
+                    }
+                ],
+                "timeRestore": false,
+                "title": "[Filebeat System] New users and groups ECS",
+                "uiStateJSON": {
+                    "P-1": {
+                        "vis": {
+                            "params": {
+                                "sort": {
+                                    "columnIndex": null,
+                                    "direction": null
+                                }
+                            }
+                        }
+                    },
+                    "P-5": {
+                        "vis": {
+                            "params": {
+                                "sort": {
+                                    "columnIndex": null,
+                                    "direction": null
+                                }
+                            }
+                        }
+                    }
+                },
+                "version": 1
+            },
+            "id": "0d3f2380-fa78-11e6-ae9b-81e5311e8cab-ecs",
+            "type": "dashboard",
+            "version": 6
+        }
+    ],
+    "version": "6.0.0-beta1-SNAPSHOT"
+}

--- a/dev/package-beats/system-1.0.0/kibana/dashboard/Filebeat-ssh-login-attempts.json
+++ b/dev/package-beats/system-1.0.0/kibana/dashboard/Filebeat-ssh-login-attempts.json
@@ -1,0 +1,477 @@
+{
+    "objects": [
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "highlightAll": true,
+                        "index": "filebeat-*",
+                        "query": {
+                            "language": "kuery",
+                                "query": "system.auth.ssh.event:Accepted"
+                            }
+                    }
+                },
+                "title": "Successful SSH logins [Filebeat System] ECS",
+                "uiStateJSON": {
+                    "vis": {
+                        "colors": {
+                            "Accepted": "#3F6833",
+                            "Failed": "#F9934E",
+                            "Invalid": "#447EBC",
+                            "password": "#BF1B00",
+                            "publickey": "#629E51"
+                        }
+                    }
+                },
+                "version": 1,
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true,
+                            "id": "1",
+                            "params": {},
+                            "schema": "metric",
+                            "type": "count"
+                        },
+                        {
+                            "enabled": true,
+                            "id": "2",
+                            "params": {
+                                "customInterval": "2h",
+                                "extended_bounds": {},
+                                "field": "@timestamp",
+                                "interval": "auto",
+                                "min_doc_count": 1
+                            },
+                            "schema": "segment",
+                            "type": "date_histogram"
+                        },
+                        {
+                            "enabled": true,
+                            "id": "3",
+                            "params": {
+                                "field": "system.auth.ssh.method",
+                                "order": "desc",
+                                "orderBy": "1",
+                                "size": 5
+                            },
+                            "schema": "group",
+                            "type": "terms"
+                        }
+                    ],
+                    "listeners": {},
+                    "params": {
+                        "addLegend": true,
+                        "addTimeMarker": false,
+                        "addTooltip": true,
+                        "defaultYExtents": false,
+                        "legendPosition": "right",
+                        "mode": "stacked",
+                        "scale": "linear",
+                        "setYExtents": false,
+                        "times": []
+                    },
+                    "title": "Successful SSH logins ECS",
+                    "type": "histogram"
+                }
+            },
+            "id": "d16bb400-f9cc-11e6-8115-a7c18106d86a-ecs",
+            "type": "visualization",
+            "version": 2
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "highlightAll": true,
+                        "index": "filebeat-*"
+                    }
+                },
+                "title": "SSH login attempts [Filebeat System] ECS",
+                "uiStateJSON": {
+                    "vis": {
+                        "colors": {
+                            "Accepted": "#3F6833",
+                            "Failed": "#F9934E",
+                            "Invalid": "#447EBC"
+                        }
+                    }
+                },
+                "version": 1,
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true,
+                            "id": "1",
+                            "params": {},
+                            "schema": "metric",
+                            "type": "count"
+                        },
+                        {
+                            "enabled": true,
+                            "id": "2",
+                            "params": {
+                                "customInterval": "2h",
+                                "extended_bounds": {},
+                                "field": "@timestamp",
+                                "interval": "auto",
+                                "min_doc_count": 1
+                            },
+                            "schema": "segment",
+                            "type": "date_histogram"
+                        },
+                        {
+                            "enabled": true,
+                            "id": "3",
+                            "params": {
+                                "field": "system.auth.ssh.event",
+                                "order": "desc",
+                                "orderBy": "1",
+                                "size": 5
+                            },
+                            "schema": "group",
+                            "type": "terms"
+                        }
+                    ],
+                    "listeners": {},
+                    "params": {
+                        "addLegend": true,
+                        "addTimeMarker": false,
+                        "addTooltip": true,
+                        "defaultYExtents": false,
+                        "legendPosition": "right",
+                        "mode": "stacked",
+                        "scale": "linear",
+                        "setYExtents": false,
+                        "times": []
+                    },
+                    "title": "SSH login attempts ECS",
+                    "type": "histogram"
+                }
+            },
+            "id": "78b74f30-f9cd-11e6-8115-a7c18106d86a-ecs",
+            "type": "visualization",
+            "version": 2
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "highlightAll": true,
+                        "index": "filebeat-*",
+                        "query": {
+                            "language": "kuery",
+                                "query": "system.auth.ssh.event:Failed OR system.auth.ssh.event:Invalid"
+                            }
+                    }
+                },
+                "title": "SSH users of failed login attempts [Filebeat System] ECS",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true,
+                            "id": "1",
+                            "params": {},
+                            "schema": "metric",
+                            "type": "count"
+                        },
+                        {
+                            "enabled": true,
+                            "id": "2",
+                            "params": {
+                                "field": "user.name",
+                                "order": "desc",
+                                "orderBy": "1",
+                                "size": 50
+                            },
+                            "schema": "segment",
+                            "type": "terms"
+                        }
+                    ],
+                    "listeners": {},
+                    "params": {
+                        "maxFontSize": 72,
+                        "minFontSize": 18,
+                        "orientation": "single",
+                        "scale": "linear"
+                    },
+                    "title": "SSH users of failed login attempts ECS",
+                    "type": "tagcloud"
+                }
+            },
+            "id": "341ffe70-f9ce-11e6-8115-a7c18106d86a-ecs",
+            "type": "visualization",
+            "version": 2
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "highlightAll": true,
+                        "index": "filebeat-*",
+                        "query": {
+                            "language": "kuery",
+                                "query": "system.auth.ssh.event:Failed OR system.auth.ssh.event:Invalid"
+                            }
+                    }
+                },
+                "title": "SSH failed login attempts source locations [Filebeat System] ECS",
+                "uiStateJSON": {
+                    "mapCenter": [
+                        17.602139123350838,
+                        69.697265625
+                    ],
+                    "mapZoom": 2
+                },
+                "version": 1,
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true,
+                            "id": "1",
+                            "params": {},
+                            "schema": "metric",
+                            "type": "count"
+                        },
+                        {
+                            "enabled": true,
+                            "id": "2",
+                            "params": {
+                                "autoPrecision": true,
+                                "field": "source.geo.location",
+                                "precision": 2
+                            },
+                            "schema": "segment",
+                            "type": "geohash_grid"
+                        }
+                    ],
+                    "listeners": {},
+                    "params": {
+                        "addTooltip": true,
+                        "heatBlur": 15,
+                        "heatMaxZoom": 16,
+                        "heatMinOpacity": 0.1,
+                        "heatNormalizeData": true,
+                        "heatRadius": 25,
+                        "isDesaturated": true,
+                        "legendPosition": "bottomright",
+                        "mapCenter": [
+                            15,
+                            5
+                        ],
+                        "mapType": "Shaded Circle Markers",
+                        "mapZoom": 2,
+                        "wms": {
+                            "enabled": false,
+                            "options": {
+                                "attribution": "Maps provided by USGS",
+                                "format": "image/png",
+                                "layers": "0",
+                                "styles": "",
+                                "transparent": true,
+                                "version": "1.3.0"
+                            },
+                            "url": "https://basemap.nationalmap.gov/arcgis/services/USGSTopo/MapServer/WMSServer"
+                        }
+                    },
+                    "title": "SSH failed login attempts source locations ECS",
+                    "type": "tile_map"
+                }
+            },
+            "id": "3cec3eb0-f9d3-11e6-8a3e-2b904044ea1d-ecs",
+            "type": "visualization",
+            "version": 2
+        },
+        {
+            "attributes": {
+                "columns": [
+                    "system.auth.ssh.event",
+                    "system.auth.ssh.method",
+                    "user.name",
+                    "source.ip",
+                    "source.geo.country_iso_code"
+                ],
+                "description": "",
+                "hits": 0,
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "highlightAll": true,
+                        "index": "filebeat-*",
+                        "query": {
+                            "language": "kuery",
+                            "query": "event.dataset:system.auth AND system.auth.ssh.event:*"
+                        }
+                    }
+                },
+                "sort": [
+                    "@timestamp",
+                    "desc"
+                ],
+                "title": "SSH login attempts [Filebeat System] ECS",
+                "version": 1
+            },
+            "id": "62439dc0-f9c9-11e6-a747-6121780e0414-ecs",
+            "type": "search",
+            "version": 2
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                },
+                "title": "Dashboards [Filebeat System] ECS",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "params": {
+                        "fontSize": 12,
+                        "markdown": "[Syslog](#/dashboard/Filebeat-syslog-dashboard-ecs) | [Sudo commands](#/dashboard/277876d0-fa2c-11e6-bbd3-29c986c96e5a-ecs) | [SSH logins](#/dashboard/5517a150-f9ce-11e6-8115-a7c18106d86a-ecs) | [New users and groups](#/dashboard/0d3f2380-fa78-11e6-ae9b-81e5311e8cab-ecs)"
+                    },
+                    "title": "Dashboards [Filebeat System] ECS",
+                    "type": "markdown"
+                }
+            },
+            "id": "327417e0-8462-11e7-bab8-bd2f0fb42c54-ecs",
+            "type": "visualization",
+            "version": 1
+        },
+        {
+            "attributes": {
+                "description": "SSH dashboard for the System module in Filebeat",
+                "hits": 0,
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "highlightAll": true,
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        },
+                        "version": true
+                    }
+                },
+                "optionsJSON": {
+                    "darkTheme": false
+                },
+                "panelsJSON": [
+                    {
+                        "col": 1,
+                        "id": "d16bb400-f9cc-11e6-8115-a7c18106d86a-ecs",
+                        "panelIndex": 1,
+                        "row": 5,
+                        "size_x": 12,
+                        "size_y": 3,
+                        "type": "visualization"
+                    },
+                    {
+                        "col": 1,
+                        "id": "78b74f30-f9cd-11e6-8115-a7c18106d86a-ecs",
+                        "panelIndex": 2,
+                        "row": 2,
+                        "size_x": 12,
+                        "size_y": 3,
+                        "type": "visualization"
+                    },
+                    {
+                        "col": 1,
+                        "id": "341ffe70-f9ce-11e6-8115-a7c18106d86a-ecs",
+                        "panelIndex": 3,
+                        "row": 8,
+                        "size_x": 6,
+                        "size_y": 4,
+                        "type": "visualization"
+                    },
+                    {
+                        "col": 7,
+                        "id": "3cec3eb0-f9d3-11e6-8a3e-2b904044ea1d-ecs",
+                        "panelIndex": 4,
+                        "row": 8,
+                        "size_x": 6,
+                        "size_y": 4,
+                        "type": "visualization"
+                    },
+                    {
+                        "col": 1,
+                        "columns": [
+                            "system.auth.ssh.event",
+                            "system.auth.ssh.method",
+                            "user.name",
+                            "source.ip",
+                            "source.geo.country_iso_code"
+                        ],
+                        "id": "62439dc0-f9c9-11e6-a747-6121780e0414-ecs",
+                        "panelIndex": 5,
+                        "row": 12,
+                        "size_x": 12,
+                        "size_y": 3,
+                        "sort": [
+                            "@timestamp",
+                            "desc"
+                        ],
+                        "type": "search"
+                    },
+                    {
+                        "col": 1,
+                        "id": "327417e0-8462-11e7-bab8-bd2f0fb42c54-ecs",
+                        "panelIndex": 6,
+                        "row": 1,
+                        "size_x": 12,
+                        "size_y": 1,
+                        "type": "visualization"
+                    }
+                ],
+                "timeRestore": false,
+                "title": "[Filebeat System] SSH login attempts ECS",
+                "uiStateJSON": {
+                    "P-4": {
+                        "mapBounds": {
+                            "bottom_right": {
+                                "lat": 10.31491928581316,
+                                "lon": 74.53125
+                            },
+                            "top_left": {
+                                "lat": 60.50052541051131,
+                                "lon": -27.94921875
+                            }
+                        },
+                        "mapCenter": [
+                            39.774769485295465,
+                            23.203125
+                        ],
+                        "mapCollar": {
+                            "bottom_right": {
+                                "lat": -14.777884999999998,
+                                "lon": 125.771485
+                            },
+                            "top_left": {
+                                "lat": 85.593335,
+                                "lon": -79.189455
+                            },
+                            "zoom": 3
+                        },
+                        "mapZoom": 3
+                    }
+                },
+                "version": 1
+            },
+            "id": "5517a150-f9ce-11e6-8115-a7c18106d86a-ecs",
+            "type": "dashboard",
+            "version": 7
+        }
+    ],
+    "version": "6.0.0-beta1-SNAPSHOT"
+}

--- a/dev/package-beats/system-1.0.0/kibana/dashboard/Filebeat-syslog.json
+++ b/dev/package-beats/system-1.0.0/kibana/dashboard/Filebeat-syslog.json
@@ -1,0 +1,277 @@
+{
+    "objects": [
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "Syslog-system-logs-ecs", 
+                "title": "Syslog events by hostname [Filebeat System] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "field": "host.hostname", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "group", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "defaultYExtents": false, 
+                        "legendPosition": "right", 
+                        "mode": "stacked", 
+                        "scale": "linear", 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "times": [], 
+                        "yAxis": {}
+                    }, 
+                    "title": "Syslog events by hostname ECS", 
+                    "type": "histogram"
+                }
+            }, 
+            "id": "Syslog-events-by-hostname-ecs", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "Syslog-system-logs-ecs", 
+                "title": "Syslog hostnames and processes [Filebeat System] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "field": "host.hostname", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "segment", 
+                            "type": "terms"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "field": "process.name", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "segment", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTooltip": true, 
+                        "isDonut": true, 
+                        "legendPosition": "bottom", 
+                        "shareYAxis": true
+                    }, 
+                    "title": "Syslog hostnames and processes ECS", 
+                    "type": "pie"
+                }
+            }, 
+            "id": "Syslog-hostnames-and-processes-ecs", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "columns": [
+                    "host.hostname", 
+                    "process.name", 
+                    "message"
+                ], 
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlight": {
+                            "fields": {
+                                "*": {}
+                            }, 
+                            "fragment_size": 2147483647, 
+                            "post_tags": [
+                                "@/kibana-highlighted-field@"
+                            ], 
+                            "pre_tags": [
+                                "@kibana-highlighted-field@"
+                            ], 
+                            "require_field_match": false
+                        }, 
+                        "highlightAll": true, 
+                        "index": "filebeat-*", 
+                        "query": {
+                            "language": "kuery",
+                                "query": "event.dataset:system.syslog"
+                            }
+                    }
+                }, 
+                "sort": [
+                    "@timestamp", 
+                    "desc"
+                ], 
+                "title": "Syslog logs [Filebeat System] ECS", 
+                "version": 1
+            }, 
+            "id": "Syslog-system-logs-ecs", 
+            "type": "search", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "Dashboards [Filebeat System] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "fontSize": 12, 
+                        "markdown": "[Syslog](#/dashboard/Filebeat-syslog-dashboard-ecs) | [Sudo commands](#/dashboard/277876d0-fa2c-11e6-bbd3-29c986c96e5a-ecs) | [SSH logins](#/dashboard/5517a150-f9ce-11e6-8115-a7c18106d86a-ecs) | [New users and groups](#/dashboard/0d3f2380-fa78-11e6-ae9b-81e5311e8cab-ecs)"
+                    }, 
+                    "title": "Dashboards [Filebeat System] ECS", 
+                    "type": "markdown"
+                }
+            }, 
+            "id": "327417e0-8462-11e7-bab8-bd2f0fb42c54-ecs", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "Syslog dashboard from the Filebeat System module", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlightAll": true, 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "optionsJSON": {
+                    "darkTheme": false
+                }, 
+                "panelsJSON": [
+                    {
+                        "col": 1, 
+                        "id": "Syslog-events-by-hostname-ecs", 
+                        "panelIndex": 1, 
+                        "row": 2, 
+                        "size_x": 8, 
+                        "size_y": 4, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 9, 
+                        "id": "Syslog-hostnames-and-processes-ecs", 
+                        "panelIndex": 2, 
+                        "row": 2, 
+                        "size_x": 4, 
+                        "size_y": 4, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "columns": [
+                            "host.hostname", 
+                            "process.name", 
+                            "message"
+                        ], 
+                        "id": "Syslog-system-logs-ecs", 
+                        "panelIndex": 3, 
+                        "row": 6, 
+                        "size_x": 12, 
+                        "size_y": 7, 
+                        "sort": [
+                            "@timestamp", 
+                            "desc"
+                        ], 
+                        "type": "search"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "327417e0-8462-11e7-bab8-bd2f0fb42c54-ecs", 
+                        "panelIndex": 4, 
+                        "row": 1, 
+                        "size_x": 12, 
+                        "size_y": 1, 
+                        "type": "visualization"
+                    }
+                ], 
+                "timeRestore": false, 
+                "title": "[Filebeat System] Syslog dashboard ECS", 
+                "uiStateJSON": {}, 
+                "version": 1
+            }, 
+            "id": "Filebeat-syslog-dashboard-ecs", 
+            "type": "dashboard", 
+            "version": 6
+        }
+    ], 
+    "version": "6.0.0-beta1-SNAPSHOT"
+}

--- a/dev/package-beats/system-1.0.0/kibana/dashboard/Metricbeat-containers-overview.json
+++ b/dev/package-beats/system-1.0.0/kibana/dashboard/Metricbeat-containers-overview.json
@@ -1,0 +1,539 @@
+{
+    "objects": [
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "index": "metricbeat-*", 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                }, 
+                "title": "Container CPU usage [Metricbeat System] ECS", 
+                "uiStateJSON": {
+                    "vis": {
+                        "params": {
+                            "sort": {
+                                "columnIndex": null, 
+                                "direction": null
+                            }
+                        }
+                    }
+                }, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "CPU user", 
+                                "field": "system.process.cgroup.cpuacct.stats.user.ns"
+                            }, 
+                            "schema": "metric", 
+                            "type": "max"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customLabel": "CPU quota", 
+                                "field": "system.process.cgroup.cpu.cfs.quota.us"
+                            }, 
+                            "schema": "metric", 
+                            "type": "max"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "customLabel": "Container ID", 
+                                "field": "system.process.cgroup.id", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "bucket", 
+                            "type": "terms"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "4", 
+                            "params": {
+                                "customLabel": "CPU throttling", 
+                                "field": "system.process.cgroup.cpu.stats.throttled.ns"
+                            }, 
+                            "schema": "metric", 
+                            "type": "max"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "5", 
+                            "params": {
+                                "customLabel": "CPU kernel", 
+                                "field": "system.process.cgroup.cpuacct.stats.system.ns"
+                            }, 
+                            "schema": "metric", 
+                            "type": "max"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "6", 
+                            "params": {
+                                "customLabel": "Process name", 
+                                "field": "process.name", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "bucket", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "params": {
+                        "perPage": 10, 
+                        "showMeticsAtAllLevels": false, 
+                        "showPartialRows": false, 
+                        "showTotal": false, 
+                        "sort": {
+                            "columnIndex": null, 
+                            "direction": null
+                        }, 
+                        "totalFunc": "sum"
+                    }, 
+                    "title": "Container CPU usage [Metricbeat System] ECS", 
+                    "type": "table"
+                }
+            }, 
+            "id": "Container-CPU-usage-ecs", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                }, 
+                "title": "System Navigation [Metricbeat System] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "fontSize": 12, 
+                        "markdown": "[System Overview](#/dashboard/Metricbeat-system-overview-ecs)  | [Host Overview](#/dashboard/79ffd6e0-faa0-11e6-947f-177f697178b8-ecs) |\n[Containers overview](#/dashboard/CPU-slash-Memory-per-container-ecs)"
+                    }, 
+                    "title": "System Navigation [Metricbeat System] ECS", 
+                    "type": "markdown"
+                }
+            }, 
+            "id": "System-Navigation-ecs", 
+            "type": "visualization", 
+            "version": 3
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "index": "metricbeat-*", 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                }, 
+                "title": "Container Memory stats [Metricbeat System] ECS", 
+                "uiStateJSON": {
+                    "vis": {
+                        "params": {
+                            "sort": {
+                                "columnIndex": null, 
+                                "direction": null
+                            }
+                        }
+                    }
+                }, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "13", 
+                            "params": {
+                                "customLabel": "Usage", 
+                                "field": "system.process.cgroup.memory.mem.usage.bytes"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "14", 
+                            "params": {
+                                "customLabel": "Max usage", 
+                                "field": "system.process.cgroup.memory.mem.usage.max.bytes"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "Page faults", 
+                                "field": "system.process.cgroup.memory.stats.page_faults"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customLabel": "Pages in memory", 
+                                "field": "system.process.cgroup.memory.stats.pages_in"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "customLabel": "Pages out of memory", 
+                                "field": "system.process.cgroup.memory.stats.pages_out"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "4", 
+                            "params": {
+                                "customLabel": "Container ID", 
+                                "field": "system.process.cgroup.id", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 50
+                            }, 
+                            "schema": "bucket", 
+                            "type": "terms"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "5", 
+                            "params": {
+                                "customLabel": "Inactive files", 
+                                "field": "system.process.cgroup.memory.stats.inactive_file.bytes"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "6", 
+                            "params": {
+                                "customLabel": "# Major page faults", 
+                                "field": "system.process.cgroup.memory.stats.major_page_faults"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "8", 
+                            "params": {
+                                "customLabel": "Process name", 
+                                "field": "process.name", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "bucket", 
+                            "type": "terms"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "12", 
+                            "params": {
+                                "customLabel": "Failures", 
+                                "field": "system.process.cgroup.memory.mem.failures"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "10", 
+                            "params": {
+                                "customLabel": "TCP buffers", 
+                                "field": "system.process.cgroup.memory.kmem_tcp.usage.bytes"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "11", 
+                            "params": {
+                                "customLabel": "Huge pages", 
+                                "field": "system.process.cgroup.memory.stats.rss_huge.bytes"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "7", 
+                            "params": {
+                                "customLabel": "Swap caches", 
+                                "field": "system.process.cgroup.memory.stats.rss.bytes"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "15", 
+                            "params": {
+                                "customLabel": "Swap usage", 
+                                "field": "system.process.cgroup.memory.stats.swap.bytes"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "16", 
+                            "params": {
+                                "customLabel": "Block I/O", 
+                                "field": "system.process.cgroup.blkio.total.ios"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }
+                    ], 
+                    "params": {
+                        "perPage": 10, 
+                        "showMeticsAtAllLevels": false, 
+                        "showPartialRows": false, 
+                        "showTotal": false, 
+                        "sort": {
+                            "columnIndex": null, 
+                            "direction": null
+                        }, 
+                        "totalFunc": "sum"
+                    }, 
+                    "title": "Container Memory stats [Metricbeat System] ECS", 
+                    "type": "table"
+                }
+            }, 
+            "id": "Container-Memory-stats-ecs", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "index": "metricbeat-*", 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                }, 
+                "title": "Container Block IO [Metricbeat System] ECS", 
+                "uiStateJSON": {
+                    "vis": {
+                        "params": {
+                            "sort": {
+                                "columnIndex": null, 
+                                "direction": null
+                            }
+                        }
+                    }
+                }, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "Total", 
+                                "field": "system.process.cgroup.blkio.total.bytes"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customLabel": "I/O", 
+                                "field": "system.process.cgroup.blkio.total.ios"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "customLabel": "Container ID", 
+                                "field": "system.process.cgroup.id", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "bucket", 
+                            "type": "terms"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "4", 
+                            "params": {
+                                "customLabel": "Process name", 
+                                "field": "process.name", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "bucket", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "params": {
+                        "perPage": 10, 
+                        "showMeticsAtAllLevels": false, 
+                        "showPartialRows": false, 
+                        "showTotal": false, 
+                        "sort": {
+                            "columnIndex": null, 
+                            "direction": null
+                        }, 
+                        "totalFunc": "sum"
+                    }, 
+                    "title": "Container Block IO [Metricbeat System] ECS", 
+                    "type": "table"
+                }
+            }, 
+            "id": "Container-Block-IO-ecs", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "Overview of container metrics",
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlightAll": true, 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "optionsJSON": {
+                    "darkTheme": false
+                }, 
+                "panelsJSON": [
+                    {
+                        "col": 1, 
+                        "id": "Container-CPU-usage-ecs", 
+                        "panelIndex": 2, 
+                        "row": 2, 
+                        "size_x": 12, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "System-Navigation-ecs", 
+                        "panelIndex": 3, 
+                        "row": 1, 
+                        "size_x": 12, 
+                        "size_y": 1, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "Container-Memory-stats-ecs", 
+                        "panelIndex": 4, 
+                        "row": 5, 
+                        "size_x": 12, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "Container-Block-IO-ecs", 
+                        "panelIndex": 5, 
+                        "row": 8, 
+                        "size_x": 12, 
+                        "size_y": 4, 
+                        "type": "visualization"
+                    }
+                ], 
+                "timeRestore": false, 
+                "title": "[Metricbeat System] Containers overview ECS", 
+                "uiStateJSON": {
+                    "P-2": {
+                        "vis": {
+                            "params": {
+                                "sort": {
+                                    "columnIndex": null, 
+                                    "direction": null
+                                }
+                            }
+                        }
+                    }, 
+                    "P-4": {
+                        "vis": {
+                            "params": {
+                                "sort": {
+                                    "columnIndex": null, 
+                                    "direction": null
+                                }
+                            }
+                        }
+                    }, 
+                    "P-5": {
+                        "vis": {
+                            "params": {
+                                "sort": {
+                                    "columnIndex": null, 
+                                    "direction": null
+                                }
+                            }
+                        }
+                    }
+                }, 
+                "version": 1
+            }, 
+            "id": "CPU-slash-Memory-per-container-ecs", 
+            "type": "dashboard", 
+            "version": 1
+        }
+    ], 
+    "version": "6.0.0-rc1-SNAPSHOT"
+}

--- a/dev/package-beats/system-1.0.0/kibana/dashboard/Metricbeat-host-overview.json
+++ b/dev/package-beats/system-1.0.0/kibana/dashboard/Metricbeat-host-overview.json
@@ -1,0 +1,2387 @@
+{
+    "objects": [
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                },
+                "title": "Network Traffic (Packets) [Metricbeat System] ECS",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "listeners": {},
+                    "params": {
+                        "axis_formatter": "number",
+                        "axis_position": "left",
+                        "filter": "-system.network.name:l*",
+                        "id": "da1046f0-faa0-11e6-86b1-cd7735ff7e23",
+                        "index_pattern": "*",
+                        "interval": "auto",
+                        "series": [
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "rgba(0,156,224,1)",
+                                "fill": "1",
+                                "formatter": "0.[00]a",
+                                "id": "da1046f1-faa0-11e6-86b1-cd7735ff7e23",
+                                "label": "Inbound",
+                                "line_width": "0",
+                                "metrics": [
+                                    {
+                                        "field": "system.network.in.packets",
+                                        "id": "da1046f2-faa0-11e6-86b1-cd7735ff7e23",
+                                        "type": "max"
+                                    },
+                                    {
+                                        "field": "da1046f2-faa0-11e6-86b1-cd7735ff7e23",
+                                        "id": "f41f9280-faa0-11e6-86b1-cd7735ff7e23",
+                                        "type": "derivative",
+                                        "unit": "1s"
+                                    },
+                                    {
+                                        "field": "f41f9280-faa0-11e6-86b1-cd7735ff7e23",
+                                        "id": "c0da3d80-1b93-11e7-8ada-3df93aab833e",
+                                        "type": "positive_only",
+                                        "unit": ""
+                                    },
+                                    {
+                                        "function": "sum",
+                                        "id": "ecaad010-2c2c-11e7-be71-3162da85303f",
+                                        "type": "series_agg"
+                                    }
+                                ],
+                                "point_size": "0",
+                                "seperate_axis": 0,
+                                "split_mode": "terms",
+                                "stacked": "none",
+                                "terms_field": "system.network.name",
+                                "value_template": "{{value}}/s"
+                            },
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "rgba(250,40,255,1)",
+                                "fill": "1",
+                                "formatter": "0.[00]a",
+                                "id": "fbbd5720-faa0-11e6-86b1-cd7735ff7e23",
+                                "label": "Outbound",
+                                "line_width": "0",
+                                "metrics": [
+                                    {
+                                        "field": "system.network.out.packets",
+                                        "id": "fbbd7e30-faa0-11e6-86b1-cd7735ff7e23",
+                                        "type": "max"
+                                    },
+                                    {
+                                        "field": "fbbd7e30-faa0-11e6-86b1-cd7735ff7e23",
+                                        "id": "fbbd7e31-faa0-11e6-86b1-cd7735ff7e23",
+                                        "type": "derivative",
+                                        "unit": "1s"
+                                    },
+                                    {
+                                        "id": "17e597a0-faa1-11e6-86b1-cd7735ff7e23",
+                                        "script": "params.rate != null && params.rate > 0 ? params.rate * -1 : null",
+                                        "type": "calculation",
+                                        "variables": [
+                                            {
+                                                "field": "fbbd7e31-faa0-11e6-86b1-cd7735ff7e23",
+                                                "id": "1940bad0-faa1-11e6-86b1-cd7735ff7e23",
+                                                "name": "rate"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "function": "sum",
+                                        "id": "fe5fbdc0-2c2c-11e7-be71-3162da85303f",
+                                        "type": "series_agg"
+                                    }
+                                ],
+                                "point_size": "0",
+                                "seperate_axis": 0,
+                                "split_mode": "terms",
+                                "stacked": "none",
+                                "terms_field": "system.network.name",
+                                "value_template": "{{value}}/s"
+                            }
+                        ],
+                        "show_legend": 1,
+                        "time_field": "@timestamp",
+                        "type": "timeseries"
+                    },
+                    "title": "Mericbeat: Network Traffic (Packets) ECS",
+                    "type": "metrics"
+                }
+            },
+            "id": "6b7b9a40-faa1-11e6-86b1-cd7735ff7e23-ecs",
+            "type": "visualization",
+            "version": 1
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                },
+                "title": "System Load [Metricbeat System] ECS",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "params": {
+                        "axis_formatter": "number",
+                        "axis_position": "left",
+                        "id": "f6264ad0-1b14-11e7-b09e-037021c4f8df",
+                        "index_pattern": "metricbeat-*",
+                        "interval": "auto",
+                        "series": [
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "rgba(115,216,255,1)",
+                                "fill": "0",
+                                "formatter": "number",
+                                "id": "f62671e0-1b14-11e7-b09e-037021c4f8df",
+                                "label": "1m",
+                                "line_width": "3",
+                                "metrics": [
+                                    {
+                                        "field": "system.load.1",
+                                        "id": "f62671e1-1b14-11e7-b09e-037021c4f8df",
+                                        "type": "avg"
+                                    }
+                                ],
+                                "point_size": 1,
+                                "seperate_axis": 0,
+                                "split_mode": "everything",
+                                "stacked": "none"
+                            },
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "rgba(0,156,224,1)",
+                                "fill": "0",
+                                "formatter": "number",
+                                "id": "1c324850-1b15-11e7-b09e-037021c4f8df",
+                                "label": "5m",
+                                "line_width": "3",
+                                "metrics": [
+                                    {
+                                        "field": "system.load.5",
+                                        "id": "1c324851-1b15-11e7-b09e-037021c4f8df",
+                                        "type": "avg"
+                                    }
+                                ],
+                                "point_size": "0",
+                                "seperate_axis": 0,
+                                "split_mode": "everything",
+                                "stacked": "none"
+                            },
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "rgba(0,98,177,1)",
+                                "fill": "0",
+                                "formatter": "number",
+                                "id": "3287e740-1b15-11e7-b09e-037021c4f8df",
+                                "label": "15m",
+                                "line_width": "3",
+                                "metrics": [
+                                    {
+                                        "field": "system.load.15",
+                                        "id": "32880e50-1b15-11e7-b09e-037021c4f8df",
+                                        "type": "avg"
+                                    }
+                                ],
+                                "point_size": "0",
+                                "seperate_axis": 0,
+                                "split_mode": "everything",
+                                "stacked": "none"
+                            }
+                        ],
+                        "show_grid": 1,
+                        "show_legend": 1,
+                        "time_field": "@timestamp",
+                        "type": "timeseries"
+                    },
+                    "title": "System Load [Metricbeat System] ECS",
+                    "type": "metrics"
+                }
+            },
+            "id": "4d546850-1b15-11e7-b09e-037021c4f8df-ecs",
+            "type": "visualization",
+            "version": 1
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                },
+                "title": "Network Traffic (Bytes) [Metricbeat System] ECS",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "listeners": {},
+                    "params": {
+                        "axis_formatter": "number",
+                        "axis_position": "left",
+                        "filter": "-system.network.name:l*",
+                        "id": "da1046f0-faa0-11e6-86b1-cd7735ff7e23",
+                        "index_pattern": "*",
+                        "interval": "auto",
+                        "series": [
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "rgba(0,156,224,1)",
+                                "fill": "1",
+                                "formatter": "bytes",
+                                "id": "da1046f1-faa0-11e6-86b1-cd7735ff7e23",
+                                "label": "Inbound ",
+                                "line_width": "0",
+                                "metrics": [
+                                    {
+                                        "field": "system.network.in.bytes",
+                                        "id": "da1046f2-faa0-11e6-86b1-cd7735ff7e23",
+                                        "type": "max"
+                                    },
+                                    {
+                                        "field": "da1046f2-faa0-11e6-86b1-cd7735ff7e23",
+                                        "id": "f41f9280-faa0-11e6-86b1-cd7735ff7e23",
+                                        "type": "derivative",
+                                        "unit": "1s"
+                                    },
+                                    {
+                                        "field": "f41f9280-faa0-11e6-86b1-cd7735ff7e23",
+                                        "id": "a87398e0-1b93-11e7-8ada-3df93aab833e",
+                                        "type": "positive_only",
+                                        "unit": ""
+                                    },
+                                    {
+                                        "function": "sum",
+                                        "id": "2d533df0-2c2d-11e7-be71-3162da85303f",
+                                        "type": "series_agg"
+                                    }
+                                ],
+                                "point_size": "0",
+                                "seperate_axis": 0,
+                                "split_mode": "terms",
+                                "stacked": "none",
+                                "terms_field": "system.network.name",
+                                "value_template": "{{value}}/s"
+                            },
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "rgba(250,40,255,1)",
+                                "fill": "1",
+                                "formatter": "bytes",
+                                "id": "fbbd5720-faa0-11e6-86b1-cd7735ff7e23",
+                                "label": "Outbound ",
+                                "line_width": "0",
+                                "metrics": [
+                                    {
+                                        "field": "system.network.out.bytes",
+                                        "id": "fbbd7e30-faa0-11e6-86b1-cd7735ff7e23",
+                                        "type": "max"
+                                    },
+                                    {
+                                        "field": "fbbd7e30-faa0-11e6-86b1-cd7735ff7e23",
+                                        "id": "fbbd7e31-faa0-11e6-86b1-cd7735ff7e23",
+                                        "type": "derivative",
+                                        "unit": "1s"
+                                    },
+                                    {
+                                        "id": "17e597a0-faa1-11e6-86b1-cd7735ff7e23",
+                                        "script": "params.rate != null && params.rate > 0 ? params.rate * -1 : null",
+                                        "type": "calculation",
+                                        "variables": [
+                                            {
+                                                "field": "fbbd7e31-faa0-11e6-86b1-cd7735ff7e23",
+                                                "id": "1940bad0-faa1-11e6-86b1-cd7735ff7e23",
+                                                "name": "rate"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "function": "sum",
+                                        "id": "533da9b0-2c2d-11e7-be71-3162da85303f",
+                                        "type": "series_agg"
+                                    }
+                                ],
+                                "point_size": "0",
+                                "seperate_axis": 0,
+                                "split_mode": "terms",
+                                "stacked": "none",
+                                "terms_field": "system.network.name",
+                                "value_template": "{{value}}/s"
+                            }
+                        ],
+                        "show_legend": 1,
+                        "time_field": "@timestamp",
+                        "type": "timeseries"
+                    },
+                    "title": "Mericbeat: Network Traffic (Bytes) ECS",
+                    "type": "metrics"
+                }
+            },
+            "id": "089b85d0-1b16-11e7-b09e-037021c4f8df-ecs",
+            "type": "visualization",
+            "version": 1
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                },
+                "title": "Memory Usage [Metricbeat System] ECS",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "params": {
+                        "axis_formatter": "number",
+                        "axis_position": "left",
+                        "id": "32f46f40-1b16-11e7-b09e-037021c4f8df",
+                        "index_pattern": "metricbeat-*",
+                        "interval": "auto",
+                        "series": [
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "rgba(211,49,21,1)",
+                                "fill": "1",
+                                "formatter": "bytes",
+                                "id": "4ff61fd0-1b16-11e7-b09e-037021c4f8df",
+                                "label": "Used",
+                                "line_width": 1,
+                                "metrics": [
+                                    {
+                                        "field": "system.memory.actual.used.bytes",
+                                        "id": "4ff61fd1-1b16-11e7-b09e-037021c4f8df",
+                                        "type": "avg"
+                                    }
+                                ],
+                                "point_size": "0",
+                                "seperate_axis": 0,
+                                "split_mode": "everything",
+                                "stacked": "stacked"
+                            },
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "rgba(0,156,224,1)",
+                                "fill": "1",
+                                "formatter": "bytes",
+                                "id": "753a6080-1b16-11e7-b09e-037021c4f8df",
+                                "label": "Cache",
+                                "line_width": 1,
+                                "metrics": [
+                                    {
+                                        "field": "system.memory.actual.used.bytes",
+                                        "id": "753a6081-1b16-11e7-b09e-037021c4f8df",
+                                        "type": "avg"
+                                    },
+                                    {
+                                        "field": "system.memory.used.bytes",
+                                        "id": "7c9d3f00-1b16-11e7-b09e-037021c4f8df",
+                                        "type": "avg"
+                                    },
+                                    {
+                                        "id": "869cc160-1b16-11e7-b09e-037021c4f8df",
+                                        "script": "params.actual != null && params.used != null ? params.used - params.actual : null",
+                                        "type": "calculation",
+                                        "variables": [
+                                            {
+                                                "field": "753a6081-1b16-11e7-b09e-037021c4f8df",
+                                                "id": "890f9620-1b16-11e7-b09e-037021c4f8df",
+                                                "name": "actual"
+                                            },
+                                            {
+                                                "field": "7c9d3f00-1b16-11e7-b09e-037021c4f8df",
+                                                "id": "8f3ab7f0-1b16-11e7-b09e-037021c4f8df",
+                                                "name": "used"
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "point_size": "0",
+                                "seperate_axis": 0,
+                                "split_mode": "everything",
+                                "stacked": "stacked"
+                            },
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "#68BC00",
+                                "fill": "1",
+                                "formatter": "bytes",
+                                "id": "32f46f41-1b16-11e7-b09e-037021c4f8df",
+                                "label": "Free",
+                                "line_width": 1,
+                                "metrics": [
+                                    {
+                                        "field": "system.memory.free",
+                                        "id": "32f46f42-1b16-11e7-b09e-037021c4f8df",
+                                        "type": "avg"
+                                    }
+                                ],
+                                "point_size": "0",
+                                "seperate_axis": 0,
+                                "split_mode": "everything",
+                                "stacked": "stacked"
+                            }
+                        ],
+                        "show_grid": 1,
+                        "show_legend": 1,
+                        "time_field": "@timestamp",
+                        "type": "timeseries"
+                    },
+                    "title": "Memory Usage [Metricbeat System] ECS",
+                    "type": "metrics"
+                }
+            },
+            "id": "bfa5e400-1b16-11e7-b09e-037021c4f8df-ecs",
+            "type": "visualization",
+            "version": 1
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                },
+                "title": "Top Processes By CPU [Metricbeat System] ECS",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "params": {
+                        "axis_formatter": "number",
+                        "axis_position": "left",
+                        "bar_color_rules": [
+                            {
+                                "bar_color": "rgba(104,188,0,1)",
+                                "id": "60e11be0-1b18-11e7-b09e-037021c4f8df",
+                                "operator": "gte",
+                                "value": 0
+                            }
+                        ],
+                        "drilldown_url": "",
+                        "filter": "",
+                        "id": "5f5b8d50-1b18-11e7-b09e-037021c4f8df",
+                        "index_pattern": "metricbeat-*",
+                        "interval": "auto",
+                        "series": [
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "#68BC00",
+                                "fill": 0.5,
+                                "formatter": "percent",
+                                "id": "5f5b8d51-1b18-11e7-b09e-037021c4f8df",
+                                "line_width": 1,
+                                "metrics": [
+                                    {
+                                        "field": "system.process.cpu.total.pct",
+                                        "id": "5f5b8d52-1b18-11e7-b09e-037021c4f8df",
+                                        "type": "avg"
+                                    }
+                                ],
+                                "point_size": 1,
+                                "seperate_axis": 0,
+                                "split_mode": "terms",
+                                "stacked": "none",
+                                "terms_field": "process.name",
+                                "terms_order_by": "5f5b8d52-1b18-11e7-b09e-037021c4f8df"
+                            }
+                        ],
+                        "show_grid": 1,
+                        "show_legend": 1,
+                        "time_field": "@timestamp",
+                        "type": "top_n"
+                    },
+                    "title": "Top Processes By CPU [Metricbeat System] ECS",
+                    "type": "metrics"
+                }
+            },
+            "id": "e0f001c0-1b18-11e7-b09e-037021c4f8df-ecs",
+            "type": "visualization",
+            "version": 1
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                },
+                "title": "Processes By Memory [Metricbeat System] ECS",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "params": {
+                        "axis_formatter": "number",
+                        "axis_position": "left",
+                        "bar_color_rules": [
+                            {
+                                "bar_color": "rgba(104,188,0,1)",
+                                "id": "efb9b660-1b18-11e7-b09e-037021c4f8df",
+                                "operator": "gte",
+                                "value": 0
+                            },
+                            {
+                                "bar_color": "rgba(254,146,0,1)",
+                                "id": "17fcb820-1b19-11e7-b09e-037021c4f8df",
+                                "operator": "gte",
+                                "value": 0.7
+                            },
+                            {
+                                "bar_color": "rgba(211,49,21,1)",
+                                "id": "1dd61070-1b19-11e7-b09e-037021c4f8df",
+                                "operator": "gte",
+                                "value": 0.85
+                            }
+                        ],
+                        "drilldown_url": "",
+                        "filter": "",
+                        "id": "edfceb30-1b18-11e7-b09e-037021c4f8df",
+                        "index_pattern": "metricbeat-*",
+                        "interval": "auto",
+                        "series": [
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "#68BC00",
+                                "fill": 0.5,
+                                "formatter": "percent",
+                                "id": "edfceb31-1b18-11e7-b09e-037021c4f8df",
+                                "line_width": 1,
+                                "metrics": [
+                                    {
+                                        "field": "system.process.memory.rss.pct",
+                                        "id": "edfceb32-1b18-11e7-b09e-037021c4f8df",
+                                        "type": "avg"
+                                    }
+                                ],
+                                "point_size": 1,
+                                "seperate_axis": 0,
+                                "split_mode": "terms",
+                                "stacked": "none",
+                                "terms_field": "process.name",
+                                "terms_order_by": "edfceb32-1b18-11e7-b09e-037021c4f8df"
+                            }
+                        ],
+                        "show_grid": 1,
+                        "show_legend": 1,
+                        "time_field": "@timestamp",
+                        "type": "top_n"
+                    },
+                    "title": "Processes By Memory [Metricbeat System] ECS",
+                    "type": "metrics"
+                }
+            },
+            "id": "2e224660-1b19-11e7-b09e-037021c4f8df-ecs",
+            "type": "visualization",
+            "version": 1
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                },
+                "title": "CPU Usage [Metricbeat System] ECS",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "params": {
+                        "axis_formatter": "number",
+                        "axis_position": "left",
+                        "id": "80a04950-1b19-11e7-b09e-037021c4f8df",
+                        "index_pattern": "metricbeat-*",
+                        "interval": "auto",
+                        "series": [
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "#68BC00",
+                                "fill": "1",
+                                "formatter": "percent",
+                                "id": "80a04951-1b19-11e7-b09e-037021c4f8df",
+                                "label": "user",
+                                "line_width": 1,
+                                "metrics": [
+                                    {
+                                        "field": "system.cpu.user.pct",
+                                        "id": "80a04952-1b19-11e7-b09e-037021c4f8df",
+                                        "type": "avg"
+                                    }
+                                ],
+                                "point_size": "0",
+                                "seperate_axis": 0,
+                                "split_mode": "everything",
+                                "stacked": "stacked"
+                            },
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "rgba(211,49,21,1)",
+                                "fill": "1",
+                                "formatter": "percent",
+                                "id": "993acf30-1b19-11e7-b09e-037021c4f8df",
+                                "label": "system",
+                                "line_width": 1,
+                                "metrics": [
+                                    {
+                                        "field": "system.cpu.system.pct",
+                                        "id": "993acf31-1b19-11e7-b09e-037021c4f8df",
+                                        "type": "avg"
+                                    }
+                                ],
+                                "point_size": "0",
+                                "seperate_axis": 0,
+                                "split_mode": "everything",
+                                "stacked": "stacked"
+                            },
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "rgba(123,100,255,1)",
+                                "fill": "1",
+                                "formatter": "percent",
+                                "id": "65ca35e0-1b1a-11e7-b09e-037021c4f8df",
+                                "label": "nice",
+                                "line_width": 1,
+                                "metrics": [
+                                    {
+                                        "field": "system.cpu.nice.pct",
+                                        "id": "65ca5cf0-1b1a-11e7-b09e-037021c4f8df",
+                                        "type": "avg"
+                                    }
+                                ],
+                                "point_size": "0",
+                                "seperate_axis": 0,
+                                "split_mode": "everything",
+                                "stacked": "stacked"
+                            },
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "rgba(226,115,0,1)",
+                                "fill": "1",
+                                "formatter": "percent",
+                                "id": "741b5f20-1b1a-11e7-b09e-037021c4f8df",
+                                "label": "irq",
+                                "line_width": 1,
+                                "metrics": [
+                                    {
+                                        "field": "system.cpu.irq.pct",
+                                        "id": "741b5f21-1b1a-11e7-b09e-037021c4f8df",
+                                        "type": "avg"
+                                    }
+                                ],
+                                "point_size": "0",
+                                "seperate_axis": 0,
+                                "split_mode": "everything",
+                                "stacked": "stacked"
+                            },
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "rgba(176,188,0,1)",
+                                "fill": "1",
+                                "formatter": "percent",
+                                "id": "2efc5d40-1b1a-11e7-b09e-037021c4f8df",
+                                "label": "softirq",
+                                "line_width": 1,
+                                "metrics": [
+                                    {
+                                        "field": "system.cpu.softirq.pct",
+                                        "id": "2efc5d41-1b1a-11e7-b09e-037021c4f8df",
+                                        "type": "avg"
+                                    }
+                                ],
+                                "point_size": "0",
+                                "seperate_axis": 0,
+                                "split_mode": "everything",
+                                "stacked": "stacked"
+                            },
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "rgba(15,20,25,1)",
+                                "fill": "1",
+                                "formatter": "percent",
+                                "id": "ae644a30-1b19-11e7-b09e-037021c4f8df",
+                                "label": "iowait",
+                                "line_width": 1,
+                                "metrics": [
+                                    {
+                                        "field": "system.cpu.iowait.pct",
+                                        "id": "ae644a31-1b19-11e7-b09e-037021c4f8df",
+                                        "type": "avg"
+                                    }
+                                ],
+                                "point_size": "0",
+                                "seperate_axis": 0,
+                                "split_mode": "everything",
+                                "stacked": "stacked"
+                            }
+                        ],
+                        "show_grid": 1,
+                        "show_legend": 1,
+                        "time_field": "@timestamp",
+                        "type": "timeseries"
+                    },
+                    "title": "CPU Usage [Metricbeat System] ECS",
+                    "type": "metrics"
+                }
+            },
+            "id": "ab2d1e90-1b1a-11e7-b09e-037021c4f8df-ecs",
+            "type": "visualization",
+            "version": 1
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                },
+                "title": "Disk IO (Bytes) [Metricbeat System] ECS",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "params": {
+                        "axis_formatter": "number",
+                        "axis_position": "left",
+                        "filter": "",
+                        "id": "d3c67db0-1b1a-11e7-b09e-037021c4f8df",
+                        "index_pattern": "metricbeat-*",
+                        "interval": "auto",
+                        "series": [
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "rgba(22,165,165,1)",
+                                "fill": "1",
+                                "formatter": "bytes",
+                                "id": "d3c67db1-1b1a-11e7-b09e-037021c4f8df",
+                                "label": "reads",
+                                "line_width": 1,
+                                "metrics": [
+                                    {
+                                        "field": "system.diskio.read.bytes",
+                                        "id": "d3c67db2-1b1a-11e7-b09e-037021c4f8df",
+                                        "type": "max"
+                                    },
+                                    {
+                                        "field": "d3c67db2-1b1a-11e7-b09e-037021c4f8df",
+                                        "id": "f55b9910-1b1a-11e7-b09e-037021c4f8df",
+                                        "type": "derivative",
+                                        "unit": "1s"
+                                    },
+                                    {
+                                        "field": "f55b9910-1b1a-11e7-b09e-037021c4f8df",
+                                        "id": "dcbbb100-1b93-11e7-8ada-3df93aab833e",
+                                        "type": "positive_only",
+                                        "unit": ""
+                                    }
+                                ],
+                                "point_size": "0",
+                                "seperate_axis": 0,
+                                "split_mode": "everything",
+                                "stacked": "none",
+                                "value_template": "{{value}}/s"
+                            },
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "rgba(251,158,0,1)",
+                                "fill": "1",
+                                "formatter": "bytes",
+                                "id": "144124d0-1b1b-11e7-b09e-037021c4f8df",
+                                "label": "writes",
+                                "line_width": 1,
+                                "metrics": [
+                                    {
+                                        "field": "system.diskio.write.bytes",
+                                        "id": "144124d1-1b1b-11e7-b09e-037021c4f8df",
+                                        "type": "max"
+                                    },
+                                    {
+                                        "field": "144124d1-1b1b-11e7-b09e-037021c4f8df",
+                                        "id": "144124d2-1b1b-11e7-b09e-037021c4f8df",
+                                        "type": "derivative",
+                                        "unit": "1s"
+                                    },
+                                    {
+                                        "id": "144124d4-1b1b-11e7-b09e-037021c4f8df",
+                                        "script": "params.rate > 0 ? params.rate * -1 : 0",
+                                        "type": "calculation",
+                                        "variables": [
+                                            {
+                                                "field": "144124d2-1b1b-11e7-b09e-037021c4f8df",
+                                                "id": "144124d3-1b1b-11e7-b09e-037021c4f8df",
+                                                "name": "rate"
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "point_size": "0",
+                                "seperate_axis": 0,
+                                "split_mode": "everything",
+                                "stacked": "none",
+                                "value_template": "{{value}}/s"
+                            }
+                        ],
+                        "show_grid": 1,
+                        "show_legend": 1,
+                        "time_field": "@timestamp",
+                        "type": "timeseries"
+                    },
+                    "title": "Disk IO (Bytes) [Metricbeat System] ECS",
+                    "type": "metrics"
+                }
+            },
+            "id": "4e4bb1e0-1b1b-11e7-b09e-037021c4f8df-ecs",
+            "type": "visualization",
+            "version": 1
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                },
+                "title": "Load Gauge [Metricbeat System] ECS",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "params": {
+                        "axis_formatter": "number",
+                        "axis_position": "left",
+                        "background_color_rules": [
+                            {
+                                "id": "feefabd0-1b90-11e7-bec4-a5e9ec5cab8b"
+                            }
+                        ],
+                        "gauge_color_rules": [
+                            {
+                                "id": "ffd94880-1b90-11e7-bec4-a5e9ec5cab8b"
+                            }
+                        ],
+                        "gauge_inner_width": 10,
+                        "gauge_style": "half",
+                        "gauge_width": 10,
+                        "id": "fdcc6180-1b90-11e7-bec4-a5e9ec5cab8b",
+                        "index_pattern": "metricbeat-*",
+                        "interval": "auto",
+                        "series": [
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "#68BC00",
+                                "fill": 0.5,
+                                "formatter": "number",
+                                "id": "fdcc6181-1b90-11e7-bec4-a5e9ec5cab8b",
+                                "label": "5m Load",
+                                "line_width": 1,
+                                "metrics": [
+                                    {
+                                        "field": "system.load.5",
+                                        "id": "fdcc6182-1b90-11e7-bec4-a5e9ec5cab8b",
+                                        "type": "avg"
+                                    }
+                                ],
+                                "point_size": 1,
+                                "seperate_axis": 0,
+                                "split_mode": "everything",
+                                "stacked": "none"
+                            }
+                        ],
+                        "show_grid": 1,
+                        "show_legend": 1,
+                        "time_field": "@timestamp",
+                        "type": "gauge"
+                    },
+                    "title": "Load Gauge [Metricbeat System] ECS",
+                    "type": "metrics"
+                }
+            },
+            "id": "26732e20-1b91-11e7-bec4-a5e9ec5cab8b-ecs",
+            "type": "visualization",
+            "version": 1
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                },
+                "title": "CPU Usage Gauge [Metricbeat System] ECS",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "params": {
+                        "axis_formatter": "number",
+                        "axis_position": "left",
+                        "filter": "",
+                        "gauge_color_rules": [
+                            {
+                                "gauge": "rgba(104,188,0,1)",
+                                "id": "4ef2c3b0-1b91-11e7-bec4-a5e9ec5cab8b",
+                                "operator": "gte",
+                                "value": 0
+                            },
+                            {
+                                "gauge": "rgba(254,146,0,1)",
+                                "id": "e6561ae0-1b91-11e7-bec4-a5e9ec5cab8b",
+                                "operator": "gte",
+                                "value": 0.7
+                            },
+                            {
+                                "gauge": "rgba(211,49,21,1)",
+                                "id": "ec655040-1b91-11e7-bec4-a5e9ec5cab8b",
+                                "operator": "gte",
+                                "value": 0.85
+                            }
+                        ],
+                        "gauge_inner_width": 10,
+                        "gauge_max": "1",
+                        "gauge_style": "half",
+                        "gauge_width": 10,
+                        "id": "4c9e2550-1b91-11e7-bec4-a5e9ec5cab8b",
+                        "index_pattern": "metricbeat-*",
+                        "interval": "auto",
+                        "series": [
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "#68BC00",
+                                "fill": 0.5,
+                                "formatter": "percent",
+                                "id": "4c9e2551-1b91-11e7-bec4-a5e9ec5cab8b",
+                                "label": "CPU Usage",
+                                "line_width": 1,
+                                "metrics": [
+                                    {
+                                        "field": "system.cpu.user.pct",
+                                        "id": "4c9e2552-1b91-11e7-bec4-a5e9ec5cab8b",
+                                        "type": "avg"
+                                    },
+                                    {
+                                        "field": "system.cpu.system.pct",
+                                        "id": "225c2140-5fd7-11e7-a63a-a937b7c1a7e1",
+                                        "type": "avg"
+                                    },
+                                    {
+                                        "field": "system.cpu.cores",
+                                        "id": "837a30c0-5fd7-11e7-a63a-a937b7c1a7e1",
+                                        "type": "avg"
+                                    },
+                                    {
+                                        "id": "587aa510-1b91-11e7-bec4-a5e9ec5cab8b",
+                                        "script": "params.n > 0 ? (params.user+params.system)/params.n : null",
+                                        "type": "calculation",
+                                        "variables": [
+                                            {
+                                                "field": "4c9e2552-1b91-11e7-bec4-a5e9ec5cab8b",
+                                                "id": "5a19af10-1b91-11e7-bec4-a5e9ec5cab8b",
+                                                "name": "user"
+                                            },
+                                            {
+                                                "field": "225c2140-5fd7-11e7-a63a-a937b7c1a7e1",
+                                                "id": "32b54f80-5fd7-11e7-a63a-a937b7c1a7e1",
+                                                "name": "system"
+                                            },
+                                            {
+                                                "field": "837a30c0-5fd7-11e7-a63a-a937b7c1a7e1",
+                                                "id": "8ba6eef0-5fd7-11e7-a63a-a937b7c1a7e1",
+                                                "name": "n"
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "point_size": 1,
+                                "seperate_axis": 0,
+                                "split_mode": "everything",
+                                "stacked": "none"
+                            }
+                        ],
+                        "show_grid": 1,
+                        "show_legend": 1,
+                        "time_field": "@timestamp",
+                        "type": "gauge"
+                    },
+                    "title": "CPU Usage Gauge [Metricbeat System] ECS",
+                    "type": "metrics"
+                }
+            },
+            "id": "83e12df0-1b91-11e7-bec4-a5e9ec5cab8b-ecs",
+            "type": "visualization",
+            "version": 2
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                },
+                "title": "Memory Usage Gauge [Metricbeat System] ECS",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "params": {
+                        "axis_formatter": "number",
+                        "axis_position": "left",
+                        "filter": "",
+                        "gauge_color_rules": [
+                            {
+                                "gauge": "rgba(104,188,0,1)",
+                                "id": "a0d522e0-1b91-11e7-bec4-a5e9ec5cab8b",
+                                "operator": "gte",
+                                "value": 0
+                            },
+                            {
+                                "gauge": "rgba(254,146,0,1)",
+                                "id": "b45ad8f0-1b91-11e7-bec4-a5e9ec5cab8b",
+                                "operator": "gte",
+                                "value": 0.7
+                            },
+                            {
+                                "gauge": "rgba(211,49,21,1)",
+                                "id": "c06e9550-1b91-11e7-bec4-a5e9ec5cab8b",
+                                "operator": "gte",
+                                "value": 0.85
+                            }
+                        ],
+                        "gauge_inner_width": 10,
+                        "gauge_max": "1",
+                        "gauge_style": "half",
+                        "gauge_width": 10,
+                        "id": "9f51b730-1b91-11e7-bec4-a5e9ec5cab8b",
+                        "index_pattern": "metricbeat-*",
+                        "interval": "auto",
+                        "series": [
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "#68BC00",
+                                "fill": 0.5,
+                                "formatter": "percent",
+                                "id": "9f51b731-1b91-11e7-bec4-a5e9ec5cab8b",
+                                "label": "Memory Usage",
+                                "line_width": 1,
+                                "metrics": [
+                                    {
+                                        "field": "system.memory.actual.used.pct",
+                                        "id": "9f51b732-1b91-11e7-bec4-a5e9ec5cab8b",
+                                        "type": "avg"
+                                    }
+                                ],
+                                "point_size": 1,
+                                "seperate_axis": 0,
+                                "split_mode": "everything",
+                                "stacked": "none"
+                            }
+                        ],
+                        "show_grid": 1,
+                        "show_legend": 1,
+                        "time_field": "@timestamp",
+                        "type": "gauge"
+                    },
+                    "title": "Memory Usage Gauge [Metricbeat System] ECS",
+                    "type": "metrics"
+                }
+            },
+            "id": "d3166e80-1b91-11e7-bec4-a5e9ec5cab8b-ecs",
+            "type": "visualization",
+            "version": 2
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                },
+                "title": "Inbound Traffic [Metricbeat System] ECS",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "params": {
+                        "axis_formatter": "number",
+                        "axis_position": "left",
+                        "background_color_rules": [
+                            {
+                                "id": "0e346760-1b92-11e7-bec4-a5e9ec5cab8b"
+                            }
+                        ],
+                        "filter": "-system.network.name:l*",
+                        "id": "0c761590-1b92-11e7-bec4-a5e9ec5cab8b",
+                        "index_pattern": "metricbeat-*",
+                        "interval": "auto",
+                        "series": [
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "#68BC00",
+                                "fill": 0.5,
+                                "formatter": "bytes",
+                                "id": "0c761591-1b92-11e7-bec4-a5e9ec5cab8b",
+                                "label": "Inbound Traffic",
+                                "line_width": 1,
+                                "metrics": [
+                                    {
+                                        "field": "system.network.in.bytes",
+                                        "id": "0c761592-1b92-11e7-bec4-a5e9ec5cab8b",
+                                        "type": "max"
+                                    },
+                                    {
+                                        "field": "0c761592-1b92-11e7-bec4-a5e9ec5cab8b",
+                                        "id": "1d659060-1b92-11e7-bec4-a5e9ec5cab8b",
+                                        "type": "derivative",
+                                        "unit": "1s"
+                                    },
+                                    {
+                                        "field": "1d659060-1b92-11e7-bec4-a5e9ec5cab8b",
+                                        "id": "f2074f70-1b92-11e7-a416-41f5ccdba2e6",
+                                        "type": "positive_only",
+                                        "unit": ""
+                                    },
+                                    {
+                                        "function": "sum",
+                                        "id": "c40e18f0-2c55-11e7-a0ad-277ce466684d",
+                                        "type": "series_agg"
+                                    }
+                                ],
+                                "point_size": 1,
+                                "seperate_axis": 0,
+                                "split_mode": "terms",
+                                "stacked": "none",
+                                "terms_field": "system.network.name",
+                                "value_template": "{{value}}/s"
+                            },
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "#68BC00",
+                                "fill": 0.5,
+                                "formatter": "bytes",
+                                "id": "37f70440-1b92-11e7-bec4-a5e9ec5cab8b",
+                                "label": "Total Transferred",
+                                "line_width": 1,
+                                "metrics": [
+                                    {
+                                        "field": "system.network.in.bytes",
+                                        "id": "37f72b50-1b92-11e7-bec4-a5e9ec5cab8b",
+                                        "type": "max"
+                                    },
+                                    {
+                                        "field": "37f72b50-1b92-11e7-bec4-a5e9ec5cab8b",
+                                        "id": "37f72b51-1b92-11e7-bec4-a5e9ec5cab8b",
+                                        "type": "derivative",
+                                        "unit": ""
+                                    },
+                                    {
+                                        "field": "37f72b51-1b92-11e7-bec4-a5e9ec5cab8b",
+                                        "id": "f9da2dd0-1b92-11e7-a416-41f5ccdba2e6",
+                                        "type": "positive_only",
+                                        "unit": ""
+                                    },
+                                    {
+                                        "field": "f9da2dd0-1b92-11e7-a416-41f5ccdba2e6",
+                                        "function": "overall_sum",
+                                        "id": "3e63c2f0-1b92-11e7-bec4-a5e9ec5cab8b",
+                                        "sigma": "",
+                                        "type": "series_agg"
+                                    }
+                                ],
+                                "point_size": 1,
+                                "seperate_axis": 0,
+                                "split_mode": "terms",
+                                "stacked": "none",
+                                "terms_field": "system.network.name",
+                                "value_template": "{{value}}"
+                            }
+                        ],
+                        "show_grid": 1,
+                        "show_legend": 1,
+                        "time_field": "@timestamp",
+                        "type": "metric"
+                    },
+                    "title": "Inbound Traffic [Metricbeat System] ECS",
+                    "type": "metrics"
+                }
+            },
+            "id": "522ee670-1b92-11e7-bec4-a5e9ec5cab8b-ecs",
+            "type": "visualization",
+            "version": 2
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                },
+                "title": "Outbound Traffic [Metricbeat System] ECS",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "params": {
+                        "axis_formatter": "number",
+                        "axis_position": "left",
+                        "background_color_rules": [
+                            {
+                                "id": "0e346760-1b92-11e7-bec4-a5e9ec5cab8b"
+                            }
+                        ],
+                        "filter": "-system.network.name:l*",
+                        "id": "0c761590-1b92-11e7-bec4-a5e9ec5cab8b",
+                        "index_pattern": "metricbeat-*",
+                        "interval": "auto",
+                        "series": [
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "#68BC00",
+                                "fill": 0.5,
+                                "formatter": "bytes",
+                                "id": "0c761591-1b92-11e7-bec4-a5e9ec5cab8b",
+                                "label": "Outbound Traffic",
+                                "line_width": 1,
+                                "metrics": [
+                                    {
+                                        "field": "system.network.out.bytes",
+                                        "id": "0c761592-1b92-11e7-bec4-a5e9ec5cab8b",
+                                        "type": "max"
+                                    },
+                                    {
+                                        "field": "0c761592-1b92-11e7-bec4-a5e9ec5cab8b",
+                                        "id": "1d659060-1b92-11e7-bec4-a5e9ec5cab8b",
+                                        "type": "derivative",
+                                        "unit": "1s"
+                                    },
+                                    {
+                                        "field": "1d659060-1b92-11e7-bec4-a5e9ec5cab8b",
+                                        "id": "f2074f70-1b92-11e7-a416-41f5ccdba2e6",
+                                        "type": "positive_only",
+                                        "unit": ""
+                                    },
+                                    {
+                                        "function": "sum",
+                                        "id": "a1737470-2c55-11e7-a0ad-277ce466684d",
+                                        "type": "series_agg"
+                                    }
+                                ],
+                                "point_size": 1,
+                                "seperate_axis": 0,
+                                "split_mode": "terms",
+                                "stacked": "none",
+                                "terms_field": "system.network.name",
+                                "value_template": "{{value}}/s"
+                            },
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "#68BC00",
+                                "fill": 0.5,
+                                "formatter": "bytes",
+                                "id": "37f70440-1b92-11e7-bec4-a5e9ec5cab8b",
+                                "label": "Total Transferred",
+                                "line_width": 1,
+                                "metrics": [
+                                    {
+                                        "field": "system.network.out.bytes",
+                                        "id": "37f72b50-1b92-11e7-bec4-a5e9ec5cab8b",
+                                        "type": "max"
+                                    },
+                                    {
+                                        "field": "37f72b50-1b92-11e7-bec4-a5e9ec5cab8b",
+                                        "id": "37f72b51-1b92-11e7-bec4-a5e9ec5cab8b",
+                                        "type": "derivative",
+                                        "unit": ""
+                                    },
+                                    {
+                                        "field": "37f72b51-1b92-11e7-bec4-a5e9ec5cab8b",
+                                        "id": "f9da2dd0-1b92-11e7-a416-41f5ccdba2e6",
+                                        "type": "positive_only",
+                                        "unit": ""
+                                    },
+                                    {
+                                        "field": "f9da2dd0-1b92-11e7-a416-41f5ccdba2e6",
+                                        "function": "overall_sum",
+                                        "id": "3e63c2f0-1b92-11e7-bec4-a5e9ec5cab8b",
+                                        "sigma": "",
+                                        "type": "series_agg"
+                                    }
+                                ],
+                                "point_size": 1,
+                                "seperate_axis": 0,
+                                "split_mode": "terms",
+                                "stacked": "none",
+                                "terms_field": "system.network.name",
+                                "value_template": "{{value}}"
+                            }
+                        ],
+                        "show_grid": 1,
+                        "show_legend": 1,
+                        "time_field": "@timestamp",
+                        "type": "metric"
+                    },
+                    "title": "Outbound Traffic [Metricbeat System] ECS",
+                    "type": "metrics"
+                }
+            },
+            "id": "1aae9140-1b93-11e7-8ada-3df93aab833e-ecs",
+            "type": "visualization",
+            "version": 2
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                },
+                "title": "Disk Usage [Metricbeat System] ECS",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "params": {
+                        "axis_formatter": "number",
+                        "axis_position": "left",
+                        "bar_color_rules": [
+                            {
+                                "bar_color": "rgba(104,188,0,1)",
+                                "id": "bf525310-1b95-11e7-8ada-3df93aab833e",
+                                "operator": "gte",
+                                "value": 0
+                            },
+                            {
+                                "bar_color": "rgba(254,146,0,1)",
+                                "id": "125fc4c0-1b96-11e7-8ada-3df93aab833e",
+                                "operator": "gte",
+                                "value": 0.7
+                            },
+                            {
+                                "bar_color": "rgba(211,49,21,1)",
+                                "id": "1a5c7240-1b96-11e7-8ada-3df93aab833e",
+                                "operator": "gte",
+                                "value": 0.85
+                            }
+                        ],
+                        "drilldown_url": "",
+                        "filter": "-system.filesystem.mount_point:\\/run* AND -system.filesystem.mount_point:\\/sys* AND -system.filesystem.mount_point:\\/dev* AND -system.filesystem.mount_point:\\/proc* AND -system.filesystem.mount_point:\\/var* AND -system.filesystem.mount_point:\\/boot",
+                        "id": "9f7e48a0-1b95-11e7-8ada-3df93aab833e",
+                        "index_pattern": "metricbeat-*",
+                        "interval": "auto",
+                        "series": [
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "#68BC00",
+                                "fill": 0.5,
+                                "formatter": "percent",
+                                "id": "9f7e48a1-1b95-11e7-8ada-3df93aab833e",
+                                "line_width": 1,
+                                "metrics": [
+                                    {
+                                        "field": "system.filesystem.used.pct",
+                                        "id": "9f7e48a2-1b95-11e7-8ada-3df93aab833e",
+                                        "type": "avg"
+                                    }
+                                ],
+                                "point_size": 1,
+                                "seperate_axis": 0,
+                                "split_mode": "terms",
+                                "stacked": "none",
+                                "terms_field": "system.filesystem.mount_point"
+                            }
+                        ],
+                        "show_grid": 1,
+                        "show_legend": 1,
+                        "time_field": "@timestamp",
+                        "type": "top_n"
+                    },
+                    "title": "Disk Usage [Metricbeat System] ECS",
+                    "type": "metrics"
+                }
+            },
+            "id": "34f97ee0-1b96-11e7-8ada-3df93aab833e-ecs",
+            "type": "visualization",
+            "version": 1
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                },
+                "title": "System Navigation [Metricbeat System] ECS",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "params": {
+                        "fontSize": 12,
+                        "markdown": "[System Overview](#/dashboard/Metricbeat-system-overview-ecs)  | [Host Overview](#/dashboard/79ffd6e0-faa0-11e6-947f-177f697178b8-ecs) |\n[Containers overview](#/dashboard/CPU-slash-Memory-per-container-ecs)"
+                    },
+                    "title": "System Navigation [Metricbeat System] ECS",
+                    "type": "markdown"
+                }
+            },
+            "id": "System-Navigation-ecs",
+            "type": "visualization",
+            "version": 3
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                },
+                "title": "Swap usage [Metricbeat System] ECS",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "params": {
+                        "axis_formatter": "number",
+                        "axis_position": "left",
+                        "filter": "",
+                        "gauge_color_rules": [
+                            {
+                                "gauge": "rgba(104,188,0,1)",
+                                "id": "d17c1e90-4d59-11e7-aee5-fdc812cc3bec",
+                                "operator": "gte",
+                                "value": 0
+                            },
+                            {
+                                "gauge": "rgba(251,158,0,1)",
+                                "id": "fc1d3490-4d59-11e7-aee5-fdc812cc3bec",
+                                "operator": "gte",
+                                "value": 0.7
+                            },
+                            {
+                                "gauge": "rgba(211,49,21,1)",
+                                "id": "0e204240-4d5a-11e7-aee5-fdc812cc3bec",
+                                "operator": "gte",
+                                "value": 0.85
+                            }
+                        ],
+                        "gauge_inner_width": 10,
+                        "gauge_max": "",
+                        "gauge_style": "half",
+                        "gauge_width": 10,
+                        "id": "cee2fd20-4d59-11e7-aee5-fdc812cc3bec",
+                        "index_pattern": "metricbeat-*",
+                        "interval": "auto",
+                        "series": [
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "#68BC00",
+                                "fill": 0.5,
+                                "formatter": "percent",
+                                "id": "cee2fd21-4d59-11e7-aee5-fdc812cc3bec",
+                                "label": "Swap usage",
+                                "line_width": 1,
+                                "metrics": [
+                                    {
+                                        "field": "system.memory.swap.used.pct",
+                                        "id": "cee2fd22-4d59-11e7-aee5-fdc812cc3bec",
+                                        "type": "avg"
+                                    }
+                                ],
+                                "point_size": 1,
+                                "seperate_axis": 0,
+                                "split_mode": "everything",
+                                "stacked": "none"
+                            }
+                        ],
+                        "show_grid": 1,
+                        "show_legend": 1,
+                        "time_field": "@timestamp",
+                        "type": "gauge"
+                    },
+                    "title": "Swap usage [Metricbeat System] ECS",
+                    "type": "metrics"
+                }
+            },
+            "id": "19e123b0-4d5a-11e7-aee5-fdc812cc3bec-ecs",
+            "type": "visualization",
+            "version": 1
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                },
+                "title": "Memory usage vs total [Metricbeat System] ECS",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "listeners": {},
+                    "params": {
+                        "axis_formatter": "number",
+                        "axis_position": "left",
+                        "background_color_rules": [
+                            {
+                                "id": "6f7618b0-4d5c-11e7-aa29-87a97a796de6"
+                            }
+                        ],
+                        "id": "6bc65720-4d5c-11e7-aa29-87a97a796de6",
+                        "index_pattern": "metricbeat-*",
+                        "interval": "auto",
+                        "series": [
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "#68BC00",
+                                "fill": 0.5,
+                                "formatter": "bytes",
+                                "id": "6bc65721-4d5c-11e7-aa29-87a97a796de6",
+                                "label": "Memory usage",
+                                "line_width": 1,
+                                "metrics": [
+                                    {
+                                        "field": "system.memory.actual.used.bytes",
+                                        "id": "6bc65722-4d5c-11e7-aa29-87a97a796de6",
+                                        "type": "avg"
+                                    }
+                                ],
+                                "point_size": 1,
+                                "seperate_axis": 0,
+                                "split_mode": "everything",
+                                "stacked": "none"
+                            },
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "#68BC00",
+                                "fill": 0.5,
+                                "formatter": "bytes",
+                                "id": "b8fe6820-4d5c-11e7-aa29-87a97a796de6",
+                                "label": "Total Memory",
+                                "line_width": 1,
+                                "metrics": [
+                                    {
+                                        "field": "system.memory.total",
+                                        "id": "b8fe6821-4d5c-11e7-aa29-87a97a796de6",
+                                        "type": "avg"
+                                    }
+                                ],
+                                "point_size": 1,
+                                "seperate_axis": 0,
+                                "split_mode": "everything",
+                                "stacked": "none"
+                            }
+                        ],
+                        "show_legend": 1,
+                        "time_field": "@timestamp",
+                        "type": "metric"
+                    },
+                    "title": "Memory usage vs total ECS",
+                    "type": "metrics"
+                }
+            },
+            "id": "d2e80340-4d5c-11e7-aa29-87a97a796de6-ecs",
+            "type": "visualization",
+            "version": 1
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                },
+                "title": "Disk used [Metricbeat System] ECS",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "params": {
+                        "axis_formatter": "number",
+                        "axis_position": "left",
+                        "filter": "",
+                        "gauge_color_rules": [
+                            {
+                                "gauge": "rgba(104,188,0,1)",
+                                "id": "51921d10-4d1d-11e7-b5f2-2b7c1895bf32",
+                                "operator": "gte",
+                                "value": 0
+                            },
+                            {
+                                "gauge": "rgba(251,158,0,1)",
+                                "id": "f26de750-4d54-11e7-b5f2-2b7c1895bf32",
+                                "operator": "gte",
+                                "value": 0.7
+                            },
+                            {
+                                "gauge": "rgba(211,49,21,1)",
+                                "id": "fa31d190-4d54-11e7-b5f2-2b7c1895bf32",
+                                "operator": "gte",
+                                "value": 0.85
+                            }
+                        ],
+                        "gauge_inner_width": 10,
+                        "gauge_max": "1",
+                        "gauge_style": "half",
+                        "gauge_width": 10,
+                        "id": "4e4dc780-4d1d-11e7-b5f2-2b7c1895bf32",
+                        "index_pattern": "metricbeat-*",
+                        "interval": "auto",
+                        "series": [
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "#68BC00",
+                                "fill": 0.5,
+                                "formatter": "percent",
+                                "id": "4e4dee90-4d1d-11e7-b5f2-2b7c1895bf32",
+                                "label": "Disk used",
+                                "line_width": 1,
+                                "metrics": [
+                                    {
+                                        "field": "system.fsstat.total_size.used",
+                                        "id": "4e4dee91-4d1d-11e7-b5f2-2b7c1895bf32",
+                                        "type": "avg"
+                                    },
+                                    {
+                                        "field": "system.fsstat.total_size.total",
+                                        "id": "57c96ee0-4d54-11e7-b5f2-2b7c1895bf32",
+                                        "type": "avg"
+                                    },
+                                    {
+                                        "id": "6304cca0-4d54-11e7-b5f2-2b7c1895bf32",
+                                        "script": "params.total != null && params.total > 0 ? params.used/params.total : null",
+                                        "type": "calculation",
+                                        "variables": [
+                                            {
+                                                "field": "4e4dee91-4d1d-11e7-b5f2-2b7c1895bf32",
+                                                "id": "6da10430-4d54-11e7-b5f2-2b7c1895bf32",
+                                                "name": "used"
+                                            },
+                                            {
+                                                "field": "57c96ee0-4d54-11e7-b5f2-2b7c1895bf32",
+                                                "id": "73b8c510-4d54-11e7-b5f2-2b7c1895bf32",
+                                                "name": "total"
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "point_size": 1,
+                                "seperate_axis": 0,
+                                "split_mode": "everything",
+                                "stacked": "none"
+                            }
+                        ],
+                        "show_grid": 1,
+                        "show_legend": 1,
+                        "time_field": "@timestamp",
+                        "type": "gauge"
+                    },
+                    "title": "Disk used [Metricbeat System] ECS",
+                    "type": "metrics"
+                }
+            },
+            "id": "825fdb80-4d1d-11e7-b5f2-2b7c1895bf32-ecs",
+            "type": "visualization",
+            "version": 2
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                },
+                "title": "Packetloss [Metricbeat System] ECS",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "params": {
+                        "axis_formatter": "number",
+                        "axis_position": "left",
+                        "background_color_rules": [
+                            {
+                                "id": "6ba9b1f0-4d5d-11e7-aa29-87a97a796de6"
+                            }
+                        ],
+                        "id": "6984af10-4d5d-11e7-aa29-87a97a796de6",
+                        "index_pattern": "metricbeat-*",
+                        "interval": "auto",
+                        "series": [
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "#68BC00",
+                                "fill": 0.5,
+                                "formatter": "number",
+                                "id": "6984af11-4d5d-11e7-aa29-87a97a796de6",
+                                "label": "In Packetloss",
+                                "line_width": 1,
+                                "metrics": [
+                                    {
+                                        "field": "system.network.in.dropped",
+                                        "id": "6984af12-4d5d-11e7-aa29-87a97a796de6",
+                                        "type": "max"
+                                    }
+                                ],
+                                "point_size": 1,
+                                "seperate_axis": 0,
+                                "split_mode": "everything",
+                                "stacked": "none"
+                            },
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "#68BC00",
+                                "fill": 0.5,
+                                "formatter": "number",
+                                "id": "ac2e6b30-4d5d-11e7-aa29-87a97a796de6",
+                                "label": "Out Packetloss",
+                                "line_width": 1,
+                                "metrics": [
+                                    {
+                                        "field": "system.network.out.dropped",
+                                        "id": "ac2e6b31-4d5d-11e7-aa29-87a97a796de6",
+                                        "type": "max"
+                                    }
+                                ],
+                                "point_size": 1,
+                                "seperate_axis": 0,
+                                "split_mode": "everything",
+                                "stacked": "none"
+                            }
+                        ],
+                        "show_grid": 1,
+                        "show_legend": 1,
+                        "time_field": "@timestamp",
+                        "type": "metric"
+                    },
+                    "title": "Packetloss [Metricbeat System] ECS",
+                    "type": "metrics"
+                }
+            },
+            "id": "96976150-4d5d-11e7-aa29-87a97a796de6-ecs",
+            "type": "visualization",
+            "version": 1
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                },
+                "title": "Interfaces by Incoming traffic [Metricbeat System] ECS",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "params": {
+                        "axis_formatter": "number",
+                        "axis_position": "left",
+                        "bar_color_rules": [
+                            {
+                                "id": "44596d40-4d60-11e7-9a4c-ed99bbcaa42b"
+                            }
+                        ],
+                        "id": "42ceae90-4d60-11e7-9a4c-ed99bbcaa42b",
+                        "index_pattern": "metricbeat-*",
+                        "interval": "auto",
+                        "series": [
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "#68BC00",
+                                "fill": 0.5,
+                                "formatter": "bytes",
+                                "id": "42ced5a0-4d60-11e7-9a4c-ed99bbcaa42b",
+                                "label": "Interfaces by Incoming traffic",
+                                "line_width": 1,
+                                "metrics": [
+                                    {
+                                        "field": "system.network.in.bytes",
+                                        "id": "42ced5a1-4d60-11e7-9a4c-ed99bbcaa42b",
+                                        "type": "avg"
+                                    }
+                                ],
+                                "point_size": 1,
+                                "seperate_axis": 0,
+                                "split_mode": "terms",
+                                "stacked": "none",
+                                "terms_field": "system.network.name",
+                                "terms_order_by": "42ced5a1-4d60-11e7-9a4c-ed99bbcaa42b"
+                            }
+                        ],
+                        "show_grid": 1,
+                        "show_legend": 1,
+                        "time_field": "@timestamp",
+                        "type": "top_n"
+                    },
+                    "title": "Interfaces by Incoming traffic [Metricbeat System] ECS",
+                    "type": "metrics"
+                }
+            },
+            "id": "99381c80-4d60-11e7-9a4c-ed99bbcaa42b-ecs",
+            "type": "visualization",
+            "version": 1
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                },
+                "title": "Interfaces by Outgoing traffic [Metricbeat System] ECS",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "params": {
+                        "axis_formatter": "number",
+                        "axis_position": "left",
+                        "bar_color_rules": [
+                            {
+                                "id": "9db20be0-4d60-11e7-9a4c-ed99bbcaa42b"
+                            }
+                        ],
+                        "id": "9cdba910-4d60-11e7-9a4c-ed99bbcaa42b",
+                        "index_pattern": "metricbeat-*",
+                        "interval": "auto",
+                        "series": [
+                            {
+                                "axis_position": "right",
+                                "chart_type": "line",
+                                "color": "#68BC00",
+                                "fill": 0.5,
+                                "formatter": "bytes",
+                                "id": "9cdba911-4d60-11e7-9a4c-ed99bbcaa42b",
+                                "label": "Interfaces by Outgoing traffic",
+                                "line_width": 1,
+                                "metrics": [
+                                    {
+                                        "field": "system.network.out.bytes",
+                                        "id": "9cdba912-4d60-11e7-9a4c-ed99bbcaa42b",
+                                        "type": "avg"
+                                    }
+                                ],
+                                "point_size": 1,
+                                "seperate_axis": 0,
+                                "split_mode": "terms",
+                                "stacked": "none",
+                                "terms_field": "system.network.name",
+                                "terms_order_by": "9cdba912-4d60-11e7-9a4c-ed99bbcaa42b"
+                            }
+                        ],
+                        "show_grid": 1,
+                        "show_legend": 1,
+                        "time_field": "@timestamp",
+                        "type": "top_n"
+                    },
+                    "title": "Interfaces by Outgoing traffic [Metricbeat System] ECS",
+                    "type": "metrics"
+                }
+            },
+            "id": "c5e3cf90-4d60-11e7-9a4c-ed99bbcaa42b-ecs",
+            "type": "visualization",
+            "version": 1
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "index": "metricbeat-*",
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                },
+                "title": "Number of processes [Metricbeat System] ECS",
+                "uiStateJSON": {
+                    "vis": {
+                        "defaultColors": {
+                            "0 - 100": "rgb(0,104,55)"
+                        }
+                    }
+                },
+                "version": 1,
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true,
+                            "id": "1",
+                            "params": {
+                                "customLabel": "Processes",
+                                "field": "process.pid"
+                            },
+                            "schema": "metric",
+                            "type": "cardinality"
+                        }
+                    ],
+                    "listeners": {},
+                    "params": {
+                        "addLegend": false,
+                        "addTooltip": true,
+                        "gauge": {
+                            "autoExtend": false,
+                            "backStyle": "Full",
+                            "colorSchema": "Green to Red",
+                            "colorsRange": [
+                                {
+                                    "from": 0,
+                                    "to": 100
+                                }
+                            ],
+                            "gaugeColorMode": "None",
+                            "gaugeStyle": "Full",
+                            "gaugeType": "Metric",
+                            "invertColors": false,
+                            "labels": {
+                                "color": "black",
+                                "show": true
+                            },
+                            "orientation": "vertical",
+                            "percentageMode": false,
+                            "scale": {
+                                "color": "#333",
+                                "labels": false,
+                                "show": false,
+                                "width": 2
+                            },
+                            "style": {
+                                "bgColor": false,
+                                "bgFill": "#000",
+                                "fontSize": 60,
+                                "labelColor": false,
+                                "subText": ""
+                            },
+                            "type": "simple",
+                            "useRange": false,
+                            "verticalSplit": false
+                        },
+                        "type": "gauge"
+                    },
+                    "title": "Number of processes ECS",
+                    "type": "metric"
+                }
+            },
+            "id": "590a60f0-5d87-11e7-8884-1bb4c3b890e4-ecs",
+            "type": "visualization",
+            "version": 1
+        },
+        {
+            "attributes": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                },
+                "title": "Tip [Metricbeat System] ECS",
+                "uiStateJSON": {},
+                "version": 1,
+                "visState": {
+                    "aggs": [],
+                    "params": {
+                        "fontSize": 12,
+                        "markdown": "**TIP:** To select another host, go to the [System Overview](#/dashboard/Metricbeat-system-overview-ecs) dashboard and double-click a host name."
+                    },
+                    "title": "Tip [Metricbeat System] ECS",
+                    "type": "markdown"
+                }
+            },
+            "id": "3d65d450-a9c3-11e7-af20-67db8aecb295-ecs",
+            "type": "visualization",
+            "version": 2
+        },
+        {
+            "attributes": {
+                "description": "Overview of host metrics",
+                "hits": 0,
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                        "highlightAll": true,
+                        "query": {
+                            "language": "kuery",
+                            "query": "host.name:\"CHANGEME_HOSTNAME\""
+                        },
+                        "version": true
+                    }
+                },
+                "optionsJSON": {
+                    "darkTheme": false
+                },
+                "panelsJSON": [
+                    {
+                        "col": 1,
+                        "id": "6b7b9a40-faa1-11e6-86b1-cd7735ff7e23-ecs",
+                        "panelIndex": 1,
+                        "row": 12,
+                        "size_x": 6,
+                        "size_y": 3,
+                        "type": "visualization"
+                    },
+                    {
+                        "col": 7,
+                        "id": "4d546850-1b15-11e7-b09e-037021c4f8df-ecs",
+                        "panelIndex": 2,
+                        "row": 6,
+                        "size_x": 6,
+                        "size_y": 3,
+                        "type": "visualization"
+                    },
+                    {
+                        "col": 7,
+                        "id": "089b85d0-1b16-11e7-b09e-037021c4f8df-ecs",
+                        "panelIndex": 3,
+                        "row": 12,
+                        "size_x": 6,
+                        "size_y": 3,
+                        "type": "visualization"
+                    },
+                    {
+                        "col": 1,
+                        "id": "bfa5e400-1b16-11e7-b09e-037021c4f8df-ecs",
+                        "panelIndex": 4,
+                        "row": 9,
+                        "size_x": 6,
+                        "size_y": 3,
+                        "type": "visualization"
+                    },
+                    {
+                        "col": 7,
+                        "id": "e0f001c0-1b18-11e7-b09e-037021c4f8df-ecs",
+                        "panelIndex": 5,
+                        "row": 15,
+                        "size_x": 6,
+                        "size_y": 3,
+                        "type": "visualization"
+                    },
+                    {
+                        "col": 1,
+                        "id": "2e224660-1b19-11e7-b09e-037021c4f8df-ecs",
+                        "panelIndex": 6,
+                        "row": 15,
+                        "size_x": 6,
+                        "size_y": 3,
+                        "type": "visualization"
+                    },
+                    {
+                        "col": 1,
+                        "id": "ab2d1e90-1b1a-11e7-b09e-037021c4f8df-ecs",
+                        "panelIndex": 7,
+                        "row": 6,
+                        "size_x": 6,
+                        "size_y": 3,
+                        "type": "visualization"
+                    },
+                    {
+                        "col": 7,
+                        "id": "4e4bb1e0-1b1b-11e7-b09e-037021c4f8df-ecs",
+                        "panelIndex": 8,
+                        "row": 9,
+                        "size_x": 6,
+                        "size_y": 3,
+                        "type": "visualization"
+                    },
+                    {
+                        "col": 5,
+                        "id": "26732e20-1b91-11e7-bec4-a5e9ec5cab8b-ecs",
+                        "panelIndex": 9,
+                        "row": 2,
+                        "size_x": 2,
+                        "size_y": 2,
+                        "type": "visualization"
+                    },
+                    {
+                        "col": 1,
+                        "id": "83e12df0-1b91-11e7-bec4-a5e9ec5cab8b-ecs",
+                        "panelIndex": 10,
+                        "row": 2,
+                        "size_x": 2,
+                        "size_y": 2,
+                        "type": "visualization"
+                    },
+                    {
+                        "col": 3,
+                        "id": "d3166e80-1b91-11e7-bec4-a5e9ec5cab8b-ecs",
+                        "panelIndex": 11,
+                        "row": 2,
+                        "size_x": 2,
+                        "size_y": 2,
+                        "type": "visualization"
+                    },
+                    {
+                        "col": 7,
+                        "id": "522ee670-1b92-11e7-bec4-a5e9ec5cab8b-ecs",
+                        "panelIndex": 12,
+                        "row": 2,
+                        "size_x": 2,
+                        "size_y": 2,
+                        "type": "visualization"
+                    },
+                    {
+                        "col": 9,
+                        "id": "1aae9140-1b93-11e7-8ada-3df93aab833e-ecs",
+                        "panelIndex": 13,
+                        "row": 2,
+                        "size_x": 2,
+                        "size_y": 2,
+                        "type": "visualization"
+                    },
+                    {
+                        "col": 9,
+                        "id": "34f97ee0-1b96-11e7-8ada-3df93aab833e-ecs",
+                        "panelIndex": 14,
+                        "row": 4,
+                        "size_x": 4,
+                        "size_y": 2,
+                        "type": "visualization"
+                    },
+                    {
+                        "col": 1,
+                        "id": "System-Navigation-ecs",
+                        "panelIndex": 16,
+                        "row": 1,
+                        "size_x": 6,
+                        "size_y": 1,
+                        "type": "visualization"
+                    },
+                    {
+                        "col": 1,
+                        "id": "19e123b0-4d5a-11e7-aee5-fdc812cc3bec-ecs",
+                        "panelIndex": 21,
+                        "row": 4,
+                        "size_x": 2,
+                        "size_y": 2,
+                        "type": "visualization"
+                    },
+                    {
+                        "col": 3,
+                        "id": "d2e80340-4d5c-11e7-aa29-87a97a796de6-ecs",
+                        "panelIndex": 22,
+                        "row": 4,
+                        "size_x": 2,
+                        "size_y": 2,
+                        "type": "visualization"
+                    },
+                    {
+                        "col": 7,
+                        "id": "825fdb80-4d1d-11e7-b5f2-2b7c1895bf32-ecs",
+                        "panelIndex": 23,
+                        "row": 4,
+                        "size_x": 2,
+                        "size_y": 2,
+                        "type": "visualization"
+                    },
+                    {
+                        "col": 11,
+                        "id": "96976150-4d5d-11e7-aa29-87a97a796de6-ecs",
+                        "panelIndex": 25,
+                        "row": 2,
+                        "size_x": 2,
+                        "size_y": 2,
+                        "type": "visualization"
+                    },
+                    {
+                        "col": 1,
+                        "id": "99381c80-4d60-11e7-9a4c-ed99bbcaa42b-ecs",
+                        "panelIndex": 27,
+                        "row": 18,
+                        "size_x": 6,
+                        "size_y": 3,
+                        "type": "visualization"
+                    },
+                    {
+                        "col": 7,
+                        "id": "c5e3cf90-4d60-11e7-9a4c-ed99bbcaa42b-ecs",
+                        "panelIndex": 28,
+                        "row": 18,
+                        "size_x": 6,
+                        "size_y": 3,
+                        "type": "visualization"
+                    },
+                    {
+                        "col": 5,
+                        "id": "590a60f0-5d87-11e7-8884-1bb4c3b890e4-ecs",
+                        "panelIndex": 29,
+                        "row": 4,
+                        "size_x": 2,
+                        "size_y": 2,
+                        "type": "visualization"
+                    },
+                    {
+                        "col": 7,
+                        "id": "3d65d450-a9c3-11e7-af20-67db8aecb295-ecs",
+                        "panelIndex": 30,
+                        "row": 1,
+                        "size_x": 6,
+                        "size_y": 1,
+                        "type": "visualization"
+                    }
+                ],
+                "timeRestore": false,
+                "title": "[Metricbeat System] Host overview ECS",
+                "uiStateJSON": {
+                    "P-29": {
+                        "vis": {
+                            "defaultColors": {
+                                "0 - 100": "rgb(0,104,55)"
+                            }
+                        }
+                    }
+                },
+                "version": 1
+            },
+            "id": "79ffd6e0-faa0-11e6-947f-177f697178b8-ecs",
+            "type": "dashboard",
+            "version": 12
+        }
+    ],
+    "version": "6.0.0-rc1-SNAPSHOT"
+}

--- a/dev/package-beats/system-1.0.0/kibana/dashboard/Metricbeat-system-overview.json
+++ b/dev/package-beats/system-1.0.0/kibana/dashboard/Metricbeat-system-overview.json
@@ -1,0 +1,1110 @@
+{
+    "objects": [
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                }, 
+                "title": "System Navigation [Metricbeat System] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "fontSize": 12, 
+                        "markdown": "[System Overview](#/dashboard/Metricbeat-system-overview-ecs)  | [Host Overview](#/dashboard/79ffd6e0-faa0-11e6-947f-177f697178b8-ecs) |\n[Containers overview](#/dashboard/CPU-slash-Memory-per-container-ecs)"
+                    }, 
+                    "title": "System Navigation [Metricbeat System] ECS", 
+                    "type": "markdown"
+                }
+            }, 
+            "id": "System-Navigation-ecs", 
+            "type": "visualization", 
+            "version": 3
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "index": "metricbeat-*", 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                }, 
+                "title": "Number of hosts [Metricbeat System] ECS", 
+                "uiStateJSON": {
+                    "vis": {
+                        "defaultColors": {
+                            "0 - 100": "rgb(0,104,55)"
+                        }
+                    }
+                }, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "Number of hosts", 
+                                "field": "host.name"
+                            }, 
+                            "schema": "metric", 
+                            "type": "cardinality"
+                        }
+                    ], 
+                    "params": {
+                        "addLegend": false, 
+                        "addTooltip": true, 
+                        "gauge": {
+                            "autoExtend": false, 
+                            "backStyle": "Full", 
+                            "colorSchema": "Green to Red", 
+                            "colorsRange": [
+                                {
+                                    "from": 0, 
+                                    "to": 100
+                                }
+                            ], 
+                            "gaugeColorMode": "None", 
+                            "gaugeStyle": "Full", 
+                            "gaugeType": "Metric", 
+                            "invertColors": false, 
+                            "labels": {
+                                "color": "black", 
+                                "show": false
+                            }, 
+                            "orientation": "vertical", 
+                            "percentageMode": false, 
+                            "scale": {
+                                "color": "#333", 
+                                "labels": false, 
+                                "show": false, 
+                                "width": 2
+                            }, 
+                            "style": {
+                                "bgColor": false, 
+                                "bgFill": "#000", 
+                                "fontSize": "63", 
+                                "labelColor": false, 
+                                "subText": ""
+                            }, 
+                            "type": "simple", 
+                            "useRange": false, 
+                            "verticalSplit": false
+                        }, 
+                        "type": "gauge"
+                    }, 
+                    "title": "Number of hosts [Metricbeat System] ECS", 
+                    "type": "metric"
+                }
+            }, 
+            "id": "c6f2ffd0-4d17-11e7-a196-69b9a7a020a9-ecs", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                }, 
+                "title": "Top Hosts By Memory (Realtime) [Metricbeat System] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "bar_color_rules": [
+                            {
+                                "bar_color": "rgba(104,188,0,1)", 
+                                "id": "33349dd0-1b1c-11e7-b09e-037021c4f8df", 
+                                "operator": "gte", 
+                                "value": 0
+                            }, 
+                            {
+                                "bar_color": "rgba(254,146,0,1)", 
+                                "id": "997dc440-1b1c-11e7-b09e-037021c4f8df", 
+                                "operator": "gte", 
+                                "value": 0.6
+                            }, 
+                            {
+                                "bar_color": "rgba(211,49,21,1)", 
+                                "id": "a10d7f20-1b1c-11e7-b09e-037021c4f8df", 
+                                "operator": "gte", 
+                                "value": 0.85
+                            }
+                        ], 
+                        "drilldown_url": "../app/kibana#/dashboard/79ffd6e0-faa0-11e6-947f-177f697178b8-ecs?_a=(query:(language:kuery,query:'host.name:\"{{key}}\"'))",
+                        "filter": "", 
+                        "id": "31e5afa0-1b1c-11e7-b09e-037021c4f8df", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": 0.5, 
+                                "formatter": "percent", 
+                                "id": "31e5afa1-1b1c-11e7-b09e-037021c4f8df", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "system.memory.actual.used.pct", 
+                                        "id": "31e5afa2-1b1c-11e7-b09e-037021c4f8df", 
+                                        "type": "avg"
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "terms", 
+                                "stacked": "none", 
+                                "terms_field": "host.name", 
+                                "terms_order_by": "31e5afa2-1b1c-11e7-b09e-037021c4f8df", 
+                                "terms_size": "10"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "top_n"
+                    }, 
+                    "title": "Top Hosts By Memory (Realtime) [Metricbeat System] ECS", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "fe064790-1b1f-11e7-bec4-a5e9ec5cab8b-ecs", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                }, 
+                "title": "Top Hosts By CPU (Realtime) [Metricbeat System] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "bar_color_rules": [
+                            {
+                                "bar_color": "rgba(104,188,0,1)", 
+                                "id": "33349dd0-1b1c-11e7-b09e-037021c4f8df", 
+                                "operator": "gte", 
+                                "value": 0
+                            }, 
+                            {
+                                "bar_color": "rgba(254,146,0,1)", 
+                                "id": "997dc440-1b1c-11e7-b09e-037021c4f8df", 
+                                "operator": "gte", 
+                                "value": 0.6
+                            }, 
+                            {
+                                "bar_color": "rgba(211,49,21,1)", 
+                                "id": "a10d7f20-1b1c-11e7-b09e-037021c4f8df", 
+                                "operator": "gte", 
+                                "value": 0.85
+                            }
+                        ], 
+                        "drilldown_url": "../app/kibana#/dashboard/79ffd6e0-faa0-11e6-947f-177f697178b8-ecs?_a=(query:(language:kuery,query:'host.name:\"{{key}}\"'))",
+                        "filter": "", 
+                        "id": "31e5afa0-1b1c-11e7-b09e-037021c4f8df", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": 0.5, 
+                                "formatter": "percent", 
+                                "id": "31e5afa1-1b1c-11e7-b09e-037021c4f8df", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "system.cpu.user.pct", 
+                                        "id": "31e5afa2-1b1c-11e7-b09e-037021c4f8df", 
+                                        "type": "avg"
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "terms", 
+                                "stacked": "none", 
+                                "terms_field": "host.name", 
+                                "terms_order_by": "31e5afa2-1b1c-11e7-b09e-037021c4f8df", 
+                                "terms_size": "10"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "top_n"
+                    }, 
+                    "title": "Top Hosts By CPU (Realtime) [Metricbeat System] ECS", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "855899e0-1b1c-11e7-b09e-037021c4f8df-ecs", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "index": "metricbeat-*", 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                }, 
+                "title": "Hosts histogram by CPU usage [Metricbeat System] ECS", 
+                "uiStateJSON": {
+                    "vis": {
+                        "defaultColors": {
+                            "0% - 5%": "rgb(247,252,245)", 
+                            "10% - 15%": "rgb(116,196,118)", 
+                            "15% - 20%": "rgb(35,139,69)", 
+                            "5% - 10%": "rgb(199,233,192)"
+                        }
+                    }
+                }, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "CPU usage", 
+                                "field": "system.cpu.user.pct"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "customLabel": "Hosts", 
+                                "field": "host.name", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 20
+                            }, 
+                            "schema": "group", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "params": {
+                        "addLegend": true, 
+                        "addTooltip": true, 
+                        "colorSchema": "Greens", 
+                        "colorsNumber": 4, 
+                        "colorsRange": [], 
+                        "enableHover": false, 
+                        "invertColors": false, 
+                        "legendPosition": "right", 
+                        "percentageMode": false, 
+                        "setColorRange": false, 
+                        "times": [], 
+                        "type": "heatmap", 
+                        "valueAxes": [
+                            {
+                                "id": "ValueAxis-1", 
+                                "labels": {
+                                    "color": "#555", 
+                                    "rotate": 0, 
+                                    "show": false
+                                }, 
+                                "scale": {
+                                    "defaultYExtents": false, 
+                                    "type": "linear"
+                                }, 
+                                "show": false, 
+                                "type": "value"
+                            }
+                        ]
+                    }, 
+                    "title": "Hosts histogram by CPU usage [Metricbeat System] ECS", 
+                    "type": "heatmap"
+                }
+            }, 
+            "id": "7cdb1330-4d1a-11e7-a196-69b9a7a020a9-ecs", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                }, 
+                "title": "Inbound Traffic [Metricbeat System] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "background_color_rules": [
+                            {
+                                "id": "0e346760-1b92-11e7-bec4-a5e9ec5cab8b"
+                            }
+                        ], 
+                        "filter": "-system.network.name:l*", 
+                        "id": "0c761590-1b92-11e7-bec4-a5e9ec5cab8b", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": 0.5, 
+                                "formatter": "bytes", 
+                                "id": "0c761591-1b92-11e7-bec4-a5e9ec5cab8b", 
+                                "label": "Inbound Traffic", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "system.network.in.bytes", 
+                                        "id": "0c761592-1b92-11e7-bec4-a5e9ec5cab8b", 
+                                        "type": "max"
+                                    }, 
+                                    {
+                                        "field": "0c761592-1b92-11e7-bec4-a5e9ec5cab8b", 
+                                        "id": "1d659060-1b92-11e7-bec4-a5e9ec5cab8b", 
+                                        "type": "derivative", 
+                                        "unit": "1s"
+                                    }, 
+                                    {
+                                        "field": "1d659060-1b92-11e7-bec4-a5e9ec5cab8b", 
+                                        "id": "f2074f70-1b92-11e7-a416-41f5ccdba2e6", 
+                                        "type": "positive_only", 
+                                        "unit": ""
+                                    }, 
+                                    {
+                                        "function": "sum", 
+                                        "id": "c40e18f0-2c55-11e7-a0ad-277ce466684d", 
+                                        "type": "series_agg"
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "terms", 
+                                "stacked": "none", 
+                                "terms_field": "system.network.name", 
+                                "value_template": "{{value}}/s"
+                            }, 
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": 0.5, 
+                                "formatter": "bytes", 
+                                "id": "37f70440-1b92-11e7-bec4-a5e9ec5cab8b", 
+                                "label": "Total Transferred", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "system.network.in.bytes", 
+                                        "id": "37f72b50-1b92-11e7-bec4-a5e9ec5cab8b", 
+                                        "type": "max"
+                                    }, 
+                                    {
+                                        "field": "37f72b50-1b92-11e7-bec4-a5e9ec5cab8b", 
+                                        "id": "37f72b51-1b92-11e7-bec4-a5e9ec5cab8b", 
+                                        "type": "derivative", 
+                                        "unit": ""
+                                    }, 
+                                    {
+                                        "field": "37f72b51-1b92-11e7-bec4-a5e9ec5cab8b", 
+                                        "id": "f9da2dd0-1b92-11e7-a416-41f5ccdba2e6", 
+                                        "type": "positive_only", 
+                                        "unit": ""
+                                    }, 
+                                    {
+                                        "field": "f9da2dd0-1b92-11e7-a416-41f5ccdba2e6", 
+                                        "function": "overall_sum", 
+                                        "id": "3e63c2f0-1b92-11e7-bec4-a5e9ec5cab8b", 
+                                        "sigma": "", 
+                                        "type": "series_agg"
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "terms", 
+                                "stacked": "none", 
+                                "terms_field": "system.network.name", 
+                                "value_template": "{{value}}"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "metric"
+                    }, 
+                    "title": "Inbound Traffic [Metricbeat System] ECS", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "522ee670-1b92-11e7-bec4-a5e9ec5cab8b-ecs", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                }, 
+                "title": "Outbound Traffic [Metricbeat System] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "background_color_rules": [
+                            {
+                                "id": "0e346760-1b92-11e7-bec4-a5e9ec5cab8b"
+                            }
+                        ], 
+                        "filter": "-system.network.name:l*", 
+                        "id": "0c761590-1b92-11e7-bec4-a5e9ec5cab8b", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": 0.5, 
+                                "formatter": "bytes", 
+                                "id": "0c761591-1b92-11e7-bec4-a5e9ec5cab8b", 
+                                "label": "Outbound Traffic", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "system.network.out.bytes", 
+                                        "id": "0c761592-1b92-11e7-bec4-a5e9ec5cab8b", 
+                                        "type": "max"
+                                    }, 
+                                    {
+                                        "field": "0c761592-1b92-11e7-bec4-a5e9ec5cab8b", 
+                                        "id": "1d659060-1b92-11e7-bec4-a5e9ec5cab8b", 
+                                        "type": "derivative", 
+                                        "unit": "1s"
+                                    }, 
+                                    {
+                                        "field": "1d659060-1b92-11e7-bec4-a5e9ec5cab8b", 
+                                        "id": "f2074f70-1b92-11e7-a416-41f5ccdba2e6", 
+                                        "type": "positive_only", 
+                                        "unit": ""
+                                    }, 
+                                    {
+                                        "function": "sum", 
+                                        "id": "a1737470-2c55-11e7-a0ad-277ce466684d", 
+                                        "type": "series_agg"
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "terms", 
+                                "stacked": "none", 
+                                "terms_field": "system.network.name", 
+                                "value_template": "{{value}}/s"
+                            }, 
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": 0.5, 
+                                "formatter": "bytes", 
+                                "id": "37f70440-1b92-11e7-bec4-a5e9ec5cab8b", 
+                                "label": "Total Transferred", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "system.network.out.bytes", 
+                                        "id": "37f72b50-1b92-11e7-bec4-a5e9ec5cab8b", 
+                                        "type": "max"
+                                    }, 
+                                    {
+                                        "field": "37f72b50-1b92-11e7-bec4-a5e9ec5cab8b", 
+                                        "id": "37f72b51-1b92-11e7-bec4-a5e9ec5cab8b", 
+                                        "type": "derivative", 
+                                        "unit": ""
+                                    }, 
+                                    {
+                                        "field": "37f72b51-1b92-11e7-bec4-a5e9ec5cab8b", 
+                                        "id": "f9da2dd0-1b92-11e7-a416-41f5ccdba2e6", 
+                                        "type": "positive_only", 
+                                        "unit": ""
+                                    }, 
+                                    {
+                                        "field": "f9da2dd0-1b92-11e7-a416-41f5ccdba2e6", 
+                                        "function": "overall_sum", 
+                                        "id": "3e63c2f0-1b92-11e7-bec4-a5e9ec5cab8b", 
+                                        "sigma": "", 
+                                        "type": "series_agg"
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "terms", 
+                                "stacked": "none", 
+                                "terms_field": "system.network.name", 
+                                "value_template": "{{value}}"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "metric"
+                    }, 
+                    "title": "Outbound Traffic [Metricbeat System] ECS", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "1aae9140-1b93-11e7-8ada-3df93aab833e-ecs", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                }, 
+                "title": "Disk used [Metricbeat System] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "filter": "", 
+                        "gauge_color_rules": [
+                            {
+                                "gauge": "rgba(104,188,0,1)", 
+                                "id": "51921d10-4d1d-11e7-b5f2-2b7c1895bf32", 
+                                "operator": "gte", 
+                                "value": 0
+                            }, 
+                            {
+                                "gauge": "rgba(251,158,0,1)", 
+                                "id": "f26de750-4d54-11e7-b5f2-2b7c1895bf32", 
+                                "operator": "gte", 
+                                "value": 0.7
+                            }, 
+                            {
+                                "gauge": "rgba(211,49,21,1)", 
+                                "id": "fa31d190-4d54-11e7-b5f2-2b7c1895bf32", 
+                                "operator": "gte", 
+                                "value": 0.85
+                            }
+                        ], 
+                        "gauge_inner_width": 10, 
+                        "gauge_max": "1", 
+                        "gauge_style": "half", 
+                        "gauge_width": 10, 
+                        "id": "4e4dc780-4d1d-11e7-b5f2-2b7c1895bf32", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": 0.5, 
+                                "formatter": "percent", 
+                                "id": "4e4dee90-4d1d-11e7-b5f2-2b7c1895bf32", 
+                                "label": "Disk used", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "system.fsstat.total_size.used", 
+                                        "id": "4e4dee91-4d1d-11e7-b5f2-2b7c1895bf32", 
+                                        "type": "avg"
+                                    }, 
+                                    {
+                                        "field": "system.fsstat.total_size.total", 
+                                        "id": "57c96ee0-4d54-11e7-b5f2-2b7c1895bf32", 
+                                        "type": "avg"
+                                    }, 
+                                    {
+                                        "id": "6304cca0-4d54-11e7-b5f2-2b7c1895bf32", 
+                                        "script": "params.total != null && params.total > 0 ? params.used/params.total : null", 
+                                        "type": "calculation", 
+                                        "variables": [
+                                            {
+                                                "field": "4e4dee91-4d1d-11e7-b5f2-2b7c1895bf32", 
+                                                "id": "6da10430-4d54-11e7-b5f2-2b7c1895bf32", 
+                                                "name": "used"
+                                            }, 
+                                            {
+                                                "field": "57c96ee0-4d54-11e7-b5f2-2b7c1895bf32", 
+                                                "id": "73b8c510-4d54-11e7-b5f2-2b7c1895bf32", 
+                                                "name": "total"
+                                            }
+                                        ]
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "gauge"
+                    }, 
+                    "title": "Disk used [Metricbeat System] ECS", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "825fdb80-4d1d-11e7-b5f2-2b7c1895bf32-ecs", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                }, 
+                "title": "Memory Usage Gauge [Metricbeat System] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "filter": "", 
+                        "gauge_color_rules": [
+                            {
+                                "gauge": "rgba(104,188,0,1)", 
+                                "id": "a0d522e0-1b91-11e7-bec4-a5e9ec5cab8b", 
+                                "operator": "gte", 
+                                "value": 0
+                            }, 
+                            {
+                                "gauge": "rgba(254,146,0,1)", 
+                                "id": "b45ad8f0-1b91-11e7-bec4-a5e9ec5cab8b", 
+                                "operator": "gte", 
+                                "value": 0.7
+                            }, 
+                            {
+                                "gauge": "rgba(211,49,21,1)", 
+                                "id": "c06e9550-1b91-11e7-bec4-a5e9ec5cab8b", 
+                                "operator": "gte", 
+                                "value": 0.85
+                            }
+                        ], 
+                        "gauge_inner_width": 10, 
+                        "gauge_max": "1", 
+                        "gauge_style": "half", 
+                        "gauge_width": 10, 
+                        "id": "9f51b730-1b91-11e7-bec4-a5e9ec5cab8b", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": 0.5, 
+                                "formatter": "percent", 
+                                "id": "9f51b731-1b91-11e7-bec4-a5e9ec5cab8b", 
+                                "label": "Memory Usage", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "system.memory.actual.used.pct", 
+                                        "id": "9f51b732-1b91-11e7-bec4-a5e9ec5cab8b", 
+                                        "type": "avg"
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "gauge"
+                    }, 
+                    "title": "Memory Usage Gauge [Metricbeat System] ECS", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "d3166e80-1b91-11e7-bec4-a5e9ec5cab8b-ecs", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                }, 
+                "title": "CPU Usage Gauge [Metricbeat System] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "axis_formatter": "number", 
+                        "axis_position": "left", 
+                        "filter": "", 
+                        "gauge_color_rules": [
+                            {
+                                "gauge": "rgba(104,188,0,1)", 
+                                "id": "4ef2c3b0-1b91-11e7-bec4-a5e9ec5cab8b", 
+                                "operator": "gte", 
+                                "value": 0
+                            }, 
+                            {
+                                "gauge": "rgba(254,146,0,1)", 
+                                "id": "e6561ae0-1b91-11e7-bec4-a5e9ec5cab8b", 
+                                "operator": "gte", 
+                                "value": 0.7
+                            }, 
+                            {
+                                "gauge": "rgba(211,49,21,1)", 
+                                "id": "ec655040-1b91-11e7-bec4-a5e9ec5cab8b", 
+                                "operator": "gte", 
+                                "value": 0.85
+                            }
+                        ], 
+                        "gauge_inner_width": 10, 
+                        "gauge_max": "1", 
+                        "gauge_style": "half", 
+                        "gauge_width": 10, 
+                        "id": "4c9e2550-1b91-11e7-bec4-a5e9ec5cab8b", 
+                        "index_pattern": "metricbeat-*", 
+                        "interval": "auto", 
+                        "series": [
+                            {
+                                "axis_position": "right", 
+                                "chart_type": "line", 
+                                "color": "#68BC00", 
+                                "fill": 0.5, 
+                                "formatter": "percent", 
+                                "id": "4c9e2551-1b91-11e7-bec4-a5e9ec5cab8b", 
+                                "label": "CPU Usage", 
+                                "line_width": 1, 
+                                "metrics": [
+                                    {
+                                        "field": "system.cpu.user.pct", 
+                                        "id": "4c9e2552-1b91-11e7-bec4-a5e9ec5cab8b", 
+                                        "type": "avg"
+                                    }, 
+                                    {
+                                        "field": "system.cpu.system.pct", 
+                                        "id": "225c2140-5fd7-11e7-a63a-a937b7c1a7e1", 
+                                        "type": "avg"
+                                    }, 
+                                    {
+                                        "field": "system.cpu.cores", 
+                                        "id": "837a30c0-5fd7-11e7-a63a-a937b7c1a7e1", 
+                                        "type": "avg"
+                                    }, 
+                                    {
+                                        "id": "587aa510-1b91-11e7-bec4-a5e9ec5cab8b", 
+                                        "script": "params.n > 0 ? (params.user+params.system)/params.n : null", 
+                                        "type": "calculation", 
+                                        "variables": [
+                                            {
+                                                "field": "4c9e2552-1b91-11e7-bec4-a5e9ec5cab8b", 
+                                                "id": "5a19af10-1b91-11e7-bec4-a5e9ec5cab8b", 
+                                                "name": "user"
+                                            }, 
+                                            {
+                                                "field": "225c2140-5fd7-11e7-a63a-a937b7c1a7e1", 
+                                                "id": "32b54f80-5fd7-11e7-a63a-a937b7c1a7e1", 
+                                                "name": "system"
+                                            }, 
+                                            {
+                                                "field": "837a30c0-5fd7-11e7-a63a-a937b7c1a7e1", 
+                                                "id": "8ba6eef0-5fd7-11e7-a63a-a937b7c1a7e1", 
+                                                "name": "n"
+                                            }
+                                        ]
+                                    }
+                                ], 
+                                "point_size": 1, 
+                                "seperate_axis": 0, 
+                                "split_mode": "everything", 
+                                "stacked": "none"
+                            }
+                        ], 
+                        "show_grid": 1, 
+                        "show_legend": 1, 
+                        "time_field": "@timestamp", 
+                        "type": "gauge"
+                    }, 
+                    "title": "CPU Usage Gauge [Metricbeat System] ECS", 
+                    "type": "metrics"
+                }
+            }, 
+            "id": "83e12df0-1b91-11e7-bec4-a5e9ec5cab8b-ecs", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "Overview of system metrics",
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlightAll": true, 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "optionsJSON": {
+                    "darkTheme": false
+                }, 
+                "panelsJSON": [
+                    {
+                        "col": 1, 
+                        "id": "System-Navigation-ecs", 
+                        "panelIndex": 9, 
+                        "row": 1, 
+                        "size_x": 12, 
+                        "size_y": 1, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "c6f2ffd0-4d17-11e7-a196-69b9a7a020a9-ecs", 
+                        "panelIndex": 11, 
+                        "row": 2, 
+                        "size_x": 2, 
+                        "size_y": 2, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 7, 
+                        "id": "fe064790-1b1f-11e7-bec4-a5e9ec5cab8b-ecs", 
+                        "panelIndex": 12, 
+                        "row": 4, 
+                        "size_x": 6, 
+                        "size_y": 5, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "855899e0-1b1c-11e7-b09e-037021c4f8df-ecs", 
+                        "panelIndex": 13, 
+                        "row": 4, 
+                        "size_x": 6, 
+                        "size_y": 5, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "7cdb1330-4d1a-11e7-a196-69b9a7a020a9-ecs", 
+                        "panelIndex": 14, 
+                        "row": 9, 
+                        "size_x": 12, 
+                        "size_y": 6, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 9, 
+                        "id": "522ee670-1b92-11e7-bec4-a5e9ec5cab8b-ecs", 
+                        "panelIndex": 16, 
+                        "row": 2, 
+                        "size_x": 2, 
+                        "size_y": 2, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 11, 
+                        "id": "1aae9140-1b93-11e7-8ada-3df93aab833e-ecs", 
+                        "panelIndex": 17, 
+                        "row": 2, 
+                        "size_x": 2, 
+                        "size_y": 2, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 7, 
+                        "id": "825fdb80-4d1d-11e7-b5f2-2b7c1895bf32-ecs", 
+                        "panelIndex": 18, 
+                        "row": 2, 
+                        "size_x": 2, 
+                        "size_y": 2, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 5, 
+                        "id": "d3166e80-1b91-11e7-bec4-a5e9ec5cab8b-ecs", 
+                        "panelIndex": 19, 
+                        "row": 2, 
+                        "size_x": 2, 
+                        "size_y": 2, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 3, 
+                        "id": "83e12df0-1b91-11e7-bec4-a5e9ec5cab8b-ecs", 
+                        "panelIndex": 20, 
+                        "row": 2, 
+                        "size_x": 2, 
+                        "size_y": 2, 
+                        "type": "visualization"
+                    }
+                ], 
+                "timeRestore": false, 
+                "title": "[Metricbeat System] Overview ECS", 
+                "uiStateJSON": {
+                    "P-11": {
+                        "vis": {
+                            "defaultColors": {
+                                "0 - 100": "rgb(0,104,55)"
+                            }
+                        }
+                    }, 
+                    "P-12": {
+                        "vis": {
+                            "defaultColors": {
+                                "0 - 100": "rgb(0,104,55)"
+                            }
+                        }
+                    }, 
+                    "P-14": {
+                        "vis": {
+                            "defaultColors": {
+                                "0% - 15%": "rgb(247,252,245)", 
+                                "15% - 30%": "rgb(199,233,192)", 
+                                "30% - 45%": "rgb(116,196,118)", 
+                                "45% - 60%": "rgb(35,139,69)"
+                            }
+                        }
+                    }, 
+                    "P-16": {
+                        "vis": {
+                            "defaultColors": {
+                                "0 - 100": "rgb(0,104,55)"
+                            }
+                        }
+                    }, 
+                    "P-2": {
+                        "vis": {
+                            "defaultColors": {
+                                "0 - 100": "rgb(0,104,55)"
+                            }
+                        }
+                    }, 
+                    "P-3": {
+                        "vis": {
+                            "defaultColors": {
+                                "0 - 100": "rgb(0,104,55)"
+                            }
+                        }
+                    }
+                }, 
+                "version": 1
+            }, 
+            "id": "Metricbeat-system-overview-ecs", 
+            "type": "dashboard", 
+            "version": 2
+        }
+    ], 
+    "version": "6.0.0-rc1-SNAPSHOT"
+}

--- a/dev/package-beats/system-1.0.0/manifest.yml
+++ b/dev/package-beats/system-1.0.0/manifest.yml
@@ -1,0 +1,14 @@
+name: system
+title: System
+version: 1.0.0
+description: |
+  System status metrics, like CPU and memory usage, that are collected from the operating system.
+type: ""
+categories:
+- logs
+- metrics
+requirement:
+  kibana:
+    version:
+      min: 6.7.0
+      max: 7.6.0

--- a/dev/package-beats/tomcat-1.0.0/manifest.yml
+++ b/dev/package-beats/tomcat-1.0.0/manifest.yml
@@ -1,0 +1,13 @@
+name: tomcat
+title: Tomcat
+version: 1.0.0
+description: |
+  Tomcat module
+type: ""
+categories:
+- metrics
+requirement:
+  kibana:
+    version:
+      min: 6.7.0
+      max: 7.6.0

--- a/dev/package-beats/traefik-1.0.0/kibana/dashboard/Filebeat-traefik-overview.json
+++ b/dev/package-beats/traefik-1.0.0/kibana/dashboard/Filebeat-traefik-overview.json
@@ -1,0 +1,583 @@
+{
+    "objects": [
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "index": "filebeat-*", 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                }, 
+                "title": "Browsers breakdown [Filebeat Traefik] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "field": "user_agent.name", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "segment", 
+                            "type": "terms"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "field": "user_agent.version", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "segment", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTooltip": true, 
+                        "isDonut": true, 
+                        "legendPosition": "bottom", 
+                        "shareYAxis": true
+                    }, 
+                    "title": "Traefik Access Browsers ECS", 
+                    "type": "pie"
+                }
+            }, 
+            "id": "Traefik-Access-Browsers-ecs", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "index": "filebeat-*", 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                }, 
+                "title": "Operating systems breakdown [Filebeat Traefik] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "field": "user_agent.os.name", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "segment", 
+                            "type": "terms"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "field": "user_agent.os.version", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "segment", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTooltip": true, 
+                        "isDonut": true, 
+                        "legendPosition": "bottom", 
+                        "shareYAxis": true
+                    }, 
+                    "title": "Traefik Access OSes ECS", 
+                    "type": "pie"
+                }
+            }, 
+            "id": "Traefik-Access-OSes-ecs", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "Filebeat-Traefik-module-ecs", 
+                "title": "Response codes over time [Filebeat Traefik] ECS", 
+                "uiStateJSON": {
+                    "vis": {
+                        "colors": {
+                            "200": "#7EB26D", 
+                            "404": "#614D93"
+                        }
+                    }
+                }, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "field": "http.response.status_code", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "group", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "defaultYExtents": false, 
+                        "legendPosition": "right", 
+                        "mode": "stacked", 
+                        "scale": "linear", 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "times": [], 
+                        "yAxis": {}
+                    }, 
+                    "title": "New Visualization ECS", 
+                    "type": "histogram"
+                }
+            }, 
+            "id": "New-Visualization-ecs", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "index": "filebeat-*", 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                }, 
+                "title": "Response codes by top URLs [Filebeat Traefik] ECS", 
+                "uiStateJSON": {
+                    "vis": {
+                        "colors": {
+                            "200": "#629E51", 
+                            "404": "#0A50A1"
+                        }
+                    }
+                }, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "field": "url.original", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "row": false, 
+                                "size": 5
+                            }, 
+                            "schema": "split", 
+                            "type": "terms"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "field": "http.response.status_code", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "segment", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTooltip": true, 
+                        "isDonut": false, 
+                        "legendPosition": "right", 
+                        "shareYAxis": true
+                    }, 
+                    "title": "Traefik Access Response codes by top URLs ECS", 
+                    "type": "pie"
+                }
+            }, 
+            "id": "Traefik-Access-Response-codes-by-top-URLs-ecs", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlight": {
+                            "fields": {
+                                "*": {}
+                            }, 
+                            "fragment_size": 2147483647, 
+                            "post_tags": [
+                                "@/kibana-highlighted-field@"
+                            ], 
+                            "pre_tags": [
+                                "@kibana-highlighted-field@"
+                            ], 
+                            "require_field_match": false
+                        }, 
+                        "index": "filebeat-*", 
+                        "query": {
+                            "language": "kuery",
+                                "query": "event.dataset:traefik.access"
+                            }
+                    }
+                }, 
+                "title": "Sent Byte Size [Filebeat Traefik] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "Data sent", 
+                                "field": "http.response.body.bytes"
+                            }, 
+                            "schema": "metric", 
+                            "type": "sum"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {}, 
+                            "schema": "radius", 
+                            "type": "count"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "defaultYExtents": false, 
+                        "drawLinesBetweenPoints": true, 
+                        "interpolate": "linear", 
+                        "legendPosition": "right", 
+                        "radiusRatio": "17", 
+                        "scale": "linear", 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "showCircles": true, 
+                        "smoothLines": true, 
+                        "times": [], 
+                        "yAxis": {}
+                    }, 
+                    "title": "Sent sizes ECS", 
+                    "type": "line"
+                }
+            }, 
+            "id": "Sent-sizes-ecs", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "Filebeat-Traefik-module-ecs", 
+                "title": "Access Map [Filebeat Traefik] ECS", 
+                "uiStateJSON": {
+                    "mapCenter": [
+                        12.039320557540572, 
+                        -0.17578125
+                    ]
+                }, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "autoPrecision": true, 
+                                "field": "source.geo.location"
+                            }, 
+                            "schema": "segment", 
+                            "type": "geohash_grid"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addTooltip": true, 
+                        "heatBlur": 15, 
+                        "heatMaxZoom": 16, 
+                        "heatMinOpacity": 0.1, 
+                        "heatNormalizeData": true, 
+                        "heatRadius": 25, 
+                        "isDesaturated": true, 
+                        "legendPosition": "bottomright", 
+                        "mapCenter": [
+                            15, 
+                            5
+                        ], 
+                        "mapType": "Scaled Circle Markers", 
+                        "mapZoom": 2, 
+                        "wms": {
+                            "enabled": false, 
+                            "options": {
+                                "attribution": "Maps provided by USGS", 
+                                "format": "image/png", 
+                                "layers": "0", 
+                                "styles": "", 
+                                "transparent": true, 
+                                "version": "1.3.0"
+                            }, 
+                            "url": "https://basemap.nationalmap.gov/arcgis/services/USGSTopo/MapServer/WMSServer"
+                        }
+                    }, 
+                    "title": "Traefik Access Map ECS", 
+                    "type": "tile_map"
+                }
+            }, 
+            "id": "Traefik-Access-Map-ecs", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "columns": [
+                    "_source"
+                ], 
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlight": {
+                            "fields": {
+                                "*": {}
+                            }, 
+                            "fragment_size": 2147483647, 
+                            "post_tags": [
+                                "@/kibana-highlighted-field@"
+                            ], 
+                            "pre_tags": [
+                                "@kibana-highlighted-field@"
+                            ], 
+                            "require_field_match": false
+                        }, 
+                        "index": "filebeat-*", 
+                        "query": {
+                            "language": "kuery",
+                                "query": "event.module:traefik"
+                            }
+                    }
+                }, 
+                "sort": [
+                    "@timestamp", 
+                    "desc"
+                ], 
+                "title": "Traefik logs [Filebeat Traefik] ECS", 
+                "version": 1
+            }, 
+            "id": "Filebeat-Traefik-module-ecs", 
+            "type": "search", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "Dashboard for the Filebeat Traefik module", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [],
+                                "query": {
+                            "language": "kuery",
+                            "query": ""
+                                }
+                            }
+                }, 
+                "optionsJSON": {
+                    "darkTheme": false
+                }, 
+                "panelsJSON": [
+                    {
+                        "col": 1, 
+                        "id": "Traefik-Access-Browsers-ecs", 
+                        "panelIndex": 3, 
+                        "row": 10, 
+                        "size_x": 4, 
+                        "size_y": 4, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 5, 
+                        "id": "Traefik-Access-OSes-ecs", 
+                        "panelIndex": 4, 
+                        "row": 10, 
+                        "size_x": 4, 
+                        "size_y": 4, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "New-Visualization-ecs", 
+                        "panelIndex": 5, 
+                        "row": 4, 
+                        "size_x": 12, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "Traefik-Access-Response-codes-by-top-URLs-ecs", 
+                        "panelIndex": 6, 
+                        "row": 7, 
+                        "size_x": 12, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 9, 
+                        "id": "Sent-sizes-ecs", 
+                        "panelIndex": 7, 
+                        "row": 10, 
+                        "size_x": 4, 
+                        "size_y": 4, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "Traefik-Access-Map-ecs", 
+                        "panelIndex": 8, 
+                        "row": 1, 
+                        "size_x": 12, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }
+                ], 
+                "timeRestore": false, 
+                "title": "[Filebeat Traefik] Access logs ECS", 
+                "uiStateJSON": {
+                    "P-4": {
+                        "vis": {
+                            "legendOpen": true
+                        }
+                    }, 
+                    "P-8": {
+                        "mapCenter": [
+                            50.51342652633956, 
+                            -0.17578125
+                        ]
+                    }
+                }, 
+                "version": 1
+            }, 
+            "id": "Filebeat-Traefik-Dashboard-ecs", 
+            "type": "dashboard", 
+            "version": 3
+        }
+    ], 
+    "version": "6.0.0-beta1-SNAPSHOT"
+}

--- a/dev/package-beats/traefik-1.0.0/manifest.yml
+++ b/dev/package-beats/traefik-1.0.0/manifest.yml
@@ -1,0 +1,14 @@
+name: traefik
+title: Traefik
+version: 1.0.0
+description: |
+  Traefik reverse proxy / load balancer metrics
+type: ""
+categories:
+- logs
+- metrics
+requirement:
+  kibana:
+    version:
+      min: 6.7.0
+      max: 7.6.0

--- a/dev/package-beats/uwsgi-1.0.0/kibana/dashboard/Metricbeat-uwsgi-overview.json
+++ b/dev/package-beats/uwsgi-1.0.0/kibana/dashboard/Metricbeat-uwsgi-overview.json
@@ -1,0 +1,188 @@
+{
+    "objects": [
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "Overview [Metricbeat uWSGI] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "params": {
+                        "expression": ".es(metric=avg:uwsgi.status.total.requests).derivative().label('Requests').title('Overview of requests per period'),\n.es(metric=avg:uwsgi.status.total.exceptions).derivative().label('Exceptions'),\n.es(metric=max:uwsgi.status.worker.avg_rt).label('Average response time').yaxis(2)", 
+                        "interval": "15s"
+                    }, 
+                    "title": "Overview [Metricbeat uWSGI] ECS", 
+                    "type": "timelion"
+                }
+            }, 
+            "id": "a5058e70-f0ae-11e7-b9ff-9f96241065de-ecs", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "Memory usage [Metricbeat uWSGI] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "params": {
+                        "expression": ".es(metric=max:uwsgi.status.worker.rss).label('Currently used (rss)').title('Memory usage'),\n.es(metric=max:uwsgi.status.worker.vsz).label('Assigned (vsz)').yaxis(2)", 
+                        "interval": "15s"
+                    }, 
+                    "title": "Memory usage [Metricbeat uWSGI] ECS", 
+                    "type": "timelion"
+                }
+            }, 
+            "id": "ac7194b0-f0ae-11e7-b9ff-9f96241065de-ecs", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "Workers [Metricbeat uWSGI] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "params": {
+                        "expression": ".es(split=uwsgi.status.core.id:16,metric=max:uwsgi.status.core.requests.total).derivative().bars().title('Requests handled by each thread (core) per period')", 
+                        "interval": "15s"
+                    }, 
+                    "title": "Workers [Metricbeat uWSGI] ECS", 
+                    "type": "timelion"
+                }
+            }, 
+            "id": "8c5f96e0-f0ae-11e7-b9ff-9f96241065de-ecs", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {}
+                }, 
+                "title": "Errors [Metricbeat uWSGI] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "params": {
+                        "expression": ".es(metric=max:uwsgi.status.total.read_errors).label('Read errors').title('Errors'),\n.es(metric=max:uwsgi.status.total.write_errors).label('Write errors'),\n.es(metric=max:uwsgi.status.worker.harakiri_count).label('Timeouted requests')", 
+                        "interval": "15s"
+                    }, 
+                    "title": "Errors [Metricbeat uWSGI] ECS", 
+                    "type": "timelion"
+                }
+            }, 
+            "id": "ba4a80b0-f0ae-11e7-b9ff-9f96241065de-ecs", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "columns": [
+                    "_source"
+                ], 
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlightAll": true, 
+                        "index": "metricbeat-*", 
+                        "query": {
+                            "language": "kuery",
+                            "query": "event.module: uwsgi"
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "sort": [
+                    "@timestamp", 
+                    "desc"
+                ], 
+                "title": "Metricbeat uWSGI status-ecs ECS", 
+                "version": 1
+            }, 
+            "id": "Metricbeat uWSGI status-ecs ECS", 
+            "type": "search", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "Overview of uWSGI service metrics",
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlightAll": true, 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "optionsJSON": {
+                    "darkTheme": false
+                }, 
+                "panelsJSON": [
+                    {
+                        "col": 1, 
+                        "id": "a5058e70-f0ae-11e7-b9ff-9f96241065de-ecs", 
+                        "panelIndex": 1, 
+                        "row": 1, 
+                        "size_x": 6, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 7, 
+                        "id": "ac7194b0-f0ae-11e7-b9ff-9f96241065de-ecs", 
+                        "panelIndex": 2, 
+                        "row": 1, 
+                        "size_x": 6, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "8c5f96e0-f0ae-11e7-b9ff-9f96241065de-ecs", 
+                        "panelIndex": 3, 
+                        "row": 4, 
+                        "size_x": 6, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 7, 
+                        "id": "ba4a80b0-f0ae-11e7-b9ff-9f96241065de-ecs", 
+                        "panelIndex": 4, 
+                        "row": 4, 
+                        "size_x": 6, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }
+                ], 
+                "timeRestore": false, 
+                "title": "[Metricbeat uWSGI] Overview ECS", 
+                "uiStateJSON": {}, 
+                "version": 1
+            }, 
+            "id": "32fca290-f0af-11e7-b9ff-9f96241065de-ecs", 
+            "type": "dashboard", 
+            "version": 1
+        }
+    ], 
+    "version": "6.0.0-rc1"
+}

--- a/dev/package-beats/uwsgi-1.0.0/manifest.yml
+++ b/dev/package-beats/uwsgi-1.0.0/manifest.yml
@@ -1,0 +1,13 @@
+name: uwsgi
+title: uwsgi
+version: 1.0.0
+description: |
+  uwsgi module
+type: ""
+categories:
+- metrics
+requirement:
+  kibana:
+    version:
+      min: 6.7.0
+      max: 7.6.0

--- a/dev/package-beats/vsphere-1.0.0/manifest.yml
+++ b/dev/package-beats/vsphere-1.0.0/manifest.yml
@@ -1,0 +1,13 @@
+name: vsphere
+title: vSphere
+version: 1.0.0
+description: |
+  vSphere module
+type: ""
+categories:
+- metrics
+requirement:
+  kibana:
+    version:
+      min: 6.7.0
+      max: 7.6.0

--- a/dev/package-beats/windows-1.0.0/kibana/dashboard/metricbeat-windows-service.json
+++ b/dev/package-beats/windows-1.0.0/kibana/dashboard/metricbeat-windows-service.json
@@ -1,0 +1,760 @@
+{
+    "objects": [
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "index": "metricbeat-*", 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                }, 
+                "title": "Service States [Metricbeat Windows] ECS", 
+                "uiStateJSON": {
+                    "vis": {
+                        "params": {
+                            "sort": {
+                                "columnIndex": null, 
+                                "direction": null
+                            }
+                        }
+                    }
+                }, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "aggregate": "concat", 
+                                "customLabel": "Latest Report", 
+                                "field": "@timestamp", 
+                                "size": 1, 
+                                "sortField": "@timestamp", 
+                                "sortOrder": "desc"
+                            }, 
+                            "schema": "metric", 
+                            "type": "top_hits"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customLabel": "Service", 
+                                "field": "windows.service.display_name", 
+                                "order": "asc", 
+                                "orderBy": "_term", 
+                                "size": 100
+                            }, 
+                            "schema": "bucket", 
+                            "type": "terms"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "5", 
+                            "params": {
+                                "customLabel": "Host", 
+                                "field": "host.name", 
+                                "order": "desc", 
+                                "orderBy": "_term", 
+                                "size": 5
+                            }, 
+                            "schema": "bucket", 
+                            "type": "terms"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "customLabel": "State", 
+                                "field": "windows.service.state", 
+                                "order": "desc", 
+                                "orderAgg": {
+                                    "enabled": true, 
+                                    "id": "3-orderAgg", 
+                                    "params": {
+                                        "field": "@timestamp"
+                                    }, 
+                                    "schema": {
+                                        "aggFilter": [
+                                            "!top_hits", 
+                                            "!percentiles", 
+                                            "!median", 
+                                            "!std_dev", 
+                                            "!derivative", 
+                                            "!moving_avg", 
+                                            "!serial_diff", 
+                                            "!cumulative_sum", 
+                                            "!avg_bucket", 
+                                            "!max_bucket", 
+                                            "!min_bucket", 
+                                            "!sum_bucket"
+                                        ], 
+                                        "deprecate": false, 
+                                        "editor": false, 
+                                        "group": "none", 
+                                        "hideCustomLabel": true, 
+                                        "max": null, 
+                                        "min": 0, 
+                                        "name": "orderAgg", 
+                                        "params": [], 
+                                        "title": "Order Agg"
+                                    }, 
+                                    "type": "max"
+                                }, 
+                                "orderBy": "custom", 
+                                "size": 1
+                            }, 
+                            "schema": "bucket", 
+                            "type": "terms"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "4", 
+                            "params": {
+                                "customLabel": "Startup Type", 
+                                "field": "windows.service.start_type", 
+                                "order": "desc", 
+                                "orderAgg": {
+                                    "enabled": true, 
+                                    "id": "4-orderAgg", 
+                                    "params": {
+                                        "field": "@timestamp"
+                                    }, 
+                                    "schema": {
+                                        "aggFilter": [
+                                            "!top_hits", 
+                                            "!percentiles", 
+                                            "!median", 
+                                            "!std_dev", 
+                                            "!derivative", 
+                                            "!moving_avg", 
+                                            "!serial_diff", 
+                                            "!cumulative_sum", 
+                                            "!avg_bucket", 
+                                            "!max_bucket", 
+                                            "!min_bucket", 
+                                            "!sum_bucket"
+                                        ], 
+                                        "deprecate": false, 
+                                        "editor": false, 
+                                        "group": "none", 
+                                        "hideCustomLabel": true, 
+                                        "max": null, 
+                                        "min": 0, 
+                                        "name": "orderAgg", 
+                                        "params": [], 
+                                        "title": "Order Agg"
+                                    }, 
+                                    "type": "max"
+                                }, 
+                                "orderBy": "custom", 
+                                "size": 1
+                            }, 
+                            "schema": "bucket", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "params": {
+                        "perPage": 10, 
+                        "showMeticsAtAllLevels": false, 
+                        "showPartialRows": false, 
+                        "showTotal": false, 
+                        "sort": {
+                            "columnIndex": null, 
+                            "direction": null
+                        }, 
+                        "totalFunc": "sum"
+                    }, 
+                    "title": "Service States [Metricbeat Windows] ECS", 
+                    "type": "table"
+                }
+            }, 
+            "id": "eb8277d0-c98c-11e7-9835-2f31fe08873b-ecs", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                }, 
+                "savedSearchId": "b6b7ccc0-c98d-11e7-9835-2f31fe08873b-ecs", 
+                "title": "Hosts [Metricbeat Windows] ECS", 
+                "uiStateJSON": {
+                    "vis": {
+                        "params": {
+                            "sort": {
+                                "columnIndex": null, 
+                                "direction": null
+                            }
+                        }
+                    }
+                }, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "Total Services", 
+                                "field": "windows.service.id"
+                            }, 
+                            "schema": "metric", 
+                            "type": "cardinality"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customLabel": "Host", 
+                                "field": "host.name", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 100
+                            }, 
+                            "schema": "bucket", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "params": {
+                        "perPage": 10, 
+                        "showMeticsAtAllLevels": false, 
+                        "showPartialRows": false, 
+                        "showTotal": false, 
+                        "sort": {
+                            "columnIndex": null, 
+                            "direction": null
+                        }, 
+                        "totalFunc": "sum"
+                    }, 
+                    "title": "Hosts [Metricbeat Windows] ECS", 
+                    "type": "table"
+                }
+            }, 
+            "id": "23a5fff0-c98e-11e7-9835-2f31fe08873b-ecs", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                }, 
+                "savedSearchId": "b6b7ccc0-c98d-11e7-9835-2f31fe08873b-ecs", 
+                "title": "Startup States [Metricbeat Windows] ECS", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "Service Count", 
+                                "field": "windows.service.id"
+                            }, 
+                            "schema": "metric", 
+                            "type": "cardinality"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "4", 
+                            "params": {
+                                "customLabel": "Startup Type", 
+                                "field": "windows.service.start_type", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "segment", 
+                            "type": "terms"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "customLabel": "State", 
+                                "field": "windows.service.state", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "segment", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "params": {
+                        "addLegend": true, 
+                        "addTooltip": true, 
+                        "isDonut": true, 
+                        "legendPosition": "right", 
+                        "type": "pie"
+                    }, 
+                    "title": "Startup States [Metricbeat Windows] ECS", 
+                    "type": "pie"
+                }
+            }, 
+            "id": "830c45f0-c991-11e7-9835-2f31fe08873b-ecs", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                }, 
+                "savedSearchId": "b6b7ccc0-c98d-11e7-9835-2f31fe08873b-ecs", 
+                "title": "Unique Services [Metricbeat Windows] ECS", 
+                "uiStateJSON": {
+                    "vis": {
+                        "defaultColors": {
+                            "0 - 100": "rgb(0,104,55)"
+                        }
+                    }
+                }, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "Services", 
+                                "field": "windows.service.id"
+                            }, 
+                            "schema": "metric", 
+                            "type": "cardinality"
+                        }
+                    ], 
+                    "params": {
+                        "addLegend": false, 
+                        "addTooltip": true, 
+                        "gauge": {
+                            "autoExtend": false, 
+                            "backStyle": "Full", 
+                            "colorSchema": "Green to Red", 
+                            "colorsRange": [
+                                {
+                                    "from": 0, 
+                                    "to": 100
+                                }
+                            ], 
+                            "gaugeColorMode": "None", 
+                            "gaugeStyle": "Full", 
+                            "gaugeType": "Metric", 
+                            "invertColors": false, 
+                            "labels": {
+                                "color": "black", 
+                                "show": false
+                            }, 
+                            "orientation": "vertical", 
+                            "percentageMode": false, 
+                            "scale": {
+                                "color": "#333", 
+                                "labels": false, 
+                                "show": false, 
+                                "width": 2
+                            }, 
+                            "style": {
+                                "bgColor": false, 
+                                "fontSize": 60, 
+                                "labelColor": false, 
+                                "subText": ""
+                            }, 
+                            "type": "simple", 
+                            "useRange": false, 
+                            "verticalSplit": false
+                        }, 
+                        "type": "gauge"
+                    }, 
+                    "title": "Unique Services [Metricbeat Windows] ECS", 
+                    "type": "metric"
+                }
+            }, 
+            "id": "35f5ad60-c996-11e7-9835-2f31fe08873b-ecs", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [
+                            {
+                                "$state": {
+                                    "store": "appState"
+                                }, 
+                                "exists": {
+                                    "field": "windows.service.exit_code"
+                                }, 
+                                "meta": {
+                                    "alias": null, 
+                                    "disabled": false, 
+                                    "index": "metricbeat-*", 
+                                    "key": "windows.service.exit_code", 
+                                    "negate": false, 
+                                    "type": "exists", 
+                                    "value": "exists"
+                                }
+                            }, 
+                            {
+                                "$state": {
+                                    "store": "appState"
+                                }, 
+                                "meta": {
+                                    "alias": null, 
+                                    "disabled": false, 
+                                    "index": "metricbeat-*", 
+                                    "key": "windows.service.exit_code", 
+                                    "negate": true, 
+                                    "params": {
+                                        "query": "0", 
+                                        "type": "phrase"
+                                    }, 
+                                    "type": "phrase", 
+                                    "value": "0"
+                                }, 
+                                "query": {
+                                    "match": {
+                                        "windows.service.exit_code": {
+                                            "query": "0", 
+                                            "type": "phrase"
+                                        }
+                                    }
+                                }
+                            }, 
+                            {
+                                "$state": {
+                                    "store": "appState"
+                                }, 
+                                "meta": {
+                                    "alias": null, 
+                                    "disabled": false, 
+                                    "index": "metricbeat-*", 
+                                    "key": "windows.service.exit_code", 
+                                    "negate": true, 
+                                    "params": {
+                                        "query": "ERROR_SERVICE_NEVER_STARTED", 
+                                        "type": "phrase"
+                                    }, 
+                                    "type": "phrase", 
+                                    "value": "ERROR_SERVICE_NEVER_STARTED"
+                                }, 
+                                "query": {
+                                    "match": {
+                                        "windows.service.exit_code": {
+                                            "query": "ERROR_SERVICE_NEVER_STARTED", 
+                                            "type": "phrase"
+                                        }
+                                    }
+                                }
+                            }
+                        ], 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                }, 
+                "savedSearchId": "b6b7ccc0-c98d-11e7-9835-2f31fe08873b-ecs", 
+                "title": "Non-zero Service Exit Codes [Metricbeat Windows] ECS", 
+                "uiStateJSON": {
+                    "vis": {
+                        "defaultColors": {
+                            "0 - 100": "rgb(0,104,55)"
+                        }
+                    }
+                }, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "Non-zero Exit Codes", 
+                                "field": "windows.service.id"
+                            }, 
+                            "schema": "metric", 
+                            "type": "cardinality"
+                        }
+                    ], 
+                    "params": {
+                        "addLegend": false, 
+                        "addTooltip": true, 
+                        "gauge": {
+                            "autoExtend": false, 
+                            "backStyle": "Full", 
+                            "colorSchema": "Green to Red", 
+                            "colorsRange": [
+                                {
+                                    "from": 0, 
+                                    "to": 100
+                                }
+                            ], 
+                            "gaugeColorMode": "None", 
+                            "gaugeStyle": "Full", 
+                            "gaugeType": "Metric", 
+                            "invertColors": false, 
+                            "labels": {
+                                "color": "black", 
+                                "show": false
+                            }, 
+                            "orientation": "vertical", 
+                            "percentageMode": false, 
+                            "scale": {
+                                "color": "#333", 
+                                "labels": false, 
+                                "show": false, 
+                                "width": 2
+                            }, 
+                            "style": {
+                                "bgColor": false, 
+                                "fontSize": 60, 
+                                "labelColor": false, 
+                                "subText": ""
+                            }, 
+                            "type": "simple", 
+                            "useRange": false, 
+                            "verticalSplit": false
+                        }, 
+                        "type": "gauge"
+                    }, 
+                    "title": "Non-zero Service Exit Codes [Metricbeat Windows] ECS", 
+                    "type": "metric"
+                }
+            }, 
+            "id": "c36b2ba0-ca29-11e7-9835-2f31fe08873b-ecs", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "columns": [
+                    "host.name", 
+                    "windows.service.display_name", 
+                    "windows.service.state", 
+                    "windows.service.start_type", 
+                    "windows.service.uptime.ms", 
+                    "windows.service.pid", 
+                    "windows.service.exit_code"
+                ], 
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [
+                            {
+                                "$state": {
+                                    "store": "appState"
+                                }, 
+                                "meta": {
+                                    "alias": null, 
+                                    "disabled": false, 
+                                    "index": "metricbeat-*", 
+                                    "key": "event.module", 
+                                    "negate": false, 
+                                    "params": {
+                                        "query": "windows", 
+                                        "type": "phrase"
+                                    }, 
+                                    "type": "phrase", 
+                                    "value": "windows"
+                                }, 
+                                "query": {
+                                    "match": {
+                                        "event.module": {
+                                            "query": "windows", 
+                                            "type": "phrase"
+                                        }
+                                    }
+                                }
+                            }, 
+                            {
+                                "$state": {
+                                    "store": "appState"
+                                }, 
+                                "meta": {
+                                    "alias": null, 
+                                    "disabled": false, 
+                                    "index": "metricbeat-*", 
+                                    "key": "metricset.name", 
+                                    "negate": false, 
+                                    "params": {
+                                        "query": "service", 
+                                        "type": "phrase"
+                                    }, 
+                                    "type": "phrase", 
+                                    "value": "service"
+                                }, 
+                                "query": {
+                                    "match": {
+                                        "metricset.name": {
+                                            "query": "service", 
+                                            "type": "phrase"
+                                        }
+                                    }
+                                }
+                            }
+                        ], 
+                        "highlightAll": true, 
+                        "index": "metricbeat-*", 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "sort": [
+                    "@timestamp", 
+                    "desc"
+                ], 
+                "title": "Services [Metricbeat Windows] ECS", 
+                "version": 1
+            }, 
+            "id": "b6b7ccc0-c98d-11e7-9835-2f31fe08873b-ecs", 
+            "type": "search", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "Overview of the Windows Service States", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlightAll": true, 
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "optionsJSON": {
+                    "darkTheme": false
+                }, 
+                "panelsJSON": [
+                    {
+                        "col": 4, 
+                        "id": "eb8277d0-c98c-11e7-9835-2f31fe08873b-ecs", 
+                        "panelIndex": 1, 
+                        "row": 4, 
+                        "size_x": 9, 
+                        "size_y": 5, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "23a5fff0-c98e-11e7-9835-2f31fe08873b-ecs", 
+                        "panelIndex": 2, 
+                        "row": 4, 
+                        "size_x": 3, 
+                        "size_y": 5, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "830c45f0-c991-11e7-9835-2f31fe08873b-ecs", 
+                        "panelIndex": 3, 
+                        "row": 1, 
+                        "size_x": 4, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 5, 
+                        "id": "35f5ad60-c996-11e7-9835-2f31fe08873b-ecs", 
+                        "panelIndex": 4, 
+                        "row": 1, 
+                        "size_x": 4, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 9, 
+                        "id": "c36b2ba0-ca29-11e7-9835-2f31fe08873b-ecs", 
+                        "panelIndex": 5, 
+                        "row": 1, 
+                        "size_x": 4, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }
+                ], 
+                "timeRestore": false, 
+                "title": "[Metricbeat Windows] Services ECS", 
+                "uiStateJSON": {
+                    "P-1": {
+                        "vis": {
+                            "params": {
+                                "sort": {
+                                    "columnIndex": null, 
+                                    "direction": null
+                                }
+                            }
+                        }
+                    }, 
+                    "P-2": {
+                        "vis": {
+                            "params": {
+                                "sort": {
+                                    "columnIndex": null, 
+                                    "direction": null
+                                }
+                            }
+                        }
+                    }, 
+                    "P-4": {
+                        "vis": {
+                            "defaultColors": {
+                                "0 - 100": "rgb(0,104,55)"
+                            }
+                        }
+                    }, 
+                    "P-5": {
+                        "vis": {
+                            "defaultColors": {
+                                "0 - 100": "rgb(0,104,55)"
+                            }
+                        }
+                    }
+                }, 
+                "version": 1
+            }, 
+            "id": "d9eba730-c991-11e7-9835-2f31fe08873b-ecs", 
+            "type": "dashboard", 
+            "version": 6
+        }
+    ], 
+    "version": "6.0.0"
+}

--- a/dev/package-beats/windows-1.0.0/manifest.yml
+++ b/dev/package-beats/windows-1.0.0/manifest.yml
@@ -1,0 +1,13 @@
+name: windows
+title: Windows
+version: 1.0.0
+description: |
+  Module for Windows
+type: ""
+categories:
+- metrics
+requirement:
+  kibana:
+    version:
+      min: 6.7.0
+      max: 7.6.0

--- a/dev/package-beats/zeek-1.0.0/kibana/dashboard/Filebeat-Zeek-Overview.json
+++ b/dev/package-beats/zeek-1.0.0/kibana/dashboard/Filebeat-Zeek-Overview.json
@@ -1,0 +1,859 @@
+{
+  "objects": [
+    {
+      "attributes": {
+        "description": "Overview of Zeek",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "optionsJSON": {
+          "hidePanelTitles": false,
+          "useMargins": true
+        },
+        "panelsJSON": [
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 20,
+              "i": "1",
+              "w": 48,
+              "x": 0,
+              "y": 0
+            },
+            "panelIndex": "1",
+            "panelRefName": "panel_0",
+            "version": "7.0.0-beta1"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 12,
+              "i": "2",
+              "w": 16,
+              "x": 0,
+              "y": 20
+            },
+            "panelIndex": "2",
+            "panelRefName": "panel_1",
+            "version": "7.0.0-beta1"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 12,
+              "i": "3",
+              "w": 16,
+              "x": 16,
+              "y": 20
+            },
+            "panelIndex": "3",
+            "panelRefName": "panel_2",
+            "version": "7.0.0-beta1"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 12,
+              "i": "4",
+              "w": 16,
+              "x": 32,
+              "y": 20
+            },
+            "panelIndex": "4",
+            "panelRefName": "panel_3",
+            "version": "7.0.0-beta1"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 12,
+              "i": "5",
+              "w": 16,
+              "x": 0,
+              "y": 32
+            },
+            "panelIndex": "5",
+            "panelRefName": "panel_4",
+            "version": "7.0.0-beta1"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 12,
+              "i": "6",
+              "w": 16,
+              "x": 16,
+              "y": 32
+            },
+            "panelIndex": "6",
+            "panelRefName": "panel_5",
+            "version": "7.0.0-beta1"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 12,
+              "i": "7",
+              "w": 16,
+              "x": 32,
+              "y": 32
+            },
+            "panelIndex": "7",
+            "panelRefName": "panel_6",
+            "version": "7.0.0-beta1"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 12,
+              "i": "8",
+              "w": 48,
+              "x": 0,
+              "y": 44
+            },
+            "panelIndex": "8",
+            "panelRefName": "panel_7",
+            "version": "7.0.0-beta1"
+          }
+        ],
+        "timeRestore": false,
+        "title": "[Filebeat Zeek] Overview",
+        "version": 1
+      },
+      "id": "7cbb5410-3700-11e9-aa6d-ff445a78330c",
+      "migrationVersion": {
+        "dashboard": "7.0.0"
+      },
+      "references": [
+        {
+          "id": "f469f230-370c-11e9-aa6d-ff445a78330c",
+          "name": "panel_0",
+          "type": "visualization"
+        },
+        {
+          "id": "1df7ea80-370d-11e9-aa6d-ff445a78330c",
+          "name": "panel_1",
+          "type": "visualization"
+        },
+        {
+          "id": "466e5850-370d-11e9-aa6d-ff445a78330c",
+          "name": "panel_2",
+          "type": "visualization"
+        },
+        {
+          "id": "649acd40-370d-11e9-aa6d-ff445a78330c",
+          "name": "panel_3",
+          "type": "visualization"
+        },
+        {
+          "id": "9436c270-370d-11e9-aa6d-ff445a78330c",
+          "name": "panel_4",
+          "type": "visualization"
+        },
+        {
+          "id": "bec2f0e0-370d-11e9-aa6d-ff445a78330c",
+          "name": "panel_5",
+          "type": "visualization"
+        },
+        {
+          "id": "e042fda0-370d-11e9-aa6d-ff445a78330c",
+          "name": "panel_6",
+          "type": "visualization"
+        },
+        {
+          "id": "f8c40810-370d-11e9-aa6d-ff445a78330c",
+          "name": "panel_7",
+          "type": "visualization"
+        }
+      ],
+      "type": "dashboard",
+      "updated_at": "2019-02-23T05:05:18.205Z",
+      "version": "WzMxMTYsNF0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Destination Geo [Filebeat Zeek]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "autoPrecision": true,
+                "field": "destination.geo.location",
+                "isFilteredByCollar": true,
+                "mapCenter": [
+                  0,
+                  0
+                ],
+                "mapZoom": 2,
+                "precision": 2,
+                "useGeocentroid": true
+              },
+              "schema": "segment",
+              "type": "geohash_grid"
+            }
+          ],
+          "params": {
+            "addTooltip": true,
+            "colorSchema": "Yellow to Red",
+            "dimensions": {
+              "geocentroid": null,
+              "geohash": null,
+              "metric": {
+                "accessor": 0,
+                "aggType": "count",
+                "format": {
+                  "id": "number"
+                },
+                "params": {}
+              }
+            },
+            "heatClusterSize": 1.5,
+            "isDesaturated": true,
+            "legendPosition": "bottomright",
+            "mapCenter": [
+              0,
+              0
+            ],
+            "mapType": "Scaled Circle Markers",
+            "mapZoom": 2,
+            "wms": {
+              "enabled": false,
+              "options": {
+                "format": "image/png",
+                "transparent": true
+              }
+            }
+          },
+          "title": "Destination Geo [Filebeat Zeek]",
+          "type": "tile_map"
+        }
+      },
+      "id": "f469f230-370c-11e9-aa6d-ff445a78330c",
+      "migrationVersion": {
+        "visualization": "7.0.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-02-26T00:06:27.634Z",
+      "version": "WzMyNzUsNV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Network Transport [Filebeat Zeek]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "field": "network.transport",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 5
+              },
+              "schema": "segment",
+              "type": "terms"
+            }
+          ],
+          "params": {
+            "addLegend": true,
+            "addTooltip": true,
+            "dimensions": {
+              "metric": {
+                "accessor": 0,
+                "aggType": "count",
+                "format": {
+                  "id": "number"
+                },
+                "params": {}
+              }
+            },
+            "isDonut": true,
+            "labels": {
+              "last_level": true,
+              "show": false,
+              "truncate": 100,
+              "values": true
+            },
+            "legendPosition": "right",
+            "type": "pie"
+          },
+          "title": "Network Transport [Filebeat Zeek]",
+          "type": "pie"
+        }
+      },
+      "id": "1df7ea80-370d-11e9-aa6d-ff445a78330c",
+      "migrationVersion": {
+        "visualization": "7.0.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-02-26T00:07:08.521Z",
+      "version": "WzMyNzgsNV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Network Application [Filebeat Zeek]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "field": "network.application",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 5
+              },
+              "schema": "segment",
+              "type": "terms"
+            }
+          ],
+          "params": {
+            "addLegend": true,
+            "addTooltip": true,
+            "dimensions": {
+              "metric": {
+                "accessor": 0,
+                "aggType": "count",
+                "format": {
+                  "id": "number"
+                },
+                "params": {}
+              }
+            },
+            "isDonut": true,
+            "labels": {
+              "last_level": true,
+              "show": false,
+              "truncate": 100,
+              "values": true
+            },
+            "legendPosition": "right",
+            "type": "pie"
+          },
+          "title": "Network Application [Filebeat Zeek]",
+          "type": "pie"
+        }
+      },
+      "id": "466e5850-370d-11e9-aa6d-ff445a78330c",
+      "migrationVersion": {
+        "visualization": "7.0.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-02-26T00:06:41.868Z",
+      "version": "WzMyNzYsNV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Network Traffic Direction [Filebeat Zeek]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "field": "network.direction",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 5
+              },
+              "schema": "segment",
+              "type": "terms"
+            }
+          ],
+          "params": {
+            "addLegend": true,
+            "addTooltip": true,
+            "dimensions": {
+              "metric": {
+                "accessor": 0,
+                "aggType": "count",
+                "format": {
+                  "id": "number"
+                },
+                "params": {}
+              }
+            },
+            "isDonut": true,
+            "labels": {
+              "last_level": true,
+              "show": false,
+              "truncate": 100,
+              "values": true
+            },
+            "legendPosition": "right",
+            "type": "pie"
+          },
+          "title": "Network Traffic Direction [Filebeat Zeek]",
+          "type": "pie"
+        }
+      },
+      "id": "649acd40-370d-11e9-aa6d-ff445a78330c",
+      "migrationVersion": {
+        "visualization": "7.0.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-02-26T00:06:55.885Z",
+      "version": "WzMyNzcsNV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Top DNS Domains [Filebeat Zeek]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "field": "zeek.dns.query",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 10
+              },
+              "schema": "segment",
+              "type": "terms"
+            }
+          ],
+          "params": {
+            "addLegend": true,
+            "addTooltip": true,
+            "dimensions": {
+              "metric": {
+                "accessor": 0,
+                "aggType": "count",
+                "format": {
+                  "id": "number"
+                },
+                "params": {}
+              }
+            },
+            "isDonut": true,
+            "labels": {
+              "last_level": true,
+              "show": false,
+              "truncate": 100,
+              "values": true
+            },
+            "legendPosition": "right",
+            "type": "pie"
+          },
+          "title": "Top DNS Domains [Filebeat Zeek]",
+          "type": "pie"
+        }
+      },
+      "id": "9436c270-370d-11e9-aa6d-ff445a78330c",
+      "migrationVersion": {
+        "visualization": "7.0.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-02-26T00:07:23.763Z",
+      "version": "WzMyNzksNV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Top URL Domains [Filebeat Zeek]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "field": "url.domain",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 10
+              },
+              "schema": "segment",
+              "type": "terms"
+            }
+          ],
+          "params": {
+            "addLegend": true,
+            "addTooltip": true,
+            "dimensions": {
+              "buckets": [
+                {
+                  "accessor": 0,
+                  "aggType": "terms",
+                  "format": {
+                    "id": "terms",
+                    "params": {
+                      "id": "string",
+                      "missingBucketLabel": "Missing",
+                      "otherBucketLabel": "Other"
+                    }
+                  },
+                  "params": {}
+                }
+              ],
+              "metric": {
+                "accessor": 1,
+                "aggType": "count",
+                "format": {
+                  "id": "number"
+                },
+                "params": {}
+              }
+            },
+            "isDonut": true,
+            "labels": {
+              "last_level": true,
+              "show": false,
+              "truncate": 100,
+              "values": true
+            },
+            "legendPosition": "right",
+            "type": "pie"
+          },
+          "title": "Top URL Domains [Filebeat Zeek]",
+          "type": "pie"
+        }
+      },
+      "id": "bec2f0e0-370d-11e9-aa6d-ff445a78330c",
+      "migrationVersion": {
+        "visualization": "7.0.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-02-26T00:07:49.910Z",
+      "version": "WzMyODEsNV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Top SSL Servers [Filebeat Zeek]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "field": "zeek.ssl.server_name",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 10
+              },
+              "schema": "segment",
+              "type": "terms"
+            }
+          ],
+          "params": {
+            "addLegend": true,
+            "addTooltip": true,
+            "dimensions": {
+              "metric": {
+                "accessor": 0,
+                "aggType": "count",
+                "format": {
+                  "id": "number"
+                },
+                "params": {}
+              }
+            },
+            "isDonut": true,
+            "labels": {
+              "last_level": true,
+              "show": false,
+              "truncate": 100,
+              "values": true
+            },
+            "legendPosition": "right",
+            "type": "pie"
+          },
+          "title": "Top SSL Servers [Filebeat Zeek]",
+          "type": "pie"
+        }
+      },
+      "id": "e042fda0-370d-11e9-aa6d-ff445a78330c",
+      "migrationVersion": {
+        "visualization": "7.0.0"
+      },
+      "references": [
+        {
+          "id": "filebeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-02-26T00:07:36.653Z",
+      "version": "WzMyODAsNV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Number of Sessions Overtime [Filebeat Zeek]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "number",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "count"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Number of Sessions Overtime [Filebeat Zeek]",
+          "type": "metrics"
+        }
+      },
+      "id": "f8c40810-370d-11e9-aa6d-ff445a78330c",
+      "migrationVersion": {
+        "visualization": "7.0.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-02-26T00:05:56.379Z",
+      "version": "WzMyNzQsNV0="
+    }
+  ],
+  "version": "7.0.0-beta1"
+}

--- a/dev/package-beats/zeek-1.0.0/manifest.yml
+++ b/dev/package-beats/zeek-1.0.0/manifest.yml
@@ -1,0 +1,13 @@
+name: zeek
+title: Zeek
+version: 1.0.0
+description: |
+  Module for handling logs produced by Zeek/Bro
+type: ""
+categories:
+- logs
+requirement:
+  kibana:
+    version:
+      min: 6.7.0
+      max: 7.6.0

--- a/dev/package-beats/zookeeper-1.0.0/kibana/dashboard/Metricbeat-zookeeper-overview.json
+++ b/dev/package-beats/zookeeper-1.0.0/kibana/dashboard/Metricbeat-zookeeper-overview.json
@@ -1,0 +1,504 @@
+{
+  "objects": [
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Approximate data size [Metricbeat Zookeeper] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_min": "0",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "bytes",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Approximate data size",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "zookeeper.mntr.approximate_data_size",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Approximate data size [Metricbeat Zookeeper] ECS",
+          "type": "metrics"
+        }
+      },
+      "id": "8d3b7770-2319-11e9-bb66-8baac426dfd4-ecs",
+      "type": "visualization",
+      "updated_at": "2019-01-30T13:29:19.163Z",
+      "version": 2
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Latency [Metricbeat Zookeeper] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_min": "0",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "ms,ms,2",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Latency",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "zookeeper.mntr.latency.avg",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Latency [Metricbeat Zookeeper] ECS",
+          "type": "metrics"
+        }
+      },
+      "id": "c0be43c0-2319-11e9-bb66-8baac426dfd4-ecs",
+      "type": "visualization",
+      "updated_at": "2019-01-30T13:29:05.974Z",
+      "version": 2
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Alive Connections [Metricbeat Zookeeper] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_min": "0",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "0,0.[00]",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Alive connections",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "zookeeper.mntr.num_alive_connections",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Alive Connections [Metricbeat Zookeeper] ECS",
+          "type": "metrics"
+        }
+      },
+      "id": "1c2f8930-231a-11e9-bb66-8baac426dfd4-ecs",
+      "type": "visualization",
+      "updated_at": "2019-01-30T13:28:52.034Z",
+      "version": 3
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Used file descriptors [Metricbeat Zookeeper] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_min": "0",
+                "axis_position": "left",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": "0.1",
+                "formatter": "percent",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Used file descriptors",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "zookeeper.mntr.open_file_descriptor_count",
+                    "id": "b92e4550-231a-11e9-9e57-679640dc0c7c",
+                    "metric_agg": "avg",
+                    "type": "avg"
+                  },
+                  {
+                    "field": "zookeeper.mntr.max_file_descriptor_count",
+                    "id": "918d0c60-231b-11e9-9e57-679640dc0c7c",
+                    "type": "avg"
+                  },
+                  {
+                    "id": "7e4d11e0-231b-11e9-9e57-679640dc0c7c",
+                    "script": "params.a/params.b",
+                    "type": "math",
+                    "variables": [
+                      {
+                        "field": "b92e4550-231a-11e9-9e57-679640dc0c7c",
+                        "id": "81c03fa0-231b-11e9-9e57-679640dc0c7c",
+                        "name": "a"
+                      },
+                      {
+                        "field": "918d0c60-231b-11e9-9e57-679640dc0c7c",
+                        "id": "8a3af6c0-231b-11e9-9e57-679640dc0c7c",
+                        "name": "b"
+                      }
+                    ]
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 1,
+                "split_mode": "everything",
+                "stacked": "none",
+                "value_template": "{{value}}"
+              },
+              {
+                "axis_min": "0",
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(0,98,177,1)",
+                "fill": "0",
+                "formatter": "0,0.[00]",
+                "id": "dffaffe0-23cc-11e9-b1ff-37c851471450",
+                "label": "Open file descriptors",
+                "line_width": "1",
+                "metrics": [
+                  {
+                    "field": "zookeeper.mntr.open_file_descriptor_count",
+                    "id": "dffaffe1-23cc-11e9-b1ff-37c851471450",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 1,
+                "split_mode": "everything",
+                "stacked": "none"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Used file descriptors [Metricbeat Zookeeper] ECS",
+          "type": "metrics"
+        }
+      },
+      "id": "ddb13c60-231b-11e9-bb66-8baac426dfd4-ecs",
+      "type": "visualization",
+      "updated_at": "2019-01-30T13:28:22.583Z",
+      "version": 5
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Packets received / sent [Metricbeat Zookeeper] ECS",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_min": "0",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": "0",
+                "formatter": "0,0.[00]",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Packets received",
+                "line_width": "2",
+                "metrics": [
+                  {
+                    "field": "zookeeper.mntr.packets.received",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  },
+                  {
+                    "field": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "id": "34949540-231c-11e9-9707-f128cdaa3bf2",
+                    "type": "derivative",
+                    "unit": ""
+                  }
+                ],
+                "point_size": "0",
+                "separate_axis": 0,
+                "split_filters": [
+                  {
+                    "color": "#68BC00",
+                    "id": "5811d190-231c-11e9-9707-f128cdaa3bf2"
+                  }
+                ],
+                "split_mode": "terms",
+                "stacked": "none"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(115,216,255,1)",
+                "fill": "0",
+                "formatter": "0,0.[00]",
+                "id": "753b2e60-231c-11e9-9707-f128cdaa3bf2",
+                "label": "Packets sent",
+                "line_width": "2",
+                "metrics": [
+                  {
+                    "field": "zookeeper.mntr.packets.sent",
+                    "id": "753b2e61-231c-11e9-9707-f128cdaa3bf2",
+                    "type": "avg"
+                  },
+                  {
+                    "field": "753b2e61-231c-11e9-9707-f128cdaa3bf2",
+                    "id": "7ed33c60-231c-11e9-9707-f128cdaa3bf2",
+                    "type": "derivative",
+                    "unit": ""
+                  }
+                ],
+                "point_size": "0",
+                "separate_axis": 0,
+                "split_mode": "everything",
+                "stacked": "none"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Packets received / sent [Metricbeat Zookeeper] ECS",
+          "type": "metrics"
+        }
+      },
+      "id": "d2f52b50-231c-11e9-bb66-8baac426dfd4-ecs",
+      "type": "visualization",
+      "updated_at": "2019-01-30T13:26:42.583Z",
+      "version": 3
+    },
+    {
+      "attributes": {
+        "description": "Overview of Zookeeper",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "optionsJSON": {
+          "darkTheme": false,
+          "hidePanelTitles": false,
+          "useMargins": true
+        },
+        "panelsJSON": [
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 15,
+              "i": "1",
+              "w": 15,
+              "x": 0,
+              "y": 15
+            },
+            "id": "8d3b7770-2319-11e9-bb66-8baac426dfd4-ecs",
+            "panelIndex": "1",
+            "title": "Approximate data size",
+            "type": "visualization",
+            "version": "7.0.0-alpha2"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 15,
+              "i": "2",
+              "w": 17,
+              "x": 15,
+              "y": 15
+            },
+            "id": "c0be43c0-2319-11e9-bb66-8baac426dfd4-ecs",
+            "panelIndex": "2",
+            "title": "Latency",
+            "type": "visualization",
+            "version": "7.0.0-alpha2"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 15,
+              "i": "3",
+              "w": 16,
+              "x": 32,
+              "y": 15
+            },
+            "id": "1c2f8930-231a-11e9-bb66-8baac426dfd4-ecs",
+            "panelIndex": "3",
+            "title": "Alive Connections",
+            "type": "visualization",
+            "version": "7.0.0-alpha2"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 15,
+              "i": "4",
+              "w": 25,
+              "x": 23,
+              "y": 0
+            },
+            "id": "ddb13c60-231b-11e9-bb66-8baac426dfd4-ecs",
+            "panelIndex": "4",
+            "title": "Used file descriptors",
+            "type": "visualization",
+            "version": "7.0.0-alpha2"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 15,
+              "i": "5",
+              "w": 23,
+              "x": 0,
+              "y": 0
+            },
+            "id": "d2f52b50-231c-11e9-bb66-8baac426dfd4-ecs",
+            "panelIndex": "5",
+            "title": "Packets received / sent",
+            "type": "visualization",
+            "version": "7.0.0-alpha2"
+          }
+        ],
+        "timeRestore": false,
+        "title": "[Metricbeat Zookeeper] Overview ECS",
+        "version": 1
+      },
+      "id": "467207a0-231e-11e9-bb66-8baac426dfd4-ecs",
+      "type": "dashboard",
+      "updated_at": "2019-01-30T13:34:01.235Z",
+      "version": 6
+    }
+  ],
+  "version": "7.0.0-alpha2"
+}

--- a/dev/package-beats/zookeeper-1.0.0/manifest.yml
+++ b/dev/package-beats/zookeeper-1.0.0/manifest.yml
@@ -1,0 +1,13 @@
+name: zookeeper
+title: ZooKeeper
+version: 1.0.0
+description: |
+  ZooKeeper metrics collected by the four-letter monitoring commands.
+type: ""
+categories:
+- metrics
+requirement:
+  kibana:
+    version:
+      min: 6.7.0
+      max: 7.6.0

--- a/magefile.go
+++ b/magefile.go
@@ -31,7 +31,7 @@ var (
 
 	publicDir    = "./public"
 	buildDir     = "./build"
-	packagePaths = []string{"./dev/package-generated/", "./dev/package-examples/"}
+	packagePaths = []string{"./dev/package-generated/", "./dev/package-examples/", "./dev/package-beats/"}
 )
 
 func Build() error {


### PR DESCRIPTION
This PR adds a script to import integrations from Metricbeat and Filebeat. Running `import_beats` will walk beats repo, create the proper manifests, and copy over assets for each module.

![image](https://user-images.githubusercontent.com/299804/67674523-03b60700-f97d-11e9-98e1-ad9afb534473.png)

Having the repo checked out in the same root folder as this repo, run to update `dev/package-beats` folder.
```
go run dev/import_beats/ -beatsDir ../beats -publicDir dev/package-beats
```

This is still a work in progress effort with many things TODO:

- [ ] Generate + copy `fields.yml`
- [ ] Come up with a plan for docs
- [ ] Dashboard screenshots
- [ ] Icons
- [ ] Input configs
- [ ] ...and more

Reviews will probably want to focus on `import_beats/main.go` file, as the rest are generated.