### PR TITLE
Rename integrations-registry to package-registry

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,7 @@
 # Ingore all files which are not needed for building or running.
 
 .DS_Store
-integrations-registry
+package-registry
 
 .idea
 .git

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .DS_Store
-integrations-registry
+package-registry
 
 .idea
 build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/elastic/integrations-registry/compare/v0.1.0...master)
+## [Unreleased](https://github.com/elastic/package-registry/compare/v0.1.0...master)
 
 ### Breaking changes
 
 * Package Kibana compatiblity version is changed to `"kibana": { "max": "1.2.3"}` [#134](https://github.com/elastic/integrations-registry/pull/134)
-
+* Rename `integrations-registry` to `package-registry`.
 
 ### Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Breaking changes
 
 * Package Kibana compatiblity version is changed to `"kibana": { "max": "1.2.3"}` [#134](https://github.com/elastic/integrations-registry/pull/134)
-* Rename `integrations-registry` to `package-registry`.
+* Rename `integrations-registry` to `package-registry`. [#138](https://github.com/elastic/integrations-registry/pull/138)
 
 ### Bugfixes
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,10 @@ RUN \
          zip \
       && rm -rf /var/lib/apt/lists/*
 
-COPY ./ /go/src/github.com/elastic/integrations-registry
+COPY ./ /go/src/github.com/elastic/package-registry
 EXPOSE 8080
 
-WORKDIR "/go/src/github.com/elastic/integrations-registry"
+WORKDIR "/go/src/github.com/elastic/package-registry"
 
 ENV GO111MODULE=on
 RUN go mod vendor

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ retriever: modernSCM(
 pipeline {
   agent { label 'docker && linux && immutable' }
   environment {
-    BASE_DIR="src/github.com/elastic/integrations-registry"
+    BASE_DIR="src/github.com/elastic/package-registry"
     JOB_GIT_CREDENTIALS = "f6c7695a-671e-4f4f-a331-acdce44ff9ba"
     PIPELINE_LOG_LEVEL='INFO'
   }

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Endpoints:
 * `/package/{name}-{version}`: Info about a package
 * `/package/{name}-{version}.tar.gz`: Download a package
 
-Examples for each API endpoint can be found here: https://github.com/elastic/integrations-registry/tree/master/docs/api
+Examples for each API endpoint can be found here: https://github.com/elastic/package-registry/tree/master/docs/api
 
 The `/search` API endpoint has few additional query parameters. More might be added in the future, but for now these are:
 

--- a/categories.go
+++ b/categories.go
@@ -10,7 +10,7 @@ import (
 	"net/http"
 	"sort"
 
-	"github.com/elastic/integrations-registry/util"
+	"github.com/elastic/package-registry/util"
 )
 
 type Category struct {

--- a/dev/generator/main.go
+++ b/dev/generator/main.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/magefile/mage/sh"
 
-	"github.com/elastic/integrations-registry/util"
+	"github.com/elastic/package-registry/util"
 )
 
 var (

--- a/dev/package-examples/longdocs-1.0.4/docs/README.md
+++ b/dev/package-examples/longdocs-1.0.4/docs/README.md
@@ -9,7 +9,7 @@ This integration is considered to be in _beta_.
 
 ## Test a link
 
-This is a [link](https://github.com/elastic/integrations-registry) inside the docs.
+This is a [link](https://github.com/elastic/package-registry) inside the docs.
 
 ## Examples from a file
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/elastic/integrations-registry
+module github.com/elastic/package-registry
 
 go 1.12
 

--- a/magefile.go
+++ b/magefile.go
@@ -159,5 +159,5 @@ func Clean() error {
 		return err
 	}
 
-	return os.Remove("integrations-registry")
+	return os.Remove("package-registry")
 }

--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ import (
 	"strconv"
 	"syscall"
 
-	"github.com/elastic/integrations-registry/util"
+	"github.com/elastic/package-registry/util"
 
 	ucfgYAML "github.com/elastic/go-ucfg/yaml"
 

--- a/search.go
+++ b/search.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/blang/semver"
 
-	"github.com/elastic/integrations-registry/util"
+	"github.com/elastic/package-registry/util"
 )
 
 func searchHandler(packagesBasePath, cacheTime string) func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
The repository was renamed to package-registry and with it all the paths inside as needed.