### PR TITLE
Add version ranges instead of min / max version

### DIFF
--- a/ASSETS.md
+++ b/ASSETS.md
@@ -35,14 +35,11 @@ os.platform: [darwin, freebsd, linux, macos, openbsd, windows]
 
 requirement:
   elasticsearch:
-    version.min: 7.0
-    version.max: 7
+    versions: >7.0
   kibana:
-    version.min: 7.0
-  metricbeat:
-    version.min: 7.1
-  filebeat:
-    version.min: 7.2
+    versions: >7.0
+  agent:
+    versions: >7.1
 
 # The order of the items listed here is the order they show up in the package overview.
 screenshots:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking changes
 
+* Change `requirements.kibana.version.min/max` to `requirements.kibana.versions: {semver-range}`
+
 ### Bugfixes
 
 ### Added

--- a/dev/package-examples/auditd-2.0.4/manifest.yml
+++ b/dev/package-examples/auditd-2.0.4/manifest.yml
@@ -9,9 +9,9 @@ requirement:
   kibana:
     versions: ">=7.1.0 <8.0.0"
   elasticsearch:
-    version.min: 7.0.1
+    versions: ">7.0.1"
   auditbeat:
-    version.min: 7.0.0
+    versions: ">7.0.0"
 
 screenshots:
   - src: /img/screenshots/auditbeat-file-integrity-dashboard.png

--- a/dev/package-examples/auditd-2.0.4/manifest.yml
+++ b/dev/package-examples/auditd-2.0.4/manifest.yml
@@ -7,8 +7,7 @@ release: ga
 
 requirement:
   kibana:
-    version.min: 7.1.0
-    version.max: 7.6.0
+    versions: ">=7.1.0 <8.0.0"
   elasticsearch:
     version.min: 7.0.1
   auditbeat:

--- a/dev/package-examples/base-1.0.0/manifest.yml
+++ b/dev/package-examples/base-1.0.0/manifest.yml
@@ -18,7 +18,7 @@ type: integration
 requirement:
   elasticsearch:
     # Requires ILM which was released in 6.6.
-    version.min: 6.6.0
+    versions: ">6.6.0"
 
 # No icons
 icons:

--- a/dev/package-examples/coredns-1.0.1/manifest.yml
+++ b/dev/package-examples/coredns-1.0.1/manifest.yml
@@ -13,10 +13,9 @@ type: integration
 
 requirement:
   kibana:
-    version.min: 6.7.0
-    version.max: 7.6.0
+    versions: ">6.7.0"
   elasticsearch:
-    version.min: 7.0.1
+    versions: ">7.0.1"
 
 icons:
 - src: "/img/icon.png"

--- a/dev/package-examples/iptables-1.0.4/manifest.yml
+++ b/dev/package-examples/iptables-1.0.4/manifest.yml
@@ -8,10 +8,9 @@ license: basic
 
 requirement:
   kibana:
-    version.min: 6.7.0
-    version.max: 7.6.0
+    versions: ">6.7.0  <7.6.0"
   elasticsearch:
-    version.min: 7.0.1
+    versions: ">7.0.1"
 
 screenshots:
 - src: /img/kibana-iptables.png

--- a/dev/package-examples/longdocs-1.0.4/manifest.yml
+++ b/dev/package-examples/longdocs-1.0.4/manifest.yml
@@ -13,9 +13,9 @@ license: basic
 
 requirement:
   kibana:
-    version.min: 6.7.0
+    versions: ">6.7.0"
   elasticsearch:
-    version.min: 7.0.1
+    versions: ">7.0.1"
 
 icons:
 - src: "/img/icon.svg"

--- a/dev/package-examples/multiversion-1.0.3/manifest.yml
+++ b/dev/package-examples/multiversion-1.0.3/manifest.yml
@@ -9,9 +9,9 @@ license: basic
 
 requirement:
   kibana:
-    version.min: 6.7.0
+    versions: ">6.7.0"
   elasticsearch:
-    version.min: 7.0.1
+    versions: ">7.0.1"
 
 icons:
 - src: "/img/icon.svg"

--- a/dev/package-examples/multiversion-1.0.4/manifest.yml
+++ b/dev/package-examples/multiversion-1.0.4/manifest.yml
@@ -10,9 +10,9 @@ type: integration
 
 requirement:
   kibana:
-    version.min: 6.7.0
+    versions: ">6.7.0"
   elasticsearch:
-    version.min: 7.0.1
+    versions: ">7.0.1"
 
 icons:
 - src: "/img/icon.svg"

--- a/dev/package-examples/multiversion-1.1.0/manifest.yml
+++ b/dev/package-examples/multiversion-1.1.0/manifest.yml
@@ -9,9 +9,9 @@ license: basic
 
 requirement:
   kibana:
-    version.min: 6.7.0
+    versions: ">6.7.0"
   elasticsearch:
-    version.min: 7.0.1
+    versions: ">7.0.1"
 
 icons:
 - src: "/img/icon.svg"

--- a/dev/package-examples/nginx-1.2.0/manifest.yml
+++ b/dev/package-examples/nginx-1.2.0/manifest.yml
@@ -7,10 +7,6 @@ release: ga
 
 requirement:
   kibana:
-    version.min: 7.1.0
-    version.max: 7.6.0
+    versions: ">7.1.0 <7.6.0"
   elasticsearch:
-    version.min: 7.0.1
-  auditbeat:
-    version.min: 7.0.0
-
+    versions: ">7.0.1"

--- a/dev/package-generated/apache-1.0.1/manifest.yml
+++ b/dev/package-generated/apache-1.0.1/manifest.yml
@@ -9,10 +9,9 @@ release: beta
 
 requirement:
   kibana:
-    version.min: 6.7.0
-    version.max: 7.6.0
+    versions: ">6.7.0 <=7.6.0"
   elasticsearch:
-    version.min: 7.0.1
+    versions: ">7.0.1"
 
 icons:
   - src: "/img/icon.svg"

--- a/dev/package-generated/docker-1.2.3/manifest.yml
+++ b/dev/package-generated/docker-1.2.3/manifest.yml
@@ -9,10 +9,9 @@ release: beta
 
 requirement:
   kibana:
-    version.min: 6.7.0
-    version.max: 7.6.0
+    versions: ">6.7.0 <=7.6.0"
   elasticsearch:
-    version.min: 7.0.1
+    versions: ">7.0.1"
 
 icons:
   - src: "/img/icon.svg"

--- a/dev/package-generated/elasticsearch-1.3.1/manifest.yml
+++ b/dev/package-generated/elasticsearch-1.3.1/manifest.yml
@@ -9,10 +9,9 @@ release: beta
 
 requirement:
   kibana:
-    version.min: 6.7.0
-    version.max: 7.6.0
+    versions: ">6.7.0 <=7.6.0"
   elasticsearch:
-    version.min: 7.0.1
+    versions: ">7.0.1"
 
 icons:
   - src: "/img/icon.svg"

--- a/dev/package-generated/haproxy-1.3.1/manifest.yml
+++ b/dev/package-generated/haproxy-1.3.1/manifest.yml
@@ -9,10 +9,9 @@ release: beta
 
 requirement:
   kibana:
-    version.min: 6.7.0
-    version.max: 7.6.0
+    versions: ">6.7.0 <=7.6.0"
   elasticsearch:
-    version.min: 7.0.1
+    versions: ">7.0.1"
 
 icons:
   - src: "/img/icon.svg"

--- a/dev/package-generated/kafka-1.0.1/manifest.yml
+++ b/dev/package-generated/kafka-1.0.1/manifest.yml
@@ -7,10 +7,9 @@ release: beta
 
 requirement:
   kibana:
-    version.min: 6.7.0
-    version.max: 7.6.0
+    versions: ">6.7.0 <=7.6.0"
   elasticsearch:
-    version.min: 7.0.1
+    versions: ">7.0.1"
 
 icons:
   - src: "/img/icon.svg"

--- a/dev/package-generated/kibana-1.3.2/manifest.yml
+++ b/dev/package-generated/kibana-1.3.2/manifest.yml
@@ -7,10 +7,9 @@ release: beta
 
 requirement:
   kibana:
-    version.min: 6.7.0
-    version.max: 7.6.0
+    versions: ">6.7.0 <=7.6.0"
   elasticsearch:
-    version.min: 7.0.1
+    versions: ">7.0.1"
 
 icons:
   - src: "/img/icon.svg"

--- a/dev/package-generated/mongodb-1.0.1/manifest.yml
+++ b/dev/package-generated/mongodb-1.0.1/manifest.yml
@@ -9,10 +9,9 @@ release: beta
 
 requirement:
   kibana:
-    version.min: 6.7.0
-    version.max: 7.6.0
+    versions: ">6.7.0 <=7.6.0"
   elasticsearch:
-    version.min: 7.0.1
+    versions: ">7.0.1"
 
 icons:
   - src: "/img/icon.svg"

--- a/dev/package-generated/mysql-1.0.1/manifest.yml
+++ b/dev/package-generated/mysql-1.0.1/manifest.yml
@@ -7,10 +7,9 @@ release: beta
 
 requirement:
   kibana:
-    version.min: 6.7.0
-    version.max: 7.6.0
+    versions: ">6.7.0 <=7.6.0"
   elasticsearch:
-    version.min: 7.0.1
+    versions: ">7.0.1"
 
 icons:
   - src: "/img/icon.svg"

--- a/dev/package-generated/mysql-1.0.2/manifest.yml
+++ b/dev/package-generated/mysql-1.0.2/manifest.yml
@@ -9,11 +9,9 @@ release: beta
 
 requirement:
   kibana:
-    version.min: 6.7.0
-    version.max: 7.6.0
+    versions: ">6.7.0 <=7.6.0"
   elasticsearch:
-    version.min: 7.0.1
-
+    versions: ">7.0.1"
 icons:
   - src: "/img/icon.svg"
     type: "image/svg+xml"

--- a/dev/package-generated/postgresql-1.0.2/manifest.yml
+++ b/dev/package-generated/postgresql-1.0.2/manifest.yml
@@ -9,10 +9,9 @@ release: beta
 
 requirement:
   kibana:
-    version.min: 6.7.0
-    version.max: 7.6.0
+    versions: ">6.7.0 <=7.6.0"
   elasticsearch:
-    version.min: 7.0.1
+    versions: ">7.0.1"
 
 icons:
   - src: "/img/icon.svg"

--- a/dev/package-generated/rabbitmq-1.0.2/manifest.yml
+++ b/dev/package-generated/rabbitmq-1.0.2/manifest.yml
@@ -9,10 +9,9 @@ release: beta
 
 requirement:
   kibana:
-    version.min: 6.7.0
-    version.max: 7.6.0
+    versions: ">6.7.0 <=7.6.0"
   elasticsearch:
-    version.min: 7.0.1
+    versions: ">7.0.1"
 
 icons:
   - src: "/img/icon.svg"

--- a/dev/package-generated/system-2.0.1/manifest.yml
+++ b/dev/package-generated/system-2.0.1/manifest.yml
@@ -7,8 +7,7 @@ release: beta
 
 requirement:
   kibana:
-    version.min: 6.7.0
-    version.max: 7.6.0
+    versions: ">6.7.0 <=7.6.0"
   elasticsearch:
-    version.min: 7.0.1
+    versions: ">7.0.1"
 

--- a/dev/package-generated/traefik-1.0.2/manifest.yml
+++ b/dev/package-generated/traefik-1.0.2/manifest.yml
@@ -7,7 +7,6 @@ release: beta
 
 requirement:
   kibana:
-    version.min: 6.7.0
-    version.max: 7.6.0
+    versions: ">6.7.0 <=7.6.0"
   elasticsearch:
-    version.min: 7.0.1
+    versions: ">7.0.1"

--- a/docs/api/package.json
+++ b/docs/api/package.json
@@ -11,9 +11,7 @@
   ],
   "requirement": {
     "kibana": {
-      "version": {
-        "min": "7.0.0"
-      }
+      "versions": "\u003e=7.0.0"
     }
   },
   "screenshots": [

--- a/testdata/package/example-0.0.2/index.json
+++ b/testdata/package/example-0.0.2/index.json
@@ -9,9 +9,7 @@
   ],
   "requirement": {
     "kibana": {
-      "version": {
-        "min": "6.0.0"
-      }
+      "versions": "\u003e=6.0.0"
     }
   },
   "assets": [

--- a/testdata/package/example-0.0.2/manifest.yml
+++ b/testdata/package/example-0.0.2/manifest.yml
@@ -6,11 +6,10 @@ categories: ["logs"]
 
 requirement:
   elasticsearch:
-    version.min: 6.0.0
-    version.max: 6.8.0
+    versions: ">=6.0.0 <=6.8.0"
   kibana:
-    version.min: 6.0.0
+    versions: ">=6.0.0"
   metricbeat:
-    version.min: 6.1.0
+    versions: ">=6.1.0"
   filebeat:
-    version.min: 6.2.0
+    versions: ">=6.2.0"

--- a/testdata/package/example-1.0.0/index.json
+++ b/testdata/package/example-1.0.0/index.json
@@ -11,9 +11,7 @@
   ],
   "requirement": {
     "kibana": {
-      "version": {
-        "min": "7.0.0"
-      }
+      "versions": "\u003e=7.0.0"
     }
   },
   "screenshots": [

--- a/testdata/package/example-1.0.0/manifest.yml
+++ b/testdata/package/example-1.0.0/manifest.yml
@@ -7,14 +7,13 @@ type: integration
 
 requirement:
   elasticsearch:
-    version.min: 7.0.0
-    version.max: 7.5.0
+    versions: ">=7.0.0 <=7.5.0"
   kibana:
-    version.min: 7.0.0
+    versions: ">=7.0.0"
   metricbeat:
-    version.min: 7.1.0
+    versions: ">=7.1.0"
   filebeat:
-    version.min: 7.2.0
+    versions: ">=7.2.0"
 
 screenshots:
   - src: /img/kibana-iptables.png

--- a/testdata/package/foo-1.0.0/index.json
+++ b/testdata/package/foo-1.0.0/index.json
@@ -9,9 +9,7 @@
   ],
   "requirement": {
     "kibana": {
-      "version": {
-        "min": "7.0.0"
-      }
+      "versions": "\u003e=7.0.0"
     }
   },
   "assets": [

--- a/testdata/package/foo-1.0.0/manifest.yml
+++ b/testdata/package/foo-1.0.0/manifest.yml
@@ -7,12 +7,11 @@ type: solution
 
 requirement:
   elasticsearch:
-    version.min: 7.0.0
-    version.max: 7.5.0
+    versions: ">=7.0.0 <=7.5.0"
   kibana:
-    version.min: 7.0.0
+    versions: ">=7.0.0"
   metricbeat:
-    version.min: 7.1.0
+    versions: ">=7.1.0"
   filebeat:
-    version.min: 7.2.0
+    versions: ">=7.2.0"
 

--- a/testdata/package/internal-1.2.0/index.json
+++ b/testdata/package/internal-1.2.0/index.json
@@ -6,9 +6,7 @@
   "type": "integration",
   "categories": [],
   "requirement": {
-    "kibana": {
-      "version": {}
-    }
+    "kibana": {}
   },
   "assets": [
     "/package/internal-1.2.0/index.json",

--- a/util/package.go
+++ b/util/package.go
@@ -46,9 +46,7 @@ type Requirement struct {
 }
 
 type Kibana struct {
-	Version        Version `yaml:"version,omitempty" json:"version,omitempty"`
-	minSemVer      semver.Version
-	maxSemVerRange semver.Range
+	Versions    string `yaml:"versions,omitempty" json:"versions,omitempty"`
 	semVerRange semver.Range
 }
 
@@ -96,17 +94,10 @@ func NewPackage(basePath, packageName string) (*Package, error) {
 		}
 	}
 
-	if p.Requirement.Kibana.Version.Max != "" {
-		p.Requirement.Kibana.maxSemVerRange, err = semver.ParseRange(p.Requirement.Kibana.Version.Max)
+	if p.Requirement.Kibana.Versions != "" {
+		p.Requirement.Kibana.semVerRange, err = semver.ParseRange(p.Requirement.Kibana.Versions)
 		if err != nil {
-			return nil, errors.Wrapf(err, "invalid Kibana max version: %s", p.Requirement.Kibana.Version.Max)
-		}
-	}
-
-	if p.Requirement.Kibana.Version.Min != "" {
-		p.Requirement.Kibana.minSemVer, err = semver.Parse(p.Requirement.Kibana.Version.Min)
-		if err != nil {
-			return nil, errors.Wrapf(err, "invalid Kibana min version: %s", p.Requirement.Kibana.Version.Min)
+			return nil, errors.Wrapf(err, "invalid Kibana versions range: %s", p.Requirement.Kibana.Versions)
 		}
 	}
 
@@ -145,18 +136,10 @@ func (p *Package) HasCategory(category string) bool {
 
 func (p *Package) HasKibanaVersion(version *semver.Version) bool {
 	if version != nil {
-		if p.Requirement.Kibana.Version.Min != "" {
-			if version.GT(p.Requirement.Kibana.minSemVer) {
-				return false
-			}
-		}
 
-		if p.Requirement.Kibana.Version.Max != "" {
-			if p.Requirement.Kibana.maxSemVerRange(*version) {
-				return false
-			}
+		if !p.Requirement.Kibana.semVerRange(*version) {
+			return false
 		}
-
 	}
 	return true
 }
@@ -232,17 +215,10 @@ func (p *Package) Validate() error {
 		return fmt.Errorf("no description set")
 	}
 
-	if p.Requirement.Kibana.Version.Max != "" {
-		_, err := semver.Parse(p.Requirement.Kibana.Version.Max)
+	if p.Requirement.Kibana.Versions != "" {
+		_, err := semver.ParseRange(p.Requirement.Kibana.Versions)
 		if err != nil {
-			return fmt.Errorf("invalid max kibana version: %s, %s", p.Requirement.Kibana.Version.Max, err)
-		}
-	}
-
-	if p.Requirement.Kibana.Version.Min != "" {
-		_, err := semver.Parse(p.Requirement.Kibana.Version.Min)
-		if err != nil {
-			return fmt.Errorf("invalid min Kibana version: %s, %s", p.Requirement.Kibana.Version.Min, err)
+			return fmt.Errorf("invalid max kibana version: %s, %s", p.Requirement.Kibana.Versions, err)
 		}
 	}
 

--- a/util/package.go
+++ b/util/package.go
@@ -218,7 +218,7 @@ func (p *Package) Validate() error {
 	if p.Requirement.Kibana.Versions != "" {
 		_, err := semver.ParseRange(p.Requirement.Kibana.Versions)
 		if err != nil {
-			return fmt.Errorf("invalid max kibana version: %s, %s", p.Requirement.Kibana.Versions, err)
+			return fmt.Errorf("invalid kibana versions: %s, %s", p.Requirement.Kibana.Versions, err)
 		}
 	}
 

--- a/util/package.go
+++ b/util/package.go
@@ -46,9 +46,10 @@ type Requirement struct {
 }
 
 type Kibana struct {
-	Version   Version `yaml:"version,omitempty" json:"version,omitempty"`
-	minSemVer semver.Version
-	maxSemVer semver.Version
+	Version        Version `yaml:"version,omitempty" json:"version,omitempty"`
+	minSemVer      semver.Version
+	maxSemVerRange semver.Range
+	semVerRange semver.Range
 }
 
 type Version struct {
@@ -96,7 +97,7 @@ func NewPackage(basePath, packageName string) (*Package, error) {
 	}
 
 	if p.Requirement.Kibana.Version.Max != "" {
-		p.Requirement.Kibana.maxSemVer, err = semver.Parse(p.Requirement.Kibana.Version.Max)
+		p.Requirement.Kibana.maxSemVerRange, err = semver.ParseRange(p.Requirement.Kibana.Version.Max)
 		if err != nil {
 			return nil, errors.Wrapf(err, "invalid Kibana max version: %s", p.Requirement.Kibana.Version.Max)
 		}
@@ -144,17 +145,18 @@ func (p *Package) HasCategory(category string) bool {
 
 func (p *Package) HasKibanaVersion(version *semver.Version) bool {
 	if version != nil {
-		if p.Requirement.Kibana.Version.Max != "" {
-			if version.GT(p.Requirement.Kibana.maxSemVer) {
+		if p.Requirement.Kibana.Version.Min != "" {
+			if version.GT(p.Requirement.Kibana.minSemVer) {
 				return false
 			}
 		}
 
-		if p.Requirement.Kibana.Version.Min != "" {
-			if version.LT(p.Requirement.Kibana.minSemVer) {
+		if p.Requirement.Kibana.Version.Max != "" {
+			if p.Requirement.Kibana.maxSemVerRange(*version) {
 				return false
 			}
 		}
+
 	}
 	return true
 }

--- a/util/package_test.go
+++ b/util/package_test.go
@@ -35,30 +35,12 @@ var packageTests = []struct {
 			Title: &title,
 			Requirement: Requirement{
 				Kibana{
-					Version: Version{
-						Min: "1.2.3",
-						Max: "bar",
-					},
+					Versions: "bar",
 				},
 			},
 		},
 		false,
-		"invalid Kibana max version",
-	},
-	{
-		Package{
-			Title: &title,
-			Requirement: Requirement{
-				Kibana{
-					Version: Version{
-						Min: "foo",
-						Max: "4.5.6",
-					},
-				},
-			},
-		},
-		false,
-		"invalid Kibana min version",
+		"invalid Kibana version",
 	},
 	{
 		Package{
@@ -66,10 +48,7 @@ var packageTests = []struct {
 			Description: "my description",
 			Requirement: Requirement{
 				Kibana{
-					Version: Version{
-						Min: "1.2.3",
-						Max: "4.5.6",
-					},
+					Versions: ">=1.2.3 <=4.5.6",
 				},
 			},
 			Categories: []string{"metrics", "logs", "foo"},


### PR DESCRIPTION
Currently it is only possible to specify a min and max version as compatibility. This has its limitations as the especially the max version is not always known in advance but all versions of the minor should be compatible.

Implementing this change I realised we should only support ranges or min / max but mixing them gets confusing. Having just one string to define the full range also becomes powerful. For example 6.8 was released after 7.0 and it could be that a package is compatible with 6.8 and 7.2. This is not possible to represent at the moment.

My proposal in this PR is to remove min / max and instead use a `version` or `versions` string.

```
requirement:
  kibana:
    versions: ">=7.1.0 <8.0.0"
```

The supported formats by the library I use can be found here: https://github.com/blang/semver#ranges