### PR TITLE
Get rid of the last include commands

### DIFF
--- a/dev/package-examples/iptables-1.0.4/docs/README.md
+++ b/dev/package-examples/iptables-1.0.4/docs/README.md
@@ -15,7 +15,7 @@ a structure suitable for visualizing in Kibana.
 
 * Deploys dashboards for visualizing the log data.
 
-include::../include/running-modules.asciidoc[]
+Note: Missing link to how to run a model
 
 ## Example dashboard
 
@@ -39,11 +39,11 @@ it can also be configured to read from a file path. See the following example.
 ```
 
 
-include::../include/config-option-intro.asciidoc[]
+Note: Missing link for the general configs.
 
 ## `log` log fileset settings
 
-include::../include/var-paths.asciidoc[]
+Note: Missing link to the vars.
 
 **`var.syslog_host`**
 The interface to listen to UDP based syslog traffic. Defaults to `localhost`.


### PR DESCRIPTION
Some `::include` commands were left over from the asciidoc conversion. This PR removes these.