### PR TITLE
Remove file include syntax from Markdown

### DIFF
--- a/dev/package-examples/longdocs-1.0.4/docs/README.md
+++ b/dev/package-examples/longdocs-1.0.4/docs/README.md
@@ -11,14 +11,6 @@ This integration is considered to be in _beta_.
 
 This is a [link](https://github.com/elastic/package-registry) inside the docs.
 
-## Examples from a file
-
-The following file shows how an event might look like:
-
-```
-{{> ./data.json }}
-```
-
 ## Template parts
 
 Some part of our documentation will require templated documentation. An example of this is to link to the download links of the Beat with the same version as Kibana. The link below with the link text is an example:

--- a/dev/package-examples/nginx-1.2.0/docs/README.md
+++ b/dev/package-examples/nginx-1.2.0/docs/README.md
@@ -9,7 +9,7 @@ The Nginx metricsets were tested with Nginx 1.9 and are expected to work with al
 
 ### Inputs
 
-{{> ../dataset/access/docs/README.md }}
+Inputs have to be copied here directly.
 
 ## Dashboard
 


### PR DESCRIPTION
We decided to go with pure Markdown for now for simplicity reason and not allow users to include other files. Because of this I am removing these examples.