### PR TITLE
Add format_version to manifest file

### DIFF
--- a/ASSETS.md
+++ b/ASSETS.md
@@ -15,11 +15,12 @@ The `manifest.yml` contains the information about the pacakge. It can contain th
 * version: Version of the package (required)
 * categories: List of categories this package falls under. The available categories still need to be defined.
 * requirement: Requirement is an object that contains all the requirements for the stack versions of this package. Inside it contains an entry for each possible service which then can contain `version.min` and `version.max`. Other requirements might be added here like dependency on a specific Elasticsearch plugin / ingest pipeline if needed. In the past this was needed for geo and user_agent as they were not installed by default.
-
+* format_version: The package format version this package was built on top of. By default this is for now always 1.0.0.
 
 An example manifest might look as following:
 
 ```
+format_version: 1.0.0
 name: envoyproxy
 title: Envoy Proxy
 description: This is the envoyproxy package.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add `/health` and `/health?ready=1` endpoint for healthcheck. [#151](https://github.com/elastic/integrations-registry/pull/151)
 * Add `default` config to dataset manifest. [#148](https://github.com/elastic/integrations-registry/pull/148)
 * Update Golang version to 1.13.4. [#159](https://github.com/elastic/integrations-registry/pull/159)
+* Add missing assets from datasets. [#146](https://github.com/elastic/integrations-registry/pull/146)
+* Add `format_version` to define the package format.
 
 ### Deprecated
 

--- a/dev/package-examples/auditd-2.0.4/manifest.yml
+++ b/dev/package-examples/auditd-2.0.4/manifest.yml
@@ -1,3 +1,5 @@
+format_version: 1.0.0
+
 name: auditd
 title: Auditd
 description: Auditd integration

--- a/dev/package-examples/base-1.0.0/manifest.yml
+++ b/dev/package-examples/base-1.0.0/manifest.yml
@@ -1,3 +1,5 @@
+format_version: 1.0.0
+
 name: base
 title: Base package
 description: >

--- a/dev/package-examples/coredns-1.0.1/manifest.yml
+++ b/dev/package-examples/coredns-1.0.1/manifest.yml
@@ -1,3 +1,5 @@
+format_version: 1.0.0
+
 name: coredns
 title: CoreDNS
 description: >

--- a/dev/package-examples/iptables-1.0.4/manifest.yml
+++ b/dev/package-examples/iptables-1.0.4/manifest.yml
@@ -1,3 +1,5 @@
+format_version: 1.0.0
+
 name: iptables
 title: IP Tables
 description: iptables logs

--- a/dev/package-examples/log-0.9.0/manifest.yml
+++ b/dev/package-examples/log-0.9.0/manifest.yml
@@ -1,3 +1,5 @@
+format_version: 1.0.0
+
 name: log
 title: Log Package
 description: >

--- a/dev/package-examples/longdocs-1.0.4/manifest.yml
+++ b/dev/package-examples/longdocs-1.0.4/manifest.yml
@@ -1,3 +1,5 @@
+format_version: 1.0.0
+
 name: longdocs
 title: Long Docs
 description: >

--- a/dev/package-examples/metricsonly-2.0.1/manifest.yml
+++ b/dev/package-examples/metricsonly-2.0.1/manifest.yml
@@ -1,3 +1,5 @@
+format_version: 1.0.0
+
 name: metricsonly
 title: Metrics Only
 description: >

--- a/dev/package-examples/multiversion-1.0.3/manifest.yml
+++ b/dev/package-examples/multiversion-1.0.3/manifest.yml
@@ -1,3 +1,5 @@
+format_version: 1.0.0
+
 name: multiversion
 title: Multi Version
 description: >

--- a/dev/package-examples/multiversion-1.0.4/manifest.yml
+++ b/dev/package-examples/multiversion-1.0.4/manifest.yml
@@ -1,3 +1,5 @@
+format_version: 1.0.0
+
 name: multiversion
 title: Multi Version
 description: >

--- a/dev/package-examples/multiversion-1.1.0/manifest.yml
+++ b/dev/package-examples/multiversion-1.1.0/manifest.yml
@@ -1,3 +1,5 @@
+format_version: 1.0.0
+
 name: multiversion
 title: Multi Version
 description: >

--- a/dev/package-examples/nginx-1.2.0/manifest.yml
+++ b/dev/package-examples/nginx-1.2.0/manifest.yml
@@ -1,3 +1,5 @@
+format_version: 1.0.0
+
 name: nginx
 title: Nginx
 description: Nginx integration

--- a/dev/package-examples/yamlpipeline-1.0.0/manifest.yml
+++ b/dev/package-examples/yamlpipeline-1.0.0/manifest.yml
@@ -1,3 +1,5 @@
+format_version: 1.0.0
+
 name: yamlpipeline
 title: Yaml Pipeline package
 description: >

--- a/dev/package-generated/apache-1.0.1/manifest.yml
+++ b/dev/package-generated/apache-1.0.1/manifest.yml
@@ -1,3 +1,5 @@
+format_version: 1.0.0
+
 name: apache
 description: Apache logs and metrics
 

--- a/dev/package-generated/docker-1.2.3/manifest.yml
+++ b/dev/package-generated/docker-1.2.3/manifest.yml
@@ -1,3 +1,5 @@
+format_version: 1.0.0
+
 name: docker
 description: Docker Logs and metrics
 

--- a/dev/package-generated/elasticsearch-1.3.1/manifest.yml
+++ b/dev/package-generated/elasticsearch-1.3.1/manifest.yml
@@ -1,3 +1,5 @@
+format_version: 1.0.0
+
 name: elasticsearch
 description: Elasticsearch Logs and metrics
 

--- a/dev/package-generated/haproxy-1.3.1/manifest.yml
+++ b/dev/package-generated/haproxy-1.3.1/manifest.yml
@@ -1,3 +1,5 @@
+format_version: 1.0.0
+
 name: haproxy
 description: HaProxy Logs and metrics
 

--- a/dev/package-generated/kafka-1.0.1/manifest.yml
+++ b/dev/package-generated/kafka-1.0.1/manifest.yml
@@ -1,3 +1,5 @@
+format_version: 1.0.0
+
 name: kafka
 description: Kafka Logs and metrics
 title: Kafka

--- a/dev/package-generated/kibana-1.3.2/manifest.yml
+++ b/dev/package-generated/kibana-1.3.2/manifest.yml
@@ -1,3 +1,5 @@
+format_version: 1.0.0
+
 name: kibana
 description: Kibana Logs and metrics
 title: Kibana

--- a/dev/package-generated/mongodb-1.0.1/manifest.yml
+++ b/dev/package-generated/mongodb-1.0.1/manifest.yml
@@ -1,3 +1,5 @@
+format_version: 1.0.0
+
 name: mongodb
 description: MongoDB Logs and metrics
 

--- a/dev/package-generated/mysql-1.0.1/manifest.yml
+++ b/dev/package-generated/mysql-1.0.1/manifest.yml
@@ -1,3 +1,5 @@
+format_version: 1.0.0
+
 name: mysql
 description: Mysql Logs and metrics
 title: MySQL

--- a/dev/package-generated/mysql-1.0.2/manifest.yml
+++ b/dev/package-generated/mysql-1.0.2/manifest.yml
@@ -1,3 +1,5 @@
+format_version: 1.0.0
+
 name: mysql
 description: Mysql Logs and metrics
 

--- a/dev/package-generated/postgresql-1.0.2/manifest.yml
+++ b/dev/package-generated/postgresql-1.0.2/manifest.yml
@@ -1,3 +1,5 @@
+format_version: 1.0.0
+
 name: postgresql
 description: Postgres SQL Logs and metrics
 

--- a/dev/package-generated/rabbitmq-1.0.2/manifest.yml
+++ b/dev/package-generated/rabbitmq-1.0.2/manifest.yml
@@ -1,3 +1,5 @@
+format_version: 1.0.0
+
 name: rabbitmq
 description: RabbitMQ Logs and metrics
 

--- a/dev/package-generated/system-2.0.1/manifest.yml
+++ b/dev/package-generated/system-2.0.1/manifest.yml
@@ -1,3 +1,5 @@
+format_version: 1.0.0
+
 name: system
 description: System SQL Logs and metrics
 title: System

--- a/dev/package-generated/traefik-1.0.2/manifest.yml
+++ b/dev/package-generated/traefik-1.0.2/manifest.yml
@@ -1,3 +1,5 @@
+format_version: 1.0.0
+
 name: traefik
 description: Traefik SQL Logs and metrics
 title: Traefik

--- a/docs/api/package.json
+++ b/docs/api/package.json
@@ -47,5 +47,6 @@
     "/package/example-1.0.0/dataset/foo/elasticsearch/ingest-pipeline/pipeline-json.json",
     "/package/example-1.0.0/dataset/foo/elasticsearch/ingest-pipeline/pipeline-plaintext.json",
     "/package/example-1.0.0/dataset/foo/elasticsearch/ingest-pipeline/pipeline-tcp.json"
-  ]
+  ],
+  "format_version": "1.0.0"
 }

--- a/testdata/package/example-0.0.2/index.json
+++ b/testdata/package/example-0.0.2/index.json
@@ -31,5 +31,6 @@
     "/package/example-0.0.2/kibana/visualization/7e4084e0-5c99-11e9-8477-077ec9664dbd.json",
     "/package/example-0.0.2/kibana/visualization/80844540-5c97-11e9-8477-077ec9664dbd.json",
     "/package/example-0.0.2/kibana/visualization/ab48c3f0-5ca6-11e9-8477-077ec9664dbd.json"
-  ]
+  ],
+  "format_version": "1.0.0"
 }

--- a/testdata/package/example-0.0.2/manifest.yml
+++ b/testdata/package/example-0.0.2/manifest.yml
@@ -1,3 +1,5 @@
+format_version: 1.0.0
+
 name: example
 title: Example
 description: This is the example integration.

--- a/testdata/package/example-1.0.0/index.json
+++ b/testdata/package/example-1.0.0/index.json
@@ -47,5 +47,6 @@
     "/package/example-1.0.0/dataset/foo/elasticsearch/ingest-pipeline/pipeline-json.json",
     "/package/example-1.0.0/dataset/foo/elasticsearch/ingest-pipeline/pipeline-plaintext.json",
     "/package/example-1.0.0/dataset/foo/elasticsearch/ingest-pipeline/pipeline-tcp.json"
-  ]
+  ],
+  "format_version": "1.0.0"
 }

--- a/testdata/package/example-1.0.0/manifest.yml
+++ b/testdata/package/example-1.0.0/manifest.yml
@@ -1,3 +1,5 @@
+format_version: 1.0.0
+
 name: example
 description: This is the example integration
 version: 1.0.0
@@ -23,3 +25,4 @@ screenshots:
     title: IP Tables Ubiquity Dashboard
     size: 1492x1464
     type: image/png
+

--- a/testdata/package/foo-1.0.0/index.json
+++ b/testdata/package/foo-1.0.0/index.json
@@ -15,5 +15,6 @@
   "assets": [
     "/package/foo-1.0.0/index.json",
     "/package/foo-1.0.0/manifest.yml"
-  ]
+  ],
+  "format_version": "1.0.0"
 }

--- a/testdata/package/foo-1.0.0/manifest.yml
+++ b/testdata/package/foo-1.0.0/manifest.yml
@@ -1,3 +1,5 @@
+format_version: 1.0.0
+
 name: foo
 description: This is the foo integration
 version: 1.0.0

--- a/testdata/package/internal-1.2.0/index.json
+++ b/testdata/package/internal-1.2.0/index.json
@@ -12,5 +12,6 @@
     "/package/internal-1.2.0/index.json",
     "/package/internal-1.2.0/manifest.yml"
   ],
-  "internal": true
+  "internal": true,
+  "format_version": "1.0.0"
 }

--- a/testdata/package/internal-1.2.0/manifest.yml
+++ b/testdata/package/internal-1.2.0/manifest.yml
@@ -1,3 +1,5 @@
+format_version: 1.0.0
+
 name: internal
 description: Internal package
 version: 1.2.0

--- a/util/package_test.go
+++ b/util/package_test.go
@@ -62,6 +62,26 @@ var packageTests = []struct {
 			Description: "my description",
 			Categories:  []string{"metrics", "logs"},
 		},
+		false,
+		"missing format_version",
+	},
+	{
+		Package{
+			Title:         &title,
+			Description:   "my description",
+			Categories:    []string{"metrics", "logs"},
+			FormatVersion: "1.0",
+		},
+		false,
+		"invalid package version",
+	},
+	{
+		Package{
+			Title:         &title,
+			Description:   "my description",
+			Categories:    []string{"metrics", "logs"},
+			FormatVersion: "1.0.0",
+		},
 		true,
 		"complete",
 	},


### PR DESCRIPTION
The field `format_version` is added to each manifest to indicate which package version format is used. This will become useful if in case one day we will make breaking changes to the structure and can then on the EPM side make a smart decision on how to process the package.

Additional changes:

* All the config reading had to be updated to `config` from `yaml` as it uses ucfg. This should have done before but was missing. The problem only showed up now because of different names of variable and field name.