### PR TITLE
Add default config to dataset

### DIFF
--- a/ASSETS.md
+++ b/ASSETS.md
@@ -276,6 +276,9 @@ type: metric
 # Each input can be in its own release status
 release: beta
 
+# If set to true, this will be enabled by default in the input selection
+default: true
+
 # Defines variables which are used in the config files and can be configured by the user / replaced by the package manager.
 vars:
   -

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Make caching headers configurable per endpoint. [#116](https://github.com/elastic/integrations-registry/pull/116)
 * Add readme entry to package endpoint. [#128](https://github.com/elastic/integrations-registry/pull/128)
 * Add `/health` and `/health?ready=1` endpoint for healthcheck. [#151](https://github.com/elastic/integrations-registry/pull/151)
+* Add `default` config to dataset manifest. [#148](https://github.com/elastic/integrations-registry/pull/148)
 
 
 ## [0.1.0]

--- a/dev/package-examples/iptables-1.0.4/dataset/log/manifest.yml
+++ b/dev/package-examples/iptables-1.0.4/dataset/log/manifest.yml
@@ -3,6 +3,7 @@ title: IPTable logs
 # Needs to describe the type of this input
 type: logs
 ingest_pipline: pipeline
+default: true
 
 vars:
   - name: paths

--- a/dev/package-examples/iptables-1.0.4/dataset/log/manifest.yml
+++ b/dev/package-examples/iptables-1.0.4/dataset/log/manifest.yml
@@ -3,6 +3,8 @@ title: IPTable logs
 # Needs to describe the type of this input
 type: logs
 ingest_pipline: pipeline
+
+# If set to true, this will be enabled by default in the input selection
 default: true
 
 vars:


### PR DESCRIPTION
Not all datasets are enabled by default. Having a config per dataset should allow the UI to decide which ones should be enabled by default. The default should be false.