### PR TITLE
Fix name in / endpoint

### DIFF
--- a/docs/api/info.json
+++ b/docs/api/info.json
@@ -1,4 +1,4 @@
 {
-    "service.name": "integration-registry",
+    "service.name": "package-registry",
     "version": "0.2.0"
 }

--- a/magefile.go
+++ b/magefile.go
@@ -56,7 +56,7 @@ func Build() error {
 func BuildRootFile() error {
 	rootData := map[string]string{
 		"version":      "0.2.0",
-		"service.name": "integration-registry",
+		"service.name": "package-registry",
 	}
 
 	return writeJsonFile(rootData, publicDir+"/index.json")

--- a/testdata/index.json
+++ b/testdata/index.json
@@ -1,4 +1,4 @@
 {
-    "service.name": "integration-registry",
+    "service.name": "package-registry",
     "version": "0.2.0"
 }


### PR DESCRIPTION
The name in the / endpoint was still integration-registry. This is now changed to package-registry to align with all the other renames.