### PR TITLE
Add health endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add healthcheck to docker file. [#115](https://github.com/elastic/integrations-registry/pull/115)
 * Make caching headers configurable per endpoint. [#116](https://github.com/elastic/integrations-registry/pull/116)
 * Add readme entry to package endpoint. [#128](https://github.com/elastic/integrations-registry/pull/128)
+* Add `/health` and `/health?ready=1` endpoint for healthcheck. [#151](https://github.com/elastic/integrations-registry/pull/151)
 
 
 ## [0.1.0]

--- a/main.go
+++ b/main.go
@@ -104,7 +104,12 @@ func getRouter(config Config, packagesBasePath string) *mux.Router {
 
 	router.HandleFunc("/search", searchHandler(packagesBasePath, searchCacheTime))
 	router.HandleFunc("/categories", categoriesHandler(packagesBasePath, categoriesCacheTime))
+	router.HandleFunc("/health", healthHandler)
 	router.PathPrefix("/").HandlerFunc(catchAll(config.PublicDir, catchAllCacheTime))
 
 	return router
 }
+
+// healthHandler is used for Docker/K8s deployments. It returns 200 if the service is live
+// In addition ?ready=true can be used for a ready request. Currently both are identical.
+func healthHandler(w http.ResponseWriter, r *http.Request) {}


### PR DESCRIPTION
Adding the `/health` endpoint which can be used for Docker / K8s deployment. There are two common calls:

* `/health` for liveliness
* `/health?ready=1` for a ready check

Currently both are implemented the same way as as soon as the service is live, it is also ready. This might change in the future.