### PR TITLE
Fix header for `tar.gz` files from `application/json` to `application/gzip`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bugfixes
 
-* Fix header for `tar.gz` files from `application/json` to `application/gzip`. [#](https://github.com/elastic/integrations-registry/pull/)
+* Fix header for `tar.gz` files from `application/json` to `application/gzip`. [#154](https://github.com/elastic/integrations-registry/pull/154)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bugfixes
 
+* Fix header for `tar.gz` files from `application/json` to `application/gzip`. [#](https://github.com/elastic/integrations-registry/pull/)
+
 ### Added
 
 ### Deprecated

--- a/handler.go
+++ b/handler.go
@@ -65,12 +65,15 @@ func jsonHeader(w http.ResponseWriter) {
 func sendHeader(w http.ResponseWriter, r *http.Request) {
 	extension := filepath.Ext(r.RequestURI)
 
+	fmt.Println(extension)
 	switch extension {
 	// No extension is always json
 	case "":
 		w.Header().Set("Content-Type", "application/json")
 	case ".asciidoc":
 		w.Header().Set("Content-Type", "text/asciidoc; charset=UTF-8")
+	case ".gz":
+		w.Header().Set("Content-Type", "application/gzip")
 	case ".jpg":
 	case ".jpeg":
 		w.Header().Set("Content-Type", "image/jpeg")

--- a/handler.go
+++ b/handler.go
@@ -65,7 +65,6 @@ func jsonHeader(w http.ResponseWriter) {
 func sendHeader(w http.ResponseWriter, r *http.Request) {
 	extension := filepath.Ext(r.RequestURI)
 
-	fmt.Println(extension)
 	switch extension {
 	// No extension is always json
 	case "":


### PR DESCRIPTION
Closing https://github.com/elastic/package-registry/issues/153