### PR TITLE
Fix typos 'pipline'->'pipeline'.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Files to be loaded into the Elastic Stack:
 {service}/{type}/{filename}
 ```
 
-Service in the above can be `elasticsearch`, `kibana` or any other component in the Elastic Stack. The type is specific to each service. In the case of Elasticsearch it can be `ingest-pipline`, `index-template` or could also be `index` data. For Kibana it could be `dashboard`, `visualization` or any other saved object type or other types. The names are taken from the API endpoints in each service. The file name needs to be unique inside the directory and best has a descriptive nature or unique id.
+Service in the above can be `elasticsearch`, `kibana` or any other component in the Elastic Stack. The type is specific to each service. In the case of Elasticsearch it can be `ingest-pipeline`, `index-template` or could also be `index` data. For Kibana it could be `dashboard`, `visualization` or any other saved object type or other types. The names are taken from the API endpoints in each service. The file name needs to be unique inside the directory and best has a descriptive nature or unique id.
 
 Each package can contain 2 additional directories:
 

--- a/dev/package-examples/coredns-1.0.1/dataset/log/manifest.yml
+++ b/dev/package-examples/coredns-1.0.1/dataset/log/manifest.yml
@@ -3,7 +3,7 @@ release: ga
 
 type: logs
 
-ingest_pipline: pipeline-entry
+ingest_pipeline: pipeline-entry
 
 vars:
   - name: paths

--- a/dev/package-examples/iptables-1.0.4/dataset/log/manifest.yml
+++ b/dev/package-examples/iptables-1.0.4/dataset/log/manifest.yml
@@ -2,7 +2,7 @@ title: IPTable logs
 
 # Needs to describe the type of this input
 type: logs
-ingest_pipline: pipeline
+ingest_pipeline: pipeline
 
 vars:
   - name: paths

--- a/dev/package-examples/nginx-1.2.0/dataset/access/manifest.yml
+++ b/dev/package-examples/nginx-1.2.0/dataset/access/manifest.yml
@@ -6,7 +6,7 @@ release: beta
 type: logs
 
 # The ingest pipeline which should be used.
-ingest_pipline: default
+ingest_pipeline: default
 
 vars:
   - name: paths

--- a/testdata/package/example-1.0.0/dataset/foo/manifest.yml
+++ b/testdata/package/example-1.0.0/dataset/foo/manifest.yml
@@ -2,4 +2,4 @@ title: Foo
 
 # Needs to describe the type of this input
 type: logs
-ingest_pipline: pipeline-entry
+ingest_pipeline: pipeline-entry


### PR DESCRIPTION
Fixes a few typos.