### PR TITLE
Add log package

### DIFF
--- a/dev/package-examples/log-0.9.0/dataset/log/agent/stream/stream.yml
+++ b/dev/package-examples/log-0.9.0/dataset/log/agent/stream/stream.yml
@@ -1,0 +1,5 @@
+type: log
+paths:
+  {{#each paths}}
+  - "{{this}}"
+  {{/each}}

--- a/dev/package-examples/log-0.9.0/dataset/log/elasticsearch/ingest-pipeline/default.yml
+++ b/dev/package-examples/log-0.9.0/dataset/log/elasticsearch/ingest-pipeline/default.yml
@@ -1,0 +1,3 @@
+---
+description: Pipeline to be completed with processors.
+processors:

--- a/dev/package-examples/log-0.9.0/dataset/log/manifest.yml
+++ b/dev/package-examples/log-0.9.0/dataset/log/manifest.yml
@@ -1,0 +1,12 @@
+title: Log Dataset
+
+type: logs
+ingest_pipeline: default
+
+default: true
+
+vars:
+  - name: paths
+    default:
+      # This example value has to be changed / overwritten by the user.
+      - /var/log/*.log

--- a/dev/package-examples/log-0.9.0/docs/README.md
+++ b/dev/package-examples/log-0.9.0/docs/README.md
@@ -1,0 +1,3 @@
+# Log Package
+
+The log package is used as a generic package based on which any log file can be tailed by adjusting the ingest pipeline.

--- a/dev/package-examples/log-0.9.0/manifest.yml
+++ b/dev/package-examples/log-0.9.0/manifest.yml
@@ -1,0 +1,15 @@
+name: log
+title: Log Package
+description: >
+  The log package should be used to create data sources for all type of logs
+  for which an package doesn't exist yet.
+version: 0.9.0
+categories: ["logs"]
+release: ga
+license: basic
+
+requirement:
+  kibana:
+    versions: "<8.0.0"
+  elasticsearch:
+    versions: "<8.0.0"


### PR DESCRIPTION
The log package is used as a generic package based on which any log file can be tailed by adjusting the ingest pipeline.

Closing https://github.com/elastic/package-registry/issues/145