### PR TITLE
Create datasets output in package info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Update Golang version to 1.13.4. [#159](https://github.com/elastic/integrations-registry/pull/159)
 * Add missing assets from datasets. [#146](https://github.com/elastic/integrations-registry/pull/146)
 * Add `format_version` to define the package format.
+* Add dataset array to package info endpoint. [#162](https://github.com/elastic/integrations-registry/pull/162)
 
 ### Deprecated
 

--- a/dev/generator/main.go
+++ b/dev/generator/main.go
@@ -130,6 +130,11 @@ func buildPackage(packagesBasePath string, p util.Package) error {
 		return err
 	}
 
+	err = p.LoadDataSets(p.GetPath())
+	if err != nil {
+		return err
+	}
+
 	err = writeJsonFile(p, p.GetPath()+"/index.json")
 	if err != nil {
 		return err

--- a/docs/api/info.json
+++ b/docs/api/info.json
@@ -1,4 +1,4 @@
 {
-    "service.name": "package-registry",
-    "version": "0.2.0"
+  "service.name": "package-registry",
+  "version": "0.2.0"
 }

--- a/docs/api/package.json
+++ b/docs/api/package.json
@@ -47,5 +47,14 @@
     "/package/example-1.0.0/dataset/foo/elasticsearch/ingest-pipeline/pipeline-plaintext.json",
     "/package/example-1.0.0/dataset/foo/elasticsearch/ingest-pipeline/pipeline-tcp.json"
   ],
-  "format_version": "1.0.0"
+  "format_version": "1.0.0",
+  "datasets": [
+    {
+      "title": "Foo",
+      "name": "foo",
+      "release": "",
+      "type": "logs",
+      "ingest_pipeline": "pipeline-entry"
+    }
+  ]
 }

--- a/magefile.go
+++ b/magefile.go
@@ -74,7 +74,18 @@ func writeJsonFile(v interface{}, path string) error {
 func Check() error {
 	Format()
 
-	err := os.RemoveAll("testdata/public")
+	publicDir = "./testdata/public"
+	err := os.RemoveAll(publicDir)
+	if err != nil {
+		return err
+	}
+
+	err = os.MkdirAll(publicDir, 0755)
+	if err != nil {
+		return err
+	}
+
+	err = BuildRootFile()
 	if err != nil {
 		return err
 	}

--- a/testdata/public/index.json
+++ b/testdata/public/index.json
@@ -1,4 +1,4 @@
 {
-    "service.name": "package-registry",
-    "version": "0.2.0"
+  "service.name": "package-registry",
+  "version": "0.2.0"
 }

--- a/testdata/public/package/example-1.0.0/index.json
+++ b/testdata/public/package/example-1.0.0/index.json
@@ -47,5 +47,14 @@
     "/package/example-1.0.0/dataset/foo/elasticsearch/ingest-pipeline/pipeline-plaintext.json",
     "/package/example-1.0.0/dataset/foo/elasticsearch/ingest-pipeline/pipeline-tcp.json"
   ],
-  "format_version": "1.0.0"
+  "format_version": "1.0.0",
+  "datasets": [
+    {
+      "title": "Foo",
+      "name": "foo",
+      "release": "",
+      "type": "logs",
+      "ingest_pipeline": "pipeline-entry"
+    }
+  ]
 }


### PR DESCRIPTION
The package info endpoint now also contains a `datasets` array with all the information from the dataset manifest. This should make it easier to build a UI on top of the dataset manifests.

An example for the CoreDNS endpoint now looks as following:

```
{
  "name": "coredns",
  "title": "CoreDNS",
  "version": "1.0.1",
  "readme": "/package/coredns-1.0.1/docs/README.md",
  "description": "CoreDNS logs and metrics integration.\nThe CoreDNS integrations allows to gather logs and metrics from the CoreDNS DNS server to get better insights.\n",
  "type": "integration",
  "categories": [
    "logs",
    "metrics"
  ],
  "requirement": {
    "kibana": {
      "versions": "\u003e6.7.0"
    }
  },
  "icons": [
    {
      "src": "/package/coredns-1.0.1/img/icon.png",
      "size": "1800x1800"
    },
    {
      "src": "/package/coredns-1.0.1/img/icon.svg",
      "size": "255x144",
      "type": "image/svg+xml"
    }
  ],
  "assets": [
    "/package/coredns-1.0.1/index.json",
    "/package/coredns-1.0.1/manifest.yml",
    "/package/coredns-1.0.1/docs/README.md",
    "/package/coredns-1.0.1/img/icon.png",
    "/package/coredns-1.0.1/img/icon.svg",
    "/package/coredns-1.0.1/img/kibana-coredns.jpg",
    "/package/coredns-1.0.1/dataset/log/manifest.yml",
    "/package/coredns-1.0.1/dataset/stats/manifest.yml",
    "/package/coredns-1.0.1/kibana/dashboard/53aa1f70-443e-11e9-8548-ab7fbe04f038.json",
    "/package/coredns-1.0.1/kibana/dashboard/Metricbeat-CoreDNS-Dashboard-ecs.json",
    "/package/coredns-1.0.1/kibana/infrastructure-ui-source/default.json",
    "/package/coredns-1.0.1/kibana/visualization/277fc650-67a9-11e9-a534-715561d0bf42.json",
    "/package/coredns-1.0.1/kibana/visualization/27da53f0-53d5-11e9-b466-9be470bbd327-ecs.json",
    "/package/coredns-1.0.1/kibana/visualization/36e08510-53c4-11e9-b466-9be470bbd327-ecs.json",
    "/package/coredns-1.0.1/kibana/visualization/3ad75810-4429-11e9-8548-ab7fbe04f038.json",
    "/package/coredns-1.0.1/kibana/visualization/4804eaa0-7315-11e9-b0d0-414c3011ddbb.json",
    "/package/coredns-1.0.1/kibana/visualization/57c74300-7308-11e9-b0d0-414c3011ddbb.json",
    "/package/coredns-1.0.1/kibana/visualization/75743f70-443c-11e9-8548-ab7fbe04f038.json",
    "/package/coredns-1.0.1/kibana/visualization/86177430-728d-11e9-b0d0-414c3011ddbb.json",
    "/package/coredns-1.0.1/kibana/visualization/9dc640e0-4432-11e9-8548-ab7fbe04f038.json",
    "/package/coredns-1.0.1/kibana/visualization/a19df590-53c4-11e9-b466-9be470bbd327-ecs.json",
    "/package/coredns-1.0.1/kibana/visualization/a58345f0-7298-11e9-b0d0-414c3011ddbb.json",
    "/package/coredns-1.0.1/kibana/visualization/cfde7fb0-443d-11e9-8548-ab7fbe04f038.json",
    "/package/coredns-1.0.1/dataset/log/fields/logs.yml",
    "/package/coredns-1.0.1/dataset/log/filebeat/module.yml",
    "/package/coredns-1.0.1/dataset/stats/fields/coredns.stats.yml",
    "/package/coredns-1.0.1/dataset/log/agent/stream/stream.yml",
    "/package/coredns-1.0.1/dataset/log/elasticsearch/ingest-pipeline/pipeline-entry.json",
    "/package/coredns-1.0.1/dataset/log/elasticsearch/ingest-pipeline/pipeline-json.json",
    "/package/coredns-1.0.1/dataset/log/elasticsearch/ingest-pipeline/pipeline-plaintext.json",
    "/package/coredns-1.0.1/dataset/log/filebeat/config/config.yml",
    "/package/coredns-1.0.1/dataset/stats/agent/input/input.yml",
    "/package/coredns-1.0.1/dataset/stats/metricbeat/config/config.yml"
  ],
  "datasets": [
    {
      "title": "CoreDNS logs",
      "name": "log",
      "release": "ga",
      "type": "logs",
      "ingest_pipeline": "pipeline-entry",
      "vars": [
        {
          "default": [
            "/var/log/coredns.log"
          ],
          "name": "paths",
          "type": "textarea"
        },
        {
          "default": [
            "coredns"
          ],
          "name": "tags",
          "type": "text"
        }
      ]
    },
    {
      "title": "CoreDNS stats metrics",
      "name": "stats",
      "release": "ga",
      "type": "metric",
      "ingest_pipeline": "",
      "vars": [
        {
          "default": [
            "http://localhost:9153"
          ],
          "description": "CoreDNS hosts",
          "name": "hosts",
          "required": true
        },
        {
          "default": "10s",
          "description": "Collection period. Valid values: 10s, 5m, 2h",
          "name": "period"
        },
        {
          "name": "username",
          "type": "text"
        },
        {
          "name": "password",
          "type": "password"
        }
      ]
    }
  ]
}
```

More follow up PR's will be done to also validate the dataset manifest.

Closing #160