### PR TITLE
Prefix package download url with /epr/{package-name}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Change `requirements.kibana.version.min/max` to `requirements.kibana.versions: {semver-range}`
 * Encode Kibana objects during packaging. [#157](https://github.com/elastic/integrations-registry/pull/157)
+* Prefix package download url with `/epr/{package-name}`.
 
 ### Bugfixes
 

--- a/dev/generator/main.go
+++ b/dev/generator/main.go
@@ -170,7 +170,12 @@ func buildPackage(packagesBasePath string, p util.Package) error {
 	}
 
 	if tarGz {
-		err = sh.RunV("tar", "cvzf", p.GetPath()+".tar.gz", filepath.Base(p.GetPath())+"/")
+		err = os.MkdirAll("../epr/"+p.Name, 0755)
+		if err != nil {
+			return err
+		}
+
+		err = sh.RunV("tar", "cvzf", "../epr/"+p.Name+"/"+p.GetPath()+".tar.gz", filepath.Base(p.GetPath())+"/")
 		if err != nil {
 			return fmt.Errorf("Error creating package: %s: %s", p.GetPath(), err)
 		}

--- a/docs/api/package.json
+++ b/docs/api/package.json
@@ -57,6 +57,6 @@
       "ingest_pipeline": "pipeline-entry"
     }
   ],
-  "download": "/package/example-1.0.0.tar.gz",
+  "download": "/epr/example/example-1.0.0.tar.gz",
   "path": "/package/example-1.0.0"
 }

--- a/docs/api/search-category-logs.json
+++ b/docs/api/search-category-logs.json
@@ -1,7 +1,7 @@
 [
   {
     "description": "This is the example integration",
-    "download": "/package/example-1.0.0.tar.gz",
+    "download": "/epr/example/example-1.0.0.tar.gz",
     "name": "example",
     "path": "/package/example-1.0.0",
     "title": "Example Integration",

--- a/docs/api/search-category-metrics.json
+++ b/docs/api/search-category-metrics.json
@@ -1,7 +1,7 @@
 [
   {
     "description": "This is the example integration",
-    "download": "/package/example-1.0.0.tar.gz",
+    "download": "/epr/example/example-1.0.0.tar.gz",
     "name": "example",
     "path": "/package/example-1.0.0",
     "title": "Example Integration",
@@ -10,7 +10,7 @@
   },
   {
     "description": "This is the foo integration",
-    "download": "/package/foo-1.0.0.tar.gz",
+    "download": "/epr/foo/foo-1.0.0.tar.gz",
     "name": "foo",
     "path": "/package/foo-1.0.0",
     "title": "Foo",

--- a/docs/api/search-kibana652.json
+++ b/docs/api/search-kibana652.json
@@ -1,7 +1,7 @@
 [
   {
     "description": "This is the example integration.",
-    "download": "/package/example-0.0.2.tar.gz",
+    "download": "/epr/example/example-0.0.2.tar.gz",
     "name": "example",
     "path": "/package/example-0.0.2",
     "title": "Example",

--- a/docs/api/search-kibana721.json
+++ b/docs/api/search-kibana721.json
@@ -1,7 +1,7 @@
 [
   {
     "description": "This is the example integration",
-    "download": "/package/example-1.0.0.tar.gz",
+    "download": "/epr/example/example-1.0.0.tar.gz",
     "name": "example",
     "path": "/package/example-1.0.0",
     "title": "Example Integration",
@@ -10,7 +10,7 @@
   },
   {
     "description": "This is the foo integration",
-    "download": "/package/foo-1.0.0.tar.gz",
+    "download": "/epr/foo/foo-1.0.0.tar.gz",
     "name": "foo",
     "path": "/package/foo-1.0.0",
     "title": "Foo",

--- a/docs/api/search-package-example.json
+++ b/docs/api/search-package-example.json
@@ -1,7 +1,7 @@
 [
   {
     "description": "This is the example integration.",
-    "download": "/package/example-0.0.2.tar.gz",
+    "download": "/epr/example/example-0.0.2.tar.gz",
     "name": "example",
     "path": "/package/example-0.0.2",
     "title": "Example",
@@ -10,7 +10,7 @@
   },
   {
     "description": "This is the example integration",
-    "download": "/package/example-1.0.0.tar.gz",
+    "download": "/epr/example/example-1.0.0.tar.gz",
     "name": "example",
     "path": "/package/example-1.0.0",
     "title": "Example Integration",

--- a/docs/api/search-package-internal.json
+++ b/docs/api/search-package-internal.json
@@ -1,7 +1,7 @@
 [
   {
     "description": "This is the example integration",
-    "download": "/package/example-1.0.0.tar.gz",
+    "download": "/epr/example/example-1.0.0.tar.gz",
     "name": "example",
     "path": "/package/example-1.0.0",
     "title": "Example Integration",
@@ -10,7 +10,7 @@
   },
   {
     "description": "This is the foo integration",
-    "download": "/package/foo-1.0.0.tar.gz",
+    "download": "/epr/foo/foo-1.0.0.tar.gz",
     "name": "foo",
     "path": "/package/foo-1.0.0",
     "title": "Foo",
@@ -19,7 +19,7 @@
   },
   {
     "description": "Internal package",
-    "download": "/package/internal-1.2.0.tar.gz",
+    "download": "/epr/internal/internal-1.2.0.tar.gz",
     "internal": true,
     "name": "internal",
     "path": "/package/internal-1.2.0",

--- a/docs/api/search.json
+++ b/docs/api/search.json
@@ -1,7 +1,7 @@
 [
   {
     "description": "This is the example integration",
-    "download": "/package/example-1.0.0.tar.gz",
+    "download": "/epr/example/example-1.0.0.tar.gz",
     "name": "example",
     "path": "/package/example-1.0.0",
     "title": "Example Integration",
@@ -10,7 +10,7 @@
   },
   {
     "description": "This is the foo integration",
-    "download": "/package/foo-1.0.0.tar.gz",
+    "download": "/epr/foo/foo-1.0.0.tar.gz",
     "name": "foo",
     "path": "/package/foo-1.0.0",
     "title": "Foo",

--- a/testdata/public/package/example-0.0.2/index.json
+++ b/testdata/public/package/example-0.0.2/index.json
@@ -32,6 +32,6 @@
     "/package/example-0.0.2/kibana/visualization/ab48c3f0-5ca6-11e9-8477-077ec9664dbd.json"
   ],
   "format_version": "1.0.0",
-  "download": "/package/example-0.0.2.tar.gz",
+  "download": "/epr/example/example-0.0.2.tar.gz",
   "path": "/package/example-0.0.2"
 }

--- a/testdata/public/package/example-1.0.0/index.json
+++ b/testdata/public/package/example-1.0.0/index.json
@@ -57,6 +57,6 @@
       "ingest_pipeline": "pipeline-entry"
     }
   ],
-  "download": "/package/example-1.0.0.tar.gz",
+  "download": "/epr/example/example-1.0.0.tar.gz",
   "path": "/package/example-1.0.0"
 }

--- a/testdata/public/package/foo-1.0.0/index.json
+++ b/testdata/public/package/foo-1.0.0/index.json
@@ -16,6 +16,6 @@
     "/package/foo-1.0.0/manifest.yml"
   ],
   "format_version": "1.0.0",
-  "download": "/package/foo-1.0.0.tar.gz",
+  "download": "/epr/foo/foo-1.0.0.tar.gz",
   "path": "/package/foo-1.0.0"
 }

--- a/testdata/public/package/internal-1.2.0/index.json
+++ b/testdata/public/package/internal-1.2.0/index.json
@@ -13,6 +13,6 @@
   ],
   "internal": true,
   "format_version": "1.0.0",
-  "download": "/package/internal-1.2.0.tar.gz",
+  "download": "/epr/internal/internal-1.2.0.tar.gz",
   "path": "/package/internal-1.2.0"
 }

--- a/util/package.go
+++ b/util/package.go
@@ -328,7 +328,7 @@ func (p *Package) GetPath() string {
 }
 
 func (p *Package) GetDownloadPath() string {
-	return "/package/" + p.Name + "-" + p.Version + ".tar.gz"
+	return "/epr/" + p.Name + "/" + p.Name + "-" + p.Version + ".tar.gz"
 }
 
 func (p *Package) GetUrlPath() string {


### PR DESCRIPTION
Prefixing it with `/epr/{package-name}` simplifies the download stats rules. Only the `.tar.gz` packages are move to a different url. An example of a download path is: `/epr/apache/apache-1.0.1.tar.gz`.

The new download path is available in the package output. It is a breaking change but I would expect that from a package manager point of view it should just work as we rely on the download field.