### PR TITLE
Add download and path urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add missing assets from datasets. [#146](https://github.com/elastic/integrations-registry/pull/146)
 * Add `format_version` to define the package format.
 * Add dataset array to package info endpoint. [#162](https://github.com/elastic/integrations-registry/pull/162)
+* Add path field to search and package info endpoint. [#174](https://github.com/elastic/integrations-registry/pull/174)
+* Add download field to package info endpoint. [#174](https://github.com/elastic/integrations-registry/pull/174)
 
 ### Deprecated
 

--- a/docs/api/package.json
+++ b/docs/api/package.json
@@ -56,5 +56,7 @@
       "type": "logs",
       "ingest_pipeline": "pipeline-entry"
     }
-  ]
+  ],
+  "download": "/package/example-1.0.0.tar.gz",
+  "path": "/package/example-1.0.0"
 }

--- a/docs/api/search-category-logs.json
+++ b/docs/api/search-category-logs.json
@@ -3,6 +3,7 @@
     "description": "This is the example integration",
     "download": "/package/example-1.0.0.tar.gz",
     "name": "example",
+    "path": "/package/example-1.0.0",
     "title": "Example Integration",
     "type": "integration",
     "version": "1.0.0"

--- a/docs/api/search-category-metrics.json
+++ b/docs/api/search-category-metrics.json
@@ -3,6 +3,7 @@
     "description": "This is the example integration",
     "download": "/package/example-1.0.0.tar.gz",
     "name": "example",
+    "path": "/package/example-1.0.0",
     "title": "Example Integration",
     "type": "integration",
     "version": "1.0.0"
@@ -11,6 +12,7 @@
     "description": "This is the foo integration",
     "download": "/package/foo-1.0.0.tar.gz",
     "name": "foo",
+    "path": "/package/foo-1.0.0",
     "title": "Foo",
     "type": "solution",
     "version": "1.0.0"

--- a/docs/api/search-kibana652.json
+++ b/docs/api/search-kibana652.json
@@ -3,6 +3,7 @@
     "description": "This is the example integration.",
     "download": "/package/example-0.0.2.tar.gz",
     "name": "example",
+    "path": "/package/example-0.0.2",
     "title": "Example",
     "type": "integration",
     "version": "0.0.2"

--- a/docs/api/search-kibana721.json
+++ b/docs/api/search-kibana721.json
@@ -3,6 +3,7 @@
     "description": "This is the example integration",
     "download": "/package/example-1.0.0.tar.gz",
     "name": "example",
+    "path": "/package/example-1.0.0",
     "title": "Example Integration",
     "type": "integration",
     "version": "1.0.0"
@@ -11,6 +12,7 @@
     "description": "This is the foo integration",
     "download": "/package/foo-1.0.0.tar.gz",
     "name": "foo",
+    "path": "/package/foo-1.0.0",
     "title": "Foo",
     "type": "solution",
     "version": "1.0.0"

--- a/docs/api/search-package-example.json
+++ b/docs/api/search-package-example.json
@@ -3,6 +3,7 @@
     "description": "This is the example integration.",
     "download": "/package/example-0.0.2.tar.gz",
     "name": "example",
+    "path": "/package/example-0.0.2",
     "title": "Example",
     "type": "integration",
     "version": "0.0.2"
@@ -11,6 +12,7 @@
     "description": "This is the example integration",
     "download": "/package/example-1.0.0.tar.gz",
     "name": "example",
+    "path": "/package/example-1.0.0",
     "title": "Example Integration",
     "type": "integration",
     "version": "1.0.0"

--- a/docs/api/search-package-internal.json
+++ b/docs/api/search-package-internal.json
@@ -3,6 +3,7 @@
     "description": "This is the example integration",
     "download": "/package/example-1.0.0.tar.gz",
     "name": "example",
+    "path": "/package/example-1.0.0",
     "title": "Example Integration",
     "type": "integration",
     "version": "1.0.0"
@@ -11,6 +12,7 @@
     "description": "This is the foo integration",
     "download": "/package/foo-1.0.0.tar.gz",
     "name": "foo",
+    "path": "/package/foo-1.0.0",
     "title": "Foo",
     "type": "solution",
     "version": "1.0.0"
@@ -20,6 +22,7 @@
     "download": "/package/internal-1.2.0.tar.gz",
     "internal": true,
     "name": "internal",
+    "path": "/package/internal-1.2.0",
     "title": "Internal",
     "type": "integration",
     "version": "1.2.0"

--- a/docs/api/search.json
+++ b/docs/api/search.json
@@ -3,6 +3,7 @@
     "description": "This is the example integration",
     "download": "/package/example-1.0.0.tar.gz",
     "name": "example",
+    "path": "/package/example-1.0.0",
     "title": "Example Integration",
     "type": "integration",
     "version": "1.0.0"
@@ -11,6 +12,7 @@
     "description": "This is the foo integration",
     "download": "/package/foo-1.0.0.tar.gz",
     "name": "foo",
+    "path": "/package/foo-1.0.0",
     "title": "Foo",
     "type": "solution",
     "version": "1.0.0"

--- a/search.go
+++ b/search.go
@@ -150,7 +150,8 @@ func getPackageOutput(packagesList map[string]map[string]util.Package) ([]byte, 
 			"description": m.Description,
 			"version":     m.Version,
 			"type":        m.Type,
-			"download":    "/package/" + m.Name + "-" + m.Version + ".tar.gz",
+			"download":    m.GetDownloadPath(),
+			"path":        m.GetUrlPath(),
 		}
 		if m.Title != nil {
 			data["title"] = *m.Title

--- a/testdata/public/package/example-0.0.2/index.json
+++ b/testdata/public/package/example-0.0.2/index.json
@@ -31,5 +31,7 @@
     "/package/example-0.0.2/kibana/visualization/80844540-5c97-11e9-8477-077ec9664dbd.json",
     "/package/example-0.0.2/kibana/visualization/ab48c3f0-5ca6-11e9-8477-077ec9664dbd.json"
   ],
-  "format_version": "1.0.0"
+  "format_version": "1.0.0",
+  "download": "/package/example-0.0.2.tar.gz",
+  "path": "/package/example-0.0.2"
 }

--- a/testdata/public/package/example-1.0.0/index.json
+++ b/testdata/public/package/example-1.0.0/index.json
@@ -56,5 +56,7 @@
       "type": "logs",
       "ingest_pipeline": "pipeline-entry"
     }
-  ]
+  ],
+  "download": "/package/example-1.0.0.tar.gz",
+  "path": "/package/example-1.0.0"
 }

--- a/testdata/public/package/foo-1.0.0/index.json
+++ b/testdata/public/package/foo-1.0.0/index.json
@@ -15,5 +15,7 @@
   "assets": [
     "/package/foo-1.0.0/manifest.yml"
   ],
-  "format_version": "1.0.0"
+  "format_version": "1.0.0",
+  "download": "/package/foo-1.0.0.tar.gz",
+  "path": "/package/foo-1.0.0"
 }

--- a/testdata/public/package/internal-1.2.0/index.json
+++ b/testdata/public/package/internal-1.2.0/index.json
@@ -12,5 +12,7 @@
     "/package/internal-1.2.0/manifest.yml"
   ],
   "internal": true,
-  "format_version": "1.0.0"
+  "format_version": "1.0.0",
+  "download": "/package/internal-1.2.0.tar.gz",
+  "path": "/package/internal-1.2.0"
 }

--- a/util/package.go
+++ b/util/package.go
@@ -42,6 +42,8 @@ type Package struct {
 	Internal      bool        `config:"internal,omitempty" json:"internal,omitempty"`
 	FormatVersion string      `config:"format_version" json:"format_version"`
 	DataSets      []*DataSet  `config:"datasets,omitempty" json:"datasets,omitempty"`
+	Download      string      `json:"download"`
+	Path          string      `json:"path"`
 }
 
 type Requirement struct {
@@ -135,6 +137,10 @@ func NewPackage(basePath, packageName string) (*Package, error) {
 		readmePathShort := "/package/" + packageName + "/docs/README.md"
 		p.Readme = &readmePathShort
 	}
+
+	// Assign download path to be part of the output
+	p.Download = p.GetDownloadPath()
+	p.Path = p.GetUrlPath()
 
 	return p, nil
 }
@@ -319,4 +325,12 @@ func (p *Package) LoadDataSets(packagePath string) error {
 
 func (p *Package) GetPath() string {
 	return p.Name + "-" + p.Version
+}
+
+func (p *Package) GetDownloadPath() string {
+	return "/package/" + p.Name + "-" + p.Version + ".tar.gz"
+}
+
+func (p *Package) GetUrlPath() string {
+	return "/package/" + p.Name + "-" + p.Version
 }


### PR DESCRIPTION
At the moment, only the `/search` endpoint contains the download url. This is now also added to the package info. In addition a field `path` is added which is the path to the package info. This should help with breaking changes in the future so EPM can rely on this information to find the info about a package instead of having to hard code it.