### PR TITLE
Add Makefile with Docker publishing targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+TAG := $(shell date +'%Y-%m-%d')-$(shell git log --pretty=format:%h -1)
+REPO := package-registry:$(TAG)
+DOCKER_PATH := push.docker.elastic.co/ruflin/$(REPO)
+
+build:
+	docker build -t $(REPO) .
+
+publish: build
+	docker tag $(REPO) $(DOCKER_PATH)
+	docker push $(DOCKER_PATH)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 TAG := $(shell date +'%Y-%m-%d')-$(shell git log --pretty=format:%h -1)
 REPO := package-registry:$(TAG)
-DOCKER_PATH := push.docker.elastic.co/ruflin/$(REPO)
+DOCKER_PATH := push.docker.elastic.co/employees/ruflin/$(REPO)
 
 build:
 	docker build -t $(REPO) .


### PR DESCRIPTION
Adds a Make target to build and publish images to Elastic's container registry so I can take advantage of it with an upcoming CI job.