### PR TITLE
Validate dataset to check for pipeline config

### DIFF
--- a/docs/api/categories.json
+++ b/docs/api/categories.json
@@ -2,7 +2,7 @@
   {
     "id": "logs",
     "title": "Logs",
-    "count": 1
+    "count": 2
   },
   {
     "id": "metrics",

--- a/docs/api/package.json
+++ b/docs/api/package.json
@@ -52,7 +52,7 @@
     {
       "title": "Foo",
       "name": "foo",
-      "release": "",
+      "release": "beta",
       "type": "logs",
       "ingest_pipeline": "pipeline-entry"
     }

--- a/docs/api/search-category-logs.json
+++ b/docs/api/search-category-logs.json
@@ -1,6 +1,6 @@
 [
   {
-    "description": "Tetss if no pipeline is set, it defaults to the default one",
+    "description": "Tests if no pipeline is set, it defaults to the default one",
     "download": "/epr/default-pipeline/default-pipeline-0.0.2.tar.gz",
     "name": "default-pipeline",
     "path": "/package/default-pipeline-0.0.2",

--- a/docs/api/search-category-logs.json
+++ b/docs/api/search-category-logs.json
@@ -1,5 +1,14 @@
 [
   {
+    "description": "Tetss if no pipeline is set, it defaults to the default one",
+    "download": "/epr/default-pipeline/default-pipeline-0.0.2.tar.gz",
+    "name": "default-pipeline",
+    "path": "/package/default-pipeline-0.0.2",
+    "title": "Default pipeline Integration",
+    "type": "integration",
+    "version": "0.0.2"
+  },
+  {
     "description": "This is the example integration",
     "download": "/epr/example/example-1.0.0.tar.gz",
     "name": "example",

--- a/docs/api/search-kibana652.json
+++ b/docs/api/search-kibana652.json
@@ -1,5 +1,14 @@
 [
   {
+    "description": "Tetss if no pipeline is set, it defaults to the default one",
+    "download": "/epr/default-pipeline/default-pipeline-0.0.2.tar.gz",
+    "name": "default-pipeline",
+    "path": "/package/default-pipeline-0.0.2",
+    "title": "Default pipeline Integration",
+    "type": "integration",
+    "version": "0.0.2"
+  },
+  {
     "description": "This is the example integration.",
     "download": "/epr/example/example-0.0.2.tar.gz",
     "name": "example",

--- a/docs/api/search-kibana652.json
+++ b/docs/api/search-kibana652.json
@@ -1,6 +1,6 @@
 [
   {
-    "description": "Tetss if no pipeline is set, it defaults to the default one",
+    "description": "Tests if no pipeline is set, it defaults to the default one",
     "download": "/epr/default-pipeline/default-pipeline-0.0.2.tar.gz",
     "name": "default-pipeline",
     "path": "/package/default-pipeline-0.0.2",

--- a/docs/api/search-kibana721.json
+++ b/docs/api/search-kibana721.json
@@ -1,6 +1,6 @@
 [
   {
-    "description": "Tetss if no pipeline is set, it defaults to the default one",
+    "description": "Tests if no pipeline is set, it defaults to the default one",
     "download": "/epr/default-pipeline/default-pipeline-0.0.2.tar.gz",
     "name": "default-pipeline",
     "path": "/package/default-pipeline-0.0.2",

--- a/docs/api/search-kibana721.json
+++ b/docs/api/search-kibana721.json
@@ -1,5 +1,14 @@
 [
   {
+    "description": "Tetss if no pipeline is set, it defaults to the default one",
+    "download": "/epr/default-pipeline/default-pipeline-0.0.2.tar.gz",
+    "name": "default-pipeline",
+    "path": "/package/default-pipeline-0.0.2",
+    "title": "Default pipeline Integration",
+    "type": "integration",
+    "version": "0.0.2"
+  },
+  {
     "description": "This is the example integration",
     "download": "/epr/example/example-1.0.0.tar.gz",
     "name": "example",

--- a/docs/api/search-package-internal.json
+++ b/docs/api/search-package-internal.json
@@ -1,6 +1,6 @@
 [
   {
-    "description": "Tetss if no pipeline is set, it defaults to the default one",
+    "description": "Tests if no pipeline is set, it defaults to the default one",
     "download": "/epr/default-pipeline/default-pipeline-0.0.2.tar.gz",
     "name": "default-pipeline",
     "path": "/package/default-pipeline-0.0.2",

--- a/docs/api/search-package-internal.json
+++ b/docs/api/search-package-internal.json
@@ -1,5 +1,14 @@
 [
   {
+    "description": "Tetss if no pipeline is set, it defaults to the default one",
+    "download": "/epr/default-pipeline/default-pipeline-0.0.2.tar.gz",
+    "name": "default-pipeline",
+    "path": "/package/default-pipeline-0.0.2",
+    "title": "Default pipeline Integration",
+    "type": "integration",
+    "version": "0.0.2"
+  },
+  {
     "description": "This is the example integration",
     "download": "/epr/example/example-1.0.0.tar.gz",
     "name": "example",

--- a/docs/api/search.json
+++ b/docs/api/search.json
@@ -1,6 +1,6 @@
 [
   {
-    "description": "Tetss if no pipeline is set, it defaults to the default one",
+    "description": "Tests if no pipeline is set, it defaults to the default one",
     "download": "/epr/default-pipeline/default-pipeline-0.0.2.tar.gz",
     "name": "default-pipeline",
     "path": "/package/default-pipeline-0.0.2",

--- a/docs/api/search.json
+++ b/docs/api/search.json
@@ -1,5 +1,14 @@
 [
   {
+    "description": "Tetss if no pipeline is set, it defaults to the default one",
+    "download": "/epr/default-pipeline/default-pipeline-0.0.2.tar.gz",
+    "name": "default-pipeline",
+    "path": "/package/default-pipeline-0.0.2",
+    "title": "Default pipeline Integration",
+    "type": "integration",
+    "version": "0.0.2"
+  },
+  {
     "description": "This is the example integration",
     "download": "/epr/example/example-1.0.0.tar.gz",
     "name": "example",

--- a/testdata/package/default-pipeline-0.0.2/dataset/foo/elasticsearch/ingest-pipeline/default.json
+++ b/testdata/package/default-pipeline-0.0.2/dataset/foo/elasticsearch/ingest-pipeline/default.json
@@ -1,0 +1,4 @@
+{
+  "description": "Pipeline for normalizing envoyproxy logs",
+  "processors": []
+}

--- a/testdata/package/default-pipeline-0.0.2/dataset/foo/manifest.yml
+++ b/testdata/package/default-pipeline-0.0.2/dataset/foo/manifest.yml
@@ -1,0 +1,4 @@
+title: Foo
+
+# Needs to describe the type of this input
+type: logs

--- a/testdata/package/default-pipeline-0.0.2/manifest.yml
+++ b/testdata/package/default-pipeline-0.0.2/manifest.yml
@@ -1,0 +1,8 @@
+format_version: 1.0.0
+
+name: default-pipeline
+description: Tests if no pipeline is set, it defaults to the default one
+version: 0.0.2
+title: Default pipeline Integration
+categories: ["logs"]
+type: integration

--- a/testdata/public/package/default-pipeline-0.0.2/dataset/foo/elasticsearch/ingest-pipeline/default.json
+++ b/testdata/public/package/default-pipeline-0.0.2/dataset/foo/elasticsearch/ingest-pipeline/default.json
@@ -1,0 +1,4 @@
+{
+  "description": "Pipeline for normalizing envoyproxy logs",
+  "processors": []
+}

--- a/testdata/public/package/default-pipeline-0.0.2/dataset/foo/manifest.yml
+++ b/testdata/public/package/default-pipeline-0.0.2/dataset/foo/manifest.yml
@@ -1,0 +1,4 @@
+title: Foo
+
+# Needs to describe the type of this input
+type: logs

--- a/testdata/public/package/default-pipeline-0.0.2/index.json
+++ b/testdata/public/package/default-pipeline-0.0.2/index.json
@@ -1,0 +1,30 @@
+{
+  "name": "default-pipeline",
+  "title": "Default pipeline Integration",
+  "version": "0.0.2",
+  "description": "Tests if no pipeline is set, it defaults to the default one",
+  "type": "integration",
+  "categories": [
+    "logs"
+  ],
+  "requirement": {
+    "kibana": {}
+  },
+  "assets": [
+    "/package/default-pipeline-0.0.2/manifest.yml",
+    "/package/default-pipeline-0.0.2/dataset/foo/manifest.yml",
+    "/package/default-pipeline-0.0.2/dataset/foo/elasticsearch/ingest-pipeline/default.json"
+  ],
+  "format_version": "1.0.0",
+  "datasets": [
+    {
+      "title": "Foo",
+      "name": "foo",
+      "release": "beta",
+      "type": "logs",
+      "ingest_pipeline": "default"
+    }
+  ],
+  "download": "/epr/default-pipeline/default-pipeline-0.0.2.tar.gz",
+  "path": "/package/default-pipeline-0.0.2"
+}

--- a/testdata/public/package/default-pipeline-0.0.2/manifest.yml
+++ b/testdata/public/package/default-pipeline-0.0.2/manifest.yml
@@ -1,0 +1,8 @@
+format_version: 1.0.0
+
+name: default-pipeline
+description: Tests if no pipeline is set, it defaults to the default one
+version: 0.0.2
+title: Default pipeline Integration
+categories: ["logs"]
+type: integration

--- a/testdata/public/package/example-1.0.0/index.json
+++ b/testdata/public/package/example-1.0.0/index.json
@@ -52,7 +52,7 @@
     {
       "title": "Foo",
       "name": "foo",
-      "release": "",
+      "release": "beta",
       "type": "logs",
       "ingest_pipeline": "pipeline-entry"
     }

--- a/util/dataset.go
+++ b/util/dataset.go
@@ -1,0 +1,53 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package util
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+type DataSet struct {
+	Title          string                   `config:"title" json:"title" validate:"required"`
+	Name           string                   `config:"name" json:"name"`
+	Release        string                   `config:"release" json:"release"`
+	Type           string                   `config:"type" json:"type" validate:"required"`
+	IngestPipeline string                   `config:"ingest_pipeline,omitempty" config:"ingest_pipeline" json:"ingest_pipeline,omitempty"`
+	Vars           []map[string]interface{} `config:"vars" json:"vars,omitempty"`
+}
+
+func (d *DataSet) Validate() error {
+	pipelineDir := d.Name + "/elasticsearch/ingest-pipeline/"
+	paths, err := filepath.Glob(pipelineDir + "*")
+	if err != nil {
+		return err
+	}
+
+	if d.IngestPipeline == "" {
+		// Check that no ingest pipeline exists in the directory except default
+		for _, path := range paths {
+			if filepath.Base(path) == "default.json" || filepath.Base(path) == "default.yml" {
+				d.IngestPipeline = "default"
+				break
+			}
+		}
+	}
+
+	if d.IngestPipeline == "" && len(paths) > 0 {
+		return fmt.Errorf("Package contains pipelines which are not used: %v, %s", paths, d.Name)
+	}
+
+	// In case an ingest pipeline is set, check if it is around
+	if d.IngestPipeline != "" {
+		_, errJSON := os.Stat(pipelineDir + d.IngestPipeline + ".json")
+		_, errYAML := os.Stat(pipelineDir + d.IngestPipeline + ".yml")
+
+		if os.IsNotExist(errYAML) && os.IsNotExist(errJSON) {
+			return fmt.Errorf("Defined ingest_pipeline does not exist: %s", pipelineDir+d.IngestPipeline)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
This PR checks a dataset manifest to make sure the config is as expected. If no pipeline is specified, it checks if pipeline files are there. If yes, it checks if a `default.json` or `default.yml` are there and takes it as the ingest pipeline. If files are there with different names but no default, it is an invalid dataset and an error is throw. The goal is to make sure, only valid packages are shipped.

Additional changes:

* Move dataset code to its own file
* Use `Validate` magic from go-ucfg
* Introduce package to test for default pipeline behaviour
* Add check that if no Kibana version is specified, it returns true by default
