### PR TITLE
change metric to metrics

### DIFF
--- a/dev/package-examples/coredns-1.0.1/dataset/stats/manifest.yml
+++ b/dev/package-examples/coredns-1.0.1/dataset/stats/manifest.yml
@@ -1,7 +1,7 @@
 title: CoreDNS stats metrics
 release: ga
 
-type: metric
+type: metrics
 
 vars:
   - name: hosts

--- a/dev/package-examples/nginx-1.2.0/dataset/stubstatus/manifest.yml
+++ b/dev/package-examples/nginx-1.2.0/dataset/stubstatus/manifest.yml
@@ -1,7 +1,7 @@
 title: Nginx stubstatus metrics
 
 # Needs to describe the type of this input
-type: metric
+type: metrics
 
 # The list of platforms this input is compatible with. Based on the platform selection,
 # this input might not show up.


### PR DESCRIPTION
Issue https://github.com/elastic/package-registry/issues/193

In some of the dataset manifests, types are specified as "metric" instead of "metrics" causing the API to return incorrect type.