### PR TITLE
Hard-code correct index pattern names

### DIFF
--- a/dev/package-examples/coredns-1.0.1/kibana/visualization/277fc650-67a9-11e9-a534-715561d0bf42.json
+++ b/dev/package-examples/coredns-1.0.1/kibana/visualization/277fc650-67a9-11e9-a534-715561d0bf42.json
@@ -193,7 +193,7 @@
   },
   "references": [
     {
-      "id": "metricbeat-*",
+      "id": "metrics-*",
       "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
       "type": "index-pattern"
     }

--- a/dev/package-examples/coredns-1.0.1/kibana/visualization/27da53f0-53d5-11e9-b466-9be470bbd327-ecs.json
+++ b/dev/package-examples/coredns-1.0.1/kibana/visualization/27da53f0-53d5-11e9-b466-9be470bbd327-ecs.json
@@ -174,7 +174,7 @@
   },
   "references": [
     {
-      "id": "metricbeat-*",
+      "id": "metrics-*",
       "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
       "type": "index-pattern"
     }

--- a/dev/package-examples/coredns-1.0.1/kibana/visualization/36e08510-53c4-11e9-b466-9be470bbd327-ecs.json
+++ b/dev/package-examples/coredns-1.0.1/kibana/visualization/36e08510-53c4-11e9-b466-9be470bbd327-ecs.json
@@ -84,12 +84,12 @@
   },
   "references": [
     {
-      "id": "metricbeat-*",
+      "id": "metrics-*",
       "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
       "type": "index-pattern"
     },
     {
-      "id": "metricbeat-*",
+      "id": "metrics-*",
       "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
       "type": "index-pattern"
     }

--- a/dev/package-examples/coredns-1.0.1/kibana/visualization/4804eaa0-7315-11e9-b0d0-414c3011ddbb.json
+++ b/dev/package-examples/coredns-1.0.1/kibana/visualization/4804eaa0-7315-11e9-b0d0-414c3011ddbb.json
@@ -19,7 +19,7 @@
         "axis_formatter": "number",
         "axis_position": "left",
         "axis_scale": "normal",
-        "default_index_pattern": "metricbeat-*",
+        "default_index_pattern": "metrics-*",
         "id": "61ca57f0-469d-11e7-af02-69e470af7417",
         "index_pattern": "",
         "interval": "auto",

--- a/dev/package-examples/coredns-1.0.1/kibana/visualization/57c74300-7308-11e9-b0d0-414c3011ddbb.json
+++ b/dev/package-examples/coredns-1.0.1/kibana/visualization/57c74300-7308-11e9-b0d0-414c3011ddbb.json
@@ -19,7 +19,7 @@
         "axis_formatter": "number",
         "axis_position": "left",
         "axis_scale": "normal",
-        "default_index_pattern": "metricbeat-*",
+        "default_index_pattern": "metrics-*",
         "id": "61ca57f0-469d-11e7-af02-69e470af7417",
         "index_pattern": "",
         "interval": "auto",

--- a/dev/package-examples/coredns-1.0.1/kibana/visualization/86177430-728d-11e9-b0d0-414c3011ddbb.json
+++ b/dev/package-examples/coredns-1.0.1/kibana/visualization/86177430-728d-11e9-b0d0-414c3011ddbb.json
@@ -181,7 +181,7 @@
   },
   "references": [
     {
-      "id": "metricbeat-*",
+      "id": "metrics-*",
       "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
       "type": "index-pattern"
     }

--- a/dev/package-examples/coredns-1.0.1/kibana/visualization/a19df590-53c4-11e9-b466-9be470bbd327-ecs.json
+++ b/dev/package-examples/coredns-1.0.1/kibana/visualization/a19df590-53c4-11e9-b466-9be470bbd327-ecs.json
@@ -85,12 +85,12 @@
   },
   "references": [
     {
-      "id": "metricbeat-*",
+      "id": "metrics-*",
       "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
       "type": "index-pattern"
     },
     {
-      "id": "metricbeat-*",
+      "id": "metrics-*",
       "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
       "type": "index-pattern"
     }

--- a/dev/package-examples/coredns-1.0.1/kibana/visualization/a58345f0-7298-11e9-b0d0-414c3011ddbb.json
+++ b/dev/package-examples/coredns-1.0.1/kibana/visualization/a58345f0-7298-11e9-b0d0-414c3011ddbb.json
@@ -173,7 +173,7 @@
   },
   "references": [
     {
-      "id": "metricbeat-*",
+      "id": "metrics-*",
       "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
       "type": "index-pattern"
     }

--- a/dev/package-examples/coredns-1.0.1/kibana/visualization/cfde7fb0-443d-11e9-8548-ab7fbe04f038.json
+++ b/dev/package-examples/coredns-1.0.1/kibana/visualization/cfde7fb0-443d-11e9-8548-ab7fbe04f038.json
@@ -29,7 +29,7 @@
             "id": "e1f6cda0-443e-11e9-94ba-69b05a5f82b8"
           }
         ],
-        "default_index_pattern": "filebeat-*",
+        "default_index_pattern": "logs-*",
         "gauge_color_rules": [
           {
             "id": "6996a6e0-443f-11e9-94ba-69b05a5f82b8"

--- a/dev/package-examples/iptables-1.0.4/kibana/search/b3f1b010-1f26-11e9-8ec4-cf5d91a864b3-ecs.json
+++ b/dev/package-examples/iptables-1.0.4/kibana/search/b3f1b010-1f26-11e9-8ec4-cf5d91a864b3-ecs.json
@@ -29,7 +29,7 @@
   },
   "references": [
     {
-      "id": "filebeat-*",
+      "id": "logs-*",
       "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
       "type": "index-pattern"
     }

--- a/dev/package-examples/nginx-1.2.0/kibana/visualization/47a8e0f0-f1a4-11e7-a9ef-93c69af7b129-ecs.json
+++ b/dev/package-examples/nginx-1.2.0/kibana/visualization/47a8e0f0-f1a4-11e7-a9ef-93c69af7b129-ecs.json
@@ -13,7 +13,7 @@
                 "axis_formatter": "number",
                 "axis_position": "left",
                 "id": "61ca57f0-469d-11e7-af02-69e470af7417",
-                "index_pattern": "metricbeat-*",
+                "index_pattern": "metrics-*",
                 "interval": "auto",
                 "legend_position": "bottom",
                 "series": [

--- a/dev/package-examples/nginx-1.2.0/kibana/visualization/555df8a0-f1a1-11e7-a9ef-93c69af7b129-ecs.json
+++ b/dev/package-examples/nginx-1.2.0/kibana/visualization/555df8a0-f1a1-11e7-a9ef-93c69af7b129-ecs.json
@@ -13,7 +13,7 @@
                 "axis_formatter": "number",
                 "axis_position": "left",
                 "id": "61ca57f0-469d-11e7-af02-69e470af7417",
-                "index_pattern": "metricbeat-*",
+                "index_pattern": "metrics-*",
                 "interval": "auto",
                 "legend_position": "bottom",
                 "series": [

--- a/dev/package-examples/nginx-1.2.0/kibana/visualization/a1d92240-f1a1-11e7-a9ef-93c69af7b129-ecs.json
+++ b/dev/package-examples/nginx-1.2.0/kibana/visualization/a1d92240-f1a1-11e7-a9ef-93c69af7b129-ecs.json
@@ -24,7 +24,7 @@
                 "axis_formatter": "number",
                 "axis_position": "left",
                 "id": "61ca57f0-469d-11e7-af02-69e470af7417",
-                "index_pattern": "metricbeat-*",
+                "index_pattern": "metrics-*",
                 "interval": "auto",
                 "legend_position": "bottom",
                 "series": [

--- a/dev/package-examples/nginx-1.2.0/kibana/visualization/d763a570-f1a1-11e7-a9ef-93c69af7b129-ecs.json
+++ b/dev/package-examples/nginx-1.2.0/kibana/visualization/d763a570-f1a1-11e7-a9ef-93c69af7b129-ecs.json
@@ -13,7 +13,7 @@
                 "axis_formatter": "number",
                 "axis_position": "left",
                 "id": "61ca57f0-469d-11e7-af02-69e470af7417",
-                "index_pattern": "metricbeat-*",
+                "index_pattern": "metrics-*",
                 "interval": "auto",
                 "legend_position": "bottom",
                 "series": [

--- a/dev/package-examples/nginx-1.2.0/kibana/visualization/dcbffe30-f1a4-11e7-a9ef-93c69af7b129-ecs.json
+++ b/dev/package-examples/nginx-1.2.0/kibana/visualization/dcbffe30-f1a4-11e7-a9ef-93c69af7b129-ecs.json
@@ -13,7 +13,7 @@
                 "axis_formatter": "number",
                 "axis_position": "left",
                 "id": "61ca57f0-469d-11e7-af02-69e470af7417",
-                "index_pattern": "metricbeat-*",
+                "index_pattern": "metrics-*",
                 "interval": "auto",
                 "legend_position": "bottom",
                 "series": [

--- a/testdata/package/example-0.0.2/kibana/visualization/0a994af0-5c9d-11e9-8477-077ec9664dbd.json
+++ b/testdata/package/example-0.0.2/kibana/visualization/0a994af0-5c9d-11e9-8477-077ec9664dbd.json
@@ -98,12 +98,12 @@
   },
   "references": [
     {
-      "id": "filebeat-*",
+      "id": "logs-*",
       "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
       "type": "index-pattern"
     },
     {
-      "id": "filebeat-*",
+      "id": "logs-*",
       "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
       "type": "index-pattern"
     }

--- a/testdata/package/example-0.0.2/kibana/visualization/36f872a0-5c03-11e9-85b4-19d0072eb4f2.json
+++ b/testdata/package/example-0.0.2/kibana/visualization/36f872a0-5c03-11e9-85b4-19d0072eb4f2.json
@@ -103,12 +103,12 @@
   },
   "references": [
     {
-      "id": "filebeat-*",
+      "id": "logs-*",
       "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
       "type": "index-pattern"
     },
     {
-      "id": "filebeat-*",
+      "id": "logs-*",
       "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
       "type": "index-pattern"
     }

--- a/testdata/package/example-0.0.2/kibana/visualization/38f96190-5c99-11e9-8477-077ec9664dbd.json
+++ b/testdata/package/example-0.0.2/kibana/visualization/38f96190-5c99-11e9-8477-077ec9664dbd.json
@@ -153,12 +153,12 @@
   },
   "references": [
     {
-      "id": "filebeat-*",
+      "id": "logs-*",
       "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
       "type": "index-pattern"
     },
     {
-      "id": "filebeat-*",
+      "id": "logs-*",
       "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
       "type": "index-pattern"
     }

--- a/testdata/package/example-0.0.2/kibana/visualization/7e4084e0-5c99-11e9-8477-077ec9664dbd.json
+++ b/testdata/package/example-0.0.2/kibana/visualization/7e4084e0-5c99-11e9-8477-077ec9664dbd.json
@@ -112,12 +112,12 @@
   },
   "references": [
     {
-      "id": "filebeat-*",
+      "id": "logs-*",
       "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
       "type": "index-pattern"
     },
     {
-      "id": "filebeat-*",
+      "id": "logs-*",
       "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
       "type": "index-pattern"
     }

--- a/testdata/package/example-0.0.2/kibana/visualization/80844540-5c97-11e9-8477-077ec9664dbd.json
+++ b/testdata/package/example-0.0.2/kibana/visualization/80844540-5c97-11e9-8477-077ec9664dbd.json
@@ -98,12 +98,12 @@
   },
   "references": [
     {
-      "id": "filebeat-*",
+      "id": "logs-*",
       "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
       "type": "index-pattern"
     },
     {
-      "id": "filebeat-*",
+      "id": "logs-*",
       "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
       "type": "index-pattern"
     }

--- a/testdata/package/example-0.0.2/kibana/visualization/ab48c3f0-5ca6-11e9-8477-077ec9664dbd.json
+++ b/testdata/package/example-0.0.2/kibana/visualization/ab48c3f0-5ca6-11e9-8477-077ec9664dbd.json
@@ -98,12 +98,12 @@
   },
   "references": [
     {
-      "id": "filebeat-*",
+      "id": "logs-*",
       "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
       "type": "index-pattern"
     },
     {
-      "id": "filebeat-*",
+      "id": "logs-*",
       "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
       "type": "index-pattern"
     }

--- a/testdata/package/example-1.0.0/kibana/visualization/0a994af0-5c9d-11e9-8477-077ec9664dbd.json
+++ b/testdata/package/example-1.0.0/kibana/visualization/0a994af0-5c9d-11e9-8477-077ec9664dbd.json
@@ -98,12 +98,12 @@
   },
   "references": [
     {
-      "id": "filebeat-*",
+      "id": "logs-*",
       "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
       "type": "index-pattern"
     },
     {
-      "id": "filebeat-*",
+      "id": "logs-*",
       "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
       "type": "index-pattern"
     }

--- a/testdata/package/example-1.0.0/kibana/visualization/36f872a0-5c03-11e9-85b4-19d0072eb4f2.json
+++ b/testdata/package/example-1.0.0/kibana/visualization/36f872a0-5c03-11e9-85b4-19d0072eb4f2.json
@@ -103,12 +103,12 @@
   },
   "references": [
     {
-      "id": "filebeat-*",
+      "id": "logs-*",
       "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
       "type": "index-pattern"
     },
     {
-      "id": "filebeat-*",
+      "id": "logs-*",
       "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
       "type": "index-pattern"
     }

--- a/testdata/package/example-1.0.0/kibana/visualization/38f96190-5c99-11e9-8477-077ec9664dbd.json
+++ b/testdata/package/example-1.0.0/kibana/visualization/38f96190-5c99-11e9-8477-077ec9664dbd.json
@@ -153,12 +153,12 @@
   },
   "references": [
     {
-      "id": "filebeat-*",
+      "id": "logs-*",
       "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
       "type": "index-pattern"
     },
     {
-      "id": "filebeat-*",
+      "id": "logs-*",
       "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
       "type": "index-pattern"
     }

--- a/testdata/package/example-1.0.0/kibana/visualization/7e4084e0-5c99-11e9-8477-077ec9664dbd.json
+++ b/testdata/package/example-1.0.0/kibana/visualization/7e4084e0-5c99-11e9-8477-077ec9664dbd.json
@@ -112,12 +112,12 @@
   },
   "references": [
     {
-      "id": "filebeat-*",
+      "id": "logs-*",
       "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
       "type": "index-pattern"
     },
     {
-      "id": "filebeat-*",
+      "id": "logs-*",
       "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
       "type": "index-pattern"
     }

--- a/testdata/package/example-1.0.0/kibana/visualization/80844540-5c97-11e9-8477-077ec9664dbd.json
+++ b/testdata/package/example-1.0.0/kibana/visualization/80844540-5c97-11e9-8477-077ec9664dbd.json
@@ -98,12 +98,12 @@
   },
   "references": [
     {
-      "id": "filebeat-*",
+      "id": "logs-*",
       "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
       "type": "index-pattern"
     },
     {
-      "id": "filebeat-*",
+      "id": "logs-*",
       "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
       "type": "index-pattern"
     }

--- a/testdata/package/example-1.0.0/kibana/visualization/ab48c3f0-5ca6-11e9-8477-077ec9664dbd.json
+++ b/testdata/package/example-1.0.0/kibana/visualization/ab48c3f0-5ca6-11e9-8477-077ec9664dbd.json
@@ -98,12 +98,12 @@
   },
   "references": [
     {
-      "id": "filebeat-*",
+      "id": "logs-*",
       "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
       "type": "index-pattern"
     },
     {
-      "id": "filebeat-*",
+      "id": "logs-*",
       "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
       "type": "index-pattern"
     }

--- a/testdata/public/package/example-0.0.2/kibana/visualization/0a994af0-5c9d-11e9-8477-077ec9664dbd.json
+++ b/testdata/public/package/example-0.0.2/kibana/visualization/0a994af0-5c9d-11e9-8477-077ec9664dbd.json
@@ -14,12 +14,12 @@
   },
   "references": [
     {
-      "id": "filebeat-*",
+      "id": "logs-*",
       "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
       "type": "index-pattern"
     },
     {
-      "id": "filebeat-*",
+      "id": "logs-*",
       "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
       "type": "index-pattern"
     }

--- a/testdata/public/package/example-0.0.2/kibana/visualization/36f872a0-5c03-11e9-85b4-19d0072eb4f2.json
+++ b/testdata/public/package/example-0.0.2/kibana/visualization/36f872a0-5c03-11e9-85b4-19d0072eb4f2.json
@@ -14,12 +14,12 @@
   },
   "references": [
     {
-      "id": "filebeat-*",
+      "id": "logs-*",
       "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
       "type": "index-pattern"
     },
     {
-      "id": "filebeat-*",
+      "id": "logs-*",
       "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
       "type": "index-pattern"
     }

--- a/testdata/public/package/example-0.0.2/kibana/visualization/38f96190-5c99-11e9-8477-077ec9664dbd.json
+++ b/testdata/public/package/example-0.0.2/kibana/visualization/38f96190-5c99-11e9-8477-077ec9664dbd.json
@@ -14,12 +14,12 @@
   },
   "references": [
     {
-      "id": "filebeat-*",
+      "id": "logs-*",
       "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
       "type": "index-pattern"
     },
     {
-      "id": "filebeat-*",
+      "id": "logs-*",
       "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
       "type": "index-pattern"
     }

--- a/testdata/public/package/example-0.0.2/kibana/visualization/7e4084e0-5c99-11e9-8477-077ec9664dbd.json
+++ b/testdata/public/package/example-0.0.2/kibana/visualization/7e4084e0-5c99-11e9-8477-077ec9664dbd.json
@@ -14,12 +14,12 @@
   },
   "references": [
     {
-      "id": "filebeat-*",
+      "id": "logs-*",
       "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
       "type": "index-pattern"
     },
     {
-      "id": "filebeat-*",
+      "id": "logs-*",
       "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
       "type": "index-pattern"
     }

--- a/testdata/public/package/example-0.0.2/kibana/visualization/80844540-5c97-11e9-8477-077ec9664dbd.json
+++ b/testdata/public/package/example-0.0.2/kibana/visualization/80844540-5c97-11e9-8477-077ec9664dbd.json
@@ -14,12 +14,12 @@
   },
   "references": [
     {
-      "id": "filebeat-*",
+      "id": "logs-*",
       "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
       "type": "index-pattern"
     },
     {
-      "id": "filebeat-*",
+      "id": "logs-*",
       "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
       "type": "index-pattern"
     }

--- a/testdata/public/package/example-0.0.2/kibana/visualization/ab48c3f0-5ca6-11e9-8477-077ec9664dbd.json
+++ b/testdata/public/package/example-0.0.2/kibana/visualization/ab48c3f0-5ca6-11e9-8477-077ec9664dbd.json
@@ -14,12 +14,12 @@
   },
   "references": [
     {
-      "id": "filebeat-*",
+      "id": "logs-*",
       "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
       "type": "index-pattern"
     },
     {
-      "id": "filebeat-*",
+      "id": "logs-*",
       "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
       "type": "index-pattern"
     }

--- a/testdata/public/package/example-1.0.0/kibana/visualization/0a994af0-5c9d-11e9-8477-077ec9664dbd.json
+++ b/testdata/public/package/example-1.0.0/kibana/visualization/0a994af0-5c9d-11e9-8477-077ec9664dbd.json
@@ -14,12 +14,12 @@
   },
   "references": [
     {
-      "id": "filebeat-*",
+      "id": "logs-*",
       "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
       "type": "index-pattern"
     },
     {
-      "id": "filebeat-*",
+      "id": "logs-*",
       "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
       "type": "index-pattern"
     }

--- a/testdata/public/package/example-1.0.0/kibana/visualization/36f872a0-5c03-11e9-85b4-19d0072eb4f2.json
+++ b/testdata/public/package/example-1.0.0/kibana/visualization/36f872a0-5c03-11e9-85b4-19d0072eb4f2.json
@@ -14,12 +14,12 @@
   },
   "references": [
     {
-      "id": "filebeat-*",
+      "id": "logs-*",
       "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
       "type": "index-pattern"
     },
     {
-      "id": "filebeat-*",
+      "id": "logs-*",
       "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
       "type": "index-pattern"
     }

--- a/testdata/public/package/example-1.0.0/kibana/visualization/38f96190-5c99-11e9-8477-077ec9664dbd.json
+++ b/testdata/public/package/example-1.0.0/kibana/visualization/38f96190-5c99-11e9-8477-077ec9664dbd.json
@@ -14,12 +14,12 @@
   },
   "references": [
     {
-      "id": "filebeat-*",
+      "id": "logs-*",
       "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
       "type": "index-pattern"
     },
     {
-      "id": "filebeat-*",
+      "id": "logs-*",
       "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
       "type": "index-pattern"
     }

--- a/testdata/public/package/example-1.0.0/kibana/visualization/7e4084e0-5c99-11e9-8477-077ec9664dbd.json
+++ b/testdata/public/package/example-1.0.0/kibana/visualization/7e4084e0-5c99-11e9-8477-077ec9664dbd.json
@@ -14,12 +14,12 @@
   },
   "references": [
     {
-      "id": "filebeat-*",
+      "id": "logs-*",
       "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
       "type": "index-pattern"
     },
     {
-      "id": "filebeat-*",
+      "id": "logs-*",
       "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
       "type": "index-pattern"
     }

--- a/testdata/public/package/example-1.0.0/kibana/visualization/80844540-5c97-11e9-8477-077ec9664dbd.json
+++ b/testdata/public/package/example-1.0.0/kibana/visualization/80844540-5c97-11e9-8477-077ec9664dbd.json
@@ -14,12 +14,12 @@
   },
   "references": [
     {
-      "id": "filebeat-*",
+      "id": "logs-*",
       "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
       "type": "index-pattern"
     },
     {
-      "id": "filebeat-*",
+      "id": "logs-*",
       "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
       "type": "index-pattern"
     }

--- a/testdata/public/package/example-1.0.0/kibana/visualization/ab48c3f0-5ca6-11e9-8477-077ec9664dbd.json
+++ b/testdata/public/package/example-1.0.0/kibana/visualization/ab48c3f0-5ca6-11e9-8477-077ec9664dbd.json
@@ -14,12 +14,12 @@
   },
   "references": [
     {
-      "id": "filebeat-*",
+      "id": "logs-*",
       "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
       "type": "index-pattern"
     },
     {
-      "id": "filebeat-*",
+      "id": "logs-*",
       "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
       "type": "index-pattern"
     }


### PR DESCRIPTION
Implements https://github.com/elastic/package-registry/issues/201

Renames index patterns referenced in Kibana visualizations and Kibana searches:
- `filebeat-*` -> `logs-*`
- `metricbeats-*` -> `metrics-*`

Note: there are also many references to `auditbeat-*`, these have not been touched.