### PR TITLE
feat: Build Docker images

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -101,11 +101,11 @@ pipeline {
             registry: "${env.DOCKER_REGISTRY}")
           sh(label: 'Build Docker image',
             script: "docker build -t ${env.DOCKER_IMG_TAG} .")
-          sh(label: 'Push Docker image',
+          sh(label: 'Push Docker image sha',
             script: "docker push ${env.DOCKER_IMG_TAG}")
           sh(label: 'Re-tag Docker image',
             script: "docker tag ${env.DOCKER_IMG_TAG} ${env.DOCKER_IMG_TAG_BRANCH}")
-            sh(label: 'Push Docker image',
+            sh(label: 'Push Docker image name',
               script: "docker push ${env.DOCKER_IMG_TAG_BRANCH}")
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,11 +1,6 @@
 #!/usr/bin/env groovy
 
-library identifier: 'apm@current',
-retriever: modernSCM(
-  [$class: 'GitSCMSource',
-  credentialsId: 'f94e9298-83ae-417e-ba91-85c279771570',
-  id: '37cf2c00-2cc7-482e-8c62-7bbffef475e2',
-  remote: 'git@github.com:elastic/apm-pipeline-library.git'])
+@Library('apm@current') _
 
 pipeline {
   agent { label 'docker && linux && immutable' }
@@ -13,6 +8,9 @@ pipeline {
     BASE_DIR="src/github.com/elastic/package-registry"
     JOB_GIT_CREDENTIALS = "f6c7695a-671e-4f4f-a331-acdce44ff9ba"
     PIPELINE_LOG_LEVEL='INFO'
+    DOCKER_REGISTRY = 'docker.elastic.co'
+    DOCKER_REGISTRY_SECRET = 'secret/observability-team/ci/docker-registry/prod'
+    DOCKER_IMG = "${env.DOCKER_REGISTRY}/package-registry/package-registry"
   }
   options {
     timeout(time: 1, unit: 'HOURS')
@@ -34,10 +32,7 @@ pipeline {
     stage('Checkout') {
       steps {
         deleteDir()
-        //gitCheckout(basedir: "${BASE_DIR}")
-        dir("${BASE_DIR}"){
-          checkout scm
-        }
+        gitCheckout(basedir: "${BASE_DIR}")
         stash allowEmpty: true, name: 'source', useDefaultExcludes: false
       }
     }
@@ -87,6 +82,31 @@ pipeline {
           junit(allowEmptyResults: true,
             keepLongStdio: true,
             testResults: "${BASE_DIR}/**/junit-*.xml")
+        }
+      }
+    }
+    /**
+      Publish Docker images.
+    */
+    stage('Publish Docker image'){
+      environment {
+        DOCKER_IMG_TAG = "${env.DOCKER_IMG}:${env.GIT_BASE_COMMIT}"
+        DOCKER_IMG_TAG_BRANCH = "${env.DOCKER_IMG}:${env.BRANCH_NAME}"
+      }
+      steps {
+        deleteDir()
+        unstash 'source'
+        dir("${BASE_DIR}"){
+          dockerLogin(secret: "${env.DOCKER_REGISTRY_SECRET}",
+            registry: "${env.DOCKER_REGISTRY}")
+          sh(label: 'Build Docker image',
+            script: "docker build -t ${env.DOCKER_IMG_TAG} .")
+          sh(label: 'Push Docker image',
+            script: "docker push ${env.DOCKER_IMG_TAG}")
+          sh(label: 'Re-tag Docker image',
+            script: "docker tag ${env.DOCKER_IMG_TAG} ${env.DOCKER_IMG_TAG_BRANCH}")
+            sh(label: 'Push Docker image',
+              script: "docker push ${env.DOCKER_IMG_TAG_BRANCH}")
         }
       }
     }

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ docker run -i -t -p 8080:8080 $(docker images -q integrations_registry:latest)
 #### Docker images published
 
 We publish a Docker image with each successful build commit on branches, tags, or PR.
-For each commit we have two docker image tags, one wit the commit as tag
+For each commit we have two docker image tags, one with the commit as tag
 `docker.elastic.co/package-registry/package-registry:f999b7a84d977cd19a379f0cec802aa1ef7ca379`
 An another Docker tag with the git branch or tag name
 `docker.elastic.co/package-registry/package-registry:master`,

--- a/README.md
+++ b/README.md
@@ -158,6 +158,16 @@ docker build --rm -t integrations_registry:latest .
 docker run -i -t -p 8080:8080 $(docker images -q integrations_registry:latest)
 ```
 
+#### Docker images published
+
+We publish a Docker image with each successful build commit on branches, tags, or PR.
+For each commit we have two docker image tags, one wit the commit as tag
+`docker.elastic.co/package-registry/package-registry:f999b7a84d977cd19a379f0cec802aa1ef7ca379`
+An another Docker tag with the git branch or tag name
+`docker.elastic.co/package-registry/package-registry:master`,
+`docker.elastic.co/package-registry/package-registry:pr-111`,
+`docker.elastic.co/package-registry/package-registry:v0.2.0`
+
 ### Healthcheck
 
 For Docker / Kubernetes the `/` endpoint can be queried. As soon as `/` returns a 200, the service is ready.


### PR DESCRIPTION
## What does this PR do?

It adds a new stage that will build and push it to the`docker.elastic.co` Docker registry.

## Why is it important?

Every commit that passes the build and test stages will build a docker image, 
then it will push the image using the commit SH1 as a tag (`docker.elastic.co/package-registry/package-registry:f999b7a84d977cd19a379f0cec802aa1ef7ca379`), 
finally, we will push another tag using the git branch or tag name (`docker.elastic.co/package-registry/package-registry:master`,
`docker.elastic.co/package-registry/package-registry:pr-111`,
`docker.elastic.co/package-registry/package-registry:v0.2.0`)

## Related issues
Closes https://github.com/elastic/package-registry/issues/205
