### PR TITLE
Validate dataset name to not contain -

### DIFF
--- a/util/dataset.go
+++ b/util/dataset.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 type DataSet struct {
@@ -25,6 +26,10 @@ func (d *DataSet) Validate() error {
 	paths, err := filepath.Glob(pipelineDir + "*")
 	if err != nil {
 		return err
+	}
+
+	if strings.Contains("-", d.Name) {
+		return fmt.Errorf("dataset name is not allowed to contain `-`: %s", d.Name)
 	}
 
 	if d.IngestPipeline == "" {

--- a/util/dataset.go
+++ b/util/dataset.go
@@ -28,7 +28,7 @@ func (d *DataSet) Validate() error {
 		return err
 	}
 
-	if strings.Contains("-", d.Name) {
+	if strings.Contains(d.Name, "-") {
 		return fmt.Errorf("dataset name is not allowed to contain `-`: %s", d.Name)
 	}
 


### PR DESCRIPTION
Because of the indexing strategy, the dataset name is not allowed to contain a -