### PR TITLE
Update logs package to support datasources

### DIFF
--- a/dev/package-examples/log-0.9.0/dataset/log/agent/stream/stream.yml
+++ b/dev/package-examples/log-0.9.0/dataset/log/agent/stream/stream.yml
@@ -1,5 +1,7 @@
 type: log
 paths:
-  {{#each paths}}
+{{#each paths}}
   - "{{this}}"
-  {{/each}}
+{{/each}}
+
+dataset: generic

--- a/dev/package-examples/log-0.9.0/dataset/log/manifest.yml
+++ b/dev/package-examples/log-0.9.0/dataset/log/manifest.yml
@@ -5,8 +5,12 @@ ingest_pipeline: default
 
 default: true
 
-vars:
-  - name: paths
-    default:
-      # This example value has to be changed / overwritten by the user.
-      - /var/log/*.log
+inputs:
+  - type: log
+    vars:
+      - name: paths
+        required: true
+        description: Path to log files to be collected
+        type: text
+        multi: true
+

--- a/dev/package-examples/log-0.9.0/manifest.yml
+++ b/dev/package-examples/log-0.9.0/manifest.yml
@@ -15,3 +15,9 @@ requirement:
     versions: "<8.0.0"
   elasticsearch:
     versions: "<8.0.0"
+
+
+datasources:
+  - name: logs
+    inputs:
+      - type: log


### PR DESCRIPTION
My initial plan was to remove the logs package as the default setup for logs-*-* is already done by alias templates. But I realised there are still two cases where we can use the logs package:

* Update the logs-*-* template to a never version
* Use the logs datasource as our generic data source template

This means, this datasource allows us to support "custom datasources" with a package without having to spend additional efforts on it. All the logs will be shipped for now to logs-generic-{namespace} but at least users can select their own paths.