### PR TITLE
Add validation for datasources and inputs

### DIFF
--- a/testdata/package/datasources-1.0.0/manifest.yml
+++ b/testdata/package/datasources-1.0.0/manifest.yml
@@ -20,7 +20,7 @@ datasources:
         # This is for selection in the stream
         # id: nginx
         type: nginx/metrics
-        descrition: Collecting metrics for nginx.
+        description: Collecting metrics for nginx.
 
         # Common configuration options for this input
         vars:

--- a/testdata/public/package/datasources-1.0.0/index.json
+++ b/testdata/public/package/datasources-1.0.0/index.json
@@ -58,7 +58,6 @@
       "name": "nginx",
       "inputs": [
         {
-          "descrition": "Collecting metrics for nginx.",
           "type": "nginx/metrics",
           "vars": [
             {
@@ -85,16 +84,15 @@
               "name": "password",
               "type": "password"
             }
-          ]
+          ],
+          "description": "Collecting metrics for nginx."
         },
         {
-          "description": "Collect nginx logs.",
           "type": "logs",
-          "vars": null
+          "description": "Collect nginx logs."
         },
         {
-          "type": "syslog",
-          "vars": null
+          "type": "syslog"
         }
       ]
     }

--- a/testdata/public/package/datasources-1.0.0/manifest.yml
+++ b/testdata/public/package/datasources-1.0.0/manifest.yml
@@ -20,7 +20,7 @@ datasources:
         # This is for selection in the stream
         # id: nginx
         type: nginx/metrics
-        descrition: Collecting metrics for nginx.
+        description: Collecting metrics for nginx.
 
         # Common configuration options for this input
         vars:

--- a/util/dataset.go
+++ b/util/dataset.go
@@ -18,8 +18,14 @@ type DataSet struct {
 	Type           string                   `config:"type" json:"type" validate:"required"`
 	IngestPipeline string                   `config:"ingest_pipeline,omitempty" config:"ingest_pipeline" json:"ingest_pipeline,omitempty"`
 	Vars           []map[string]interface{} `config:"vars" json:"vars,omitempty"`
-	Inputs         []map[string]interface{} `config:"inputs" json:"inputs,omitempty"`
+	Inputs         []Input                  `config:"inputs" json:"inputs,omitempty"`
 	Package        string                   `json:"package"`
+}
+
+type Input struct {
+	Type        string                   `config:"type" json:"type" validate:"required"`
+	Vars        []map[string]interface{} `config:"vars" json:"vars,omitempty" `
+	Description string                   `config:"description" json:"description,omitempty" `
 }
 
 func (d *DataSet) Validate() error {

--- a/util/package.go
+++ b/util/package.go
@@ -47,8 +47,8 @@ type Package struct {
 }
 
 type Datasource struct {
-	Name   string        `config:"name" json:"name"`
-	Inputs []interface{} `config:"inputs" json:"inputs"`
+	Name   string  `config:"name" json:"name"`
+	Inputs []Input `config:"inputs" json:"inputs"`
 }
 
 type Requirement struct {


### PR DESCRIPTION
This adds basic format validation for the datasources and input definitons in the manifests. With the validation it also skips empty fields.