### PR TITLE
Add basic logs and metrics template

### DIFF
--- a/dev/package-examples/base-1.0.0/elasticsearch/index-template/logs-mapping.json
+++ b/dev/package-examples/base-1.0.0/elasticsearch/index-template/logs-mapping.json
@@ -1,0 +1,134 @@
+{
+    "order": 1,
+    "index_patterns": [
+        "logs-*-*"
+    ],
+    "mappings": {
+        "_meta": {
+        },
+        "dynamic_templates": [
+            {
+                "strings_as_keyword": {
+                    "mapping": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "match_mapping_type": "string"
+                }
+            }
+        ],
+        "date_detection": false,
+        "properties": {
+            "agent": {
+                "properties": {
+                    "hostname": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "name": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "id": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "ephemeral_id": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "type": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "version": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    }
+                }
+            },
+            "ecs": {
+                "properties": {
+                    "version": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    }
+                }
+            },
+            "host": {
+                "properties": {
+                    "hostname": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "os": {
+                        "properties": {
+                            "build": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "kernel": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "codename": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "name": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "family": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "version": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "platform": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "full": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            }
+                        }
+                    },
+                    "ip": {
+                        "type": "ip"
+                    },
+                    "containerized": {
+                        "type": "boolean"
+                    },
+                    "name": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "id": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "type": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "mac": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "architecture": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    }
+                }
+            },
+            "message": {
+                "type": "text"
+            }
+        }
+    },
+    "aliases": {}
+}

--- a/dev/package-examples/base-1.0.0/elasticsearch/index-template/logs-settings.json
+++ b/dev/package-examples/base-1.0.0/elasticsearch/index-template/logs-settings.json
@@ -1,0 +1,24 @@
+{
+    "order": 1,
+    "index_patterns": [
+        "logs-*-*"
+    ],
+    "settings": {
+        "index": {
+            "lifecycle": {
+                "name": "logs-default",
+                "rollover_alias": "logs-generic-default"
+            },
+            "codec": "best_compression",
+            "refresh_interval": "5s",
+            "number_of_shards": "1",
+            "query": {
+                "default_field": [
+                    "message"
+                ]
+            },
+            "number_of_routing_shards": "30"
+        }
+    },
+    "aliases": {}
+}

--- a/dev/package-examples/base-1.0.0/elasticsearch/index-template/metrics-mapping.json
+++ b/dev/package-examples/base-1.0.0/elasticsearch/index-template/metrics-mapping.json
@@ -1,0 +1,131 @@
+{
+    "order": 1,
+    "index_patterns": [
+        "metrics-*-*"
+    ],
+    "mappings": {
+        "_meta": {
+        },
+        "dynamic_templates": [
+            {
+                "strings_as_keyword": {
+                    "mapping": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "match_mapping_type": "string"
+                }
+            }
+        ],
+        "date_detection": false,
+        "properties": {
+            "agent": {
+                "properties": {
+                    "hostname": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "name": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "id": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "ephemeral_id": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "type": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "version": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    }
+                }
+            },
+            "ecs": {
+                "properties": {
+                    "version": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    }
+                }
+            },
+            "host": {
+                "properties": {
+                    "hostname": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "os": {
+                        "properties": {
+                            "build": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "kernel": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "codename": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "name": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "family": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "version": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "platform": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "full": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            }
+                        }
+                    },
+                    "ip": {
+                        "type": "ip"
+                    },
+                    "containerized": {
+                        "type": "boolean"
+                    },
+                    "name": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "id": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "type": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "mac": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "architecture": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    }
+                }
+            }
+        }
+    },
+    "aliases": {}
+}

--- a/dev/package-examples/base-1.0.0/elasticsearch/index-template/metrics-settings.json
+++ b/dev/package-examples/base-1.0.0/elasticsearch/index-template/metrics-settings.json
@@ -1,0 +1,24 @@
+{
+    "order": 1,
+    "index_patterns": [
+        "metrics-*-*"
+    ],
+    "settings": {
+        "index": {
+            "lifecycle": {
+                "name": "metrics-default",
+                "rollover_alias": "metrics-generic-default"
+            },
+            "codec": "best_compression",
+            "refresh_interval": "5s",
+            "number_of_shards": "1",
+            "query": {
+                "default_field": [
+                    "message"
+                ]
+            },
+            "number_of_routing_shards": "30"
+        }
+    },
+    "aliases": {}
+}


### PR DESCRIPTION
For logs and metrics indices, we will provide default templates. This makes sure, that all indices which are created in logs-*-* and metrics-*-* follow the convention.

In this PR, a first example of these templates is provided. In total there are 4 templates, one for mapping and one for settings for each. The content of the templates itself is very basic at the moment. It contains a few fields from ECS and defaulting to keyword for all fields otherwise if it is a string. More work must be put into these templates in the future.

These templates are a bit different from the other fields.yml as they are installed globally and don't depend on a data source. Because of this they are in the top level Elasticsearch directory and directly in the json format. From an installation perspective in the package manager my expectations are as following:

* EPM takes the name of the file and the content and puts it directly into Elasticsearch (no processing)