### PR TITLE
Rename dataset inputs to streams

### DIFF
--- a/dev/package-examples/nginx-1.2.0/dataset/access/manifest.yml
+++ b/dev/package-examples/nginx-1.2.0/dataset/access/manifest.yml
@@ -11,6 +11,8 @@ ingest_pipeline: default
 # List of supported streams. There can be multiple stream definitions for different input types.
 streams:
   - input: log
+    title: Nginx access logs
+    description: Collecting the nginx access logs from file.
     vars:
       - name: paths
         required: true

--- a/dev/package-examples/nginx-1.2.0/dataset/access/manifest.yml
+++ b/dev/package-examples/nginx-1.2.0/dataset/access/manifest.yml
@@ -8,9 +8,9 @@ type: logs
 # The ingest pipeline which should be used.
 ingest_pipeline: default
 
-# List of supported inputs
-inputs:
-  - type: log
+# List of supported streams. There can be multiple stream definitions for different input types.
+streams:
+  - input: log
     vars:
       - name: paths
         required: true

--- a/dev/package-examples/nginx-1.2.0/dataset/error/manifest.yml
+++ b/dev/package-examples/nginx-1.2.0/dataset/error/manifest.yml
@@ -4,8 +4,8 @@ ingest_pipeline: pipeline
 
 
 # This is an example that multiple inputs are supported by one dataset
-inputs:
-  - type: log
+streams:
+  - input: log
     vars:
       - name: paths
         required: true
@@ -18,7 +18,7 @@ inputs:
         os.windows:
           - c:/programdata/nginx/logs/error.log*
 
-  - type: syslog
+  - input: syslog
     vars:
       # Are udp and tcp syslog input two different inputs?
       - name: protocol.udp.host

--- a/dev/package-examples/nginx-1.2.0/dataset/error/manifest.yml
+++ b/dev/package-examples/nginx-1.2.0/dataset/error/manifest.yml
@@ -3,9 +3,11 @@ type: logs
 ingest_pipeline: pipeline
 
 
-# This is an example that multiple inputs are supported by one dataset
+# This is an example that multiple streams with different inputs are supported by one dataset
 streams:
   - input: log
+    title: Nginx error logs
+    description: Collecting the Nginx error logs from file.
     vars:
       - name: paths
         required: true
@@ -19,6 +21,8 @@ streams:
           - c:/programdata/nginx/logs/error.log*
 
   - input: syslog
+    title: Nginx error logs
+    description: Collecting the Nginx error logs from syslog.
     vars:
       # Are udp and tcp syslog input two different inputs?
       - name: protocol.udp.host

--- a/dev/package-examples/nginx-1.2.0/dataset/stubstatus/manifest.yml
+++ b/dev/package-examples/nginx-1.2.0/dataset/stubstatus/manifest.yml
@@ -10,9 +10,8 @@ compatibility: linux, freebsd
 # Each input can be in its own release status
 release: beta
 
-# List of inputs this dataset supports
-inputs:
-  - type: "metric/nginx"
+streams:
+  - input: "metric/nginx"
 
     # Only the variables have to be repeated that are not specified as part of the input
     vars:

--- a/dev/package-examples/nginx-1.2.0/manifest.yml
+++ b/dev/package-examples/nginx-1.2.0/manifest.yml
@@ -17,6 +17,8 @@ datasources:
   -
     # Do we need a name for the data source?
     name: nginx
+    title: Nginx logs and metrics.
+    description: Collecting logs and metrics from nginx.
 
     # List of inputs this datasource supports
     inputs:

--- a/dev/package-examples/nginx-1.2.0/manifest.yml
+++ b/dev/package-examples/nginx-1.2.0/manifest.yml
@@ -27,7 +27,7 @@ datasources:
         # This is for selection in the stream
         # id: nginx
         type: nginx/metrics
-        descrition: Collecting metrics for nginx.
+        description: Collecting metrics for nginx.
 
         # Common configuration options for this input
         vars:

--- a/testdata/package/datasources-1.0.0/dataset/example/manifest.yml
+++ b/testdata/package/datasources-1.0.0/dataset/example/manifest.yml
@@ -2,8 +2,10 @@ title: Example dataset with inputs
 type: logs
 
 # List of supported inputs
-inputs:
-  - type: log
+streams:
+  - input: log
+    title: Title of the stream
+    description: Description of the stream with more details.
     vars:
       - name: paths
         required: true

--- a/testdata/package/datasources-1.0.0/manifest.yml
+++ b/testdata/package/datasources-1.0.0/manifest.yml
@@ -12,6 +12,8 @@ datasources:
   -
     # Do we need a name for the data source?
     name: nginx
+    title: Datasource title
+    description: Details about the data source.
 
     # List of inputs this datasource supports
     inputs:

--- a/testdata/public/package/datasources-1.0.0/dataset/example/manifest.yml
+++ b/testdata/public/package/datasources-1.0.0/dataset/example/manifest.yml
@@ -2,8 +2,10 @@ title: Example dataset with inputs
 type: logs
 
 # List of supported inputs
-inputs:
-  - type: log
+streams:
+  - input: log
+    title: Title of the stream
+    description: Description of the stream with more details.
     vars:
       - name: paths
         required: true

--- a/testdata/public/package/datasources-1.0.0/index.json
+++ b/testdata/public/package/datasources-1.0.0/index.json
@@ -21,9 +21,11 @@
       "name": "example",
       "release": "beta",
       "type": "logs",
-      "inputs": [
+      "streams": [
         {
-          "type": "log",
+          "description": "Description of the stream with more details.",
+          "input": "log",
+          "title": "Title of the stream",
           "vars": [
             {
               "default": [

--- a/testdata/public/package/datasources-1.0.0/index.json
+++ b/testdata/public/package/datasources-1.0.0/index.json
@@ -58,6 +58,10 @@
       "name": "nginx",
       "inputs": [
         {
+<<<<<<< HEAD
+=======
+          "description": "Collecting metrics for nginx.",
+>>>>>>> fix typo
           "type": "nginx/metrics",
           "vars": [
             {

--- a/testdata/public/package/datasources-1.0.0/index.json
+++ b/testdata/public/package/datasources-1.0.0/index.json
@@ -60,10 +60,6 @@
       "name": "nginx",
       "inputs": [
         {
-<<<<<<< HEAD
-=======
-          "description": "Collecting metrics for nginx.",
->>>>>>> fix typo
           "type": "nginx/metrics",
           "vars": [
             {

--- a/testdata/public/package/datasources-1.0.0/manifest.yml
+++ b/testdata/public/package/datasources-1.0.0/manifest.yml
@@ -12,6 +12,8 @@ datasources:
   -
     # Do we need a name for the data source?
     name: nginx
+    title: Datasource title
+    description: Details about the data source.
 
     # List of inputs this datasource supports
     inputs:

--- a/util/dataset.go
+++ b/util/dataset.go
@@ -18,7 +18,7 @@ type DataSet struct {
 	Type           string                   `config:"type" json:"type" validate:"required"`
 	IngestPipeline string                   `config:"ingest_pipeline,omitempty" config:"ingest_pipeline" json:"ingest_pipeline,omitempty"`
 	Vars           []map[string]interface{} `config:"vars" json:"vars,omitempty"`
-	Inputs         []Input                  `config:"inputs" json:"inputs,omitempty"`
+	Streams        []map[string]interface{} `config:"streams" json:"streams,omitempty"`
 	Package        string                   `json:"package"`
 }
 


### PR DESCRIPTION
The manifest on the dataset level defines the streams which use an input. Because of this naming it streams instead of input makes probably more sense.