### PR TITLE
Add streams as part of Datasource / Inputs

### DIFF
--- a/testdata/package/datasources-1.0.0/dataset/examplelog1/manifest.yml
+++ b/testdata/package/datasources-1.0.0/dataset/examplelog1/manifest.yml
@@ -1,25 +1,23 @@
 title: Example dataset with inputs
 type: logs
 
-# List of supported inputs
 streams:
-  - input: log
+  - input: logs
     title: Title of the stream
     description: Description of the stream with more details.
     vars:
       - name: paths
         required: true
-        # Should we define this as array? How will the UI best make sense of it?
-        description: Paths to the nginx access log file.
+        description: Paths to the nginx error log file.
         type: text
         multi: true
         default:
-          - /var/log/nginx/access.log*
+          - /var/log/nginx/error.log*
         # I suggest to use ECS fields for this config options here: https://github.com/elastic/ecs/blob/master/schemas/os.yml
         # This would need to be based on a predefined definition on what can be filtered on
         os.darwin:
           default:
-            - /usr/local/var/log/nginx/access.log*
+            - /usr/local/var/log/nginx/error.log*
         os.windows:
           default:
-            - c:/programdata/nginx/logs/*access.log*
+            - c:/programdata/nginx/logs/*error.log*

--- a/testdata/package/datasources-1.0.0/dataset/examplelog2/manifest.yml
+++ b/testdata/package/datasources-1.0.0/dataset/examplelog2/manifest.yml
@@ -1,0 +1,24 @@
+title: Example dataset with inputs
+type: logs
+
+streams:
+  - input: logs
+    title: Title of the stream
+    description: Description of the stream with more details.
+    vars:
+      - name: paths
+        required: true
+        # Should we define this as array? How will the UI best make sense of it?
+        description: Paths to the nginx access log file.
+        type: text
+        multi: true
+        default:
+          - /var/log/nginx/access.log*
+        # I suggest to use ECS fields for this config options here: https://github.com/elastic/ecs/blob/master/schemas/os.yml
+        # This would need to be based on a predefined definition on what can be filtered on
+        os.darwin:
+          default:
+            - /usr/local/var/log/nginx/access.log*
+        os.windows:
+          default:
+            - c:/programdata/nginx/logs/*access.log*

--- a/testdata/package/datasources-1.0.0/dataset/examplemetric/manifest.yml
+++ b/testdata/package/datasources-1.0.0/dataset/examplemetric/manifest.yml
@@ -1,0 +1,14 @@
+title: Example dataset with inputs
+type: metrics
+
+streams:
+  - input: nginx/metrics
+    title: Title of the stream
+    description: Description of the stream with more details.
+    vars:
+      - name: url
+        required: true
+        # Should we define this as array? How will the UI best make sense of it?
+        description: Paths to the nginx access log file.
+        type: text
+        default: localhost

--- a/testdata/public/package/datasources-1.0.0/dataset/examplelog1/manifest.yml
+++ b/testdata/public/package/datasources-1.0.0/dataset/examplelog1/manifest.yml
@@ -1,25 +1,23 @@
 title: Example dataset with inputs
 type: logs
 
-# List of supported inputs
 streams:
-  - input: log
+  - input: logs
     title: Title of the stream
     description: Description of the stream with more details.
     vars:
       - name: paths
         required: true
-        # Should we define this as array? How will the UI best make sense of it?
-        description: Paths to the nginx access log file.
+        description: Paths to the nginx error log file.
         type: text
         multi: true
         default:
-          - /var/log/nginx/access.log*
+          - /var/log/nginx/error.log*
         # I suggest to use ECS fields for this config options here: https://github.com/elastic/ecs/blob/master/schemas/os.yml
         # This would need to be based on a predefined definition on what can be filtered on
         os.darwin:
           default:
-            - /usr/local/var/log/nginx/access.log*
+            - /usr/local/var/log/nginx/error.log*
         os.windows:
           default:
-            - c:/programdata/nginx/logs/*access.log*
+            - c:/programdata/nginx/logs/*error.log*

--- a/testdata/public/package/datasources-1.0.0/dataset/examplelog2/manifest.yml
+++ b/testdata/public/package/datasources-1.0.0/dataset/examplelog2/manifest.yml
@@ -1,0 +1,24 @@
+title: Example dataset with inputs
+type: logs
+
+streams:
+  - input: logs
+    title: Title of the stream
+    description: Description of the stream with more details.
+    vars:
+      - name: paths
+        required: true
+        # Should we define this as array? How will the UI best make sense of it?
+        description: Paths to the nginx access log file.
+        type: text
+        multi: true
+        default:
+          - /var/log/nginx/access.log*
+        # I suggest to use ECS fields for this config options here: https://github.com/elastic/ecs/blob/master/schemas/os.yml
+        # This would need to be based on a predefined definition on what can be filtered on
+        os.darwin:
+          default:
+            - /usr/local/var/log/nginx/access.log*
+        os.windows:
+          default:
+            - c:/programdata/nginx/logs/*access.log*

--- a/testdata/public/package/datasources-1.0.0/dataset/examplemetric/manifest.yml
+++ b/testdata/public/package/datasources-1.0.0/dataset/examplemetric/manifest.yml
@@ -1,0 +1,14 @@
+title: Example dataset with inputs
+type: metrics
+
+streams:
+  - input: nginx/metrics
+    title: Title of the stream
+    description: Description of the stream with more details.
+    vars:
+      - name: url
+        required: true
+        # Should we define this as array? How will the UI best make sense of it?
+        description: Paths to the nginx access log file.
+        type: text
+        default: localhost

--- a/testdata/public/package/datasources-1.0.0/index.json
+++ b/testdata/public/package/datasources-1.0.0/index.json
@@ -12,20 +12,57 @@
   },
   "assets": [
     "/package/datasources-1.0.0/manifest.yml",
-    "/package/datasources-1.0.0/dataset/example/manifest.yml"
+    "/package/datasources-1.0.0/dataset/examplelog1/manifest.yml",
+    "/package/datasources-1.0.0/dataset/examplelog2/manifest.yml",
+    "/package/datasources-1.0.0/dataset/examplemetric/manifest.yml"
   ],
   "format_version": "1.0.0",
   "datasets": [
     {
       "title": "Example dataset with inputs",
-      "name": "example",
+      "name": "examplelog1",
       "release": "beta",
       "type": "logs",
       "streams": [
         {
-          "description": "Description of the stream with more details.",
-          "input": "log",
-          "title": "Title of the stream",
+          "input": "logs",
+          "vars": [
+            {
+              "default": [
+                "/var/log/nginx/error.log*"
+              ],
+              "description": "Paths to the nginx error log file.",
+              "multi": true,
+              "name": "paths",
+              "os": {
+                "darwin": {
+                  "default": [
+                    "/usr/local/var/log/nginx/error.log*"
+                  ]
+                },
+                "windows": {
+                  "default": [
+                    "c:/programdata/nginx/logs/*error.log*"
+                  ]
+                }
+              },
+              "required": true,
+              "type": "text"
+            }
+          ],
+          "description": "Description of the stream with more details."
+        }
+      ],
+      "package": "datasources"
+    },
+    {
+      "title": "Example dataset with inputs",
+      "name": "examplelog2",
+      "release": "beta",
+      "type": "logs",
+      "streams": [
+        {
+          "input": "logs",
           "vars": [
             {
               "default": [
@@ -49,7 +86,30 @@
               "required": true,
               "type": "text"
             }
-          ]
+          ],
+          "description": "Description of the stream with more details."
+        }
+      ],
+      "package": "datasources"
+    },
+    {
+      "title": "Example dataset with inputs",
+      "name": "examplemetric",
+      "release": "beta",
+      "type": "metrics",
+      "streams": [
+        {
+          "input": "nginx/metrics",
+          "vars": [
+            {
+              "default": "localhost",
+              "description": "Paths to the nginx access log file.",
+              "name": "url",
+              "required": true,
+              "type": "text"
+            }
+          ],
+          "description": "Description of the stream with more details."
         }
       ],
       "package": "datasources"
@@ -87,11 +147,84 @@
               "type": "password"
             }
           ],
-          "description": "Collecting metrics for nginx."
+          "description": "Collecting metrics for nginx.",
+          "streams": [
+            {
+              "input": "nginx/metrics",
+              "vars": [
+                {
+                  "default": "localhost",
+                  "description": "Paths to the nginx access log file.",
+                  "name": "url",
+                  "required": true,
+                  "type": "text"
+                }
+              ],
+              "description": "Description of the stream with more details."
+            }
+          ]
         },
         {
           "type": "logs",
-          "description": "Collect nginx logs."
+          "description": "Collect nginx logs.",
+          "streams": [
+            {
+              "input": "logs",
+              "vars": [
+                {
+                  "default": [
+                    "/var/log/nginx/error.log*"
+                  ],
+                  "description": "Paths to the nginx error log file.",
+                  "multi": true,
+                  "name": "paths",
+                  "os": {
+                    "darwin": {
+                      "default": [
+                        "/usr/local/var/log/nginx/error.log*"
+                      ]
+                    },
+                    "windows": {
+                      "default": [
+                        "c:/programdata/nginx/logs/*error.log*"
+                      ]
+                    }
+                  },
+                  "required": true,
+                  "type": "text"
+                }
+              ],
+              "description": "Description of the stream with more details."
+            },
+            {
+              "input": "logs",
+              "vars": [
+                {
+                  "default": [
+                    "/var/log/nginx/access.log*"
+                  ],
+                  "description": "Paths to the nginx access log file.",
+                  "multi": true,
+                  "name": "paths",
+                  "os": {
+                    "darwin": {
+                      "default": [
+                        "/usr/local/var/log/nginx/access.log*"
+                      ]
+                    },
+                    "windows": {
+                      "default": [
+                        "c:/programdata/nginx/logs/*access.log*"
+                      ]
+                    }
+                  },
+                  "required": true,
+                  "type": "text"
+                }
+              ],
+              "description": "Description of the stream with more details."
+            }
+          ]
         },
         {
           "type": "syslog"

--- a/testdata/public/package/datasources-1.0.0/index.json
+++ b/testdata/public/package/datasources-1.0.0/index.json
@@ -160,6 +160,7 @@
                   "type": "text"
                 }
               ],
+              "dataset": "examplemetric",
               "description": "Description of the stream with more details."
             }
           ]
@@ -194,6 +195,7 @@
                   "type": "text"
                 }
               ],
+              "dataset": "examplelog1",
               "description": "Description of the stream with more details."
             },
             {
@@ -222,6 +224,7 @@
                   "type": "text"
                 }
               ],
+              "dataset": "examplelog2",
               "description": "Description of the stream with more details."
             }
           ]

--- a/testdata/public/package/datasources-1.0.0/index.json
+++ b/testdata/public/package/datasources-1.0.0/index.json
@@ -19,8 +19,8 @@
   "format_version": "1.0.0",
   "datasets": [
     {
+      "id": "datasources.examplelog1",
       "title": "Example dataset with inputs",
-      "name": "examplelog1",
       "release": "beta",
       "type": "logs",
       "streams": [
@@ -53,11 +53,12 @@
           "description": "Description of the stream with more details."
         }
       ],
-      "package": "datasources"
+      "package": "datasources",
+      "path": "examplelog1"
     },
     {
+      "id": "datasources.examplelog2",
       "title": "Example dataset with inputs",
-      "name": "examplelog2",
       "release": "beta",
       "type": "logs",
       "streams": [
@@ -90,11 +91,12 @@
           "description": "Description of the stream with more details."
         }
       ],
-      "package": "datasources"
+      "package": "datasources",
+      "path": "examplelog2"
     },
     {
+      "id": "datasources.examplemetric",
       "title": "Example dataset with inputs",
-      "name": "examplemetric",
       "release": "beta",
       "type": "metrics",
       "streams": [
@@ -112,7 +114,8 @@
           "description": "Description of the stream with more details."
         }
       ],
-      "package": "datasources"
+      "package": "datasources",
+      "path": "examplemetric"
     }
   ],
   "datasources": [
@@ -160,7 +163,7 @@
                   "type": "text"
                 }
               ],
-              "dataset": "examplemetric",
+              "dataset": "datasources.examplemetric",
               "description": "Description of the stream with more details."
             }
           ]
@@ -195,7 +198,7 @@
                   "type": "text"
                 }
               ],
-              "dataset": "examplelog1",
+              "dataset": "datasources.examplelog1",
               "description": "Description of the stream with more details."
             },
             {
@@ -224,7 +227,7 @@
                   "type": "text"
                 }
               ],
-              "dataset": "examplelog2",
+              "dataset": "datasources.examplelog2",
               "description": "Description of the stream with more details."
             }
           ]

--- a/util/dataset.go
+++ b/util/dataset.go
@@ -18,7 +18,7 @@ type DataSet struct {
 	Type           string                   `config:"type" json:"type" validate:"required"`
 	IngestPipeline string                   `config:"ingest_pipeline,omitempty" config:"ingest_pipeline" json:"ingest_pipeline,omitempty"`
 	Vars           []map[string]interface{} `config:"vars" json:"vars,omitempty"`
-	Streams        []map[string]interface{} `config:"streams" json:"streams,omitempty"`
+	Streams        []Stream                 `config:"streams" json:"streams,omitempty"`
 	Package        string                   `json:"package"`
 
 	// Generated fields
@@ -27,6 +27,13 @@ type DataSet struct {
 
 type Input struct {
 	Type        string                   `config:"type" json:"type" validate:"required"`
+	Vars        []map[string]interface{} `config:"vars" json:"vars,omitempty" `
+	Description string                   `config:"description" json:"description,omitempty" `
+	Streams     []Stream                 `config:"streams" json:"streams,omitempty"`
+}
+
+type Stream struct {
+	Input       string                   `config:"input" json:"input" validate:"required"`
 	Vars        []map[string]interface{} `config:"vars" json:"vars,omitempty" `
 	Description string                   `config:"description" json:"description,omitempty" `
 }

--- a/util/dataset.go
+++ b/util/dataset.go
@@ -35,6 +35,7 @@ type Input struct {
 type Stream struct {
 	Input       string                   `config:"input" json:"input" validate:"required"`
 	Vars        []map[string]interface{} `config:"vars" json:"vars,omitempty" `
+	Dataset     string                   `config:"dataset" json:"dataset,omitempty" `
 	Description string                   `config:"description" json:"description,omitempty" `
 }
 

--- a/util/package.go
+++ b/util/package.go
@@ -334,6 +334,7 @@ func (p *Package) LoadDataSets(packagePath string) error {
 			for iK, _ := range datasource.Inputs {
 				for _, stream := range d.Streams {
 					if stream.Input == p.Datasources[dK].Inputs[iK].Type {
+						stream.Dataset = d.Name
 						p.Datasources[dK].Inputs[iK].Streams = append(p.Datasources[dK].Inputs[iK].Streams, stream)
 					}
 				}

--- a/util/package.go
+++ b/util/package.go
@@ -334,7 +334,7 @@ func (p *Package) LoadDataSets(packagePath string) error {
 			for iK, _ := range datasource.Inputs {
 				for _, stream := range d.Streams {
 					if stream.Input == p.Datasources[dK].Inputs[iK].Type {
-						stream.Dataset = d.Name
+						stream.Dataset = d.ID
 						p.Datasources[dK].Inputs[iK].Streams = append(p.Datasources[dK].Inputs[iK].Streams, stream)
 					}
 				}

--- a/util/package.go
+++ b/util/package.go
@@ -329,6 +329,17 @@ func (p *Package) LoadDataSets(packagePath string) error {
 			d.Release = "beta"
 		}
 
+		// Iterate through all datatsource and inputs to find the matching streams and add them to the output.
+		for dK, datasource := range p.Datasources {
+			for iK, _ := range datasource.Inputs {
+				for _, stream := range d.Streams {
+					if stream.Input == p.Datasources[dK].Inputs[iK].Type {
+						p.Datasources[dK].Inputs[iK].Streams = append(p.Datasources[dK].Inputs[iK].Streams, stream)
+					}
+				}
+			}
+		}
+
 		p.DataSets = append(p.DataSets, d)
 	}
 


### PR DESCRIPTION
The streams are defined in the dataset and reference an input. The input is defined in the datasource. For the UI to not have to combine to two together, the API already provides the datasource with all inputs and streams listed inside.

This change also extended the test packages to have better examples for this change.

Note: This PR gets the job done. Code could be cleaned up later.