### PR TITLE
Add basic "import-beats" scripts

### DIFF
--- a/dev/import-beats/main.go
+++ b/dev/import-beats/main.go
@@ -15,22 +15,22 @@ func main() {
 	// Beats repository directory
 	var beatsDir string
 	// Target public directory where the generated packages should end up in
-	var publicDir string
+	var outputDir string
 
 	flag.StringVar(&beatsDir, "beatsDir", "", "Path to the beats repository")
-	flag.StringVar(&publicDir, "publicDir", "", "Path to the public directory ")
+	flag.StringVar(&outputDir, "outputDir", "", "Path to the output directory ")
 	flag.Parse()
 
-	if beatsDir == "" || publicDir == "" {
-		log.Fatal("beatsDir and publicDir must be set")
+	if beatsDir == "" || outputDir == "" {
+		log.Fatal("beatsDir and outputDir must be set")
 	}
 
-	if err := build(beatsDir, publicDir); err != nil {
+	if err := build(beatsDir, outputDir); err != nil {
 		log.Fatal(err)
 	}
 }
 
-func build(beatsDir, publicDir string) error {
+func build(beatsDir, outputDir string) error {
 	packages := packageMap{}
 
 	for _, beatName := range logSources {
@@ -47,5 +47,5 @@ func build(beatsDir, publicDir string) error {
 		}
 	}
 
-	return packages.writePackages(publicDir)
+	return packages.writePackages(outputDir)
 }

--- a/dev/import-beats/main.go
+++ b/dev/import-beats/main.go
@@ -30,6 +30,10 @@ func main() {
 	}
 }
 
+// build method visits all beats in beatsDir to collect configuration data for modules.
+// The package-registry groups integrations per target product not per module type. It's opposite to the beats project,
+// where logs and metrics are distributed with different beats (oriented either on logs or metrics - metricbeat,
+// filebeat, etc.).
 func build(beatsDir, outputDir string) error {
 	packages := packageMap{}
 

--- a/dev/import-beats/main.go
+++ b/dev/import-beats/main.go
@@ -1,0 +1,51 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package main
+
+import (
+	"flag"
+	"log"
+
+	"github.com/pkg/errors"
+)
+
+func main() {
+	// Beats repository directory
+	var beatsDir string
+	// Target public directory where the generated packages should end up in
+	var publicDir string
+
+	flag.StringVar(&beatsDir, "beatsDir", "", "Path to the beats repository")
+	flag.StringVar(&publicDir, "publicDir", "", "Path to the public directory ")
+	flag.Parse()
+
+	if beatsDir == "" || publicDir == "" {
+		log.Fatal("beatsDir and publicDir must be set")
+	}
+
+	if err := build(beatsDir, publicDir); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func build(beatsDir, publicDir string) error {
+	packages := packageMap{}
+
+	for _, beatName := range logSources {
+		err := packages.loadFromSource(beatsDir, beatName, "logs")
+		if err != nil {
+			return errors.Wrap(err, "loading logs source failed")
+		}
+	}
+
+	for _, beatName := range metricSources {
+		err := packages.loadFromSource(beatsDir, beatName, "metrics")
+		if err != nil {
+			return errors.Wrap(err, "loading metrics source failed")
+		}
+	}
+
+	return packages.writePackages(publicDir)
+}

--- a/dev/import-beats/packages.go
+++ b/dev/import-beats/packages.go
@@ -1,0 +1,73 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package main
+
+import (
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v2"
+
+	"github.com/elastic/package-registry/util"
+)
+
+type packageMap map[string]*util.Package
+
+func (p packageMap) loadFromSource(beatsDir, beatName, packageType string) error {
+	path := filepath.Join(beatsDir, beatName, "module")
+	moduleDirs, err := ioutil.ReadDir(path)
+	if err != nil {
+		return errors.Wrapf(err, "cannot read directory '%s'", path)
+	}
+
+	for _, moduleDir := range moduleDirs {
+		if !moduleDir.IsDir() {
+			continue
+		}
+
+		log.Printf("Visit '%s:%s'\n", beatName, moduleDir.Name())
+
+		_, ok := p[moduleDir.Name()]
+		if !ok {
+			p[moduleDir.Name()] = &util.Package{
+				FormatVersion: "1.0.0",
+				Name:          moduleDir.Name(),
+				Version:       "0.0.1", // TODO
+				Type:          "integration",
+				Categories:    []string{},
+			}
+		}
+
+		p[moduleDir.Name()].Categories = append(p[moduleDir.Name()].Categories, packageType)
+	}
+	return nil
+}
+
+func (p packageMap) writePackages(publicDir string) error {
+	for name, content := range p {
+		log.Printf("Writing package '%s' (version: %s)\n", name, content.Version)
+
+		path := filepath.Join(publicDir, name+"-"+content.Version)
+		err := os.MkdirAll(path, 0755)
+		if err != nil {
+			return errors.Wrapf(err, "cannot make directory '%s'", path)
+		}
+
+		m, err := yaml.Marshal(content)
+		if err != nil {
+			return errors.Wrapf(err, "marshaling package content failed (package name: %s)", name)
+		}
+
+		manifestFilePath := filepath.Join(path, "manifest.yml")
+		err = ioutil.WriteFile(manifestFilePath, m, 0644)
+		if err != nil {
+			return errors.Wrapf(err, "writing manifest file failed (path: %s)", manifestFilePath)
+		}
+	}
+	return nil
+}

--- a/dev/import-beats/packages.go
+++ b/dev/import-beats/packages.go
@@ -48,11 +48,11 @@ func (p packageMap) loadFromSource(beatsDir, beatName, packageType string) error
 	return nil
 }
 
-func (p packageMap) writePackages(publicDir string) error {
+func (p packageMap) writePackages(outputDir string) error {
 	for name, content := range p {
 		log.Printf("Writing package '%s' (version: %s)\n", name, content.Version)
 
-		path := filepath.Join(publicDir, name+"-"+content.Version)
+		path := filepath.Join(outputDir, name+"-"+content.Version)
 		err := os.MkdirAll(path, 0755)
 		if err != nil {
 			return errors.Wrapf(err, "cannot make directory '%s'", path)

--- a/dev/import-beats/sources.go
+++ b/dev/import-beats/sources.go
@@ -1,0 +1,15 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package main
+
+var metricSources = []string{
+	"metricbeat",
+	"x-pack/metricbeat",
+}
+
+var logSources = []string{
+	"filebeat",
+	"x-pack/filebeat",
+}

--- a/dev/package-beats/activemq-0.0.1/manifest.yml
+++ b/dev/package-beats/activemq-0.0.1/manifest.yml
@@ -1,0 +1,13 @@
+format_version: 1.0.0
+name: activemq
+version: 0.0.1
+description: ""
+type: integration
+categories:
+- logs
+- metrics
+requirement:
+  kibana:
+    versions: ""
+download: ""
+path: ""

--- a/dev/package-beats/activemq-0.0.1/manifest.yml
+++ b/dev/package-beats/activemq-0.0.1/manifest.yml
@@ -9,5 +9,3 @@ categories:
 requirement:
   kibana:
     versions: ""
-download: ""
-path: ""

--- a/dev/package-beats/aerospike-0.0.1/manifest.yml
+++ b/dev/package-beats/aerospike-0.0.1/manifest.yml
@@ -8,5 +8,3 @@ categories:
 requirement:
   kibana:
     versions: ""
-download: ""
-path: ""

--- a/dev/package-beats/aerospike-0.0.1/manifest.yml
+++ b/dev/package-beats/aerospike-0.0.1/manifest.yml
@@ -1,0 +1,12 @@
+format_version: 1.0.0
+name: aerospike
+version: 0.0.1
+description: ""
+type: integration
+categories:
+- metrics
+requirement:
+  kibana:
+    versions: ""
+download: ""
+path: ""

--- a/dev/package-beats/apache-0.0.1/manifest.yml
+++ b/dev/package-beats/apache-0.0.1/manifest.yml
@@ -1,0 +1,13 @@
+format_version: 1.0.0
+name: apache
+version: 0.0.1
+description: ""
+type: integration
+categories:
+- logs
+- metrics
+requirement:
+  kibana:
+    versions: ""
+download: ""
+path: ""

--- a/dev/package-beats/apache-0.0.1/manifest.yml
+++ b/dev/package-beats/apache-0.0.1/manifest.yml
@@ -9,5 +9,3 @@ categories:
 requirement:
   kibana:
     versions: ""
-download: ""
-path: ""

--- a/dev/package-beats/apache2-0.0.1/manifest.yml
+++ b/dev/package-beats/apache2-0.0.1/manifest.yml
@@ -1,0 +1,12 @@
+format_version: 1.0.0
+name: apache2
+version: 0.0.1
+description: ""
+type: integration
+categories:
+- logs
+requirement:
+  kibana:
+    versions: ""
+download: ""
+path: ""

--- a/dev/package-beats/apache2-0.0.1/manifest.yml
+++ b/dev/package-beats/apache2-0.0.1/manifest.yml
@@ -8,5 +8,3 @@ categories:
 requirement:
   kibana:
     versions: ""
-download: ""
-path: ""

--- a/dev/package-beats/appsearch-0.0.1/manifest.yml
+++ b/dev/package-beats/appsearch-0.0.1/manifest.yml
@@ -8,5 +8,3 @@ categories:
 requirement:
   kibana:
     versions: ""
-download: ""
-path: ""

--- a/dev/package-beats/appsearch-0.0.1/manifest.yml
+++ b/dev/package-beats/appsearch-0.0.1/manifest.yml
@@ -1,0 +1,12 @@
+format_version: 1.0.0
+name: appsearch
+version: 0.0.1
+description: ""
+type: integration
+categories:
+- metrics
+requirement:
+  kibana:
+    versions: ""
+download: ""
+path: ""

--- a/dev/package-beats/auditd-0.0.1/manifest.yml
+++ b/dev/package-beats/auditd-0.0.1/manifest.yml
@@ -8,5 +8,3 @@ categories:
 requirement:
   kibana:
     versions: ""
-download: ""
-path: ""

--- a/dev/package-beats/auditd-0.0.1/manifest.yml
+++ b/dev/package-beats/auditd-0.0.1/manifest.yml
@@ -1,0 +1,12 @@
+format_version: 1.0.0
+name: auditd
+version: 0.0.1
+description: ""
+type: integration
+categories:
+- logs
+requirement:
+  kibana:
+    versions: ""
+download: ""
+path: ""

--- a/dev/package-beats/aws-0.0.1/manifest.yml
+++ b/dev/package-beats/aws-0.0.1/manifest.yml
@@ -1,0 +1,13 @@
+format_version: 1.0.0
+name: aws
+version: 0.0.1
+description: ""
+type: integration
+categories:
+- logs
+- metrics
+requirement:
+  kibana:
+    versions: ""
+download: ""
+path: ""

--- a/dev/package-beats/aws-0.0.1/manifest.yml
+++ b/dev/package-beats/aws-0.0.1/manifest.yml
@@ -9,5 +9,3 @@ categories:
 requirement:
   kibana:
     versions: ""
-download: ""
-path: ""

--- a/dev/package-beats/azure-0.0.1/manifest.yml
+++ b/dev/package-beats/azure-0.0.1/manifest.yml
@@ -1,0 +1,13 @@
+format_version: 1.0.0
+name: azure
+version: 0.0.1
+description: ""
+type: integration
+categories:
+- logs
+- metrics
+requirement:
+  kibana:
+    versions: ""
+download: ""
+path: ""

--- a/dev/package-beats/azure-0.0.1/manifest.yml
+++ b/dev/package-beats/azure-0.0.1/manifest.yml
@@ -9,5 +9,3 @@ categories:
 requirement:
   kibana:
     versions: ""
-download: ""
-path: ""

--- a/dev/package-beats/beat-0.0.1/manifest.yml
+++ b/dev/package-beats/beat-0.0.1/manifest.yml
@@ -8,5 +8,3 @@ categories:
 requirement:
   kibana:
     versions: ""
-download: ""
-path: ""

--- a/dev/package-beats/beat-0.0.1/manifest.yml
+++ b/dev/package-beats/beat-0.0.1/manifest.yml
@@ -1,0 +1,12 @@
+format_version: 1.0.0
+name: beat
+version: 0.0.1
+description: ""
+type: integration
+categories:
+- metrics
+requirement:
+  kibana:
+    versions: ""
+download: ""
+path: ""

--- a/dev/package-beats/cef-0.0.1/manifest.yml
+++ b/dev/package-beats/cef-0.0.1/manifest.yml
@@ -8,5 +8,3 @@ categories:
 requirement:
   kibana:
     versions: ""
-download: ""
-path: ""

--- a/dev/package-beats/cef-0.0.1/manifest.yml
+++ b/dev/package-beats/cef-0.0.1/manifest.yml
@@ -1,0 +1,12 @@
+format_version: 1.0.0
+name: cef
+version: 0.0.1
+description: ""
+type: integration
+categories:
+- logs
+requirement:
+  kibana:
+    versions: ""
+download: ""
+path: ""

--- a/dev/package-beats/ceph-0.0.1/manifest.yml
+++ b/dev/package-beats/ceph-0.0.1/manifest.yml
@@ -8,5 +8,3 @@ categories:
 requirement:
   kibana:
     versions: ""
-download: ""
-path: ""

--- a/dev/package-beats/ceph-0.0.1/manifest.yml
+++ b/dev/package-beats/ceph-0.0.1/manifest.yml
@@ -1,0 +1,12 @@
+format_version: 1.0.0
+name: ceph
+version: 0.0.1
+description: ""
+type: integration
+categories:
+- metrics
+requirement:
+  kibana:
+    versions: ""
+download: ""
+path: ""

--- a/dev/package-beats/cisco-0.0.1/manifest.yml
+++ b/dev/package-beats/cisco-0.0.1/manifest.yml
@@ -8,5 +8,3 @@ categories:
 requirement:
   kibana:
     versions: ""
-download: ""
-path: ""

--- a/dev/package-beats/cisco-0.0.1/manifest.yml
+++ b/dev/package-beats/cisco-0.0.1/manifest.yml
@@ -1,0 +1,12 @@
+format_version: 1.0.0
+name: cisco
+version: 0.0.1
+description: ""
+type: integration
+categories:
+- logs
+requirement:
+  kibana:
+    versions: ""
+download: ""
+path: ""

--- a/dev/package-beats/cloudfoundry-0.0.1/manifest.yml
+++ b/dev/package-beats/cloudfoundry-0.0.1/manifest.yml
@@ -1,0 +1,12 @@
+format_version: 1.0.0
+name: cloudfoundry
+version: 0.0.1
+description: ""
+type: integration
+categories:
+- metrics
+requirement:
+  kibana:
+    versions: ""
+download: ""
+path: ""

--- a/dev/package-beats/cloudfoundry-0.0.1/manifest.yml
+++ b/dev/package-beats/cloudfoundry-0.0.1/manifest.yml
@@ -8,5 +8,3 @@ categories:
 requirement:
   kibana:
     versions: ""
-download: ""
-path: ""

--- a/dev/package-beats/cockroachdb-0.0.1/manifest.yml
+++ b/dev/package-beats/cockroachdb-0.0.1/manifest.yml
@@ -1,0 +1,12 @@
+format_version: 1.0.0
+name: cockroachdb
+version: 0.0.1
+description: ""
+type: integration
+categories:
+- metrics
+requirement:
+  kibana:
+    versions: ""
+download: ""
+path: ""

--- a/dev/package-beats/cockroachdb-0.0.1/manifest.yml
+++ b/dev/package-beats/cockroachdb-0.0.1/manifest.yml
@@ -8,5 +8,3 @@ categories:
 requirement:
   kibana:
     versions: ""
-download: ""
-path: ""

--- a/dev/package-beats/consul-0.0.1/manifest.yml
+++ b/dev/package-beats/consul-0.0.1/manifest.yml
@@ -1,0 +1,12 @@
+format_version: 1.0.0
+name: consul
+version: 0.0.1
+description: ""
+type: integration
+categories:
+- metrics
+requirement:
+  kibana:
+    versions: ""
+download: ""
+path: ""

--- a/dev/package-beats/consul-0.0.1/manifest.yml
+++ b/dev/package-beats/consul-0.0.1/manifest.yml
@@ -8,5 +8,3 @@ categories:
 requirement:
   kibana:
     versions: ""
-download: ""
-path: ""

--- a/dev/package-beats/coredns-0.0.1/manifest.yml
+++ b/dev/package-beats/coredns-0.0.1/manifest.yml
@@ -1,0 +1,13 @@
+format_version: 1.0.0
+name: coredns
+version: 0.0.1
+description: ""
+type: integration
+categories:
+- logs
+- metrics
+requirement:
+  kibana:
+    versions: ""
+download: ""
+path: ""

--- a/dev/package-beats/coredns-0.0.1/manifest.yml
+++ b/dev/package-beats/coredns-0.0.1/manifest.yml
@@ -9,5 +9,3 @@ categories:
 requirement:
   kibana:
     versions: ""
-download: ""
-path: ""

--- a/dev/package-beats/couchbase-0.0.1/manifest.yml
+++ b/dev/package-beats/couchbase-0.0.1/manifest.yml
@@ -8,5 +8,3 @@ categories:
 requirement:
   kibana:
     versions: ""
-download: ""
-path: ""

--- a/dev/package-beats/couchbase-0.0.1/manifest.yml
+++ b/dev/package-beats/couchbase-0.0.1/manifest.yml
@@ -1,0 +1,12 @@
+format_version: 1.0.0
+name: couchbase
+version: 0.0.1
+description: ""
+type: integration
+categories:
+- metrics
+requirement:
+  kibana:
+    versions: ""
+download: ""
+path: ""

--- a/dev/package-beats/couchdb-0.0.1/manifest.yml
+++ b/dev/package-beats/couchdb-0.0.1/manifest.yml
@@ -8,5 +8,3 @@ categories:
 requirement:
   kibana:
     versions: ""
-download: ""
-path: ""

--- a/dev/package-beats/couchdb-0.0.1/manifest.yml
+++ b/dev/package-beats/couchdb-0.0.1/manifest.yml
@@ -1,0 +1,12 @@
+format_version: 1.0.0
+name: couchdb
+version: 0.0.1
+description: ""
+type: integration
+categories:
+- metrics
+requirement:
+  kibana:
+    versions: ""
+download: ""
+path: ""

--- a/dev/package-beats/docker-0.0.1/manifest.yml
+++ b/dev/package-beats/docker-0.0.1/manifest.yml
@@ -1,0 +1,12 @@
+format_version: 1.0.0
+name: docker
+version: 0.0.1
+description: ""
+type: integration
+categories:
+- metrics
+requirement:
+  kibana:
+    versions: ""
+download: ""
+path: ""

--- a/dev/package-beats/docker-0.0.1/manifest.yml
+++ b/dev/package-beats/docker-0.0.1/manifest.yml
@@ -8,5 +8,3 @@ categories:
 requirement:
   kibana:
     versions: ""
-download: ""
-path: ""

--- a/dev/package-beats/dropwizard-0.0.1/manifest.yml
+++ b/dev/package-beats/dropwizard-0.0.1/manifest.yml
@@ -8,5 +8,3 @@ categories:
 requirement:
   kibana:
     versions: ""
-download: ""
-path: ""

--- a/dev/package-beats/dropwizard-0.0.1/manifest.yml
+++ b/dev/package-beats/dropwizard-0.0.1/manifest.yml
@@ -1,0 +1,12 @@
+format_version: 1.0.0
+name: dropwizard
+version: 0.0.1
+description: ""
+type: integration
+categories:
+- metrics
+requirement:
+  kibana:
+    versions: ""
+download: ""
+path: ""

--- a/dev/package-beats/elasticsearch-0.0.1/manifest.yml
+++ b/dev/package-beats/elasticsearch-0.0.1/manifest.yml
@@ -1,0 +1,13 @@
+format_version: 1.0.0
+name: elasticsearch
+version: 0.0.1
+description: ""
+type: integration
+categories:
+- logs
+- metrics
+requirement:
+  kibana:
+    versions: ""
+download: ""
+path: ""

--- a/dev/package-beats/elasticsearch-0.0.1/manifest.yml
+++ b/dev/package-beats/elasticsearch-0.0.1/manifest.yml
@@ -9,5 +9,3 @@ categories:
 requirement:
   kibana:
     versions: ""
-download: ""
-path: ""

--- a/dev/package-beats/envoyproxy-0.0.1/manifest.yml
+++ b/dev/package-beats/envoyproxy-0.0.1/manifest.yml
@@ -1,0 +1,13 @@
+format_version: 1.0.0
+name: envoyproxy
+version: 0.0.1
+description: ""
+type: integration
+categories:
+- logs
+- metrics
+requirement:
+  kibana:
+    versions: ""
+download: ""
+path: ""

--- a/dev/package-beats/envoyproxy-0.0.1/manifest.yml
+++ b/dev/package-beats/envoyproxy-0.0.1/manifest.yml
@@ -9,5 +9,3 @@ categories:
 requirement:
   kibana:
     versions: ""
-download: ""
-path: ""

--- a/dev/package-beats/etcd-0.0.1/manifest.yml
+++ b/dev/package-beats/etcd-0.0.1/manifest.yml
@@ -8,5 +8,3 @@ categories:
 requirement:
   kibana:
     versions: ""
-download: ""
-path: ""

--- a/dev/package-beats/etcd-0.0.1/manifest.yml
+++ b/dev/package-beats/etcd-0.0.1/manifest.yml
@@ -1,0 +1,12 @@
+format_version: 1.0.0
+name: etcd
+version: 0.0.1
+description: ""
+type: integration
+categories:
+- metrics
+requirement:
+  kibana:
+    versions: ""
+download: ""
+path: ""

--- a/dev/package-beats/golang-0.0.1/manifest.yml
+++ b/dev/package-beats/golang-0.0.1/manifest.yml
@@ -8,5 +8,3 @@ categories:
 requirement:
   kibana:
     versions: ""
-download: ""
-path: ""

--- a/dev/package-beats/golang-0.0.1/manifest.yml
+++ b/dev/package-beats/golang-0.0.1/manifest.yml
@@ -1,0 +1,12 @@
+format_version: 1.0.0
+name: golang
+version: 0.0.1
+description: ""
+type: integration
+categories:
+- metrics
+requirement:
+  kibana:
+    versions: ""
+download: ""
+path: ""

--- a/dev/package-beats/googlecloud-0.0.1/manifest.yml
+++ b/dev/package-beats/googlecloud-0.0.1/manifest.yml
@@ -9,5 +9,3 @@ categories:
 requirement:
   kibana:
     versions: ""
-download: ""
-path: ""

--- a/dev/package-beats/googlecloud-0.0.1/manifest.yml
+++ b/dev/package-beats/googlecloud-0.0.1/manifest.yml
@@ -1,0 +1,13 @@
+format_version: 1.0.0
+name: googlecloud
+version: 0.0.1
+description: ""
+type: integration
+categories:
+- logs
+- metrics
+requirement:
+  kibana:
+    versions: ""
+download: ""
+path: ""

--- a/dev/package-beats/graphite-0.0.1/manifest.yml
+++ b/dev/package-beats/graphite-0.0.1/manifest.yml
@@ -8,5 +8,3 @@ categories:
 requirement:
   kibana:
     versions: ""
-download: ""
-path: ""

--- a/dev/package-beats/graphite-0.0.1/manifest.yml
+++ b/dev/package-beats/graphite-0.0.1/manifest.yml
@@ -1,0 +1,12 @@
+format_version: 1.0.0
+name: graphite
+version: 0.0.1
+description: ""
+type: integration
+categories:
+- metrics
+requirement:
+  kibana:
+    versions: ""
+download: ""
+path: ""

--- a/dev/package-beats/haproxy-0.0.1/manifest.yml
+++ b/dev/package-beats/haproxy-0.0.1/manifest.yml
@@ -1,0 +1,13 @@
+format_version: 1.0.0
+name: haproxy
+version: 0.0.1
+description: ""
+type: integration
+categories:
+- logs
+- metrics
+requirement:
+  kibana:
+    versions: ""
+download: ""
+path: ""

--- a/dev/package-beats/haproxy-0.0.1/manifest.yml
+++ b/dev/package-beats/haproxy-0.0.1/manifest.yml
@@ -9,5 +9,3 @@ categories:
 requirement:
   kibana:
     versions: ""
-download: ""
-path: ""

--- a/dev/package-beats/http-0.0.1/manifest.yml
+++ b/dev/package-beats/http-0.0.1/manifest.yml
@@ -8,5 +8,3 @@ categories:
 requirement:
   kibana:
     versions: ""
-download: ""
-path: ""

--- a/dev/package-beats/http-0.0.1/manifest.yml
+++ b/dev/package-beats/http-0.0.1/manifest.yml
@@ -1,0 +1,12 @@
+format_version: 1.0.0
+name: http
+version: 0.0.1
+description: ""
+type: integration
+categories:
+- metrics
+requirement:
+  kibana:
+    versions: ""
+download: ""
+path: ""

--- a/dev/package-beats/ibmmq-0.0.1/manifest.yml
+++ b/dev/package-beats/ibmmq-0.0.1/manifest.yml
@@ -1,0 +1,13 @@
+format_version: 1.0.0
+name: ibmmq
+version: 0.0.1
+description: ""
+type: integration
+categories:
+- logs
+- metrics
+requirement:
+  kibana:
+    versions: ""
+download: ""
+path: ""

--- a/dev/package-beats/ibmmq-0.0.1/manifest.yml
+++ b/dev/package-beats/ibmmq-0.0.1/manifest.yml
@@ -9,5 +9,3 @@ categories:
 requirement:
   kibana:
     versions: ""
-download: ""
-path: ""

--- a/dev/package-beats/icinga-0.0.1/manifest.yml
+++ b/dev/package-beats/icinga-0.0.1/manifest.yml
@@ -8,5 +8,3 @@ categories:
 requirement:
   kibana:
     versions: ""
-download: ""
-path: ""

--- a/dev/package-beats/icinga-0.0.1/manifest.yml
+++ b/dev/package-beats/icinga-0.0.1/manifest.yml
@@ -1,0 +1,12 @@
+format_version: 1.0.0
+name: icinga
+version: 0.0.1
+description: ""
+type: integration
+categories:
+- logs
+requirement:
+  kibana:
+    versions: ""
+download: ""
+path: ""

--- a/dev/package-beats/iis-0.0.1/manifest.yml
+++ b/dev/package-beats/iis-0.0.1/manifest.yml
@@ -1,0 +1,13 @@
+format_version: 1.0.0
+name: iis
+version: 0.0.1
+description: ""
+type: integration
+categories:
+- logs
+- metrics
+requirement:
+  kibana:
+    versions: ""
+download: ""
+path: ""

--- a/dev/package-beats/iis-0.0.1/manifest.yml
+++ b/dev/package-beats/iis-0.0.1/manifest.yml
@@ -9,5 +9,3 @@ categories:
 requirement:
   kibana:
     versions: ""
-download: ""
-path: ""

--- a/dev/package-beats/iptables-0.0.1/manifest.yml
+++ b/dev/package-beats/iptables-0.0.1/manifest.yml
@@ -8,5 +8,3 @@ categories:
 requirement:
   kibana:
     versions: ""
-download: ""
-path: ""

--- a/dev/package-beats/iptables-0.0.1/manifest.yml
+++ b/dev/package-beats/iptables-0.0.1/manifest.yml
@@ -1,0 +1,12 @@
+format_version: 1.0.0
+name: iptables
+version: 0.0.1
+description: ""
+type: integration
+categories:
+- logs
+requirement:
+  kibana:
+    versions: ""
+download: ""
+path: ""

--- a/dev/package-beats/istio-0.0.1/manifest.yml
+++ b/dev/package-beats/istio-0.0.1/manifest.yml
@@ -8,5 +8,3 @@ categories:
 requirement:
   kibana:
     versions: ""
-download: ""
-path: ""

--- a/dev/package-beats/istio-0.0.1/manifest.yml
+++ b/dev/package-beats/istio-0.0.1/manifest.yml
@@ -1,0 +1,12 @@
+format_version: 1.0.0
+name: istio
+version: 0.0.1
+description: ""
+type: integration
+categories:
+- metrics
+requirement:
+  kibana:
+    versions: ""
+download: ""
+path: ""

--- a/dev/package-beats/jolokia-0.0.1/manifest.yml
+++ b/dev/package-beats/jolokia-0.0.1/manifest.yml
@@ -8,5 +8,3 @@ categories:
 requirement:
   kibana:
     versions: ""
-download: ""
-path: ""

--- a/dev/package-beats/jolokia-0.0.1/manifest.yml
+++ b/dev/package-beats/jolokia-0.0.1/manifest.yml
@@ -1,0 +1,12 @@
+format_version: 1.0.0
+name: jolokia
+version: 0.0.1
+description: ""
+type: integration
+categories:
+- metrics
+requirement:
+  kibana:
+    versions: ""
+download: ""
+path: ""

--- a/dev/package-beats/kafka-0.0.1/manifest.yml
+++ b/dev/package-beats/kafka-0.0.1/manifest.yml
@@ -9,5 +9,3 @@ categories:
 requirement:
   kibana:
     versions: ""
-download: ""
-path: ""

--- a/dev/package-beats/kafka-0.0.1/manifest.yml
+++ b/dev/package-beats/kafka-0.0.1/manifest.yml
@@ -1,0 +1,13 @@
+format_version: 1.0.0
+name: kafka
+version: 0.0.1
+description: ""
+type: integration
+categories:
+- logs
+- metrics
+requirement:
+  kibana:
+    versions: ""
+download: ""
+path: ""

--- a/dev/package-beats/kibana-0.0.1/manifest.yml
+++ b/dev/package-beats/kibana-0.0.1/manifest.yml
@@ -1,0 +1,13 @@
+format_version: 1.0.0
+name: kibana
+version: 0.0.1
+description: ""
+type: integration
+categories:
+- logs
+- metrics
+requirement:
+  kibana:
+    versions: ""
+download: ""
+path: ""

--- a/dev/package-beats/kibana-0.0.1/manifest.yml
+++ b/dev/package-beats/kibana-0.0.1/manifest.yml
@@ -9,5 +9,3 @@ categories:
 requirement:
   kibana:
     versions: ""
-download: ""
-path: ""

--- a/dev/package-beats/kubernetes-0.0.1/manifest.yml
+++ b/dev/package-beats/kubernetes-0.0.1/manifest.yml
@@ -8,5 +8,3 @@ categories:
 requirement:
   kibana:
     versions: ""
-download: ""
-path: ""

--- a/dev/package-beats/kubernetes-0.0.1/manifest.yml
+++ b/dev/package-beats/kubernetes-0.0.1/manifest.yml
@@ -1,0 +1,12 @@
+format_version: 1.0.0
+name: kubernetes
+version: 0.0.1
+description: ""
+type: integration
+categories:
+- metrics
+requirement:
+  kibana:
+    versions: ""
+download: ""
+path: ""

--- a/dev/package-beats/kvm-0.0.1/manifest.yml
+++ b/dev/package-beats/kvm-0.0.1/manifest.yml
@@ -8,5 +8,3 @@ categories:
 requirement:
   kibana:
     versions: ""
-download: ""
-path: ""

--- a/dev/package-beats/kvm-0.0.1/manifest.yml
+++ b/dev/package-beats/kvm-0.0.1/manifest.yml
@@ -1,0 +1,12 @@
+format_version: 1.0.0
+name: kvm
+version: 0.0.1
+description: ""
+type: integration
+categories:
+- metrics
+requirement:
+  kibana:
+    versions: ""
+download: ""
+path: ""

--- a/dev/package-beats/logstash-0.0.1/manifest.yml
+++ b/dev/package-beats/logstash-0.0.1/manifest.yml
@@ -1,0 +1,13 @@
+format_version: 1.0.0
+name: logstash
+version: 0.0.1
+description: ""
+type: integration
+categories:
+- logs
+- metrics
+requirement:
+  kibana:
+    versions: ""
+download: ""
+path: ""

--- a/dev/package-beats/logstash-0.0.1/manifest.yml
+++ b/dev/package-beats/logstash-0.0.1/manifest.yml
@@ -9,5 +9,3 @@ categories:
 requirement:
   kibana:
     versions: ""
-download: ""
-path: ""

--- a/dev/package-beats/memcached-0.0.1/manifest.yml
+++ b/dev/package-beats/memcached-0.0.1/manifest.yml
@@ -8,5 +8,3 @@ categories:
 requirement:
   kibana:
     versions: ""
-download: ""
-path: ""

--- a/dev/package-beats/memcached-0.0.1/manifest.yml
+++ b/dev/package-beats/memcached-0.0.1/manifest.yml
@@ -1,0 +1,12 @@
+format_version: 1.0.0
+name: memcached
+version: 0.0.1
+description: ""
+type: integration
+categories:
+- metrics
+requirement:
+  kibana:
+    versions: ""
+download: ""
+path: ""

--- a/dev/package-beats/misp-0.0.1/manifest.yml
+++ b/dev/package-beats/misp-0.0.1/manifest.yml
@@ -8,5 +8,3 @@ categories:
 requirement:
   kibana:
     versions: ""
-download: ""
-path: ""

--- a/dev/package-beats/misp-0.0.1/manifest.yml
+++ b/dev/package-beats/misp-0.0.1/manifest.yml
@@ -1,0 +1,12 @@
+format_version: 1.0.0
+name: misp
+version: 0.0.1
+description: ""
+type: integration
+categories:
+- logs
+requirement:
+  kibana:
+    versions: ""
+download: ""
+path: ""

--- a/dev/package-beats/mongodb-0.0.1/manifest.yml
+++ b/dev/package-beats/mongodb-0.0.1/manifest.yml
@@ -9,5 +9,3 @@ categories:
 requirement:
   kibana:
     versions: ""
-download: ""
-path: ""

--- a/dev/package-beats/mongodb-0.0.1/manifest.yml
+++ b/dev/package-beats/mongodb-0.0.1/manifest.yml
@@ -1,0 +1,13 @@
+format_version: 1.0.0
+name: mongodb
+version: 0.0.1
+description: ""
+type: integration
+categories:
+- logs
+- metrics
+requirement:
+  kibana:
+    versions: ""
+download: ""
+path: ""

--- a/dev/package-beats/mssql-0.0.1/manifest.yml
+++ b/dev/package-beats/mssql-0.0.1/manifest.yml
@@ -9,5 +9,3 @@ categories:
 requirement:
   kibana:
     versions: ""
-download: ""
-path: ""

--- a/dev/package-beats/mssql-0.0.1/manifest.yml
+++ b/dev/package-beats/mssql-0.0.1/manifest.yml
@@ -1,0 +1,13 @@
+format_version: 1.0.0
+name: mssql
+version: 0.0.1
+description: ""
+type: integration
+categories:
+- logs
+- metrics
+requirement:
+  kibana:
+    versions: ""
+download: ""
+path: ""

--- a/dev/package-beats/munin-0.0.1/manifest.yml
+++ b/dev/package-beats/munin-0.0.1/manifest.yml
@@ -8,5 +8,3 @@ categories:
 requirement:
   kibana:
     versions: ""
-download: ""
-path: ""

--- a/dev/package-beats/munin-0.0.1/manifest.yml
+++ b/dev/package-beats/munin-0.0.1/manifest.yml
@@ -1,0 +1,12 @@
+format_version: 1.0.0
+name: munin
+version: 0.0.1
+description: ""
+type: integration
+categories:
+- metrics
+requirement:
+  kibana:
+    versions: ""
+download: ""
+path: ""

--- a/dev/package-beats/mysql-0.0.1/manifest.yml
+++ b/dev/package-beats/mysql-0.0.1/manifest.yml
@@ -1,0 +1,13 @@
+format_version: 1.0.0
+name: mysql
+version: 0.0.1
+description: ""
+type: integration
+categories:
+- logs
+- metrics
+requirement:
+  kibana:
+    versions: ""
+download: ""
+path: ""

--- a/dev/package-beats/mysql-0.0.1/manifest.yml
+++ b/dev/package-beats/mysql-0.0.1/manifest.yml
@@ -9,5 +9,3 @@ categories:
 requirement:
   kibana:
     versions: ""
-download: ""
-path: ""

--- a/dev/package-beats/nats-0.0.1/manifest.yml
+++ b/dev/package-beats/nats-0.0.1/manifest.yml
@@ -1,0 +1,13 @@
+format_version: 1.0.0
+name: nats
+version: 0.0.1
+description: ""
+type: integration
+categories:
+- logs
+- metrics
+requirement:
+  kibana:
+    versions: ""
+download: ""
+path: ""

--- a/dev/package-beats/nats-0.0.1/manifest.yml
+++ b/dev/package-beats/nats-0.0.1/manifest.yml
@@ -9,5 +9,3 @@ categories:
 requirement:
   kibana:
     versions: ""
-download: ""
-path: ""

--- a/dev/package-beats/netflow-0.0.1/manifest.yml
+++ b/dev/package-beats/netflow-0.0.1/manifest.yml
@@ -8,5 +8,3 @@ categories:
 requirement:
   kibana:
     versions: ""
-download: ""
-path: ""

--- a/dev/package-beats/netflow-0.0.1/manifest.yml
+++ b/dev/package-beats/netflow-0.0.1/manifest.yml
@@ -1,0 +1,12 @@
+format_version: 1.0.0
+name: netflow
+version: 0.0.1
+description: ""
+type: integration
+categories:
+- logs
+requirement:
+  kibana:
+    versions: ""
+download: ""
+path: ""

--- a/dev/package-beats/nginx-0.0.1/manifest.yml
+++ b/dev/package-beats/nginx-0.0.1/manifest.yml
@@ -1,0 +1,13 @@
+format_version: 1.0.0
+name: nginx
+version: 0.0.1
+description: ""
+type: integration
+categories:
+- logs
+- metrics
+requirement:
+  kibana:
+    versions: ""
+download: ""
+path: ""

--- a/dev/package-beats/nginx-0.0.1/manifest.yml
+++ b/dev/package-beats/nginx-0.0.1/manifest.yml
@@ -9,5 +9,3 @@ categories:
 requirement:
   kibana:
     versions: ""
-download: ""
-path: ""

--- a/dev/package-beats/oracle-0.0.1/manifest.yml
+++ b/dev/package-beats/oracle-0.0.1/manifest.yml
@@ -1,0 +1,12 @@
+format_version: 1.0.0
+name: oracle
+version: 0.0.1
+description: ""
+type: integration
+categories:
+- metrics
+requirement:
+  kibana:
+    versions: ""
+download: ""
+path: ""

--- a/dev/package-beats/oracle-0.0.1/manifest.yml
+++ b/dev/package-beats/oracle-0.0.1/manifest.yml
@@ -8,5 +8,3 @@ categories:
 requirement:
   kibana:
     versions: ""
-download: ""
-path: ""

--- a/dev/package-beats/osquery-0.0.1/manifest.yml
+++ b/dev/package-beats/osquery-0.0.1/manifest.yml
@@ -8,5 +8,3 @@ categories:
 requirement:
   kibana:
     versions: ""
-download: ""
-path: ""

--- a/dev/package-beats/osquery-0.0.1/manifest.yml
+++ b/dev/package-beats/osquery-0.0.1/manifest.yml
@@ -1,0 +1,12 @@
+format_version: 1.0.0
+name: osquery
+version: 0.0.1
+description: ""
+type: integration
+categories:
+- logs
+requirement:
+  kibana:
+    versions: ""
+download: ""
+path: ""

--- a/dev/package-beats/panw-0.0.1/manifest.yml
+++ b/dev/package-beats/panw-0.0.1/manifest.yml
@@ -8,5 +8,3 @@ categories:
 requirement:
   kibana:
     versions: ""
-download: ""
-path: ""

--- a/dev/package-beats/panw-0.0.1/manifest.yml
+++ b/dev/package-beats/panw-0.0.1/manifest.yml
@@ -1,0 +1,12 @@
+format_version: 1.0.0
+name: panw
+version: 0.0.1
+description: ""
+type: integration
+categories:
+- logs
+requirement:
+  kibana:
+    versions: ""
+download: ""
+path: ""

--- a/dev/package-beats/php_fpm-0.0.1/manifest.yml
+++ b/dev/package-beats/php_fpm-0.0.1/manifest.yml
@@ -1,0 +1,12 @@
+format_version: 1.0.0
+name: php_fpm
+version: 0.0.1
+description: ""
+type: integration
+categories:
+- metrics
+requirement:
+  kibana:
+    versions: ""
+download: ""
+path: ""

--- a/dev/package-beats/php_fpm-0.0.1/manifest.yml
+++ b/dev/package-beats/php_fpm-0.0.1/manifest.yml
@@ -8,5 +8,3 @@ categories:
 requirement:
   kibana:
     versions: ""
-download: ""
-path: ""

--- a/dev/package-beats/postgresql-0.0.1/manifest.yml
+++ b/dev/package-beats/postgresql-0.0.1/manifest.yml
@@ -9,5 +9,3 @@ categories:
 requirement:
   kibana:
     versions: ""
-download: ""
-path: ""

--- a/dev/package-beats/postgresql-0.0.1/manifest.yml
+++ b/dev/package-beats/postgresql-0.0.1/manifest.yml
@@ -1,0 +1,13 @@
+format_version: 1.0.0
+name: postgresql
+version: 0.0.1
+description: ""
+type: integration
+categories:
+- logs
+- metrics
+requirement:
+  kibana:
+    versions: ""
+download: ""
+path: ""

--- a/dev/package-beats/prometheus-0.0.1/manifest.yml
+++ b/dev/package-beats/prometheus-0.0.1/manifest.yml
@@ -8,5 +8,3 @@ categories:
 requirement:
   kibana:
     versions: ""
-download: ""
-path: ""

--- a/dev/package-beats/prometheus-0.0.1/manifest.yml
+++ b/dev/package-beats/prometheus-0.0.1/manifest.yml
@@ -1,0 +1,12 @@
+format_version: 1.0.0
+name: prometheus
+version: 0.0.1
+description: ""
+type: integration
+categories:
+- metrics
+requirement:
+  kibana:
+    versions: ""
+download: ""
+path: ""

--- a/dev/package-beats/rabbitmq-0.0.1/manifest.yml
+++ b/dev/package-beats/rabbitmq-0.0.1/manifest.yml
@@ -1,0 +1,13 @@
+format_version: 1.0.0
+name: rabbitmq
+version: 0.0.1
+description: ""
+type: integration
+categories:
+- logs
+- metrics
+requirement:
+  kibana:
+    versions: ""
+download: ""
+path: ""

--- a/dev/package-beats/rabbitmq-0.0.1/manifest.yml
+++ b/dev/package-beats/rabbitmq-0.0.1/manifest.yml
@@ -9,5 +9,3 @@ categories:
 requirement:
   kibana:
     versions: ""
-download: ""
-path: ""

--- a/dev/package-beats/redis-0.0.1/manifest.yml
+++ b/dev/package-beats/redis-0.0.1/manifest.yml
@@ -1,0 +1,13 @@
+format_version: 1.0.0
+name: redis
+version: 0.0.1
+description: ""
+type: integration
+categories:
+- logs
+- metrics
+requirement:
+  kibana:
+    versions: ""
+download: ""
+path: ""

--- a/dev/package-beats/redis-0.0.1/manifest.yml
+++ b/dev/package-beats/redis-0.0.1/manifest.yml
@@ -9,5 +9,3 @@ categories:
 requirement:
   kibana:
     versions: ""
-download: ""
-path: ""

--- a/dev/package-beats/redisenterprise-0.0.1/manifest.yml
+++ b/dev/package-beats/redisenterprise-0.0.1/manifest.yml
@@ -8,5 +8,3 @@ categories:
 requirement:
   kibana:
     versions: ""
-download: ""
-path: ""

--- a/dev/package-beats/redisenterprise-0.0.1/manifest.yml
+++ b/dev/package-beats/redisenterprise-0.0.1/manifest.yml
@@ -1,0 +1,12 @@
+format_version: 1.0.0
+name: redisenterprise
+version: 0.0.1
+description: ""
+type: integration
+categories:
+- metrics
+requirement:
+  kibana:
+    versions: ""
+download: ""
+path: ""

--- a/dev/package-beats/santa-0.0.1/manifest.yml
+++ b/dev/package-beats/santa-0.0.1/manifest.yml
@@ -8,5 +8,3 @@ categories:
 requirement:
   kibana:
     versions: ""
-download: ""
-path: ""

--- a/dev/package-beats/santa-0.0.1/manifest.yml
+++ b/dev/package-beats/santa-0.0.1/manifest.yml
@@ -1,0 +1,12 @@
+format_version: 1.0.0
+name: santa
+version: 0.0.1
+description: ""
+type: integration
+categories:
+- logs
+requirement:
+  kibana:
+    versions: ""
+download: ""
+path: ""

--- a/dev/package-beats/sql-0.0.1/manifest.yml
+++ b/dev/package-beats/sql-0.0.1/manifest.yml
@@ -8,5 +8,3 @@ categories:
 requirement:
   kibana:
     versions: ""
-download: ""
-path: ""

--- a/dev/package-beats/sql-0.0.1/manifest.yml
+++ b/dev/package-beats/sql-0.0.1/manifest.yml
@@ -1,0 +1,12 @@
+format_version: 1.0.0
+name: sql
+version: 0.0.1
+description: ""
+type: integration
+categories:
+- metrics
+requirement:
+  kibana:
+    versions: ""
+download: ""
+path: ""

--- a/dev/package-beats/stan-0.0.1/manifest.yml
+++ b/dev/package-beats/stan-0.0.1/manifest.yml
@@ -8,5 +8,3 @@ categories:
 requirement:
   kibana:
     versions: ""
-download: ""
-path: ""

--- a/dev/package-beats/stan-0.0.1/manifest.yml
+++ b/dev/package-beats/stan-0.0.1/manifest.yml
@@ -1,0 +1,12 @@
+format_version: 1.0.0
+name: stan
+version: 0.0.1
+description: ""
+type: integration
+categories:
+- metrics
+requirement:
+  kibana:
+    versions: ""
+download: ""
+path: ""

--- a/dev/package-beats/statsd-0.0.1/manifest.yml
+++ b/dev/package-beats/statsd-0.0.1/manifest.yml
@@ -8,5 +8,3 @@ categories:
 requirement:
   kibana:
     versions: ""
-download: ""
-path: ""

--- a/dev/package-beats/statsd-0.0.1/manifest.yml
+++ b/dev/package-beats/statsd-0.0.1/manifest.yml
@@ -1,0 +1,12 @@
+format_version: 1.0.0
+name: statsd
+version: 0.0.1
+description: ""
+type: integration
+categories:
+- metrics
+requirement:
+  kibana:
+    versions: ""
+download: ""
+path: ""

--- a/dev/package-beats/suricata-0.0.1/manifest.yml
+++ b/dev/package-beats/suricata-0.0.1/manifest.yml
@@ -8,5 +8,3 @@ categories:
 requirement:
   kibana:
     versions: ""
-download: ""
-path: ""

--- a/dev/package-beats/suricata-0.0.1/manifest.yml
+++ b/dev/package-beats/suricata-0.0.1/manifest.yml
@@ -1,0 +1,12 @@
+format_version: 1.0.0
+name: suricata
+version: 0.0.1
+description: ""
+type: integration
+categories:
+- logs
+requirement:
+  kibana:
+    versions: ""
+download: ""
+path: ""

--- a/dev/package-beats/system-0.0.1/manifest.yml
+++ b/dev/package-beats/system-0.0.1/manifest.yml
@@ -1,0 +1,13 @@
+format_version: 1.0.0
+name: system
+version: 0.0.1
+description: ""
+type: integration
+categories:
+- logs
+- metrics
+requirement:
+  kibana:
+    versions: ""
+download: ""
+path: ""

--- a/dev/package-beats/system-0.0.1/manifest.yml
+++ b/dev/package-beats/system-0.0.1/manifest.yml
@@ -9,5 +9,3 @@ categories:
 requirement:
   kibana:
     versions: ""
-download: ""
-path: ""

--- a/dev/package-beats/tomcat-0.0.1/manifest.yml
+++ b/dev/package-beats/tomcat-0.0.1/manifest.yml
@@ -8,5 +8,3 @@ categories:
 requirement:
   kibana:
     versions: ""
-download: ""
-path: ""

--- a/dev/package-beats/tomcat-0.0.1/manifest.yml
+++ b/dev/package-beats/tomcat-0.0.1/manifest.yml
@@ -1,0 +1,12 @@
+format_version: 1.0.0
+name: tomcat
+version: 0.0.1
+description: ""
+type: integration
+categories:
+- metrics
+requirement:
+  kibana:
+    versions: ""
+download: ""
+path: ""

--- a/dev/package-beats/traefik-0.0.1/manifest.yml
+++ b/dev/package-beats/traefik-0.0.1/manifest.yml
@@ -1,0 +1,13 @@
+format_version: 1.0.0
+name: traefik
+version: 0.0.1
+description: ""
+type: integration
+categories:
+- logs
+- metrics
+requirement:
+  kibana:
+    versions: ""
+download: ""
+path: ""

--- a/dev/package-beats/traefik-0.0.1/manifest.yml
+++ b/dev/package-beats/traefik-0.0.1/manifest.yml
@@ -9,5 +9,3 @@ categories:
 requirement:
   kibana:
     versions: ""
-download: ""
-path: ""

--- a/dev/package-beats/uwsgi-0.0.1/manifest.yml
+++ b/dev/package-beats/uwsgi-0.0.1/manifest.yml
@@ -1,0 +1,12 @@
+format_version: 1.0.0
+name: uwsgi
+version: 0.0.1
+description: ""
+type: integration
+categories:
+- metrics
+requirement:
+  kibana:
+    versions: ""
+download: ""
+path: ""

--- a/dev/package-beats/uwsgi-0.0.1/manifest.yml
+++ b/dev/package-beats/uwsgi-0.0.1/manifest.yml
@@ -8,5 +8,3 @@ categories:
 requirement:
   kibana:
     versions: ""
-download: ""
-path: ""

--- a/dev/package-beats/vsphere-0.0.1/manifest.yml
+++ b/dev/package-beats/vsphere-0.0.1/manifest.yml
@@ -8,5 +8,3 @@ categories:
 requirement:
   kibana:
     versions: ""
-download: ""
-path: ""

--- a/dev/package-beats/vsphere-0.0.1/manifest.yml
+++ b/dev/package-beats/vsphere-0.0.1/manifest.yml
@@ -1,0 +1,12 @@
+format_version: 1.0.0
+name: vsphere
+version: 0.0.1
+description: ""
+type: integration
+categories:
+- metrics
+requirement:
+  kibana:
+    versions: ""
+download: ""
+path: ""

--- a/dev/package-beats/windows-0.0.1/manifest.yml
+++ b/dev/package-beats/windows-0.0.1/manifest.yml
@@ -8,5 +8,3 @@ categories:
 requirement:
   kibana:
     versions: ""
-download: ""
-path: ""

--- a/dev/package-beats/windows-0.0.1/manifest.yml
+++ b/dev/package-beats/windows-0.0.1/manifest.yml
@@ -1,0 +1,12 @@
+format_version: 1.0.0
+name: windows
+version: 0.0.1
+description: ""
+type: integration
+categories:
+- metrics
+requirement:
+  kibana:
+    versions: ""
+download: ""
+path: ""

--- a/dev/package-beats/zeek-0.0.1/manifest.yml
+++ b/dev/package-beats/zeek-0.0.1/manifest.yml
@@ -1,0 +1,12 @@
+format_version: 1.0.0
+name: zeek
+version: 0.0.1
+description: ""
+type: integration
+categories:
+- logs
+requirement:
+  kibana:
+    versions: ""
+download: ""
+path: ""

--- a/dev/package-beats/zeek-0.0.1/manifest.yml
+++ b/dev/package-beats/zeek-0.0.1/manifest.yml
@@ -8,5 +8,3 @@ categories:
 requirement:
   kibana:
     versions: ""
-download: ""
-path: ""

--- a/dev/package-beats/zookeeper-0.0.1/manifest.yml
+++ b/dev/package-beats/zookeeper-0.0.1/manifest.yml
@@ -1,0 +1,12 @@
+format_version: 1.0.0
+name: zookeeper
+version: 0.0.1
+description: ""
+type: integration
+categories:
+- metrics
+requirement:
+  kibana:
+    versions: ""
+download: ""
+path: ""

--- a/dev/package-beats/zookeeper-0.0.1/manifest.yml
+++ b/dev/package-beats/zookeeper-0.0.1/manifest.yml
@@ -8,5 +8,3 @@ categories:
 requirement:
   kibana:
     versions: ""
-download: ""
-path: ""

--- a/docs/api/package.json
+++ b/docs/api/package.json
@@ -1,4 +1,5 @@
 {
+  "format_version": "1.0.0",
   "name": "example",
   "title": "Example Integration",
   "version": "1.0.0",
@@ -47,7 +48,6 @@
     "/package/example-1.0.0/dataset/foo/elasticsearch/ingest-pipeline/pipeline-plaintext.json",
     "/package/example-1.0.0/dataset/foo/elasticsearch/ingest-pipeline/pipeline-tcp.json"
   ],
-  "format_version": "1.0.0",
   "datasets": [
     {
       "title": "Foo",

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/elastic/go-ucfg v0.7.0
 	github.com/gorilla/mux v1.7.2
 	github.com/jstemmer/go-junit-report v0.9.1 // indirect
-	github.com/magefile/mage v1.8.0
+	github.com/magefile/mage v1.9.0
 	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.4.0
 	gopkg.in/yaml.v2 v2.2.2

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/jstemmer/go-junit-report v0.9.1 h1:6QPYqodiu3GuPL+7mfx+NwDdp2eTkp9IfE
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/magefile/mage v1.8.0 h1:mzL+xIopvPURVBwHG9A50JcjBO+xV3b5iZ7khFRI+5E=
 github.com/magefile/mage v1.8.0/go.mod h1:IUDi13rsHje59lecXokTfGX0QIzO45uVPlXnJYsXepA=
+github.com/magefile/mage v1.9.0 h1:t3AU2wNwehMCW97vuqQLtw6puppWXHO+O2MHo5a50XE=
+github.com/magefile/mage v1.9.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/testdata/public/package/datasources-1.0.0/index.json
+++ b/testdata/public/package/datasources-1.0.0/index.json
@@ -1,4 +1,5 @@
 {
+  "format_version": "1.0.0",
   "name": "datasources",
   "title": "Default datasource Integration",
   "version": "1.0.0",
@@ -14,7 +15,6 @@
     "/package/datasources-1.0.0/manifest.yml",
     "/package/datasources-1.0.0/dataset/example/manifest.yml"
   ],
-  "format_version": "1.0.0",
   "datasets": [
     {
       "title": "Example dataset with inputs",

--- a/testdata/public/package/default-pipeline-0.0.2/index.json
+++ b/testdata/public/package/default-pipeline-0.0.2/index.json
@@ -1,4 +1,5 @@
 {
+  "format_version": "1.0.0",
   "name": "default-pipeline",
   "title": "Default pipeline Integration",
   "version": "0.0.2",
@@ -15,7 +16,6 @@
     "/package/default-pipeline-0.0.2/dataset/foo/manifest.yml",
     "/package/default-pipeline-0.0.2/dataset/foo/elasticsearch/ingest-pipeline/default.json"
   ],
-  "format_version": "1.0.0",
   "datasets": [
     {
       "title": "Foo",

--- a/testdata/public/package/example-0.0.2/index.json
+++ b/testdata/public/package/example-0.0.2/index.json
@@ -1,4 +1,5 @@
 {
+  "format_version": "1.0.0",
   "name": "example",
   "title": "Example",
   "version": "0.0.2",
@@ -31,7 +32,6 @@
     "/package/example-0.0.2/kibana/visualization/80844540-5c97-11e9-8477-077ec9664dbd.json",
     "/package/example-0.0.2/kibana/visualization/ab48c3f0-5ca6-11e9-8477-077ec9664dbd.json"
   ],
-  "format_version": "1.0.0",
   "download": "/epr/example/example-0.0.2.tar.gz",
   "path": "/package/example-0.0.2"
 }

--- a/testdata/public/package/example-1.0.0/index.json
+++ b/testdata/public/package/example-1.0.0/index.json
@@ -1,4 +1,5 @@
 {
+  "format_version": "1.0.0",
   "name": "example",
   "title": "Example Integration",
   "version": "1.0.0",
@@ -47,7 +48,6 @@
     "/package/example-1.0.0/dataset/foo/elasticsearch/ingest-pipeline/pipeline-plaintext.json",
     "/package/example-1.0.0/dataset/foo/elasticsearch/ingest-pipeline/pipeline-tcp.json"
   ],
-  "format_version": "1.0.0",
   "datasets": [
     {
       "title": "Foo",

--- a/testdata/public/package/foo-1.0.0/index.json
+++ b/testdata/public/package/foo-1.0.0/index.json
@@ -1,4 +1,5 @@
 {
+  "format_version": "1.0.0",
   "name": "foo",
   "title": "Foo",
   "version": "1.0.0",
@@ -15,7 +16,6 @@
   "assets": [
     "/package/foo-1.0.0/manifest.yml"
   ],
-  "format_version": "1.0.0",
   "download": "/epr/foo/foo-1.0.0.tar.gz",
   "path": "/package/foo-1.0.0"
 }

--- a/testdata/public/package/internal-1.2.0/index.json
+++ b/testdata/public/package/internal-1.2.0/index.json
@@ -1,4 +1,5 @@
 {
+  "format_version": "1.0.0",
   "name": "internal",
   "title": "Internal",
   "version": "1.2.0",
@@ -12,7 +13,6 @@
     "/package/internal-1.2.0/manifest.yml"
   ],
   "internal": true,
-  "format_version": "1.0.0",
   "download": "/epr/internal/internal-1.2.0.tar.gz",
   "path": "/package/internal-1.2.0"
 }

--- a/util/package.go
+++ b/util/package.go
@@ -43,8 +43,8 @@ type Package struct {
 	Internal      bool         `config:"internal,omitempty" json:"internal,omitempty" yaml:"internal,omitempty"`
 	DataSets      []*DataSet   `config:"datasets,omitempty" json:"datasets,omitempty" yaml:"datasets,omitempty"`
 	Datasources   []Datasource `config:"datasources,omitempty" json:"datasources,omitempty" yaml:"datasources,omitempty"`
-	Download      string       `json:"download"`
-	Path          string       `json:"path"`
+	Download      string       `json:"download" yaml:"download,omitempty"`
+	Path          string       `json:"path" yaml:"path,omitempty"`
 }
 
 type Datasource struct {

--- a/util/package.go
+++ b/util/package.go
@@ -26,22 +26,23 @@ var CategoryTitles = map[string]string{
 }
 
 type Package struct {
+	FormatVersion string `config:"format_version" json:"format_version" yaml:"format_version"`
+
 	Name          string  `config:"name" json:"name"`
-	Title         *string `config:"title,omitempty" json:"title,omitempty"`
+	Title         *string `config:"title,omitempty" json:"title,omitempty" yaml:"title,omitempty"`
 	Version       string  `config:"version" json:"version"`
-	Readme        *string `config:"readme,omitempty" json:"readme,omitempty"`
+	Readme        *string `config:"readme,omitempty" json:"readme,omitempty" yaml:"readme,omitempty"`
 	versionSemVer semver.Version
 	Description   string       `config:"description" json:"description"`
 	Type          string       `config:"type" json:"type"`
 	Categories    []string     `config:"categories" json:"categories"`
 	Requirement   Requirement  `config:"requirement" json:"requirement"`
-	Screenshots   []Image      `config:"screenshots,omitempty" json:"screenshots,omitempty"`
-	Icons         []Image      `config:"icons,omitempty" json:"icons,omitempty"`
-	Assets        []string     `config:"assets,omitempty" json:"assets,omitempty"`
-	Internal      bool         `config:"internal,omitempty" json:"internal,omitempty"`
-	FormatVersion string       `config:"format_version" json:"format_version"`
-	DataSets      []*DataSet   `config:"datasets,omitempty" json:"datasets,omitempty"`
-	Datasources   []Datasource `config:"datasources,omitempty" json:"datasources,omitempty"`
+	Screenshots   []Image      `config:"screenshots,omitempty" json:"screenshots,omitempty" yaml:"screenshots,omitempty"`
+	Icons         []Image      `config:"icons,omitempty" json:"icons,omitempty" yaml:"icons,omitempty"`
+	Assets        []string     `config:"assets,omitempty" json:"assets,omitempty" yaml:"assets,omitempty"`
+	Internal      bool         `config:"internal,omitempty" json:"internal,omitempty" yaml:"internal,omitempty"`
+	DataSets      []*DataSet   `config:"datasets,omitempty" json:"datasets,omitempty" yaml:"datasets,omitempty"`
+	Datasources   []Datasource `config:"datasources,omitempty" json:"datasources,omitempty" yaml:"datasources,omitempty"`
 	Download      string       `json:"download"`
 	Path          string       `json:"path"`
 }


### PR DESCRIPTION
This PR creates an initial script that fills the directories an basic manifest.yml.

How to run:
```bash
$ go run dev/import-beats/*.go -beatsDir=../beats -outputDir=dev/package-beats
```

Sample generated manifest.yml:
```
format_version: 1.0.0
name: ibmmq
version: 0.0.1
description: ""
type: integration
categories:
- logs
- metrics
requirement:
  kibana:
    versions: ""
download: ""
path: ""
```

Missing data will be filled in during next iterations (need to open fields.yml).

Issue: https://github.com/elastic/package-registry/issues/221