### PR TITLE
Adding id for endpoint so the naming of the templates is clear

### DIFF
--- a/dev/package-examples/endpoint-0.0.1/dataset/events/manifest.yml
+++ b/dev/package-examples/endpoint-0.0.1/dataset/events/manifest.yml
@@ -2,5 +2,7 @@ title: Endpoint Events
 
 type: events
 
+id: endpoint
+
 # If set to true, this will be enabled by default in the input selection
 default: true

--- a/dev/package-examples/endpoint-0.0.1/dataset/metadata/manifest.yml
+++ b/dev/package-examples/endpoint-0.0.1/dataset/metadata/manifest.yml
@@ -2,6 +2,8 @@ title: Endpoint Metadata
 
 type: metrics
 
+id: endpoint
+
 # If set to true, this will be enabled by default in the input selection
 default: true
 


### PR DESCRIPTION
Adding the `id` field so the generated names are more clear

![image](https://user-images.githubusercontent.com/56361221/75908096-819c8a00-5e17-11ea-9521-f1f7ce3d0221.png)
