### PR TITLE
Change path for dashboard encoding test

### DIFF
--- a/dev/generator/main_test.go
+++ b/dev/generator/main_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestEncodeSavedObject(t *testing.T) {
-	file := "../packages/example/auditd-2.0.4/kibana/dashboard/7de391b0-c1ca-11e7-8995-936807a28b16-ecs.json"
+	file := "../../testdata/package/example-0.0.2/kibana/dashboard/0c610510-5cbd-11e9-8477-077ec9664dbd.json"
 
 	data, err := ioutil.ReadFile(file)
 	assert.NoError(t, err)


### PR DESCRIPTION
The current path was pointing to an actual package. As packages will be moved out of this repository in the end, this should not be the case. Instead now using a dashboard file from the testdata.