### PR TITLE
RFC: Have datasource type to link to correct solution

### DIFF
--- a/dev/packages/example/endpoint-0.0.1/manifest.yml
+++ b/dev/packages/example/endpoint-0.0.1/manifest.yml
@@ -11,6 +11,19 @@ release: beta
 type: solution
 license: basic
 
+
+
+datasources:
+  -
+    name: endpoint
+    title: Endpoint data source
+    description: Interact with the endpoint.
+
+    # This tells the UI that for configuration, it must link to a specific solution
+    # Only solution packages can contain this field.
+    solution: endpoint
+
+
 requirement:
   elasticsearch:
     versions: ">7.4.0"

--- a/util/package.go
+++ b/util/package.go
@@ -53,7 +53,8 @@ type Datasource struct {
 	Name        string  `config:"name" json:"name" validate:"required"`
 	Title       string  `config:"title" json:"title" validate:"required"`
 	Description string  `config:"description" json:"description" validate:"required"`
-	Inputs      []Input `config:"inputs" json:"inputs" validate:"required"`
+	Solution    string  `config:"solution" json:"solution" `
+	Inputs      []Input `config:"inputs" json:"inputs"`
 }
 
 type Requirement struct {


### PR DESCRIPTION
Some of the datasources will not be configured by the ingest manager UI. An example for this are Endpoint or Uptime. The UI still shows the datasource entry and must know which solution to link to when someone selects such a datasource. For this, a field `solution: endpoint` was introduced inside a datasource.