### PR TITLE
Make dataset configurable for log dataset

### DIFF
--- a/dev/packages/example/log-0.9.0/dataset/log/agent/stream/stream.yml
+++ b/dev/packages/example/log-0.9.0/dataset/log/agent/stream/stream.yml
@@ -4,4 +4,4 @@ paths:
   - "{{this}}"
 {{/each}}
 
-dataset: generic
+dataset: {{dataset}}

--- a/dev/packages/example/log-0.9.0/dataset/log/manifest.yml
+++ b/dev/packages/example/log-0.9.0/dataset/log/manifest.yml
@@ -24,4 +24,3 @@ streams:
           Set the name for your dataset. Changing the dataset will send the data to a different index.
           You can't use `-` in the name of a dataset and only valid characters for [Elasticsearch index names](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html).
         type: text
-        multi: true

--- a/dev/packages/example/log-0.9.0/dataset/log/manifest.yml
+++ b/dev/packages/example/log-0.9.0/dataset/log/manifest.yml
@@ -16,3 +16,12 @@ streams:
         type: text
         multi: true
 
+      - name: dataset
+        required: true
+        default: generic
+        title: Dataset name
+        description: >
+          Set the name for your dataset. Changing the dataset will send the data to a different index.
+          You can't use `-` in the name of a dataset and only valid characters for [Elasticsearch index names](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html).
+        type: text
+        multi: true


### PR DESCRIPTION
This would allow a user to configure multiple log datasources and send the data to different indices. One of the challenges with this is that we need to verify that dataset only contains valid chars. Other question is if we should allow it or rather have users building packages.