### PR TITLE
Reduce cache time to 10min

### DIFF
--- a/main.go
+++ b/main.go
@@ -31,9 +31,9 @@ var (
 	configPath       = "config.yml"
 
 	// Cache times for the different endpoints
-	searchCacheTime     = strconv.Itoa(60 * 60)      // 1 hour
-	categoriesCacheTime = strconv.Itoa(60 * 60)      // 1 hour
-	catchAllCacheTime   = strconv.Itoa(24 * 60 * 60) // 24 hour
+	searchCacheTime     = strconv.Itoa(10 * 60) // 10 min
+	categoriesCacheTime = strconv.Itoa(10 * 60) // 10 min
+	catchAllCacheTime   = strconv.Itoa(10 * 60) // 10 min
 )
 
 func init() {


### PR DESCRIPTION
We are currently still in development and not always update the version of the packages. Because of this we use a much shorter cache time at the moment.