### PR TITLE
Define datasources without input vars

### DIFF
--- a/dev/import-beats/datasources.go
+++ b/dev/import-beats/datasources.go
@@ -1,0 +1,90 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/elastic/package-registry/util"
+)
+
+type datasourceContent struct {
+	packageTypes []string
+
+	moduleName string
+}
+
+type datasourceContentArray []datasourceContent
+
+func (datasources datasourceContentArray) toMetadataDatasources() []util.Datasource {
+	var ud []util.Datasource
+	for _, ds := range datasources {
+		var title, description string
+		if len(ds.packageTypes) == 2 {
+			title = toDatasourceTitleForTwoTypes(ds.moduleName, ds.packageTypes[0], ds.packageTypes[1])
+			description = toDatasourceDescriptionForTwoTypes(ds.moduleName, ds.packageTypes[0], ds.packageTypes[1])
+		} else {
+			title = toDatasourceTitle(ds.moduleName, ds.packageTypes[0])
+			description = toDatasourceDescription(ds.moduleName, ds.packageTypes[0])
+		}
+
+		var inputs []util.Input
+		for _, packageType := range ds.packageTypes {
+			pt := packageType
+			if pt == "metrics" {
+				pt = fmt.Sprintf("%s/%s", ds.moduleName, pt)
+			}
+
+			inputs = append(inputs, util.Input{
+				Type:        pt,
+				Description: toDatasourceInputDescription(ds.moduleName, packageType),
+			})
+		}
+
+		ud = append(ud, util.Datasource{
+			Name:        ds.moduleName,
+			Title:       title,
+			Description: description,
+			Inputs:      inputs,
+		})
+	}
+	return ud
+}
+
+func updateDatasources(datasources datasourceContentArray, moduleName, packageType string) (datasourceContentArray, error) {
+	var updated datasourceContentArray
+
+	if len(datasources) > 0 {
+		updated = append(updated, datasources...)
+		updated[0].packageTypes = append(updated[0].packageTypes, packageType)
+	} else {
+		updated = append(updated, datasourceContent{
+			packageTypes: []string{packageType},
+			moduleName:   moduleName,
+		})
+	}
+	return updated, nil
+}
+
+func toDatasourceTitle(moduleName, packageType string) string {
+	return fmt.Sprintf("%s %s", strings.Title(moduleName), packageType)
+}
+
+func toDatasourceDescription(moduleName, packageType string) string {
+	return fmt.Sprintf("Collect %s from %s instances", packageType, strings.Title(moduleName))
+}
+
+func toDatasourceTitleForTwoTypes(moduleName, firstPackageType, secondPackageType string) string {
+	return fmt.Sprintf("%s %s and %s", strings.Title(moduleName), firstPackageType, secondPackageType)
+}
+
+func toDatasourceDescriptionForTwoTypes(moduleName, firstPackageType, secondPackageType string) string {
+	return fmt.Sprintf("Collect %s and %s from %s instances", firstPackageType, secondPackageType, strings.Title(moduleName))
+}
+
+func toDatasourceInputDescription(moduleName, packageType string) string {
+	return fmt.Sprintf("Collecting %s for %s", packageType, strings.Title(moduleName))
+}

--- a/dev/import-beats/icons.go
+++ b/dev/import-beats/icons.go
@@ -156,7 +156,7 @@ func aliasModuleName(moduleName string) string {
 	return moduleName
 }
 
-func createIcons(iconRepository *iconRepository, moduleName string) ([]imageContent, error) {
+func createIcons(iconRepository *iconRepository, moduleName string) (imageContentArray, error) {
 	anIcon, err := iconRepository.iconForModule(moduleName)
 	if err == errIconNotFound {
 		log.Printf("\t%s: icon not found", moduleName)

--- a/dev/import-beats/images.go
+++ b/dev/import-beats/images.go
@@ -30,7 +30,9 @@ type imageContent struct {
 	source string
 }
 
-func createImages(beatDocsPath, modulePath string) ([]imageContent, error) {
+type imageContentArray []imageContent
+
+func createImages(beatDocsPath, modulePath string) (imageContentArray, error) {
 	var images []imageContent
 
 	moduleDocsPath := path.Join(modulePath, "_meta", "docs.asciidoc")
@@ -89,7 +91,7 @@ func extractImages(beatDocsPath string, docsFile []byte) []imageContent {
 	return contents
 }
 
-func createManifestImages(images []imageContent) ([]util.Image, error) {
+func (images imageContentArray) toManifestImages() ([]util.Image, error) {
 	var imgs []util.Image
 	for _, image := range images {
 		i := strings.LastIndex(image.source, "/")

--- a/dev/import-beats/packages.go
+++ b/dev/import-beats/packages.go
@@ -22,11 +22,12 @@ import (
 var ignoredModules = map[string]bool{"apache2": true}
 
 type packageContent struct {
-	manifest util.Package
-	datasets map[string]datasetContent
-	images   []imageContent
-	kibana   kibanaContent
-	docs     []docContent
+	manifest    util.Package
+	datasets    map[string]datasetContent
+	images      []imageContent
+	kibana      kibanaContent
+	docs        []docContent
+	datasources datasourceContentArray
 }
 
 func newPackageContent(name string) packageContent {
@@ -138,7 +139,7 @@ func (r *packageRepository) createPackagesFromSource(beatsDir, beatName, package
 			}
 			aPackage.images = append(aPackage.images, icons...)
 
-			manifestIcons, err := createManifestImages(icons)
+			manifestIcons, err := icons.toManifestImages()
 			if err != nil {
 				return err
 			}
@@ -146,7 +147,7 @@ func (r *packageRepository) createPackagesFromSource(beatsDir, beatName, package
 		}
 
 		// img/screenshots
-		screenshots, err := createManifestImages(images)
+		screenshots, err := images.toManifestImages()
 		if err != nil {
 			return err
 		}
@@ -167,6 +168,13 @@ func (r *packageRepository) createPackagesFromSource(beatsDir, beatName, package
 			}
 			aPackage.docs = append(aPackage.docs, docs...)
 		}
+
+		// datasources
+		aPackage.datasources, err = updateDatasources(aPackage.datasources, moduleName, packageType)
+		if err != nil {
+			return err
+		}
+		manifest.Datasources = aPackage.datasources.toMetadataDatasources()
 
 		aPackage.manifest = manifest
 		r.packages[moduleDir.Name()] = aPackage

--- a/dev/packages/beats/activemq-0.0.1/manifest.yml
+++ b/dev/packages/beats/activemq-0.0.1/manifest.yml
@@ -37,3 +37,12 @@ icons:
   title: Logo Activemq
   size: 32x32
   type: image/svg+xml
+datasources:
+- name: activemq
+  title: Activemq logs and metrics
+  description: Collect logs and metrics from Activemq instances
+  inputs:
+  - type: logs
+    description: Collecting logs for Activemq
+  - type: activemq/metrics
+    description: Collecting metrics for Activemq

--- a/dev/packages/beats/aerospike-0.0.1/manifest.yml
+++ b/dev/packages/beats/aerospike-0.0.1/manifest.yml
@@ -20,3 +20,10 @@ icons:
   title: Logo Aerospike
   size: 32x32
   type: image/svg+xml
+datasources:
+- name: aerospike
+  title: Aerospike metrics
+  description: Collect metrics from Aerospike instances
+  inputs:
+  - type: aerospike/metrics
+    description: Collecting metrics for Aerospike

--- a/dev/packages/beats/apache-0.0.1/manifest.yml
+++ b/dev/packages/beats/apache-0.0.1/manifest.yml
@@ -25,3 +25,12 @@ icons:
   title: Logo Apache
   size: 32x32
   type: image/svg+xml
+datasources:
+- name: apache
+  title: Apache logs and metrics
+  description: Collect logs and metrics from Apache instances
+  inputs:
+  - type: logs
+    description: Collecting logs for Apache
+  - type: apache/metrics
+    description: Collecting metrics for Apache

--- a/dev/packages/beats/appsearch-0.0.1/manifest.yml
+++ b/dev/packages/beats/appsearch-0.0.1/manifest.yml
@@ -15,3 +15,10 @@ icons:
   title: Logo App Search
   size: 32x32
   type: image/svg+xml
+datasources:
+- name: appsearch
+  title: Appsearch metrics
+  description: Collect metrics from Appsearch instances
+  inputs:
+  - type: appsearch/metrics
+    description: Collecting metrics for Appsearch

--- a/dev/packages/beats/auditd-0.0.1/manifest.yml
+++ b/dev/packages/beats/auditd-0.0.1/manifest.yml
@@ -15,3 +15,10 @@ screenshots:
   title: Kibana Audit Auditd
   size: 1230x997
   type: image/png
+datasources:
+- name: auditd
+  title: Auditd logs
+  description: Collect logs from Auditd instances
+  inputs:
+  - type: logs
+    description: Collecting logs for Auditd

--- a/dev/packages/beats/aws-0.0.1/manifest.yml
+++ b/dev/packages/beats/aws-0.0.1/manifest.yml
@@ -117,3 +117,12 @@ icons:
   title: Logo Aws
   size: 32x32
   type: image/svg+xml
+datasources:
+- name: aws
+  title: Aws logs and metrics
+  description: Collect logs and metrics from Aws instances
+  inputs:
+  - type: logs
+    description: Collecting logs for Aws
+  - type: aws/metrics
+    description: Collecting metrics for Aws

--- a/dev/packages/beats/azure-0.0.1/manifest.yml
+++ b/dev/packages/beats/azure-0.0.1/manifest.yml
@@ -37,3 +37,12 @@ icons:
   title: Logo Azure
   size: 32x32
   type: image/svg+xml
+datasources:
+- name: azure
+  title: Azure logs and metrics
+  description: Collect logs and metrics from Azure instances
+  inputs:
+  - type: logs
+    description: Collecting logs for Azure
+  - type: azure/metrics
+    description: Collecting metrics for Azure

--- a/dev/packages/beats/beat-0.0.1/manifest.yml
+++ b/dev/packages/beats/beat-0.0.1/manifest.yml
@@ -10,3 +10,10 @@ categories:
 requirement:
   kibana:
     versions: ""
+datasources:
+- name: beat
+  title: Beat metrics
+  description: Collect metrics from Beat instances
+  inputs:
+  - type: beat/metrics
+    description: Collecting metrics for Beat

--- a/dev/packages/beats/cef-0.0.1/manifest.yml
+++ b/dev/packages/beats/cef-0.0.1/manifest.yml
@@ -10,3 +10,10 @@ categories:
 requirement:
   kibana:
     versions: ""
+datasources:
+- name: cef
+  title: Cef logs
+  description: Collect logs from Cef instances
+  inputs:
+  - type: logs
+    description: Collecting logs for Cef

--- a/dev/packages/beats/ceph-0.0.1/manifest.yml
+++ b/dev/packages/beats/ceph-0.0.1/manifest.yml
@@ -20,3 +20,10 @@ icons:
   title: Logo Ceph
   size: 32x32
   type: image/svg+xml
+datasources:
+- name: ceph
+  title: Ceph metrics
+  description: Collect metrics from Ceph instances
+  inputs:
+  - type: ceph/metrics
+    description: Collecting metrics for Ceph

--- a/dev/packages/beats/cisco-0.0.1/manifest.yml
+++ b/dev/packages/beats/cisco-0.0.1/manifest.yml
@@ -15,3 +15,10 @@ screenshots:
   title: Kibana Cisco Asa
   size: 1800x1559
   type: image/png
+datasources:
+- name: cisco
+  title: Cisco logs
+  description: Collect logs from Cisco instances
+  inputs:
+  - type: logs
+    description: Collecting logs for Cisco

--- a/dev/packages/beats/cloudfoundry-0.0.1/manifest.yml
+++ b/dev/packages/beats/cloudfoundry-0.0.1/manifest.yml
@@ -10,3 +10,10 @@ categories:
 requirement:
   kibana:
     versions: ""
+datasources:
+- name: cloudfoundry
+  title: Cloudfoundry metrics
+  description: Collect metrics from Cloudfoundry instances
+  inputs:
+  - type: cloudfoundry/metrics
+    description: Collecting metrics for Cloudfoundry

--- a/dev/packages/beats/cockroachdb-0.0.1/manifest.yml
+++ b/dev/packages/beats/cockroachdb-0.0.1/manifest.yml
@@ -20,3 +20,10 @@ icons:
   title: Cockroachdb
   size: 35x35
   type: image/svg+xml
+datasources:
+- name: cockroachdb
+  title: Cockroachdb metrics
+  description: Collect metrics from Cockroachdb instances
+  inputs:
+  - type: cockroachdb/metrics
+    description: Collecting metrics for Cockroachdb

--- a/dev/packages/beats/consul-0.0.1/manifest.yml
+++ b/dev/packages/beats/consul-0.0.1/manifest.yml
@@ -20,3 +20,10 @@ icons:
   title: Consul
   size: 79x113
   type: image/svg+xml
+datasources:
+- name: consul
+  title: Consul metrics
+  description: Collect metrics from Consul instances
+  inputs:
+  - type: consul/metrics
+    description: Collecting metrics for Consul

--- a/dev/packages/beats/coredns-0.0.1/manifest.yml
+++ b/dev/packages/beats/coredns-0.0.1/manifest.yml
@@ -25,3 +25,12 @@ icons:
   title: Coredns
   size: 163x145
   type: image/svg+xml
+datasources:
+- name: coredns
+  title: Coredns logs and metrics
+  description: Collect logs and metrics from Coredns instances
+  inputs:
+  - type: logs
+    description: Collecting logs for Coredns
+  - type: coredns/metrics
+    description: Collecting metrics for Coredns

--- a/dev/packages/beats/couchbase-0.0.1/manifest.yml
+++ b/dev/packages/beats/couchbase-0.0.1/manifest.yml
@@ -20,3 +20,10 @@ icons:
   title: Logo Couchbase
   size: 32x32
   type: image/svg+xml
+datasources:
+- name: couchbase
+  title: Couchbase metrics
+  description: Collect metrics from Couchbase instances
+  inputs:
+  - type: couchbase/metrics
+    description: Collecting metrics for Couchbase

--- a/dev/packages/beats/couchdb-0.0.1/manifest.yml
+++ b/dev/packages/beats/couchdb-0.0.1/manifest.yml
@@ -20,3 +20,10 @@ icons:
   title: Couchdb
   size: 289x293
   type: image/svg+xml
+datasources:
+- name: couchdb
+  title: Couchdb metrics
+  description: Collect metrics from Couchdb instances
+  inputs:
+  - type: couchdb/metrics
+    description: Collecting metrics for Couchdb

--- a/dev/packages/beats/docker-0.0.1/manifest.yml
+++ b/dev/packages/beats/docker-0.0.1/manifest.yml
@@ -15,3 +15,10 @@ icons:
   title: Logo Docker
   size: 32x32
   type: image/svg+xml
+datasources:
+- name: docker
+  title: Docker metrics
+  description: Collect metrics from Docker instances
+  inputs:
+  - type: docker/metrics
+    description: Collecting metrics for Docker

--- a/dev/packages/beats/dropwizard-0.0.1/manifest.yml
+++ b/dev/packages/beats/dropwizard-0.0.1/manifest.yml
@@ -15,3 +15,10 @@ icons:
   title: Logo Dropwizard
   size: 32x32
   type: image/svg+xml
+datasources:
+- name: dropwizard
+  title: Dropwizard metrics
+  description: Collect metrics from Dropwizard instances
+  inputs:
+  - type: dropwizard/metrics
+    description: Collecting metrics for Dropwizard

--- a/dev/packages/beats/elasticsearch-0.0.1/manifest.yml
+++ b/dev/packages/beats/elasticsearch-0.0.1/manifest.yml
@@ -16,3 +16,12 @@ icons:
   title: Logo Elasticsearch
   size: 32x32
   type: image/svg+xml
+datasources:
+- name: elasticsearch
+  title: Elasticsearch logs and metrics
+  description: Collect logs and metrics from Elasticsearch instances
+  inputs:
+  - type: logs
+    description: Collecting logs for Elasticsearch
+  - type: elasticsearch/metrics
+    description: Collecting metrics for Elasticsearch

--- a/dev/packages/beats/envoyproxy-0.0.1/manifest.yml
+++ b/dev/packages/beats/envoyproxy-0.0.1/manifest.yml
@@ -21,3 +21,12 @@ icons:
   title: Envoyproxy
   size: 300x300
   type: image/svg+xml
+datasources:
+- name: envoyproxy
+  title: Envoyproxy logs and metrics
+  description: Collect logs and metrics from Envoyproxy instances
+  inputs:
+  - type: logs
+    description: Collecting logs for Envoyproxy
+  - type: envoyproxy/metrics
+    description: Collecting metrics for Envoyproxy

--- a/dev/packages/beats/etcd-0.0.1/manifest.yml
+++ b/dev/packages/beats/etcd-0.0.1/manifest.yml
@@ -15,3 +15,10 @@ icons:
   title: Logo Etcd
   size: 32x32
   type: image/svg+xml
+datasources:
+- name: etcd
+  title: Etcd metrics
+  description: Collect metrics from Etcd instances
+  inputs:
+  - type: etcd/metrics
+    description: Collecting metrics for Etcd

--- a/dev/packages/beats/golang-0.0.1/manifest.yml
+++ b/dev/packages/beats/golang-0.0.1/manifest.yml
@@ -15,3 +15,10 @@ icons:
   title: Logo Golang
   size: 32x32
   type: image/svg+xml
+datasources:
+- name: golang
+  title: Golang metrics
+  description: Collect metrics from Golang instances
+  inputs:
+  - type: golang/metrics
+    description: Collecting metrics for Golang

--- a/dev/packages/beats/googlecloud-0.0.1/manifest.yml
+++ b/dev/packages/beats/googlecloud-0.0.1/manifest.yml
@@ -16,3 +16,12 @@ icons:
   title: Logo Gcp
   size: 32x32
   type: image/svg+xml
+datasources:
+- name: googlecloud
+  title: Googlecloud logs and metrics
+  description: Collect logs and metrics from Googlecloud instances
+  inputs:
+  - type: logs
+    description: Collecting logs for Googlecloud
+  - type: googlecloud/metrics
+    description: Collecting metrics for Googlecloud

--- a/dev/packages/beats/graphite-0.0.1/manifest.yml
+++ b/dev/packages/beats/graphite-0.0.1/manifest.yml
@@ -10,3 +10,10 @@ categories:
 requirement:
   kibana:
     versions: ""
+datasources:
+- name: graphite
+  title: Graphite metrics
+  description: Collect metrics from Graphite instances
+  inputs:
+  - type: graphite/metrics
+    description: Collecting metrics for Graphite

--- a/dev/packages/beats/haproxy-0.0.1/manifest.yml
+++ b/dev/packages/beats/haproxy-0.0.1/manifest.yml
@@ -21,3 +21,12 @@ icons:
   title: Logo Haproxy
   size: 32x32
   type: image/svg+xml
+datasources:
+- name: haproxy
+  title: Haproxy logs and metrics
+  description: Collect logs and metrics from Haproxy instances
+  inputs:
+  - type: logs
+    description: Collecting logs for Haproxy
+  - type: haproxy/metrics
+    description: Collecting metrics for Haproxy

--- a/dev/packages/beats/http-0.0.1/manifest.yml
+++ b/dev/packages/beats/http-0.0.1/manifest.yml
@@ -10,3 +10,10 @@ categories:
 requirement:
   kibana:
     versions: ""
+datasources:
+- name: http
+  title: Http metrics
+  description: Collect metrics from Http instances
+  inputs:
+  - type: http/metrics
+    description: Collecting metrics for Http

--- a/dev/packages/beats/ibmmq-0.0.1/manifest.yml
+++ b/dev/packages/beats/ibmmq-0.0.1/manifest.yml
@@ -33,3 +33,12 @@ icons:
   title: Ibmmq
   size: 32x32
   type: image/svg+xml
+datasources:
+- name: ibmmq
+  title: Ibmmq logs and metrics
+  description: Collect logs and metrics from Ibmmq instances
+  inputs:
+  - type: logs
+    description: Collecting logs for Ibmmq
+  - type: ibmmq/metrics
+    description: Collecting metrics for Ibmmq

--- a/dev/packages/beats/icinga-0.0.1/manifest.yml
+++ b/dev/packages/beats/icinga-0.0.1/manifest.yml
@@ -15,3 +15,10 @@ screenshots:
   title: Kibana Icinga Main
   size: 1216x635
   type: image/png
+datasources:
+- name: icinga
+  title: Icinga logs
+  description: Collect logs from Icinga instances
+  inputs:
+  - type: logs
+    description: Collecting logs for Icinga

--- a/dev/packages/beats/iis-0.0.1/manifest.yml
+++ b/dev/packages/beats/iis-0.0.1/manifest.yml
@@ -16,3 +16,12 @@ screenshots:
   title: Kibana Iis
   size: 1960x2820
   type: image/png
+datasources:
+- name: iis
+  title: Iis logs and metrics
+  description: Collect logs and metrics from Iis instances
+  inputs:
+  - type: logs
+    description: Collecting logs for Iis
+  - type: iis/metrics
+    description: Collecting metrics for Iis

--- a/dev/packages/beats/iptables-0.0.1/manifest.yml
+++ b/dev/packages/beats/iptables-0.0.1/manifest.yml
@@ -19,3 +19,10 @@ screenshots:
   title: Kibana Iptables Ubiquiti
   size: 1492x1464
   type: image/png
+datasources:
+- name: iptables
+  title: Iptables logs
+  description: Collect logs from Iptables instances
+  inputs:
+  - type: logs
+    description: Collecting logs for Iptables

--- a/dev/packages/beats/istio-0.0.1/manifest.yml
+++ b/dev/packages/beats/istio-0.0.1/manifest.yml
@@ -10,3 +10,10 @@ categories:
 requirement:
   kibana:
     versions: ""
+datasources:
+- name: istio
+  title: Istio metrics
+  description: Collect metrics from Istio instances
+  inputs:
+  - type: istio/metrics
+    description: Collecting metrics for Istio

--- a/dev/packages/beats/jolokia-0.0.1/manifest.yml
+++ b/dev/packages/beats/jolokia-0.0.1/manifest.yml
@@ -10,3 +10,10 @@ categories:
 requirement:
   kibana:
     versions: ""
+datasources:
+- name: jolokia
+  title: Jolokia metrics
+  description: Collect metrics from Jolokia instances
+  inputs:
+  - type: jolokia/metrics
+    description: Collecting metrics for Jolokia

--- a/dev/packages/beats/kafka-0.0.1/manifest.yml
+++ b/dev/packages/beats/kafka-0.0.1/manifest.yml
@@ -25,3 +25,12 @@ icons:
   title: Logo Kafka
   size: 32x32
   type: image/svg+xml
+datasources:
+- name: kafka
+  title: Kafka logs and metrics
+  description: Collect logs and metrics from Kafka instances
+  inputs:
+  - type: logs
+    description: Collecting logs for Kafka
+  - type: kafka/metrics
+    description: Collecting metrics for Kafka

--- a/dev/packages/beats/kibana-0.0.1/manifest.yml
+++ b/dev/packages/beats/kibana-0.0.1/manifest.yml
@@ -16,3 +16,12 @@ icons:
   title: Logo Kibana
   size: 32x32
   type: image/svg+xml
+datasources:
+- name: kibana
+  title: Kibana logs and metrics
+  description: Collect logs and metrics from Kibana instances
+  inputs:
+  - type: logs
+    description: Collecting logs for Kibana
+  - type: kibana/metrics
+    description: Collecting metrics for Kibana

--- a/dev/packages/beats/kubernetes-0.0.1/manifest.yml
+++ b/dev/packages/beats/kubernetes-0.0.1/manifest.yml
@@ -28,3 +28,10 @@ icons:
   title: Logo Kubernetes
   size: 32x32
   type: image/svg+xml
+datasources:
+- name: kubernetes
+  title: Kubernetes metrics
+  description: Collect metrics from Kubernetes instances
+  inputs:
+  - type: kubernetes/metrics
+    description: Collecting metrics for Kubernetes

--- a/dev/packages/beats/kvm-0.0.1/manifest.yml
+++ b/dev/packages/beats/kvm-0.0.1/manifest.yml
@@ -10,3 +10,10 @@ categories:
 requirement:
   kibana:
     versions: ""
+datasources:
+- name: kvm
+  title: Kvm metrics
+  description: Collect metrics from Kvm instances
+  inputs:
+  - type: kvm/metrics
+    description: Collecting metrics for Kvm

--- a/dev/packages/beats/logstash-0.0.1/manifest.yml
+++ b/dev/packages/beats/logstash-0.0.1/manifest.yml
@@ -25,3 +25,12 @@ icons:
   title: Logo Logstash
   size: 32x32
   type: image/svg+xml
+datasources:
+- name: logstash
+  title: Logstash logs and metrics
+  description: Collect logs and metrics from Logstash instances
+  inputs:
+  - type: logs
+    description: Collecting logs for Logstash
+  - type: logstash/metrics
+    description: Collecting metrics for Logstash

--- a/dev/packages/beats/memcached-0.0.1/manifest.yml
+++ b/dev/packages/beats/memcached-0.0.1/manifest.yml
@@ -15,3 +15,10 @@ icons:
   title: Logo Memcached
   size: 32x32
   type: image/svg+xml
+datasources:
+- name: memcached
+  title: Memcached metrics
+  description: Collect metrics from Memcached instances
+  inputs:
+  - type: memcached/metrics
+    description: Collecting metrics for Memcached

--- a/dev/packages/beats/misp-0.0.1/manifest.yml
+++ b/dev/packages/beats/misp-0.0.1/manifest.yml
@@ -15,3 +15,10 @@ screenshots:
   title: Kibana Misp
   size: 1280x882
   type: image/png
+datasources:
+- name: misp
+  title: Misp logs
+  description: Collect logs from Misp instances
+  inputs:
+  - type: logs
+    description: Collecting logs for Misp

--- a/dev/packages/beats/mongodb-0.0.1/manifest.yml
+++ b/dev/packages/beats/mongodb-0.0.1/manifest.yml
@@ -21,3 +21,12 @@ icons:
   title: Logo Mongodb
   size: 32x32
   type: image/svg+xml
+datasources:
+- name: mongodb
+  title: Mongodb logs and metrics
+  description: Collect logs and metrics from Mongodb instances
+  inputs:
+  - type: logs
+    description: Collecting logs for Mongodb
+  - type: mongodb/metrics
+    description: Collecting metrics for Mongodb

--- a/dev/packages/beats/mssql-0.0.1/manifest.yml
+++ b/dev/packages/beats/mssql-0.0.1/manifest.yml
@@ -11,3 +11,12 @@ categories:
 requirement:
   kibana:
     versions: ""
+datasources:
+- name: mssql
+  title: Mssql logs and metrics
+  description: Collect logs and metrics from Mssql instances
+  inputs:
+  - type: logs
+    description: Collecting logs for Mssql
+  - type: mssql/metrics
+    description: Collecting metrics for Mssql

--- a/dev/packages/beats/munin-0.0.1/manifest.yml
+++ b/dev/packages/beats/munin-0.0.1/manifest.yml
@@ -10,3 +10,10 @@ categories:
 requirement:
   kibana:
     versions: ""
+datasources:
+- name: munin
+  title: Munin metrics
+  description: Collect metrics from Munin instances
+  inputs:
+  - type: munin/metrics
+    description: Collecting metrics for Munin

--- a/dev/packages/beats/mysql-0.0.1/manifest.yml
+++ b/dev/packages/beats/mysql-0.0.1/manifest.yml
@@ -25,3 +25,12 @@ icons:
   title: Logo Mysql
   size: 32x32
   type: image/svg+xml
+datasources:
+- name: mysql
+  title: Mysql logs and metrics
+  description: Collect logs and metrics from Mysql instances
+  inputs:
+  - type: logs
+    description: Collecting logs for Mysql
+  - type: mysql/metrics
+    description: Collecting metrics for Mysql

--- a/dev/packages/beats/nats-0.0.1/manifest.yml
+++ b/dev/packages/beats/nats-0.0.1/manifest.yml
@@ -25,3 +25,12 @@ icons:
   title: Nats
   size: 32x32
   type: image/svg+xml
+datasources:
+- name: nats
+  title: Nats logs and metrics
+  description: Collect logs and metrics from Nats instances
+  inputs:
+  - type: logs
+    description: Collecting logs for Nats
+  - type: nats/metrics
+    description: Collecting metrics for Nats

--- a/dev/packages/beats/netflow-0.0.1/manifest.yml
+++ b/dev/packages/beats/netflow-0.0.1/manifest.yml
@@ -10,3 +10,10 @@ categories:
 requirement:
   kibana:
     versions: ""
+datasources:
+- name: netflow
+  title: Netflow logs
+  description: Collect logs from Netflow instances
+  inputs:
+  - type: logs
+    description: Collecting logs for Netflow

--- a/dev/packages/beats/nginx-0.0.1/manifest.yml
+++ b/dev/packages/beats/nginx-0.0.1/manifest.yml
@@ -25,3 +25,12 @@ icons:
   title: Logo Nginx
   size: 32x32
   type: image/svg+xml
+datasources:
+- name: nginx
+  title: Nginx logs and metrics
+  description: Collect logs and metrics from Nginx instances
+  inputs:
+  - type: logs
+    description: Collecting logs for Nginx
+  - type: nginx/metrics
+    description: Collecting metrics for Nginx

--- a/dev/packages/beats/openmetrics-0.0.1/manifest.yml
+++ b/dev/packages/beats/openmetrics-0.0.1/manifest.yml
@@ -10,3 +10,10 @@ categories:
 requirement:
   kibana:
     versions: ""
+datasources:
+- name: openmetrics
+  title: Openmetrics metrics
+  description: Collect metrics from Openmetrics instances
+  inputs:
+  - type: openmetrics/metrics
+    description: Collecting metrics for Openmetrics

--- a/dev/packages/beats/oracle-0.0.1/manifest.yml
+++ b/dev/packages/beats/oracle-0.0.1/manifest.yml
@@ -15,3 +15,10 @@ screenshots:
   title: Metricbeat Oracle Overview
   size: 3840x2160
   type: image/png
+datasources:
+- name: oracle
+  title: Oracle metrics
+  description: Collect metrics from Oracle instances
+  inputs:
+  - type: oracle/metrics
+    description: Collecting metrics for Oracle

--- a/dev/packages/beats/osquery-0.0.1/manifest.yml
+++ b/dev/packages/beats/osquery-0.0.1/manifest.yml
@@ -20,3 +20,10 @@ icons:
   title: Logo Osquery
   size: 32x32
   type: image/svg+xml
+datasources:
+- name: osquery
+  title: Osquery logs
+  description: Collect logs from Osquery instances
+  inputs:
+  - type: logs
+    description: Collecting logs for Osquery

--- a/dev/packages/beats/panw-0.0.1/manifest.yml
+++ b/dev/packages/beats/panw-0.0.1/manifest.yml
@@ -19,3 +19,10 @@ screenshots:
   title: Filebeat Panw Threat
   size: 2546x2496
   type: image/png
+datasources:
+- name: panw
+  title: Panw logs
+  description: Collect logs from Panw instances
+  inputs:
+  - type: logs
+    description: Collecting logs for Panw

--- a/dev/packages/beats/php_fpm-0.0.1/manifest.yml
+++ b/dev/packages/beats/php_fpm-0.0.1/manifest.yml
@@ -15,3 +15,10 @@ icons:
   title: Logo Php
   size: 32x32
   type: image/svg+xml
+datasources:
+- name: php_fpm
+  title: Php_fpm metrics
+  description: Collect metrics from Php_fpm instances
+  inputs:
+  - type: php_fpm/metrics
+    description: Collecting metrics for Php_fpm

--- a/dev/packages/beats/postgresql-0.0.1/manifest.yml
+++ b/dev/packages/beats/postgresql-0.0.1/manifest.yml
@@ -29,3 +29,12 @@ icons:
   title: Logo Postgres
   size: 32x32
   type: image/svg+xml
+datasources:
+- name: postgresql
+  title: Postgresql logs and metrics
+  description: Collect logs and metrics from Postgresql instances
+  inputs:
+  - type: logs
+    description: Collecting logs for Postgresql
+  - type: postgresql/metrics
+    description: Collecting metrics for Postgresql

--- a/dev/packages/beats/prometheus-0.0.1/manifest.yml
+++ b/dev/packages/beats/prometheus-0.0.1/manifest.yml
@@ -20,3 +20,10 @@ icons:
   title: Logo Prometheus
   size: 32x32
   type: image/svg+xml
+datasources:
+- name: prometheus
+  title: Prometheus metrics
+  description: Collect metrics from Prometheus instances
+  inputs:
+  - type: prometheus/metrics
+    description: Collecting metrics for Prometheus

--- a/dev/packages/beats/rabbitmq-0.0.1/manifest.yml
+++ b/dev/packages/beats/rabbitmq-0.0.1/manifest.yml
@@ -16,3 +16,12 @@ icons:
   title: Logo Rabbitmq
   size: 32x32
   type: image/svg+xml
+datasources:
+- name: rabbitmq
+  title: Rabbitmq logs and metrics
+  description: Collect logs and metrics from Rabbitmq instances
+  inputs:
+  - type: logs
+    description: Collecting logs for Rabbitmq
+  - type: rabbitmq/metrics
+    description: Collecting metrics for Rabbitmq

--- a/dev/packages/beats/redis-0.0.1/manifest.yml
+++ b/dev/packages/beats/redis-0.0.1/manifest.yml
@@ -25,3 +25,12 @@ icons:
   title: Logo Redis
   size: 32x32
   type: image/svg+xml
+datasources:
+- name: redis
+  title: Redis logs and metrics
+  description: Collect logs and metrics from Redis instances
+  inputs:
+  - type: logs
+    description: Collecting logs for Redis
+  - type: redis/metrics
+    description: Collecting metrics for Redis

--- a/dev/packages/beats/redisenterprise-0.0.1/manifest.yml
+++ b/dev/packages/beats/redisenterprise-0.0.1/manifest.yml
@@ -20,3 +20,10 @@ icons:
   title: Logo Redis
   size: 32x32
   type: image/svg+xml
+datasources:
+- name: redisenterprise
+  title: Redisenterprise metrics
+  description: Collect metrics from Redisenterprise instances
+  inputs:
+  - type: redisenterprise/metrics
+    description: Collecting metrics for Redisenterprise

--- a/dev/packages/beats/santa-0.0.1/manifest.yml
+++ b/dev/packages/beats/santa-0.0.1/manifest.yml
@@ -15,3 +15,10 @@ screenshots:
   title: Kibana Santa Log Overview
   size: 2912x2024
   type: image/png
+datasources:
+- name: santa
+  title: Santa logs
+  description: Collect logs from Santa instances
+  inputs:
+  - type: logs
+    description: Collecting logs for Santa

--- a/dev/packages/beats/sql-0.0.1/manifest.yml
+++ b/dev/packages/beats/sql-0.0.1/manifest.yml
@@ -10,3 +10,10 @@ categories:
 requirement:
   kibana:
     versions: ""
+datasources:
+- name: sql
+  title: Sql metrics
+  description: Collect metrics from Sql instances
+  inputs:
+  - type: sql/metrics
+    description: Collecting metrics for Sql

--- a/dev/packages/beats/stan-0.0.1/manifest.yml
+++ b/dev/packages/beats/stan-0.0.1/manifest.yml
@@ -20,3 +20,10 @@ icons:
   title: Stan
   size: 32x32
   type: image/svg+xml
+datasources:
+- name: stan
+  title: Stan metrics
+  description: Collect metrics from Stan instances
+  inputs:
+  - type: stan/metrics
+    description: Collecting metrics for Stan

--- a/dev/packages/beats/statsd-0.0.1/manifest.yml
+++ b/dev/packages/beats/statsd-0.0.1/manifest.yml
@@ -15,3 +15,10 @@ icons:
   title: Statsd
   size: 266x266
   type: image/svg+xml
+datasources:
+- name: statsd
+  title: Statsd metrics
+  description: Collect metrics from Statsd instances
+  inputs:
+  - type: statsd/metrics
+    description: Collecting metrics for Statsd

--- a/dev/packages/beats/suricata-0.0.1/manifest.yml
+++ b/dev/packages/beats/suricata-0.0.1/manifest.yml
@@ -19,3 +19,10 @@ screenshots:
   title: Filebeat Suricata Alerts
   size: 1386x1115
   type: image/png
+datasources:
+- name: suricata
+  title: Suricata logs
+  description: Collect logs from Suricata instances
+  inputs:
+  - type: logs
+    description: Collecting logs for Suricata

--- a/dev/packages/beats/system-0.0.1/manifest.yml
+++ b/dev/packages/beats/system-0.0.1/manifest.yml
@@ -24,3 +24,12 @@ screenshots:
   title: Metricbeat Services Host
   size: 5006x2260
   type: image/png
+datasources:
+- name: system
+  title: System logs and metrics
+  description: Collect logs and metrics from System instances
+  inputs:
+  - type: logs
+    description: Collecting logs for System
+  - type: system/metrics
+    description: Collecting metrics for System

--- a/dev/packages/beats/tomcat-0.0.1/manifest.yml
+++ b/dev/packages/beats/tomcat-0.0.1/manifest.yml
@@ -15,3 +15,10 @@ screenshots:
   title: Metricbeat Tomcat Overview
   size: 3836x2148
   type: image/png
+datasources:
+- name: tomcat
+  title: Tomcat metrics
+  description: Collect metrics from Tomcat instances
+  inputs:
+  - type: tomcat/metrics
+    description: Collecting metrics for Tomcat

--- a/dev/packages/beats/traefik-0.0.1/manifest.yml
+++ b/dev/packages/beats/traefik-0.0.1/manifest.yml
@@ -21,3 +21,12 @@ icons:
   title: Traefik
   size: 340x456
   type: image/svg+xml
+datasources:
+- name: traefik
+  title: Traefik logs and metrics
+  description: Collect logs and metrics from Traefik instances
+  inputs:
+  - type: logs
+    description: Collecting logs for Traefik
+  - type: traefik/metrics
+    description: Collecting metrics for Traefik

--- a/dev/packages/beats/uwsgi-0.0.1/manifest.yml
+++ b/dev/packages/beats/uwsgi-0.0.1/manifest.yml
@@ -15,3 +15,10 @@ screenshots:
   title: Uwsgi Dashboard
   size: 1305x747
   type: image/png
+datasources:
+- name: uwsgi
+  title: Uwsgi metrics
+  description: Collect metrics from Uwsgi instances
+  inputs:
+  - type: uwsgi/metrics
+    description: Collecting metrics for Uwsgi

--- a/dev/packages/beats/vsphere-0.0.1/manifest.yml
+++ b/dev/packages/beats/vsphere-0.0.1/manifest.yml
@@ -19,3 +19,10 @@ screenshots:
   title: Metricbeat Vsphere Vm Dashboard
   size: 3744x4048
   type: image/png
+datasources:
+- name: vsphere
+  title: Vsphere metrics
+  description: Collect metrics from Vsphere instances
+  inputs:
+  - type: vsphere/metrics
+    description: Collecting metrics for Vsphere

--- a/dev/packages/beats/windows-0.0.1/manifest.yml
+++ b/dev/packages/beats/windows-0.0.1/manifest.yml
@@ -20,3 +20,10 @@ icons:
   title: Logo Windows
   size: 32x32
   type: image/svg+xml
+datasources:
+- name: windows
+  title: Windows metrics
+  description: Collect metrics from Windows instances
+  inputs:
+  - type: windows/metrics
+    description: Collecting metrics for Windows

--- a/dev/packages/beats/zeek-0.0.1/manifest.yml
+++ b/dev/packages/beats/zeek-0.0.1/manifest.yml
@@ -15,3 +15,10 @@ screenshots:
   title: Kibana Zeek
   size: 3530x2414
   type: image/png
+datasources:
+- name: zeek
+  title: Zeek logs
+  description: Collect logs from Zeek instances
+  inputs:
+  - type: logs
+    description: Collecting logs for Zeek

--- a/dev/packages/beats/zookeeper-0.0.1/manifest.yml
+++ b/dev/packages/beats/zookeeper-0.0.1/manifest.yml
@@ -15,3 +15,10 @@ screenshots:
   title: Metricbeat Zookeeper
   size: 3808x2018
   type: image/png
+datasources:
+- name: zookeeper
+  title: Zookeeper metrics
+  description: Collect metrics from Zookeeper instances
+  inputs:
+  - type: zookeeper/metrics
+    description: Collecting metrics for Zookeeper

--- a/util/dataset.go
+++ b/util/dataset.go
@@ -26,9 +26,9 @@ type DataSet struct {
 
 type Input struct {
 	Type        string                   `config:"type" json:"type" validate:"required"`
-	Vars        []map[string]interface{} `config:"vars" json:"vars,omitempty" `
+	Vars        []map[string]interface{} `config:"vars" json:"vars,omitempty" yaml:"vars,omitempty"`
 	Description string                   `config:"description" json:"description,omitempty" `
-	Streams     []Stream                 `config:"streams" json:"streams,omitempty"`
+	Streams     []Stream                 `config:"streams" json:"streams,omitempty" yaml:"streams,omitempty"`
 }
 
 type Stream struct {


### PR DESCRIPTION
This PR extends "import-beats" script to define datasources for integrations without input vars (will come in next iteration).

Issue: https://github.com/elastic/package-registry/issues/221