### PR TITLE
Add show_user flag to AWS and nginx

### DIFF
--- a/dev/packages/example/aws-1.0.0/manifest.yml
+++ b/dev/packages/example/aws-1.0.0/manifest.yml
@@ -45,6 +45,7 @@ datasources:
               Credential profile name. This can be used as an alternative to the keys and tokens in the config.
             default: 'test-mb'
             type: text
+            show_user: true
 
           - name: shared_credential_file
             description: >

--- a/dev/packages/example/nginx-1.2.0/dataset/access/manifest.yml
+++ b/dev/packages/example/nginx-1.2.0/dataset/access/manifest.yml
@@ -16,7 +16,8 @@ streams:
     vars:
       - name: paths
         required: true
-        # Should we define this as array? How will the UI best make sense of it?
+        show_user: true
+        title: Access log paths
         description: Paths to the nginx access log file.
         type: text
         multi: true


### PR DESCRIPTION
The show_user flag indicates config options which should be shown to the user by default in the UI. For now the changes has been applied on the input level for AWS and nginx access logs on the stream level.