### PR TITLE
Make README around docker images more readable

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,11 +162,16 @@ docker run -i -t -p 8080:8080 $(docker images -q integrations_registry:latest)
 
 We publish a Docker image with each successful build commit on branches, tags, or PR.
 For each commit we have two docker image tags, one with the commit as tag
+
 `docker.elastic.co/package-registry/package-registry:f999b7a84d977cd19a379f0cec802aa1ef7ca379`
+
 An another Docker tag with the git branch or tag name
-`docker.elastic.co/package-registry/package-registry:master`,
-`docker.elastic.co/package-registry/package-registry:pr-111`,
-`docker.elastic.co/package-registry/package-registry:v0.2.0`
+
+* `docker.elastic.co/package-registry/package-registry:master`
+* `docker.elastic.co/package-registry/package-registry:pr-111`
+* `docker.elastic.co/package-registry/package-registry:v0.2.0`
+
+If you want to run the most recent registry, run the master tag.
 
 ### Healthcheck
 


### PR DESCRIPTION
Before the content was all in one line which made it hard to read and copy paste image paths.