### PR TITLE
Remove cache headers for error cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bugfixes
 
+* Remove caching headers in case of errors. [#275](https://github.com/elastic/integrations-registry/pull/275)
+
 ### Added
 
 * Allow to set cache times through config. [#271](https://github.com/elastic/integrations-registry/pull/271)

--- a/categories.go
+++ b/categories.go
@@ -23,8 +23,6 @@ type Category struct {
 // categoriesHandler is a dynamic handler as it will also allow filtering in the future.
 func categoriesHandler(packagesBasePath string, cacheTime time.Duration) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
-		cacheHeaders(w, cacheTime)
-
 		packages, err := util.GetPackages(packagesBasePath)
 		if err != nil {
 			notFound(w, err)
@@ -70,6 +68,8 @@ func categoriesHandler(packagesBasePath string, cacheTime time.Duration) func(w 
 			notFound(w, err)
 			return
 		}
+
+		cacheHeaders(w, cacheTime)
 		jsonHeader(w)
 		fmt.Fprint(w, string(data))
 	}

--- a/handler.go
+++ b/handler.go
@@ -18,12 +18,12 @@ func notFound(w http.ResponseWriter, err error) {
 	if err != nil {
 		errString = err.Error()
 	}
+
 	http.Error(w, errString, http.StatusNotFound)
 }
 
 func catchAll(publicPath string, cacheTime time.Duration) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
-		cacheHeaders(w, cacheTime)
 
 		path := r.RequestURI
 
@@ -54,6 +54,8 @@ func catchAll(publicPath string, cacheTime time.Duration) func(w http.ResponseWr
 			notFound(w, fmt.Errorf("404 Page Not Found Error"))
 			return
 		}
+
+		cacheHeaders(w, cacheTime)
 		sendHeader(w, r)
 		w.Write(data)
 	}

--- a/search.go
+++ b/search.go
@@ -20,8 +20,6 @@ import (
 
 func searchHandler(packagesBasePath string, cacheTime time.Duration) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
-		cacheHeaders(w, cacheTime)
-
 		query := r.URL.Query()
 
 		var kibanaVersion *semver.Version
@@ -124,6 +122,7 @@ func searchHandler(packagesBasePath string, cacheTime time.Duration) func(w http
 			return
 		}
 
+		cacheHeaders(w, cacheTime)
 		jsonHeader(w)
 		fmt.Fprint(w, string(data))
 	}


### PR DESCRIPTION
Based on https://github.com/elastic/package-registry/pull/271#pullrequestreview-376656371 in the error case, we should not send any cache headers for the error pages.