### PR TITLE
Add stream fields to basic templates

### DIFF
--- a/dev/packages/example/base-1.0.0/elasticsearch/index-template/events-mappings.json
+++ b/dev/packages/example/base-1.0.0/elasticsearch/index-template/events-mappings.json
@@ -25,15 +25,12 @@
             "stream": {
                 "properties": {
                     "type": {
-                        "ignore_above": 1024,
                         "type": "constant_keyword"
                     },
                     "dataset": {
-                        "ignore_above": 1024,
                         "type": "constant_keyword"
                     },
                     "namespace": {
-                        "ignore_above": 1024,
                         "type": "constant_keyword"
                     }
                 }

--- a/dev/packages/example/base-1.0.0/elasticsearch/index-template/events-mappings.json
+++ b/dev/packages/example/base-1.0.0/elasticsearch/index-template/events-mappings.json
@@ -22,6 +22,22 @@
             "@timestamp": {
                 "type": "date"
             },
+            "stream": {
+                "properties": {
+                    "type": {
+                        "ignore_above": 1024,
+                        "type": "constant_keyword"
+                    },
+                    "dataset": {
+                        "ignore_above": 1024,
+                        "type": "constant_keyword"
+                    },
+                    "namespace": {
+                        "ignore_above": 1024,
+                        "type": "constant_keyword"
+                    }
+                }
+            },
             "agent": {
                 "properties": {
                     "hostname": {

--- a/dev/packages/example/base-1.0.0/elasticsearch/index-template/logs-mappings.json
+++ b/dev/packages/example/base-1.0.0/elasticsearch/index-template/logs-mappings.json
@@ -25,15 +25,12 @@
             "stream": {
                 "properties": {
                     "type": {
-                        "ignore_above": 1024,
                         "type": "constant_keyword"
                     },
                     "dataset": {
-                        "ignore_above": 1024,
                         "type": "constant_keyword"
                     },
                     "namespace": {
-                        "ignore_above": 1024,
                         "type": "constant_keyword"
                     }
                 }

--- a/dev/packages/example/base-1.0.0/elasticsearch/index-template/logs-mappings.json
+++ b/dev/packages/example/base-1.0.0/elasticsearch/index-template/logs-mappings.json
@@ -22,6 +22,22 @@
             "@timestamp": {
                 "type": "date"
             },
+            "stream": {
+                "properties": {
+                    "type": {
+                        "ignore_above": 1024,
+                        "type": "constant_keyword"
+                    },
+                    "dataset": {
+                        "ignore_above": 1024,
+                        "type": "constant_keyword"
+                    },
+                    "namespace": {
+                        "ignore_above": 1024,
+                        "type": "constant_keyword"
+                    }
+                }
+            },
             "agent": {
                 "properties": {
                     "hostname": {

--- a/dev/packages/example/base-1.0.0/elasticsearch/index-template/metrics-mappings.json
+++ b/dev/packages/example/base-1.0.0/elasticsearch/index-template/metrics-mappings.json
@@ -25,15 +25,12 @@
             "stream": {
                 "properties": {
                     "type": {
-                        "ignore_above": 1024,
                         "type": "constant_keyword"
                     },
                     "dataset": {
-                        "ignore_above": 1024,
                         "type": "constant_keyword"
                     },
                     "namespace": {
-                        "ignore_above": 1024,
                         "type": "constant_keyword"
                     }
                 }

--- a/dev/packages/example/base-1.0.0/elasticsearch/index-template/metrics-mappings.json
+++ b/dev/packages/example/base-1.0.0/elasticsearch/index-template/metrics-mappings.json
@@ -22,6 +22,22 @@
             "@timestamp": {
                 "type": "date"
             },
+            "stream": {
+                "properties": {
+                    "type": {
+                        "ignore_above": 1024,
+                        "type": "constant_keyword"
+                    },
+                    "dataset": {
+                        "ignore_above": 1024,
+                        "type": "constant_keyword"
+                    },
+                    "namespace": {
+                        "ignore_above": 1024,
+                        "type": "constant_keyword"
+                    }
+                }
+            },
             "agent": {
                 "properties": {
                     "hostname": {


### PR DESCRIPTION
The stream fields are part of each event and important for the new indexing strategy. These fields also have to be added to each dataset. This could either happen during the build step of a package of directly in EPM (TBD).