### PR TITLE
Remove more usage of os.Chdir on saved objects and tar.gz.

### DIFF
--- a/dev/generator/main.go
+++ b/dev/generator/main.go
@@ -132,23 +132,17 @@ func buildPackage(packagesBasePath string, p util.Package) error {
 		return err
 	}
 
-	err = os.Chdir(packagesBasePath)
-	if err != nil {
-		return err
-	}
-	defer os.Chdir(currentPath)
-
-	err = writeJsonFile(p, p.GetPath()+"/index.json")
+	err = writeJsonFile(p, packagesBasePath+"/"+p.GetPath()+"/index.json")
 	if err != nil {
 		return err
 	}
 
 	// Get all Kibana files
-	savedObjects1, err := filepath.Glob(p.GetPath() + "/dataset/*/kibana/*/*")
+	savedObjects1, err := filepath.Glob(packagesBasePath + "/" + p.GetPath() + "/dataset/*/kibana/*/*")
 	if err != nil {
 		return err
 	}
-	savedObjects2, err := filepath.Glob(p.GetPath() + "/kibana/*/*")
+	savedObjects2, err := filepath.Glob(packagesBasePath + "/" + p.GetPath() + "/kibana/*/*")
 	if err != nil {
 		return err
 	}
@@ -173,12 +167,12 @@ func buildPackage(packagesBasePath string, p util.Package) error {
 	}
 
 	if tarGz {
-		err = os.MkdirAll("../epr/"+p.Name, 0755)
+		err = os.MkdirAll(packagesBasePath+"/../epr/"+p.Name, 0755)
 		if err != nil {
 			return err
 		}
 
-		err = sh.RunV("tar", "cvzf", "../epr/"+p.Name+"/"+p.GetPath()+".tar.gz", filepath.Base(p.GetPath())+"/")
+		err = sh.RunV("tar", "czf", packagesBasePath+"/../epr/"+p.Name+"/"+p.GetPath()+".tar.gz", "-C", packagesBasePath+"/", filepath.Base(p.GetPath())+"/")
 		if err != nil {
 			return fmt.Errorf("Error creating package: %s: %s", p.GetPath(), err)
 		}


### PR DESCRIPTION
Removes the usage of os.Chdir for saved objects. Path code needs some cleanup after this.