### PR TITLE
Introduce Package.getDataset method

### DIFF
--- a/util/package.go
+++ b/util/package.go
@@ -7,6 +7,7 @@ package util
 import (
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -273,53 +274,65 @@ func (p *Package) Validate() error {
 	return nil
 }
 
-func (p *Package) LoadDataSets(packagePath string) error {
-
+func (p *Package) GetDatasets() ([]string, error) {
 	datasetBasePath := p.BasePath + "/dataset"
 
 	// Check if this package has datasets
 	_, err := os.Stat(datasetBasePath)
 	// If no datasets exist, just return
 	if os.IsNotExist(err) {
-		return nil
+		return nil, nil
 	}
 	// An other error happened, report it
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	datasetPaths, err := filepath.Glob(datasetBasePath + "/*")
+	paths, err := filepath.Glob(datasetBasePath + "/*")
+	if err != nil {
+		return nil, err
+	}
+
+	for i, _ := range paths {
+		paths[i] = paths[i][len(datasetBasePath)-1:]
+	}
+
+	return paths, nil
+}
+
+func (p *Package) LoadDataSets(packagePath string) error {
+
+	datasets, err := p.GetDatasets()
 	if err != nil {
 		return err
 	}
 
-	for _, datasetPath := range datasetPaths {
+	datasetBasePath := p.BasePath + "/dataset"
+
+	for _, dataset := range datasets {
 		// Check if manifest exists
-		manifestPath := datasetPath + "/manifest.yml"
+		manifestPath := path.Join(datasetBasePath, dataset, "manifest.yml")
 		_, err := os.Stat(manifestPath)
 		if err != nil && os.IsNotExist(err) {
 			return errors.Wrapf(err, "manifest does not exist for package: %s", packagePath)
 		}
 
-		// Extract the local path name
-		localPath := datasetPath[len(datasetBasePath)-1:]
-
 		manifest, err := yaml.NewConfigWithFile(manifestPath, ucfg.PathSep("."))
 		var d = &DataSet{
 			Package: p.Name,
 			// This is the name of the directory of the dataset
-			Path:     localPath,
+			Path:     dataset,
 			BasePath: datasetBasePath,
 		}
 		// go-ucfg automatically calls the `Validate` method on the Dataset object here
 		err = manifest.Unpack(d)
 		if err != nil {
-			return errors.Wrapf(err, "error building dataset (path: %s) in package: %s", datasetPath, p.Name)
+			return errors.Wrapf(err, "error building dataset (path: %s) in package: %s", dataset, p.Name)
 		}
 
 		// if id is not set, {package}.{datasetPath} is the default
 		if d.ID == "" {
-			d.ID = p.Name + "." + localPath
+			d.ID = p.Name + "." + dataset
 		}
 
 		if d.Release == "" {


### PR DESCRIPTION
This method will be used in other places where also the list of datasets in a package is relevant but not the full manifest info has to be loaded.