### PR TITLE
Add stream fields to each dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Allow to set cache times through config. [#271](https://github.com/elastic/integrations-registry/pull/271)
 * Make README.md file a required file for a package. [#287](https://github.com/elastic/integrations-registry/pull/287)
+*  Add stream fields to each dataset [#296](https://github.com/elastic/integrations-registry/pull/296)
 
 ### Deprecated
 

--- a/dev/generator/main.go
+++ b/dev/generator/main.go
@@ -11,7 +11,6 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-	"path"
 	"path/filepath"
 
 	"github.com/magefile/mage/sh"
@@ -144,13 +143,13 @@ func buildPackage(packagesBasePath string, p util.Package) error {
 
 	// Add stream.yml to all dataset with the basic stream fields
 	for _, dataset := range datasets {
-		dirPath := path.Join(p.BasePath, "dataset", dataset, "fields")
+		dirPath := filepath.Join(p.BasePath, "dataset", dataset, "fields")
 		err := os.MkdirAll(dirPath, 0755)
 		if err != nil {
 			return err
 		}
 
-		err = ioutil.WriteFile(path.Join(dirPath, "stream.yml"), []byte(streamFields), 0644)
+		err = ioutil.WriteFile(filepath.Join(dirPath, "stream.yml"), []byte(streamFields), 0644)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
During the generation of the datasets, a stream.yml file is created with the stream fields inside. These are required for each dataset.