### PR TITLE
Refactor code base to use (file)path.Join 

### DIFF
--- a/dev/generator/main.go
+++ b/dev/generator/main.go
@@ -52,7 +52,7 @@ func main() {
 
 func Build(sourceDir, publicDir string) error {
 
-	err := BuildPackages(sourceDir, publicDir+"/"+packageDirName)
+	err := BuildPackages(sourceDir, filepath.Join(publicDir, packageDirName))
 	if err != nil {
 		return err
 	}
@@ -87,13 +87,13 @@ func BuildPackages(sourceDir, packagesPath string) error {
 		}
 
 		if copy {
-			err := CopyPackage(sourceDir+"/"+packageName, packagesPath)
+			err := CopyPackage(filepath.Join(sourceDir, packageName), packagesPath)
 			if err != nil {
 				return err
 			}
 		}
 
-		p, err := util.NewPackage(packagesPath, packageName)
+		p, err := util.NewPackage(filepath.Join(packagesPath, packageName))
 		if err != nil {
 			return err
 		}
@@ -120,7 +120,7 @@ func buildPackage(packagesBasePath string, p util.Package) error {
 		return fmt.Errorf("Invalid package: %s: %s", p.GetPath(), err)
 	}
 
-	p.BasePath = currentPath + "/" + packagesBasePath + "/" + p.GetPath()
+	p.BasePath = filepath.Join(currentPath, packagesBasePath, p.GetPath())
 
 	err = p.LoadAssets(p.GetPath())
 	if err != nil {
@@ -132,17 +132,17 @@ func buildPackage(packagesBasePath string, p util.Package) error {
 		return err
 	}
 
-	err = writeJsonFile(p, packagesBasePath+"/"+p.GetPath()+"/index.json")
+	err = writeJsonFile(p, filepath.Join(packagesBasePath, p.GetPath(), "index.json"))
 	if err != nil {
 		return err
 	}
 
 	// Get all Kibana files
-	savedObjects1, err := filepath.Glob(packagesBasePath + "/" + p.GetPath() + "/dataset/*/kibana/*/*")
+	savedObjects1, err := filepath.Glob(filepath.Join(packagesBasePath, p.GetPath(), "dataset", "*", "kibana", "*", "*"))
 	if err != nil {
 		return err
 	}
-	savedObjects2, err := filepath.Glob(packagesBasePath + "/" + p.GetPath() + "/kibana/*/*")
+	savedObjects2, err := filepath.Glob(filepath.Join(packagesBasePath, p.GetPath(), "kibana", "*", "*"))
 	if err != nil {
 		return err
 	}
@@ -167,12 +167,12 @@ func buildPackage(packagesBasePath string, p util.Package) error {
 	}
 
 	if tarGz {
-		err = os.MkdirAll(packagesBasePath+"/../epr/"+p.Name, 0755)
+		err = os.MkdirAll(filepath.Join(packagesBasePath, "..", "epr", p.Name), 0755)
 		if err != nil {
 			return err
 		}
 
-		err = sh.RunV("tar", "czf", packagesBasePath+"/../epr/"+p.Name+"/"+p.GetPath()+".tar.gz", "-C", packagesBasePath+"/", filepath.Base(p.GetPath())+"/")
+		err = sh.RunV("tar", "czf", filepath.Join(packagesBasePath, "..", "epr", p.Name, p.GetPath()+".tar.gz"), "-C", packagesBasePath+"/", filepath.Base(p.GetPath())+"/")
 		if err != nil {
 			return fmt.Errorf("Error creating package: %s: %s", p.GetPath(), err)
 		}

--- a/dev/import-beats/datasets.go
+++ b/dev/import-beats/datasets.go
@@ -9,7 +9,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -67,8 +67,8 @@ func createDatasets(modulePath, moduleName, moduleRelease, beatType string) (dat
 			continue
 		}
 
-		datasetPath := path.Join(modulePath, datasetName)
-		_, err := os.Stat(path.Join(datasetPath, "_meta"))
+		datasetPath := filepath.Join(modulePath, datasetName)
+		_, err := os.Stat(filepath.Join(datasetPath, "_meta"))
 		if os.IsNotExist(err) {
 			log.Printf("\t%s: not a valid dataset, skipped", datasetName)
 			continue

--- a/dev/import-beats/elasticsearch.go
+++ b/dev/import-beats/elasticsearch.go
@@ -9,7 +9,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -28,7 +28,7 @@ type ingestPipelineContent struct {
 func loadElasticsearchContent(datasetPath string) (elasticsearchContent, error) {
 	var esc elasticsearchContent
 
-	datasetManifestPath := path.Join(datasetPath, "manifest.yml")
+	datasetManifestPath := filepath.Join(datasetPath, "manifest.yml")
 	datasetManifestFile, err := ioutil.ReadFile(datasetManifestPath)
 	if os.IsNotExist(err) {
 		return elasticsearchContent{}, nil // no manifest.yml file found,
@@ -74,7 +74,7 @@ func loadElasticsearchContent(datasetPath string) (elasticsearchContent, error) 
 			}
 		}
 		esc.ingestPipelines = append(esc.ingestPipelines, ingestPipelineContent{
-			source:         path.Join(datasetPath, ingestPipeline),
+			source:         filepath.Join(datasetPath, ingestPipeline),
 			targetFileName: targetFileName,
 		})
 	}

--- a/dev/import-beats/streams.go
+++ b/dev/import-beats/streams.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -50,7 +49,7 @@ func createStreams(modulePath, moduleName, datasetName, beatType string) ([]util
 // createLogStreams method builds a set of stream inputs for logs oriented dataset.
 // The method unmarshals "manifest.yml" file and picks all configuration variables.
 func createLogStreams(modulePath, moduleName, datasetName string) ([]util.Stream, error) {
-	manifestPath := path.Join(modulePath, datasetName, "manifest.yml")
+	manifestPath := filepath.Join(modulePath, datasetName, "manifest.yml")
 	manifestFile, err := ioutil.ReadFile(manifestPath)
 	if err != nil {
 		return nil, errors.Wrapf(err, "reading manifest file failed (path: %s)", manifestPath)

--- a/util/dataset.go
+++ b/util/dataset.go
@@ -44,8 +44,8 @@ type Stream struct {
 }
 
 func (d *DataSet) Validate() error {
-	pipelineDir := d.BasePath + "/" + d.Path + "/elasticsearch/ingest-pipeline/"
-	paths, err := filepath.Glob(pipelineDir + "*")
+	pipelineDir := filepath.Join(d.BasePath, "elasticsearch", "ingest-pipeline")
+	paths, err := filepath.Glob(filepath.Join(pipelineDir, "*"))
 	if err != nil {
 		return err
 	}
@@ -70,8 +70,8 @@ func (d *DataSet) Validate() error {
 
 	// In case an ingest pipeline is set, check if it is around
 	if d.IngestPipeline != "" {
-		_, errJSON := os.Stat(pipelineDir + d.IngestPipeline + ".json")
-		_, errYAML := os.Stat(pipelineDir + d.IngestPipeline + ".yml")
+		_, errJSON := os.Stat(filepath.Join(pipelineDir, d.IngestPipeline+".json"))
+		_, errYAML := os.Stat(filepath.Join(pipelineDir, d.IngestPipeline+".yml"))
 
 		if os.IsNotExist(errYAML) && os.IsNotExist(errJSON) {
 			return fmt.Errorf("Defined ingest_pipeline does not exist: %s", pipelineDir+d.IngestPipeline)

--- a/util/packages.go
+++ b/util/packages.go
@@ -6,6 +6,7 @@ package util
 
 import (
 	"io/ioutil"
+	"path/filepath"
 )
 
 var packageList []Package
@@ -25,7 +26,7 @@ func GetPackages(packagesBasePath string) ([]Package, error) {
 	}
 
 	for _, i := range packagePaths {
-		p, err := NewPackage(packagesBasePath, i)
+		p, err := NewPackage(filepath.Join(packagesBasePath, i))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This is a refactoring of the packages and dataset code base. Changes:

* All the joined file paths are replaced by `filepath.Join`
* All the joined paths are replaced by `path.Join`
* basePath passed to package and dataset includes the name of the package / dataset

This change is only refactoring, should not have any effect on the registry service itself.