### PR TITLE
Change default for /search endpoint with package filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Allow to set cache times through config. [#271](https://github.com/elastic/integrations-registry/pull/271)
 * Make README.md file a required file for a package. [#287](https://github.com/elastic/integrations-registry/pull/287)
 *  Add stream fields to each dataset [#296](https://github.com/elastic/integrations-registry/pull/296)
-* Add `all` query param to return all packages. By default is set false. [#](https://github.com/elastic/integrations-registry/pull/)
+* Add `all` query param to return all packages. By default is set false. [#301](https://github.com/elastic/integrations-registry/pull/301)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking changes
 
-* Change package path from /package/{packagename}-{version} to /package/{packagename}/{version} [#](https://github.com/elastic/integrations-registry/pull/)
+* Change package path from /package/{packagename}-{version} to /package/{packagename}/{version} [#300](https://github.com/elastic/integrations-registry/pull/300)
+* By default /search?package= now only returns the most recent package. [#301](https://github.com/elastic/integrations-registry/pull/301)
 
 ### Bugfixes
 
@@ -20,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Allow to set cache times through config. [#271](https://github.com/elastic/integrations-registry/pull/271)
 * Make README.md file a required file for a package. [#287](https://github.com/elastic/integrations-registry/pull/287)
 *  Add stream fields to each dataset [#296](https://github.com/elastic/integrations-registry/pull/296)
+* Add `all` query param to return all packages. By default is set false. [#](https://github.com/elastic/integrations-registry/pull/)
 
 ### Deprecated
 

--- a/docs/api/search-all.json
+++ b/docs/api/search-all.json
@@ -1,0 +1,47 @@
+[
+  {
+    "description": "Package with data sources",
+    "download": "/epr/datasources/datasources-1.0.0.tar.gz",
+    "name": "datasources",
+    "path": "/package/datasources/1.0.0",
+    "title": "Default datasource Integration",
+    "type": "integration",
+    "version": "1.0.0"
+  },
+  {
+    "description": "Tests if no pipeline is set, it defaults to the default one",
+    "download": "/epr/default-pipeline/default-pipeline-0.0.2.tar.gz",
+    "name": "default-pipeline",
+    "path": "/package/default-pipeline/0.0.2",
+    "title": "Default pipeline Integration",
+    "type": "integration",
+    "version": "0.0.2"
+  },
+  {
+    "description": "This is the example integration.",
+    "download": "/epr/example/example-0.0.2.tar.gz",
+    "name": "example",
+    "path": "/package/example/0.0.2",
+    "title": "Example",
+    "type": "integration",
+    "version": "0.0.2"
+  },
+  {
+    "description": "This is the example integration",
+    "download": "/epr/example/example-1.0.0.tar.gz",
+    "name": "example",
+    "path": "/package/example/1.0.0",
+    "title": "Example Integration",
+    "type": "integration",
+    "version": "1.0.0"
+  },
+  {
+    "description": "This is the foo integration",
+    "download": "/epr/foo/foo-1.0.0.tar.gz",
+    "name": "foo",
+    "path": "/package/foo/1.0.0",
+    "title": "Foo",
+    "type": "solution",
+    "version": "1.0.0"
+  }
+]

--- a/docs/api/search-package-example-all.json
+++ b/docs/api/search-package-example-all.json
@@ -1,5 +1,14 @@
 [
   {
+    "description": "This is the example integration.",
+    "download": "/epr/example/example-0.0.2.tar.gz",
+    "name": "example",
+    "path": "/package/example/0.0.2",
+    "title": "Example",
+    "type": "integration",
+    "version": "0.0.2"
+  },
+  {
     "description": "This is the example integration",
     "download": "/epr/example/example-1.0.0.tar.gz",
     "name": "example",

--- a/main_test.go
+++ b/main_test.go
@@ -37,12 +37,14 @@ func TestEndpoints(t *testing.T) {
 	}{
 		{"/", "", "info.json", catchAll(publicPath, testCacheTime)},
 		{"/search", "/search", "search.json", searchHandler(packagesBasePath, testCacheTime)},
+		{"/search?all=true", "/search", "search-all.json", searchHandler(packagesBasePath, testCacheTime)},
 		{"/categories", "/categories", "categories.json", categoriesHandler(packagesBasePath, testCacheTime)},
 		{"/search?kibana=6.5.2", "/search", "search-kibana652.json", searchHandler(packagesBasePath, testCacheTime)},
 		{"/search?kibana=7.2.1", "/search", "search-kibana721.json", searchHandler(packagesBasePath, testCacheTime)},
 		{"/search?category=metrics", "/search", "search-category-metrics.json", searchHandler(packagesBasePath, testCacheTime)},
 		{"/search?category=logs", "/search", "search-category-logs.json", searchHandler(packagesBasePath, testCacheTime)},
 		{"/search?package=example", "/search", "search-package-example.json", searchHandler(packagesBasePath, testCacheTime)},
+		{"/search?package=example&all=true", "/search", "search-package-example-all.json", searchHandler(packagesBasePath, testCacheTime)},
 		{"/search?internal=true", "/search", "search-package-internal.json", searchHandler(packagesBasePath, testCacheTime)},
 		{"/package/example/1.0.0", "", "package.json", catchAll(publicPath, testCacheTime)},
 	}

--- a/search.go
+++ b/search.go
@@ -26,6 +26,7 @@ func searchHandler(packagesBasePath string, cacheTime time.Duration) func(w http
 		var category string
 		// Leaving out `a` here to not use a reserved name
 		var packageQuery string
+		var all bool
 		var internal bool
 		var err error
 
@@ -48,6 +49,13 @@ func searchHandler(packagesBasePath string, cacheTime time.Duration) func(w http
 			if v := query.Get("package"); v != "" {
 				if v != "" {
 					packageQuery = v
+				}
+			}
+
+			if v := query.Get("all"); v != "" {
+				if v != "" {
+					// Default is false, also on error
+					all, _ = strconv.ParseBool(v)
 				}
 			}
 
@@ -92,8 +100,7 @@ func searchHandler(packagesBasePath string, cacheTime time.Duration) func(w http
 				continue
 			}
 
-			// If no package Query is set, only the newest version of a package is returned
-			if packageQuery == "" {
+			if !all {
 				// Check if the version exists and if it should be added or not.
 				for _, versions := range packagesList {
 					for _, pp := range versions {


### PR DESCRIPTION
So far when a `/search?package=foo` query was run, by default all versions of the package found were returned. This was in contrast to that by default only the most recent version of a package is returned. To make the API less surprising the behavior was changed that by default only the most recent package is returned.

As there might be still a need to return all packages, and additional param `all=true` was added. This can now be used in combination with all query params. To get the same result as before, `/search?package=foo&all=true` has to be run. By default all is false.