### PR TITLE
Fix: stream metrics description

### DIFF
--- a/dev/import-beats/streams.go
+++ b/dev/import-beats/streams.go
@@ -151,7 +151,7 @@ func createMetricStreams(modulePath, moduleName, moduleTitle, datasetName string
 	return []util.Stream{
 		{
 			Input:       moduleName + "/metrics",
-			Title:       fmt.Sprintf("%s %s logs", moduleTitle, datasetName),
+			Title:       fmt.Sprintf("%s %s metrics", moduleTitle, datasetName),
 			Description: fmt.Sprintf("Collect %s %s metrics", moduleTitle, datasetName),
 			Vars:        configOptions,
 		},

--- a/dev/packages/beats/activemq-0.0.1/dataset/broker/manifest.yml
+++ b/dev/packages/beats/activemq-0.0.1/dataset/broker/manifest.yml
@@ -16,5 +16,5 @@ streams:
     name: period
   - default: admin
     name: username
-  title: activemq broker logs
+  title: activemq broker metrics
   description: Collect activemq broker metrics

--- a/dev/packages/beats/activemq-0.0.1/dataset/queue/manifest.yml
+++ b/dev/packages/beats/activemq-0.0.1/dataset/queue/manifest.yml
@@ -16,5 +16,5 @@ streams:
     name: period
   - default: admin
     name: username
-  title: activemq queue logs
+  title: activemq queue metrics
   description: Collect activemq queue metrics

--- a/dev/packages/beats/activemq-0.0.1/dataset/topic/manifest.yml
+++ b/dev/packages/beats/activemq-0.0.1/dataset/topic/manifest.yml
@@ -16,5 +16,5 @@ streams:
     name: period
   - default: admin
     name: username
-  title: activemq topic logs
+  title: activemq topic metrics
   description: Collect activemq topic metrics

--- a/dev/packages/beats/aerospike-0.0.1/dataset/namespace/manifest.yml
+++ b/dev/packages/beats/aerospike-0.0.1/dataset/namespace/manifest.yml
@@ -10,5 +10,5 @@ streams:
     name: hosts
   - default: 10s
     name: period
-  title: Aerospike namespace logs
+  title: Aerospike namespace metrics
   description: Collect Aerospike namespace metrics

--- a/dev/packages/beats/apache-0.0.1/dataset/status/manifest.yml
+++ b/dev/packages/beats/apache-0.0.1/dataset/status/manifest.yml
@@ -10,5 +10,5 @@ streams:
     name: hosts
   - default: 10s
     name: period
-  title: Apache status logs
+  title: Apache status metrics
   description: Collect Apache status metrics

--- a/dev/packages/beats/appsearch-0.0.1/dataset/stats/manifest.yml
+++ b/dev/packages/beats/appsearch-0.0.1/dataset/stats/manifest.yml
@@ -10,5 +10,5 @@ streams:
     name: hosts
   - default: 10s
     name: period
-  title: App Search stats logs
+  title: App Search stats metrics
   description: Collect App Search stats metrics

--- a/dev/packages/beats/aws-0.0.1/dataset/billing/manifest.yml
+++ b/dev/packages/beats/aws-0.0.1/dataset/billing/manifest.yml
@@ -10,5 +10,5 @@ streams:
   - default:
     - us-east-1
     name: regions
-  title: aws billing logs
+  title: aws billing metrics
   description: Collect aws billing metrics

--- a/dev/packages/beats/aws-0.0.1/dataset/cloudwatch-metrics/manifest.yml
+++ b/dev/packages/beats/aws-0.0.1/dataset/cloudwatch-metrics/manifest.yml
@@ -23,5 +23,5 @@ streams:
     name: metrics
   - default: 300s
     name: period
-  title: aws cloudwatch logs
+  title: aws cloudwatch metrics
   description: Collect aws cloudwatch metrics

--- a/dev/packages/beats/aws-0.0.1/dataset/dynamodb/manifest.yml
+++ b/dev/packages/beats/aws-0.0.1/dataset/dynamodb/manifest.yml
@@ -7,5 +7,5 @@ streams:
   vars:
   - default: 5m
     name: period
-  title: aws dynamodb logs
+  title: aws dynamodb metrics
   description: Collect aws dynamodb metrics

--- a/dev/packages/beats/aws-0.0.1/dataset/ebs/manifest.yml
+++ b/dev/packages/beats/aws-0.0.1/dataset/ebs/manifest.yml
@@ -7,5 +7,5 @@ streams:
   vars:
   - default: 5m
     name: period
-  title: aws ebs logs
+  title: aws ebs metrics
   description: Collect aws ebs metrics

--- a/dev/packages/beats/aws-0.0.1/dataset/ec2-metrics/manifest.yml
+++ b/dev/packages/beats/aws-0.0.1/dataset/ec2-metrics/manifest.yml
@@ -13,5 +13,5 @@ streams:
     - key: Organization
       value: Engineering
     name: tags_filter
-  title: aws ec2 logs
+  title: aws ec2 metrics
   description: Collect aws ec2 metrics

--- a/dev/packages/beats/aws-0.0.1/dataset/elb-metrics/manifest.yml
+++ b/dev/packages/beats/aws-0.0.1/dataset/elb-metrics/manifest.yml
@@ -13,5 +13,5 @@ streams:
     - key: dept
       value: eng
     name: tags_filter
-  title: aws elb logs
+  title: aws elb metrics
   description: Collect aws elb metrics

--- a/dev/packages/beats/aws-0.0.1/dataset/lambda/manifest.yml
+++ b/dev/packages/beats/aws-0.0.1/dataset/lambda/manifest.yml
@@ -7,5 +7,5 @@ streams:
   vars:
   - default: 5m
     name: period
-  title: aws lambda logs
+  title: aws lambda metrics
   description: Collect aws lambda metrics

--- a/dev/packages/beats/aws-0.0.1/dataset/natgateway/manifest.yml
+++ b/dev/packages/beats/aws-0.0.1/dataset/natgateway/manifest.yml
@@ -13,5 +13,5 @@ streams:
     - key: dept
       value: eng
     name: tags_filter
-  title: aws natgateway logs
+  title: aws natgateway metrics
   description: Collect aws natgateway metrics

--- a/dev/packages/beats/aws-0.0.1/dataset/rds/manifest.yml
+++ b/dev/packages/beats/aws-0.0.1/dataset/rds/manifest.yml
@@ -13,5 +13,5 @@ streams:
     - key: dept
       value: eng
     name: tags_filter
-  title: aws rds logs
+  title: aws rds metrics
   description: Collect aws rds metrics

--- a/dev/packages/beats/aws-0.0.1/dataset/s3_daily_storage/manifest.yml
+++ b/dev/packages/beats/aws-0.0.1/dataset/s3_daily_storage/manifest.yml
@@ -13,5 +13,5 @@ streams:
     name: secret_access_key
   - default: ${AWS_SESSION_TOKEN:""}
     name: session_token
-  title: aws s3_daily_storage logs
+  title: aws s3_daily_storage metrics
   description: Collect aws s3_daily_storage metrics

--- a/dev/packages/beats/aws-0.0.1/dataset/s3_request/manifest.yml
+++ b/dev/packages/beats/aws-0.0.1/dataset/s3_request/manifest.yml
@@ -13,5 +13,5 @@ streams:
     name: secret_access_key
   - default: ${AWS_SESSION_TOKEN:""}
     name: session_token
-  title: aws s3_request logs
+  title: aws s3_request metrics
   description: Collect aws s3_request metrics

--- a/dev/packages/beats/aws-0.0.1/dataset/sns/manifest.yml
+++ b/dev/packages/beats/aws-0.0.1/dataset/sns/manifest.yml
@@ -7,5 +7,5 @@ streams:
   vars:
   - default: 5m
     name: period
-  title: aws sns logs
+  title: aws sns metrics
   description: Collect aws sns metrics

--- a/dev/packages/beats/aws-0.0.1/dataset/sqs/manifest.yml
+++ b/dev/packages/beats/aws-0.0.1/dataset/sqs/manifest.yml
@@ -12,5 +12,5 @@ streams:
   - default:
     - us-west-1
     name: regions
-  title: aws sqs logs
+  title: aws sqs metrics
   description: Collect aws sqs metrics

--- a/dev/packages/beats/aws-0.0.1/dataset/transitgateway/manifest.yml
+++ b/dev/packages/beats/aws-0.0.1/dataset/transitgateway/manifest.yml
@@ -13,5 +13,5 @@ streams:
     - key: dept
       value: eng
     name: tags_filter
-  title: aws transitgateway logs
+  title: aws transitgateway metrics
   description: Collect aws transitgateway metrics

--- a/dev/packages/beats/aws-0.0.1/dataset/usage/manifest.yml
+++ b/dev/packages/beats/aws-0.0.1/dataset/usage/manifest.yml
@@ -13,5 +13,5 @@ streams:
     - key: dept
       value: eng
     name: tags_filter
-  title: aws usage logs
+  title: aws usage metrics
   description: Collect aws usage metrics

--- a/dev/packages/beats/aws-0.0.1/dataset/vpn/manifest.yml
+++ b/dev/packages/beats/aws-0.0.1/dataset/vpn/manifest.yml
@@ -13,5 +13,5 @@ streams:
     - key: dept
       value: eng
     name: tags_filter
-  title: aws vpn logs
+  title: aws vpn metrics
   description: Collect aws vpn metrics

--- a/dev/packages/beats/azure-0.0.1/dataset/compute_vm/manifest.yml
+++ b/dev/packages/beats/azure-0.0.1/dataset/compute_vm/manifest.yml
@@ -15,5 +15,5 @@ streams:
     name: subscription_id
   - default: ${AZURE_TENANT_ID:""}
     name: tenant_id
-  title: azure compute_vm logs
+  title: azure compute_vm metrics
   description: Collect azure compute_vm metrics

--- a/dev/packages/beats/azure-0.0.1/dataset/compute_vm_scaleset/manifest.yml
+++ b/dev/packages/beats/azure-0.0.1/dataset/compute_vm_scaleset/manifest.yml
@@ -15,5 +15,5 @@ streams:
     name: subscription_id
   - default: ${AZURE_TENANT_ID:""}
     name: tenant_id
-  title: azure compute_vm_scaleset logs
+  title: azure compute_vm_scaleset metrics
   description: Collect azure compute_vm_scaleset metrics

--- a/dev/packages/beats/azure-0.0.1/dataset/container_instance/manifest.yml
+++ b/dev/packages/beats/azure-0.0.1/dataset/container_instance/manifest.yml
@@ -15,5 +15,5 @@ streams:
     name: subscription_id
   - default: ${AZURE_TENANT_ID:""}
     name: tenant_id
-  title: azure container_instance logs
+  title: azure container_instance metrics
   description: Collect azure container_instance metrics

--- a/dev/packages/beats/azure-0.0.1/dataset/container_registry/manifest.yml
+++ b/dev/packages/beats/azure-0.0.1/dataset/container_registry/manifest.yml
@@ -15,5 +15,5 @@ streams:
     name: subscription_id
   - default: ${AZURE_TENANT_ID:""}
     name: tenant_id
-  title: azure container_registry logs
+  title: azure container_registry metrics
   description: Collect azure container_registry metrics

--- a/dev/packages/beats/azure-0.0.1/dataset/container_service/manifest.yml
+++ b/dev/packages/beats/azure-0.0.1/dataset/container_service/manifest.yml
@@ -15,5 +15,5 @@ streams:
     name: subscription_id
   - default: ${AZURE_TENANT_ID:""}
     name: tenant_id
-  title: azure container_service logs
+  title: azure container_service metrics
   description: Collect azure container_service metrics

--- a/dev/packages/beats/azure-0.0.1/dataset/database_account/manifest.yml
+++ b/dev/packages/beats/azure-0.0.1/dataset/database_account/manifest.yml
@@ -15,5 +15,5 @@ streams:
     name: subscription_id
   - default: ${AZURE_TENANT_ID:""}
     name: tenant_id
-  title: azure database_account logs
+  title: azure database_account metrics
   description: Collect azure database_account metrics

--- a/dev/packages/beats/azure-0.0.1/dataset/monitor/manifest.yml
+++ b/dev/packages/beats/azure-0.0.1/dataset/monitor/manifest.yml
@@ -26,5 +26,5 @@ streams:
     name: subscription_id
   - default: ${AZURE_TENANT_ID:""}
     name: tenant_id
-  title: azure monitor logs
+  title: azure monitor metrics
   description: Collect azure monitor metrics

--- a/dev/packages/beats/azure-0.0.1/dataset/storage/manifest.yml
+++ b/dev/packages/beats/azure-0.0.1/dataset/storage/manifest.yml
@@ -15,5 +15,5 @@ streams:
     name: subscription_id
   - default: ${AZURE_TENANT_ID:""}
     name: tenant_id
-  title: azure storage logs
+  title: azure storage metrics
   description: Collect azure storage metrics

--- a/dev/packages/beats/beat-0.0.1/dataset/state/manifest.yml
+++ b/dev/packages/beats/beat-0.0.1/dataset/state/manifest.yml
@@ -12,5 +12,5 @@ streams:
     name: period
   - default: true
     name: xpack.enabled
-  title: Beat state logs
+  title: Beat state metrics
   description: Collect Beat state metrics

--- a/dev/packages/beats/beat-0.0.1/dataset/stats/manifest.yml
+++ b/dev/packages/beats/beat-0.0.1/dataset/stats/manifest.yml
@@ -12,5 +12,5 @@ streams:
     name: period
   - default: true
     name: xpack.enabled
-  title: Beat stats logs
+  title: Beat stats metrics
   description: Collect Beat stats metrics

--- a/dev/packages/beats/ceph-0.0.1/dataset/cluster_disk/manifest.yml
+++ b/dev/packages/beats/ceph-0.0.1/dataset/cluster_disk/manifest.yml
@@ -10,5 +10,5 @@ streams:
     name: hosts
   - default: 10s
     name: period
-  title: Ceph cluster_disk logs
+  title: Ceph cluster_disk metrics
   description: Collect Ceph cluster_disk metrics

--- a/dev/packages/beats/ceph-0.0.1/dataset/cluster_health/manifest.yml
+++ b/dev/packages/beats/ceph-0.0.1/dataset/cluster_health/manifest.yml
@@ -10,5 +10,5 @@ streams:
     name: hosts
   - default: 10s
     name: period
-  title: Ceph cluster_health logs
+  title: Ceph cluster_health metrics
   description: Collect Ceph cluster_health metrics

--- a/dev/packages/beats/ceph-0.0.1/dataset/cluster_status/manifest.yml
+++ b/dev/packages/beats/ceph-0.0.1/dataset/cluster_status/manifest.yml
@@ -4,5 +4,5 @@ release: ga
 type: metrics
 streams:
 - input: ceph/metrics
-  title: Ceph cluster_status logs
+  title: Ceph cluster_status metrics
   description: Collect Ceph cluster_status metrics

--- a/dev/packages/beats/ceph-0.0.1/dataset/mgr_cluster_disk/manifest.yml
+++ b/dev/packages/beats/ceph-0.0.1/dataset/mgr_cluster_disk/manifest.yml
@@ -10,5 +10,5 @@ streams:
     name: hosts
   - default: 1m
     name: period
-  title: Ceph mgr_cluster_disk logs
+  title: Ceph mgr_cluster_disk metrics
   description: Collect Ceph mgr_cluster_disk metrics

--- a/dev/packages/beats/ceph-0.0.1/dataset/mgr_cluster_health/manifest.yml
+++ b/dev/packages/beats/ceph-0.0.1/dataset/mgr_cluster_health/manifest.yml
@@ -10,5 +10,5 @@ streams:
     name: hosts
   - default: 10s
     name: period
-  title: Ceph mgr_cluster_health logs
+  title: Ceph mgr_cluster_health metrics
   description: Collect Ceph mgr_cluster_health metrics

--- a/dev/packages/beats/ceph-0.0.1/dataset/mgr_osd_perf/manifest.yml
+++ b/dev/packages/beats/ceph-0.0.1/dataset/mgr_osd_perf/manifest.yml
@@ -10,5 +10,5 @@ streams:
     name: hosts
   - default: 1m
     name: period
-  title: Ceph mgr_osd_perf logs
+  title: Ceph mgr_osd_perf metrics
   description: Collect Ceph mgr_osd_perf metrics

--- a/dev/packages/beats/ceph-0.0.1/dataset/mgr_osd_pool_stats/manifest.yml
+++ b/dev/packages/beats/ceph-0.0.1/dataset/mgr_osd_pool_stats/manifest.yml
@@ -4,5 +4,5 @@ release: beta
 type: metrics
 streams:
 - input: ceph/metrics
-  title: Ceph mgr_osd_pool_stats logs
+  title: Ceph mgr_osd_pool_stats metrics
   description: Collect Ceph mgr_osd_pool_stats metrics

--- a/dev/packages/beats/ceph-0.0.1/dataset/mgr_osd_tree/manifest.yml
+++ b/dev/packages/beats/ceph-0.0.1/dataset/mgr_osd_tree/manifest.yml
@@ -4,5 +4,5 @@ release: beta
 type: metrics
 streams:
 - input: ceph/metrics
-  title: Ceph mgr_osd_tree logs
+  title: Ceph mgr_osd_tree metrics
   description: Collect Ceph mgr_osd_tree metrics

--- a/dev/packages/beats/ceph-0.0.1/dataset/mgr_pool_disk/manifest.yml
+++ b/dev/packages/beats/ceph-0.0.1/dataset/mgr_pool_disk/manifest.yml
@@ -10,5 +10,5 @@ streams:
     name: hosts
   - default: 1m
     name: period
-  title: Ceph mgr_pool_disk logs
+  title: Ceph mgr_pool_disk metrics
   description: Collect Ceph mgr_pool_disk metrics

--- a/dev/packages/beats/ceph-0.0.1/dataset/monitor_health/manifest.yml
+++ b/dev/packages/beats/ceph-0.0.1/dataset/monitor_health/manifest.yml
@@ -10,5 +10,5 @@ streams:
     name: hosts
   - default: 10s
     name: period
-  title: Ceph monitor_health logs
+  title: Ceph monitor_health metrics
   description: Collect Ceph monitor_health metrics

--- a/dev/packages/beats/ceph-0.0.1/dataset/osd_df/manifest.yml
+++ b/dev/packages/beats/ceph-0.0.1/dataset/osd_df/manifest.yml
@@ -4,5 +4,5 @@ release: ga
 type: metrics
 streams:
 - input: ceph/metrics
-  title: Ceph osd_df logs
+  title: Ceph osd_df metrics
   description: Collect Ceph osd_df metrics

--- a/dev/packages/beats/ceph-0.0.1/dataset/osd_tree/manifest.yml
+++ b/dev/packages/beats/ceph-0.0.1/dataset/osd_tree/manifest.yml
@@ -10,5 +10,5 @@ streams:
     name: hosts
   - default: 10s
     name: period
-  title: Ceph osd_tree logs
+  title: Ceph osd_tree metrics
   description: Collect Ceph osd_tree metrics

--- a/dev/packages/beats/ceph-0.0.1/dataset/pool_disk/manifest.yml
+++ b/dev/packages/beats/ceph-0.0.1/dataset/pool_disk/manifest.yml
@@ -10,5 +10,5 @@ streams:
     name: hosts
   - default: 10s
     name: period
-  title: Ceph pool_disk logs
+  title: Ceph pool_disk metrics
   description: Collect Ceph pool_disk metrics

--- a/dev/packages/beats/cloudfoundry-0.0.1/dataset/container/manifest.yml
+++ b/dev/packages/beats/cloudfoundry-0.0.1/dataset/container/manifest.yml
@@ -17,5 +17,5 @@ streams:
     name: rlp_address
   - default: ${CLOUDFOUNDRY_UAA_ADDRESS:""}
     name: uaa_address
-  title: cloudfoundry container logs
+  title: cloudfoundry container metrics
   description: Collect cloudfoundry container metrics

--- a/dev/packages/beats/cloudfoundry-0.0.1/dataset/counter/manifest.yml
+++ b/dev/packages/beats/cloudfoundry-0.0.1/dataset/counter/manifest.yml
@@ -17,5 +17,5 @@ streams:
     name: rlp_address
   - default: ${CLOUDFOUNDRY_UAA_ADDRESS:""}
     name: uaa_address
-  title: cloudfoundry counter logs
+  title: cloudfoundry counter metrics
   description: Collect cloudfoundry counter metrics

--- a/dev/packages/beats/cloudfoundry-0.0.1/dataset/value/manifest.yml
+++ b/dev/packages/beats/cloudfoundry-0.0.1/dataset/value/manifest.yml
@@ -17,5 +17,5 @@ streams:
     name: rlp_address
   - default: ${CLOUDFOUNDRY_UAA_ADDRESS:""}
     name: uaa_address
-  title: cloudfoundry value logs
+  title: cloudfoundry value metrics
   description: Collect cloudfoundry value metrics

--- a/dev/packages/beats/cockroachdb-0.0.1/dataset/status/manifest.yml
+++ b/dev/packages/beats/cockroachdb-0.0.1/dataset/status/manifest.yml
@@ -10,5 +10,5 @@ streams:
     name: hosts
   - default: 10s
     name: period
-  title: CockroachDB status logs
+  title: CockroachDB status metrics
   description: Collect CockroachDB status metrics

--- a/dev/packages/beats/consul-0.0.1/dataset/agent/manifest.yml
+++ b/dev/packages/beats/consul-0.0.1/dataset/agent/manifest.yml
@@ -10,5 +10,5 @@ streams:
     name: hosts
   - default: 10s
     name: period
-  title: consul agent logs
+  title: consul agent metrics
   description: Collect consul agent metrics

--- a/dev/packages/beats/coredns-0.0.1/dataset/stats/manifest.yml
+++ b/dev/packages/beats/coredns-0.0.1/dataset/stats/manifest.yml
@@ -10,5 +10,5 @@ streams:
     name: hosts
   - default: 10s
     name: period
-  title: coredns stats logs
+  title: coredns stats metrics
   description: Collect coredns stats metrics

--- a/dev/packages/beats/couchbase-0.0.1/dataset/bucket/manifest.yml
+++ b/dev/packages/beats/couchbase-0.0.1/dataset/bucket/manifest.yml
@@ -10,5 +10,5 @@ streams:
     name: hosts
   - default: 10s
     name: period
-  title: Couchbase bucket logs
+  title: Couchbase bucket metrics
   description: Collect Couchbase bucket metrics

--- a/dev/packages/beats/couchbase-0.0.1/dataset/cluster/manifest.yml
+++ b/dev/packages/beats/couchbase-0.0.1/dataset/cluster/manifest.yml
@@ -10,5 +10,5 @@ streams:
     name: hosts
   - default: 10s
     name: period
-  title: Couchbase cluster logs
+  title: Couchbase cluster metrics
   description: Collect Couchbase cluster metrics

--- a/dev/packages/beats/couchbase-0.0.1/dataset/node/manifest.yml
+++ b/dev/packages/beats/couchbase-0.0.1/dataset/node/manifest.yml
@@ -10,5 +10,5 @@ streams:
     name: hosts
   - default: 10s
     name: period
-  title: Couchbase node logs
+  title: Couchbase node metrics
   description: Collect Couchbase node metrics

--- a/dev/packages/beats/couchdb-0.0.1/dataset/server/manifest.yml
+++ b/dev/packages/beats/couchdb-0.0.1/dataset/server/manifest.yml
@@ -10,5 +10,5 @@ streams:
     name: hosts
   - default: 10s
     name: period
-  title: CouchDB server logs
+  title: CouchDB server metrics
   description: Collect CouchDB server metrics

--- a/dev/packages/beats/docker-0.0.1/dataset/container/manifest.yml
+++ b/dev/packages/beats/docker-0.0.1/dataset/container/manifest.yml
@@ -10,5 +10,5 @@ streams:
     name: hosts
   - default: 10s
     name: period
-  title: Docker container logs
+  title: Docker container metrics
   description: Collect Docker container metrics

--- a/dev/packages/beats/docker-0.0.1/dataset/cpu/manifest.yml
+++ b/dev/packages/beats/docker-0.0.1/dataset/cpu/manifest.yml
@@ -10,5 +10,5 @@ streams:
     name: hosts
   - default: 10s
     name: period
-  title: Docker cpu logs
+  title: Docker cpu metrics
   description: Collect Docker cpu metrics

--- a/dev/packages/beats/docker-0.0.1/dataset/diskio/manifest.yml
+++ b/dev/packages/beats/docker-0.0.1/dataset/diskio/manifest.yml
@@ -10,5 +10,5 @@ streams:
     name: hosts
   - default: 10s
     name: period
-  title: Docker diskio logs
+  title: Docker diskio metrics
   description: Collect Docker diskio metrics

--- a/dev/packages/beats/docker-0.0.1/dataset/event/manifest.yml
+++ b/dev/packages/beats/docker-0.0.1/dataset/event/manifest.yml
@@ -10,5 +10,5 @@ streams:
     name: hosts
   - default: 10s
     name: period
-  title: Docker event logs
+  title: Docker event metrics
   description: Collect Docker event metrics

--- a/dev/packages/beats/docker-0.0.1/dataset/healthcheck/manifest.yml
+++ b/dev/packages/beats/docker-0.0.1/dataset/healthcheck/manifest.yml
@@ -10,5 +10,5 @@ streams:
     name: hosts
   - default: 10s
     name: period
-  title: Docker healthcheck logs
+  title: Docker healthcheck metrics
   description: Collect Docker healthcheck metrics

--- a/dev/packages/beats/docker-0.0.1/dataset/image/manifest.yml
+++ b/dev/packages/beats/docker-0.0.1/dataset/image/manifest.yml
@@ -4,5 +4,5 @@ release: ga
 type: metrics
 streams:
 - input: docker/metrics
-  title: Docker image logs
+  title: Docker image metrics
   description: Collect Docker image metrics

--- a/dev/packages/beats/docker-0.0.1/dataset/info/manifest.yml
+++ b/dev/packages/beats/docker-0.0.1/dataset/info/manifest.yml
@@ -10,5 +10,5 @@ streams:
     name: hosts
   - default: 10s
     name: period
-  title: Docker info logs
+  title: Docker info metrics
   description: Collect Docker info metrics

--- a/dev/packages/beats/docker-0.0.1/dataset/memory/manifest.yml
+++ b/dev/packages/beats/docker-0.0.1/dataset/memory/manifest.yml
@@ -10,5 +10,5 @@ streams:
     name: hosts
   - default: 10s
     name: period
-  title: Docker memory logs
+  title: Docker memory metrics
   description: Collect Docker memory metrics

--- a/dev/packages/beats/docker-0.0.1/dataset/network/manifest.yml
+++ b/dev/packages/beats/docker-0.0.1/dataset/network/manifest.yml
@@ -10,5 +10,5 @@ streams:
     name: hosts
   - default: 10s
     name: period
-  title: Docker network logs
+  title: Docker network metrics
   description: Collect Docker network metrics

--- a/dev/packages/beats/dropwizard-0.0.1/dataset/collector/manifest.yml
+++ b/dev/packages/beats/dropwizard-0.0.1/dataset/collector/manifest.yml
@@ -14,5 +14,5 @@ streams:
     name: namespace
   - default: 10s
     name: period
-  title: Dropwizard collector logs
+  title: Dropwizard collector metrics
   description: Collect Dropwizard collector metrics

--- a/dev/packages/beats/elasticsearch-0.0.1/dataset/ccr/manifest.yml
+++ b/dev/packages/beats/elasticsearch-0.0.1/dataset/ccr/manifest.yml
@@ -12,5 +12,5 @@ streams:
     name: period
   - default: true
     name: xpack.enabled
-  title: Elasticsearch ccr logs
+  title: Elasticsearch ccr metrics
   description: Collect Elasticsearch ccr metrics

--- a/dev/packages/beats/elasticsearch-0.0.1/dataset/cluster_stats/manifest.yml
+++ b/dev/packages/beats/elasticsearch-0.0.1/dataset/cluster_stats/manifest.yml
@@ -12,5 +12,5 @@ streams:
     name: period
   - default: true
     name: xpack.enabled
-  title: Elasticsearch cluster_stats logs
+  title: Elasticsearch cluster_stats metrics
   description: Collect Elasticsearch cluster_stats metrics

--- a/dev/packages/beats/elasticsearch-0.0.1/dataset/enrich/manifest.yml
+++ b/dev/packages/beats/elasticsearch-0.0.1/dataset/enrich/manifest.yml
@@ -12,5 +12,5 @@ streams:
     name: period
   - default: true
     name: xpack.enabled
-  title: Elasticsearch enrich logs
+  title: Elasticsearch enrich metrics
   description: Collect Elasticsearch enrich metrics

--- a/dev/packages/beats/elasticsearch-0.0.1/dataset/index/manifest.yml
+++ b/dev/packages/beats/elasticsearch-0.0.1/dataset/index/manifest.yml
@@ -12,5 +12,5 @@ streams:
     name: period
   - default: true
     name: xpack.enabled
-  title: Elasticsearch index logs
+  title: Elasticsearch index metrics
   description: Collect Elasticsearch index metrics

--- a/dev/packages/beats/elasticsearch-0.0.1/dataset/index_recovery/manifest.yml
+++ b/dev/packages/beats/elasticsearch-0.0.1/dataset/index_recovery/manifest.yml
@@ -12,5 +12,5 @@ streams:
     name: period
   - default: true
     name: xpack.enabled
-  title: Elasticsearch index_recovery logs
+  title: Elasticsearch index_recovery metrics
   description: Collect Elasticsearch index_recovery metrics

--- a/dev/packages/beats/elasticsearch-0.0.1/dataset/index_summary/manifest.yml
+++ b/dev/packages/beats/elasticsearch-0.0.1/dataset/index_summary/manifest.yml
@@ -12,5 +12,5 @@ streams:
     name: period
   - default: true
     name: xpack.enabled
-  title: Elasticsearch index_summary logs
+  title: Elasticsearch index_summary metrics
   description: Collect Elasticsearch index_summary metrics

--- a/dev/packages/beats/elasticsearch-0.0.1/dataset/ml_job/manifest.yml
+++ b/dev/packages/beats/elasticsearch-0.0.1/dataset/ml_job/manifest.yml
@@ -12,5 +12,5 @@ streams:
     name: period
   - default: true
     name: xpack.enabled
-  title: Elasticsearch ml_job logs
+  title: Elasticsearch ml_job metrics
   description: Collect Elasticsearch ml_job metrics

--- a/dev/packages/beats/elasticsearch-0.0.1/dataset/node/manifest.yml
+++ b/dev/packages/beats/elasticsearch-0.0.1/dataset/node/manifest.yml
@@ -10,5 +10,5 @@ streams:
     name: hosts
   - default: 10s
     name: period
-  title: Elasticsearch node logs
+  title: Elasticsearch node metrics
   description: Collect Elasticsearch node metrics

--- a/dev/packages/beats/elasticsearch-0.0.1/dataset/node_stats/manifest.yml
+++ b/dev/packages/beats/elasticsearch-0.0.1/dataset/node_stats/manifest.yml
@@ -12,5 +12,5 @@ streams:
     name: period
   - default: true
     name: xpack.enabled
-  title: Elasticsearch node_stats logs
+  title: Elasticsearch node_stats metrics
   description: Collect Elasticsearch node_stats metrics

--- a/dev/packages/beats/elasticsearch-0.0.1/dataset/pending_tasks/manifest.yml
+++ b/dev/packages/beats/elasticsearch-0.0.1/dataset/pending_tasks/manifest.yml
@@ -4,5 +4,5 @@ release: ga
 type: metrics
 streams:
 - input: elasticsearch/metrics
-  title: Elasticsearch pending_tasks logs
+  title: Elasticsearch pending_tasks metrics
   description: Collect Elasticsearch pending_tasks metrics

--- a/dev/packages/beats/elasticsearch-0.0.1/dataset/shard/manifest.yml
+++ b/dev/packages/beats/elasticsearch-0.0.1/dataset/shard/manifest.yml
@@ -12,5 +12,5 @@ streams:
     name: period
   - default: true
     name: xpack.enabled
-  title: Elasticsearch shard logs
+  title: Elasticsearch shard metrics
   description: Collect Elasticsearch shard metrics

--- a/dev/packages/beats/envoyproxy-0.0.1/dataset/server/manifest.yml
+++ b/dev/packages/beats/envoyproxy-0.0.1/dataset/server/manifest.yml
@@ -10,5 +10,5 @@ streams:
     name: hosts
   - default: 10s
     name: period
-  title: envoyproxy server logs
+  title: envoyproxy server metrics
   description: Collect envoyproxy server metrics

--- a/dev/packages/beats/etcd-0.0.1/dataset/leader/manifest.yml
+++ b/dev/packages/beats/etcd-0.0.1/dataset/leader/manifest.yml
@@ -10,5 +10,5 @@ streams:
     name: hosts
   - default: 10s
     name: period
-  title: Etcd leader logs
+  title: Etcd leader metrics
   description: Collect Etcd leader metrics

--- a/dev/packages/beats/etcd-0.0.1/dataset/metrics/manifest.yml
+++ b/dev/packages/beats/etcd-0.0.1/dataset/metrics/manifest.yml
@@ -4,5 +4,5 @@ release: beta
 type: metrics
 streams:
 - input: etcd/metrics
-  title: Etcd metrics logs
+  title: Etcd metrics metrics
   description: Collect Etcd metrics metrics

--- a/dev/packages/beats/etcd-0.0.1/dataset/self/manifest.yml
+++ b/dev/packages/beats/etcd-0.0.1/dataset/self/manifest.yml
@@ -10,5 +10,5 @@ streams:
     name: hosts
   - default: 10s
     name: period
-  title: Etcd self logs
+  title: Etcd self metrics
   description: Collect Etcd self metrics

--- a/dev/packages/beats/etcd-0.0.1/dataset/store/manifest.yml
+++ b/dev/packages/beats/etcd-0.0.1/dataset/store/manifest.yml
@@ -10,5 +10,5 @@ streams:
     name: hosts
   - default: 10s
     name: period
-  title: Etcd store logs
+  title: Etcd store metrics
   description: Collect Etcd store metrics

--- a/dev/packages/beats/golang-0.0.1/dataset/expvar/manifest.yml
+++ b/dev/packages/beats/golang-0.0.1/dataset/expvar/manifest.yml
@@ -9,5 +9,5 @@ streams:
     name: expvar.namespace
   - default: /debug/vars
     name: expvar.path
-  title: Golang expvar logs
+  title: Golang expvar metrics
   description: Collect Golang expvar metrics

--- a/dev/packages/beats/golang-0.0.1/dataset/heap/manifest.yml
+++ b/dev/packages/beats/golang-0.0.1/dataset/heap/manifest.yml
@@ -7,5 +7,5 @@ streams:
   vars:
   - default: /debug/vars
     name: heap.path
-  title: Golang heap logs
+  title: Golang heap metrics
   description: Collect Golang heap metrics

--- a/dev/packages/beats/googlecloud-0.0.1/dataset/compute/manifest.yml
+++ b/dev/packages/beats/googlecloud-0.0.1/dataset/compute/manifest.yml
@@ -15,5 +15,5 @@ streams:
     name: project_id
   - default: us-central1-a
     name: zone
-  title: Google Cloud Platform compute logs
+  title: Google Cloud Platform compute metrics
   description: Collect Google Cloud Platform compute metrics

--- a/dev/packages/beats/googlecloud-0.0.1/dataset/loadbalancing/manifest.yml
+++ b/dev/packages/beats/googlecloud-0.0.1/dataset/loadbalancing/manifest.yml
@@ -15,5 +15,5 @@ streams:
     name: project_id
   - default: us-central1-a
     name: zone
-  title: Google Cloud Platform loadbalancing logs
+  title: Google Cloud Platform loadbalancing metrics
   description: Collect Google Cloud Platform loadbalancing metrics

--- a/dev/packages/beats/googlecloud-0.0.1/dataset/pubsub/manifest.yml
+++ b/dev/packages/beats/googlecloud-0.0.1/dataset/pubsub/manifest.yml
@@ -15,5 +15,5 @@ streams:
     name: project_id
   - default: us-central1-a
     name: zone
-  title: Google Cloud Platform pubsub logs
+  title: Google Cloud Platform pubsub metrics
   description: Collect Google Cloud Platform pubsub metrics

--- a/dev/packages/beats/googlecloud-0.0.1/dataset/stackdriver/manifest.yml
+++ b/dev/packages/beats/googlecloud-0.0.1/dataset/stackdriver/manifest.yml
@@ -4,5 +4,5 @@ release: beta
 type: metrics
 streams:
 - input: googlecloud/metrics
-  title: Google Cloud Platform stackdriver logs
+  title: Google Cloud Platform stackdriver metrics
   description: Collect Google Cloud Platform stackdriver metrics

--- a/dev/packages/beats/googlecloud-0.0.1/dataset/storage/manifest.yml
+++ b/dev/packages/beats/googlecloud-0.0.1/dataset/storage/manifest.yml
@@ -15,5 +15,5 @@ streams:
     name: project_id
   - default: us-central1
     name: region
-  title: Google Cloud Platform storage logs
+  title: Google Cloud Platform storage metrics
   description: Collect Google Cloud Platform storage metrics

--- a/dev/packages/beats/graphite-0.0.1/dataset/server/manifest.yml
+++ b/dev/packages/beats/graphite-0.0.1/dataset/server/manifest.yml
@@ -4,5 +4,5 @@ release: ga
 type: metrics
 streams:
 - input: graphite/metrics
-  title: Graphite server logs
+  title: Graphite server metrics
   description: Collect Graphite server metrics

--- a/dev/packages/beats/haproxy-0.0.1/dataset/info/manifest.yml
+++ b/dev/packages/beats/haproxy-0.0.1/dataset/info/manifest.yml
@@ -14,5 +14,5 @@ streams:
     name: period
   - default: admin
     name: username
-  title: HAProxy info logs
+  title: HAProxy info metrics
   description: Collect HAProxy info metrics

--- a/dev/packages/beats/haproxy-0.0.1/dataset/stat/manifest.yml
+++ b/dev/packages/beats/haproxy-0.0.1/dataset/stat/manifest.yml
@@ -14,5 +14,5 @@ streams:
     name: period
   - default: admin
     name: username
-  title: HAProxy stat logs
+  title: HAProxy stat metrics
   description: Collect HAProxy stat metrics

--- a/dev/packages/beats/http-0.0.1/dataset/json/manifest.yml
+++ b/dev/packages/beats/http-0.0.1/dataset/json/manifest.yml
@@ -4,5 +4,5 @@ release: ga
 type: metrics
 streams:
 - input: http/metrics
-  title: HTTP json logs
+  title: HTTP json metrics
   description: Collect HTTP json metrics

--- a/dev/packages/beats/http-0.0.1/dataset/server/manifest.yml
+++ b/dev/packages/beats/http-0.0.1/dataset/server/manifest.yml
@@ -4,5 +4,5 @@ release: ga
 type: metrics
 streams:
 - input: http/metrics
-  title: HTTP server logs
+  title: HTTP server metrics
   description: Collect HTTP server metrics

--- a/dev/packages/beats/ibmmq-0.0.1/dataset/qmgr/manifest.yml
+++ b/dev/packages/beats/ibmmq-0.0.1/dataset/qmgr/manifest.yml
@@ -12,5 +12,5 @@ streams:
     name: metrics_path
   - default: 10s
     name: period
-  title: IBM MQ qmgr logs
+  title: IBM MQ qmgr metrics
   description: Collect IBM MQ qmgr metrics

--- a/dev/packages/beats/iis-0.0.1/dataset/application_pool/manifest.yml
+++ b/dev/packages/beats/iis-0.0.1/dataset/application_pool/manifest.yml
@@ -7,5 +7,5 @@ streams:
   vars:
   - default: 10s
     name: period
-  title: iis application_pool logs
+  title: iis application_pool metrics
   description: Collect iis application_pool metrics

--- a/dev/packages/beats/iis-0.0.1/dataset/webserver/manifest.yml
+++ b/dev/packages/beats/iis-0.0.1/dataset/webserver/manifest.yml
@@ -7,5 +7,5 @@ streams:
   vars:
   - default: 10s
     name: period
-  title: iis webserver logs
+  title: iis webserver metrics
   description: Collect iis webserver metrics

--- a/dev/packages/beats/iis-0.0.1/dataset/website/manifest.yml
+++ b/dev/packages/beats/iis-0.0.1/dataset/website/manifest.yml
@@ -7,5 +7,5 @@ streams:
   vars:
   - default: 10s
     name: period
-  title: iis website logs
+  title: iis website metrics
   description: Collect iis website metrics

--- a/dev/packages/beats/istio-0.0.1/dataset/citadel/manifest.yml
+++ b/dev/packages/beats/istio-0.0.1/dataset/citadel/manifest.yml
@@ -10,5 +10,5 @@ streams:
     name: hosts
   - default: 10s
     name: period
-  title: istio citadel logs
+  title: istio citadel metrics
   description: Collect istio citadel metrics

--- a/dev/packages/beats/istio-0.0.1/dataset/galley/manifest.yml
+++ b/dev/packages/beats/istio-0.0.1/dataset/galley/manifest.yml
@@ -10,5 +10,5 @@ streams:
     name: hosts
   - default: 10s
     name: period
-  title: istio galley logs
+  title: istio galley metrics
   description: Collect istio galley metrics

--- a/dev/packages/beats/istio-0.0.1/dataset/mesh/manifest.yml
+++ b/dev/packages/beats/istio-0.0.1/dataset/mesh/manifest.yml
@@ -10,5 +10,5 @@ streams:
     name: hosts
   - default: 10s
     name: period
-  title: istio mesh logs
+  title: istio mesh metrics
   description: Collect istio mesh metrics

--- a/dev/packages/beats/istio-0.0.1/dataset/mixer/manifest.yml
+++ b/dev/packages/beats/istio-0.0.1/dataset/mixer/manifest.yml
@@ -10,5 +10,5 @@ streams:
     name: hosts
   - default: 10s
     name: period
-  title: istio mixer logs
+  title: istio mixer metrics
   description: Collect istio mixer metrics

--- a/dev/packages/beats/istio-0.0.1/dataset/pilot/manifest.yml
+++ b/dev/packages/beats/istio-0.0.1/dataset/pilot/manifest.yml
@@ -10,5 +10,5 @@ streams:
     name: hosts
   - default: 10s
     name: period
-  title: istio pilot logs
+  title: istio pilot metrics
   description: Collect istio pilot metrics

--- a/dev/packages/beats/jolokia-0.0.1/dataset/jmx/manifest.yml
+++ b/dev/packages/beats/jolokia-0.0.1/dataset/jmx/manifest.yml
@@ -4,5 +4,5 @@ release: ga
 type: metrics
 streams:
 - input: jolokia/metrics
-  title: Jolokia jmx logs
+  title: Jolokia jmx metrics
   description: Collect Jolokia jmx metrics

--- a/dev/packages/beats/kafka-0.0.1/dataset/broker/manifest.yml
+++ b/dev/packages/beats/kafka-0.0.1/dataset/broker/manifest.yml
@@ -4,5 +4,5 @@ release: beta
 type: metrics
 streams:
 - input: kafka/metrics
-  title: Kafka broker logs
+  title: Kafka broker metrics
   description: Collect Kafka broker metrics

--- a/dev/packages/beats/kafka-0.0.1/dataset/consumer/manifest.yml
+++ b/dev/packages/beats/kafka-0.0.1/dataset/consumer/manifest.yml
@@ -4,5 +4,5 @@ release: beta
 type: metrics
 streams:
 - input: kafka/metrics
-  title: Kafka consumer logs
+  title: Kafka consumer metrics
   description: Collect Kafka consumer metrics

--- a/dev/packages/beats/kafka-0.0.1/dataset/consumergroup/manifest.yml
+++ b/dev/packages/beats/kafka-0.0.1/dataset/consumergroup/manifest.yml
@@ -4,5 +4,5 @@ release: ga
 type: metrics
 streams:
 - input: kafka/metrics
-  title: Kafka consumergroup logs
+  title: Kafka consumergroup metrics
   description: Collect Kafka consumergroup metrics

--- a/dev/packages/beats/kafka-0.0.1/dataset/partition/manifest.yml
+++ b/dev/packages/beats/kafka-0.0.1/dataset/partition/manifest.yml
@@ -4,5 +4,5 @@ release: ga
 type: metrics
 streams:
 - input: kafka/metrics
-  title: Kafka partition logs
+  title: Kafka partition metrics
   description: Collect Kafka partition metrics

--- a/dev/packages/beats/kafka-0.0.1/dataset/producer/manifest.yml
+++ b/dev/packages/beats/kafka-0.0.1/dataset/producer/manifest.yml
@@ -4,5 +4,5 @@ release: beta
 type: metrics
 streams:
 - input: kafka/metrics
-  title: Kafka producer logs
+  title: Kafka producer metrics
   description: Collect Kafka producer metrics

--- a/dev/packages/beats/kibana-0.0.1/dataset/stats/manifest.yml
+++ b/dev/packages/beats/kibana-0.0.1/dataset/stats/manifest.yml
@@ -12,5 +12,5 @@ streams:
     name: period
   - default: true
     name: xpack.enabled
-  title: Kibana stats logs
+  title: Kibana stats metrics
   description: Collect Kibana stats metrics

--- a/dev/packages/beats/kibana-0.0.1/dataset/status/manifest.yml
+++ b/dev/packages/beats/kibana-0.0.1/dataset/status/manifest.yml
@@ -12,5 +12,5 @@ streams:
     name: hosts
   - default: 10s
     name: period
-  title: Kibana status logs
+  title: Kibana status metrics
   description: Collect Kibana status metrics

--- a/dev/packages/beats/kubernetes-0.0.1/dataset/apiserver/manifest.yml
+++ b/dev/packages/beats/kubernetes-0.0.1/dataset/apiserver/manifest.yml
@@ -8,5 +8,5 @@ streams:
   - default:
     - https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}
     name: hosts
-  title: Kubernetes apiserver logs
+  title: Kubernetes apiserver metrics
   description: Collect Kubernetes apiserver metrics

--- a/dev/packages/beats/kubernetes-0.0.1/dataset/container/manifest.yml
+++ b/dev/packages/beats/kubernetes-0.0.1/dataset/container/manifest.yml
@@ -16,5 +16,5 @@ streams:
     name: period
   - default: none
     name: ssl.verification_mode
-  title: Kubernetes container logs
+  title: Kubernetes container metrics
   description: Collect Kubernetes container metrics

--- a/dev/packages/beats/kubernetes-0.0.1/dataset/controllermanager/manifest.yml
+++ b/dev/packages/beats/kubernetes-0.0.1/dataset/controllermanager/manifest.yml
@@ -10,5 +10,5 @@ streams:
     name: hosts
   - default: 10s
     name: period
-  title: Kubernetes controllermanager logs
+  title: Kubernetes controllermanager metrics
   description: Collect Kubernetes controllermanager metrics

--- a/dev/packages/beats/kubernetes-0.0.1/dataset/event/manifest.yml
+++ b/dev/packages/beats/kubernetes-0.0.1/dataset/event/manifest.yml
@@ -4,5 +4,5 @@ release: ga
 type: metrics
 streams:
 - input: kubernetes/metrics
-  title: Kubernetes event logs
+  title: Kubernetes event metrics
   description: Collect Kubernetes event metrics

--- a/dev/packages/beats/kubernetes-0.0.1/dataset/node/manifest.yml
+++ b/dev/packages/beats/kubernetes-0.0.1/dataset/node/manifest.yml
@@ -16,5 +16,5 @@ streams:
     name: period
   - default: none
     name: ssl.verification_mode
-  title: Kubernetes node logs
+  title: Kubernetes node metrics
   description: Collect Kubernetes node metrics

--- a/dev/packages/beats/kubernetes-0.0.1/dataset/pod/manifest.yml
+++ b/dev/packages/beats/kubernetes-0.0.1/dataset/pod/manifest.yml
@@ -16,5 +16,5 @@ streams:
     name: period
   - default: none
     name: ssl.verification_mode
-  title: Kubernetes pod logs
+  title: Kubernetes pod metrics
   description: Collect Kubernetes pod metrics

--- a/dev/packages/beats/kubernetes-0.0.1/dataset/proxy/manifest.yml
+++ b/dev/packages/beats/kubernetes-0.0.1/dataset/proxy/manifest.yml
@@ -10,5 +10,5 @@ streams:
     name: hosts
   - default: 10s
     name: period
-  title: Kubernetes proxy logs
+  title: Kubernetes proxy metrics
   description: Collect Kubernetes proxy metrics

--- a/dev/packages/beats/kubernetes-0.0.1/dataset/scheduler/manifest.yml
+++ b/dev/packages/beats/kubernetes-0.0.1/dataset/scheduler/manifest.yml
@@ -10,5 +10,5 @@ streams:
     name: hosts
   - default: 10s
     name: period
-  title: Kubernetes scheduler logs
+  title: Kubernetes scheduler metrics
   description: Collect Kubernetes scheduler metrics

--- a/dev/packages/beats/kubernetes-0.0.1/dataset/state_container/manifest.yml
+++ b/dev/packages/beats/kubernetes-0.0.1/dataset/state_container/manifest.yml
@@ -12,5 +12,5 @@ streams:
     name: hosts
   - default: 10s
     name: period
-  title: Kubernetes state_container logs
+  title: Kubernetes state_container metrics
   description: Collect Kubernetes state_container metrics

--- a/dev/packages/beats/kubernetes-0.0.1/dataset/state_cronjob/manifest.yml
+++ b/dev/packages/beats/kubernetes-0.0.1/dataset/state_cronjob/manifest.yml
@@ -12,5 +12,5 @@ streams:
     name: hosts
   - default: 10s
     name: period
-  title: Kubernetes state_cronjob logs
+  title: Kubernetes state_cronjob metrics
   description: Collect Kubernetes state_cronjob metrics

--- a/dev/packages/beats/kubernetes-0.0.1/dataset/state_deployment/manifest.yml
+++ b/dev/packages/beats/kubernetes-0.0.1/dataset/state_deployment/manifest.yml
@@ -12,5 +12,5 @@ streams:
     name: hosts
   - default: 10s
     name: period
-  title: Kubernetes state_deployment logs
+  title: Kubernetes state_deployment metrics
   description: Collect Kubernetes state_deployment metrics

--- a/dev/packages/beats/kubernetes-0.0.1/dataset/state_node/manifest.yml
+++ b/dev/packages/beats/kubernetes-0.0.1/dataset/state_node/manifest.yml
@@ -12,5 +12,5 @@ streams:
     name: hosts
   - default: 10s
     name: period
-  title: Kubernetes state_node logs
+  title: Kubernetes state_node metrics
   description: Collect Kubernetes state_node metrics

--- a/dev/packages/beats/kubernetes-0.0.1/dataset/state_persistentvolume/manifest.yml
+++ b/dev/packages/beats/kubernetes-0.0.1/dataset/state_persistentvolume/manifest.yml
@@ -12,5 +12,5 @@ streams:
     name: hosts
   - default: 10s
     name: period
-  title: Kubernetes state_persistentvolume logs
+  title: Kubernetes state_persistentvolume metrics
   description: Collect Kubernetes state_persistentvolume metrics

--- a/dev/packages/beats/kubernetes-0.0.1/dataset/state_persistentvolumeclaim/manifest.yml
+++ b/dev/packages/beats/kubernetes-0.0.1/dataset/state_persistentvolumeclaim/manifest.yml
@@ -12,5 +12,5 @@ streams:
     name: hosts
   - default: 10s
     name: period
-  title: Kubernetes state_persistentvolumeclaim logs
+  title: Kubernetes state_persistentvolumeclaim metrics
   description: Collect Kubernetes state_persistentvolumeclaim metrics

--- a/dev/packages/beats/kubernetes-0.0.1/dataset/state_pod/manifest.yml
+++ b/dev/packages/beats/kubernetes-0.0.1/dataset/state_pod/manifest.yml
@@ -12,5 +12,5 @@ streams:
     name: hosts
   - default: 10s
     name: period
-  title: Kubernetes state_pod logs
+  title: Kubernetes state_pod metrics
   description: Collect Kubernetes state_pod metrics

--- a/dev/packages/beats/kubernetes-0.0.1/dataset/state_replicaset/manifest.yml
+++ b/dev/packages/beats/kubernetes-0.0.1/dataset/state_replicaset/manifest.yml
@@ -12,5 +12,5 @@ streams:
     name: hosts
   - default: 10s
     name: period
-  title: Kubernetes state_replicaset logs
+  title: Kubernetes state_replicaset metrics
   description: Collect Kubernetes state_replicaset metrics

--- a/dev/packages/beats/kubernetes-0.0.1/dataset/state_resourcequota/manifest.yml
+++ b/dev/packages/beats/kubernetes-0.0.1/dataset/state_resourcequota/manifest.yml
@@ -12,5 +12,5 @@ streams:
     name: hosts
   - default: 10s
     name: period
-  title: Kubernetes state_resourcequota logs
+  title: Kubernetes state_resourcequota metrics
   description: Collect Kubernetes state_resourcequota metrics

--- a/dev/packages/beats/kubernetes-0.0.1/dataset/state_service/manifest.yml
+++ b/dev/packages/beats/kubernetes-0.0.1/dataset/state_service/manifest.yml
@@ -12,5 +12,5 @@ streams:
     name: hosts
   - default: 10s
     name: period
-  title: Kubernetes state_service logs
+  title: Kubernetes state_service metrics
   description: Collect Kubernetes state_service metrics

--- a/dev/packages/beats/kubernetes-0.0.1/dataset/state_statefulset/manifest.yml
+++ b/dev/packages/beats/kubernetes-0.0.1/dataset/state_statefulset/manifest.yml
@@ -12,5 +12,5 @@ streams:
     name: hosts
   - default: 10s
     name: period
-  title: Kubernetes state_statefulset logs
+  title: Kubernetes state_statefulset metrics
   description: Collect Kubernetes state_statefulset metrics

--- a/dev/packages/beats/kubernetes-0.0.1/dataset/state_storageclass/manifest.yml
+++ b/dev/packages/beats/kubernetes-0.0.1/dataset/state_storageclass/manifest.yml
@@ -12,5 +12,5 @@ streams:
     name: hosts
   - default: 10s
     name: period
-  title: Kubernetes state_storageclass logs
+  title: Kubernetes state_storageclass metrics
   description: Collect Kubernetes state_storageclass metrics

--- a/dev/packages/beats/kubernetes-0.0.1/dataset/system/manifest.yml
+++ b/dev/packages/beats/kubernetes-0.0.1/dataset/system/manifest.yml
@@ -16,5 +16,5 @@ streams:
     name: period
   - default: none
     name: ssl.verification_mode
-  title: Kubernetes system logs
+  title: Kubernetes system metrics
   description: Collect Kubernetes system metrics

--- a/dev/packages/beats/kubernetes-0.0.1/dataset/volume/manifest.yml
+++ b/dev/packages/beats/kubernetes-0.0.1/dataset/volume/manifest.yml
@@ -16,5 +16,5 @@ streams:
     name: period
   - default: none
     name: ssl.verification_mode
-  title: Kubernetes volume logs
+  title: Kubernetes volume metrics
   description: Collect Kubernetes volume metrics

--- a/dev/packages/beats/kvm-0.0.1/dataset/dommemstat/manifest.yml
+++ b/dev/packages/beats/kvm-0.0.1/dataset/dommemstat/manifest.yml
@@ -10,5 +10,5 @@ streams:
     name: hosts
   - default: 10s
     name: period
-  title: kvm dommemstat logs
+  title: kvm dommemstat metrics
   description: Collect kvm dommemstat metrics

--- a/dev/packages/beats/logstash-0.0.1/dataset/node/manifest.yml
+++ b/dev/packages/beats/logstash-0.0.1/dataset/node/manifest.yml
@@ -12,5 +12,5 @@ streams:
     name: period
   - default: true
     name: xpack.enabled
-  title: Logstash node logs
+  title: Logstash node metrics
   description: Collect Logstash node metrics

--- a/dev/packages/beats/logstash-0.0.1/dataset/node_stats/manifest.yml
+++ b/dev/packages/beats/logstash-0.0.1/dataset/node_stats/manifest.yml
@@ -12,5 +12,5 @@ streams:
     name: period
   - default: true
     name: xpack.enabled
-  title: Logstash node_stats logs
+  title: Logstash node_stats metrics
   description: Collect Logstash node_stats metrics

--- a/dev/packages/beats/memcached-0.0.1/dataset/stats/manifest.yml
+++ b/dev/packages/beats/memcached-0.0.1/dataset/stats/manifest.yml
@@ -10,5 +10,5 @@ streams:
     name: hosts
   - default: 10s
     name: period
-  title: Memcached stats logs
+  title: Memcached stats metrics
   description: Collect Memcached stats metrics

--- a/dev/packages/beats/mongodb-0.0.1/dataset/collstats/manifest.yml
+++ b/dev/packages/beats/mongodb-0.0.1/dataset/collstats/manifest.yml
@@ -10,5 +10,5 @@ streams:
     name: hosts
   - default: 10s
     name: period
-  title: MongoDB collstats logs
+  title: MongoDB collstats metrics
   description: Collect MongoDB collstats metrics

--- a/dev/packages/beats/mongodb-0.0.1/dataset/dbstats/manifest.yml
+++ b/dev/packages/beats/mongodb-0.0.1/dataset/dbstats/manifest.yml
@@ -10,5 +10,5 @@ streams:
     name: hosts
   - default: 10s
     name: period
-  title: MongoDB dbstats logs
+  title: MongoDB dbstats metrics
   description: Collect MongoDB dbstats metrics

--- a/dev/packages/beats/mongodb-0.0.1/dataset/metrics/manifest.yml
+++ b/dev/packages/beats/mongodb-0.0.1/dataset/metrics/manifest.yml
@@ -10,5 +10,5 @@ streams:
     name: hosts
   - default: 10s
     name: period
-  title: MongoDB metrics logs
+  title: MongoDB metrics metrics
   description: Collect MongoDB metrics metrics

--- a/dev/packages/beats/mongodb-0.0.1/dataset/replstatus/manifest.yml
+++ b/dev/packages/beats/mongodb-0.0.1/dataset/replstatus/manifest.yml
@@ -10,5 +10,5 @@ streams:
     name: hosts
   - default: 10s
     name: period
-  title: MongoDB replstatus logs
+  title: MongoDB replstatus metrics
   description: Collect MongoDB replstatus metrics

--- a/dev/packages/beats/mongodb-0.0.1/dataset/status/manifest.yml
+++ b/dev/packages/beats/mongodb-0.0.1/dataset/status/manifest.yml
@@ -10,5 +10,5 @@ streams:
     name: hosts
   - default: 10s
     name: period
-  title: MongoDB status logs
+  title: MongoDB status metrics
   description: Collect MongoDB status metrics

--- a/dev/packages/beats/mssql-0.0.1/dataset/performance/manifest.yml
+++ b/dev/packages/beats/mssql-0.0.1/dataset/performance/manifest.yml
@@ -14,5 +14,5 @@ streams:
     name: period
   - default: domain\username
     name: username
-  title: MSSQL performance logs
+  title: MSSQL performance metrics
   description: Collect MSSQL performance metrics

--- a/dev/packages/beats/mssql-0.0.1/dataset/transaction_log/manifest.yml
+++ b/dev/packages/beats/mssql-0.0.1/dataset/transaction_log/manifest.yml
@@ -14,5 +14,5 @@ streams:
     name: period
   - default: domain\username
     name: username
-  title: MSSQL transaction_log logs
+  title: MSSQL transaction_log metrics
   description: Collect MSSQL transaction_log metrics

--- a/dev/packages/beats/munin-0.0.1/dataset/node/manifest.yml
+++ b/dev/packages/beats/munin-0.0.1/dataset/node/manifest.yml
@@ -10,5 +10,5 @@ streams:
     name: hosts
   - default: 10s
     name: period
-  title: Munin node logs
+  title: Munin node metrics
   description: Collect Munin node metrics

--- a/dev/packages/beats/mysql-0.0.1/dataset/galera_status/manifest.yml
+++ b/dev/packages/beats/mysql-0.0.1/dataset/galera_status/manifest.yml
@@ -4,5 +4,5 @@ release: beta
 type: metrics
 streams:
 - input: mysql/metrics
-  title: MySQL galera_status logs
+  title: MySQL galera_status metrics
   description: Collect MySQL galera_status metrics

--- a/dev/packages/beats/mysql-0.0.1/dataset/status/manifest.yml
+++ b/dev/packages/beats/mysql-0.0.1/dataset/status/manifest.yml
@@ -10,5 +10,5 @@ streams:
     name: hosts
   - default: 10s
     name: period
-  title: MySQL status logs
+  title: MySQL status metrics
   description: Collect MySQL status metrics

--- a/dev/packages/beats/nats-0.0.1/dataset/connections/manifest.yml
+++ b/dev/packages/beats/nats-0.0.1/dataset/connections/manifest.yml
@@ -10,5 +10,5 @@ streams:
     name: hosts
   - default: 10s
     name: period
-  title: Nats connections logs
+  title: Nats connections metrics
   description: Collect Nats connections metrics

--- a/dev/packages/beats/nats-0.0.1/dataset/routes/manifest.yml
+++ b/dev/packages/beats/nats-0.0.1/dataset/routes/manifest.yml
@@ -10,5 +10,5 @@ streams:
     name: hosts
   - default: 10s
     name: period
-  title: Nats routes logs
+  title: Nats routes metrics
   description: Collect Nats routes metrics

--- a/dev/packages/beats/nats-0.0.1/dataset/stats/manifest.yml
+++ b/dev/packages/beats/nats-0.0.1/dataset/stats/manifest.yml
@@ -10,5 +10,5 @@ streams:
     name: hosts
   - default: 10s
     name: period
-  title: Nats stats logs
+  title: Nats stats metrics
   description: Collect Nats stats metrics

--- a/dev/packages/beats/nats-0.0.1/dataset/subscriptions/manifest.yml
+++ b/dev/packages/beats/nats-0.0.1/dataset/subscriptions/manifest.yml
@@ -10,5 +10,5 @@ streams:
     name: hosts
   - default: 10s
     name: period
-  title: Nats subscriptions logs
+  title: Nats subscriptions metrics
   description: Collect Nats subscriptions metrics

--- a/dev/packages/beats/nginx-0.0.1/dataset/stubstatus/manifest.yml
+++ b/dev/packages/beats/nginx-0.0.1/dataset/stubstatus/manifest.yml
@@ -12,5 +12,5 @@ streams:
     name: period
   - default: nginx_status
     name: server_status_path
-  title: Nginx stubstatus logs
+  title: Nginx stubstatus metrics
   description: Collect Nginx stubstatus metrics

--- a/dev/packages/beats/openmetrics-0.0.1/dataset/collector/manifest.yml
+++ b/dev/packages/beats/openmetrics-0.0.1/dataset/collector/manifest.yml
@@ -16,5 +16,5 @@ streams:
     name: metrics_path
   - default: 10s
     name: period
-  title: Openmetrics collector logs
+  title: Openmetrics collector metrics
   description: Collect Openmetrics collector metrics

--- a/dev/packages/beats/oracle-0.0.1/dataset/performance/manifest.yml
+++ b/dev/packages/beats/oracle-0.0.1/dataset/performance/manifest.yml
@@ -10,5 +10,5 @@ streams:
     name: hosts
   - default: 10s
     name: period
-  title: Oracle performance logs
+  title: Oracle performance metrics
   description: Collect Oracle performance metrics

--- a/dev/packages/beats/oracle-0.0.1/dataset/tablespace/manifest.yml
+++ b/dev/packages/beats/oracle-0.0.1/dataset/tablespace/manifest.yml
@@ -10,5 +10,5 @@ streams:
     name: hosts
   - default: 10s
     name: period
-  title: Oracle tablespace logs
+  title: Oracle tablespace metrics
   description: Collect Oracle tablespace metrics

--- a/dev/packages/beats/php_fpm-0.0.1/dataset/pool/manifest.yml
+++ b/dev/packages/beats/php_fpm-0.0.1/dataset/pool/manifest.yml
@@ -12,5 +12,5 @@ streams:
     name: period
   - default: /status
     name: status_path
-  title: PHP_FPM pool logs
+  title: PHP_FPM pool metrics
   description: Collect PHP_FPM pool metrics

--- a/dev/packages/beats/php_fpm-0.0.1/dataset/process/manifest.yml
+++ b/dev/packages/beats/php_fpm-0.0.1/dataset/process/manifest.yml
@@ -4,5 +4,5 @@ release: ga
 type: metrics
 streams:
 - input: php_fpm/metrics
-  title: PHP_FPM process logs
+  title: PHP_FPM process metrics
   description: Collect PHP_FPM process metrics

--- a/dev/packages/beats/postgresql-0.0.1/dataset/activity/manifest.yml
+++ b/dev/packages/beats/postgresql-0.0.1/dataset/activity/manifest.yml
@@ -10,5 +10,5 @@ streams:
     name: hosts
   - default: 10s
     name: period
-  title: PostgreSQL activity logs
+  title: PostgreSQL activity metrics
   description: Collect PostgreSQL activity metrics

--- a/dev/packages/beats/postgresql-0.0.1/dataset/bgwriter/manifest.yml
+++ b/dev/packages/beats/postgresql-0.0.1/dataset/bgwriter/manifest.yml
@@ -10,5 +10,5 @@ streams:
     name: hosts
   - default: 10s
     name: period
-  title: PostgreSQL bgwriter logs
+  title: PostgreSQL bgwriter metrics
   description: Collect PostgreSQL bgwriter metrics

--- a/dev/packages/beats/postgresql-0.0.1/dataset/database/manifest.yml
+++ b/dev/packages/beats/postgresql-0.0.1/dataset/database/manifest.yml
@@ -10,5 +10,5 @@ streams:
     name: hosts
   - default: 10s
     name: period
-  title: PostgreSQL database logs
+  title: PostgreSQL database metrics
   description: Collect PostgreSQL database metrics

--- a/dev/packages/beats/postgresql-0.0.1/dataset/statement/manifest.yml
+++ b/dev/packages/beats/postgresql-0.0.1/dataset/statement/manifest.yml
@@ -4,5 +4,5 @@ release: ga
 type: metrics
 streams:
 - input: postgresql/metrics
-  title: PostgreSQL statement logs
+  title: PostgreSQL statement metrics
   description: Collect PostgreSQL statement metrics

--- a/dev/packages/beats/prometheus-0.0.1/dataset/collector-metrics/manifest.yml
+++ b/dev/packages/beats/prometheus-0.0.1/dataset/collector-metrics/manifest.yml
@@ -4,5 +4,5 @@ release: ga
 type: metrics
 streams:
 - input: prometheus/metrics
-  title: Prometheus typed metrics collector logs
+  title: Prometheus typed metrics collector metrics
   description: Collect Prometheus typed metrics collector metrics

--- a/dev/packages/beats/prometheus-0.0.1/dataset/query/manifest.yml
+++ b/dev/packages/beats/prometheus-0.0.1/dataset/query/manifest.yml
@@ -10,5 +10,5 @@ streams:
     name: hosts
   - default: 10s
     name: period
-  title: Prometheus query logs
+  title: Prometheus query metrics
   description: Collect Prometheus query metrics

--- a/dev/packages/beats/prometheus-0.0.1/dataset/remote_write/manifest.yml
+++ b/dev/packages/beats/prometheus-0.0.1/dataset/remote_write/manifest.yml
@@ -9,5 +9,5 @@ streams:
     name: host
   - default: "9201"
     name: port
-  title: Prometheus remote_write logs
+  title: Prometheus remote_write metrics
   description: Collect Prometheus remote_write metrics

--- a/dev/packages/beats/rabbitmq-0.0.1/dataset/connection/manifest.yml
+++ b/dev/packages/beats/rabbitmq-0.0.1/dataset/connection/manifest.yml
@@ -10,5 +10,5 @@ streams:
     name: hosts
   - default: 10s
     name: period
-  title: RabbitMQ connection logs
+  title: RabbitMQ connection metrics
   description: Collect RabbitMQ connection metrics

--- a/dev/packages/beats/rabbitmq-0.0.1/dataset/exchange/manifest.yml
+++ b/dev/packages/beats/rabbitmq-0.0.1/dataset/exchange/manifest.yml
@@ -4,5 +4,5 @@ release: ga
 type: metrics
 streams:
 - input: rabbitmq/metrics
-  title: RabbitMQ exchange logs
+  title: RabbitMQ exchange metrics
   description: Collect RabbitMQ exchange metrics

--- a/dev/packages/beats/rabbitmq-0.0.1/dataset/node/manifest.yml
+++ b/dev/packages/beats/rabbitmq-0.0.1/dataset/node/manifest.yml
@@ -10,5 +10,5 @@ streams:
     name: hosts
   - default: 10s
     name: period
-  title: RabbitMQ node logs
+  title: RabbitMQ node metrics
   description: Collect RabbitMQ node metrics

--- a/dev/packages/beats/rabbitmq-0.0.1/dataset/queue/manifest.yml
+++ b/dev/packages/beats/rabbitmq-0.0.1/dataset/queue/manifest.yml
@@ -10,5 +10,5 @@ streams:
     name: hosts
   - default: 10s
     name: period
-  title: RabbitMQ queue logs
+  title: RabbitMQ queue metrics
   description: Collect RabbitMQ queue metrics

--- a/dev/packages/beats/redis-0.0.1/dataset/info/manifest.yml
+++ b/dev/packages/beats/redis-0.0.1/dataset/info/manifest.yml
@@ -10,5 +10,5 @@ streams:
     name: hosts
   - default: 10s
     name: period
-  title: Redis info logs
+  title: Redis info metrics
   description: Collect Redis info metrics

--- a/dev/packages/beats/redis-0.0.1/dataset/key/manifest.yml
+++ b/dev/packages/beats/redis-0.0.1/dataset/key/manifest.yml
@@ -4,5 +4,5 @@ release: ga
 type: metrics
 streams:
 - input: redis/metrics
-  title: Redis key logs
+  title: Redis key metrics
   description: Collect Redis key metrics

--- a/dev/packages/beats/redis-0.0.1/dataset/keyspace/manifest.yml
+++ b/dev/packages/beats/redis-0.0.1/dataset/keyspace/manifest.yml
@@ -10,5 +10,5 @@ streams:
     name: hosts
   - default: 10s
     name: period
-  title: Redis keyspace logs
+  title: Redis keyspace metrics
   description: Collect Redis keyspace metrics

--- a/dev/packages/beats/redisenterprise-0.0.1/dataset/node/manifest.yml
+++ b/dev/packages/beats/redisenterprise-0.0.1/dataset/node/manifest.yml
@@ -10,5 +10,5 @@ streams:
     name: hosts
   - default: 1m
     name: period
-  title: Redis Enterprise node logs
+  title: Redis Enterprise node metrics
   description: Collect Redis Enterprise node metrics

--- a/dev/packages/beats/redisenterprise-0.0.1/dataset/proxy/manifest.yml
+++ b/dev/packages/beats/redisenterprise-0.0.1/dataset/proxy/manifest.yml
@@ -10,5 +10,5 @@ streams:
     name: hosts
   - default: 1m
     name: period
-  title: Redis Enterprise proxy logs
+  title: Redis Enterprise proxy metrics
   description: Collect Redis Enterprise proxy metrics

--- a/dev/packages/beats/sql-0.0.1/dataset/query/manifest.yml
+++ b/dev/packages/beats/sql-0.0.1/dataset/query/manifest.yml
@@ -16,5 +16,5 @@ streams:
     name: sql_query
   - default: table
     name: sql_response_format
-  title: sql query logs
+  title: sql query metrics
   description: Collect sql query metrics

--- a/dev/packages/beats/stan-0.0.1/dataset/channels/manifest.yml
+++ b/dev/packages/beats/stan-0.0.1/dataset/channels/manifest.yml
@@ -10,5 +10,5 @@ streams:
     name: hosts
   - default: 60s
     name: period
-  title: Stan channels logs
+  title: Stan channels metrics
   description: Collect Stan channels metrics

--- a/dev/packages/beats/stan-0.0.1/dataset/stats/manifest.yml
+++ b/dev/packages/beats/stan-0.0.1/dataset/stats/manifest.yml
@@ -10,5 +10,5 @@ streams:
     name: hosts
   - default: 60s
     name: period
-  title: Stan stats logs
+  title: Stan stats metrics
   description: Collect Stan stats metrics

--- a/dev/packages/beats/stan-0.0.1/dataset/subscriptions/manifest.yml
+++ b/dev/packages/beats/stan-0.0.1/dataset/subscriptions/manifest.yml
@@ -10,5 +10,5 @@ streams:
     name: hosts
   - default: 60s
     name: period
-  title: Stan subscriptions logs
+  title: Stan subscriptions metrics
   description: Collect Stan subscriptions metrics

--- a/dev/packages/beats/statsd-0.0.1/dataset/server/manifest.yml
+++ b/dev/packages/beats/statsd-0.0.1/dataset/server/manifest.yml
@@ -4,5 +4,5 @@ release: ga
 type: metrics
 streams:
 - input: statsd/metrics
-  title: Statsd server logs
+  title: Statsd server metrics
   description: Collect Statsd server metrics

--- a/dev/packages/beats/system-0.0.1/dataset/core/manifest.yml
+++ b/dev/packages/beats/system-0.0.1/dataset/core/manifest.yml
@@ -8,5 +8,5 @@ streams:
   - default:
     - percentages
     name: core.metrics
-  title: System core logs
+  title: System core metrics
   description: Collect System core metrics

--- a/dev/packages/beats/system-0.0.1/dataset/cpu/manifest.yml
+++ b/dev/packages/beats/system-0.0.1/dataset/cpu/manifest.yml
@@ -21,5 +21,5 @@ streams:
   - default:
     - .*
     name: processes
-  title: System cpu logs
+  title: System cpu metrics
   description: Collect System cpu metrics

--- a/dev/packages/beats/system-0.0.1/dataset/diskio/manifest.yml
+++ b/dev/packages/beats/system-0.0.1/dataset/diskio/manifest.yml
@@ -4,5 +4,5 @@ release: ga
 type: metrics
 streams:
 - input: system/metrics
-  title: System diskio logs
+  title: System diskio metrics
   description: Collect System diskio metrics

--- a/dev/packages/beats/system-0.0.1/dataset/entropy/manifest.yml
+++ b/dev/packages/beats/system-0.0.1/dataset/entropy/manifest.yml
@@ -4,5 +4,5 @@ release: ga
 type: metrics
 streams:
 - input: system/metrics
-  title: System entropy logs
+  title: System entropy metrics
   description: Collect System entropy metrics

--- a/dev/packages/beats/system-0.0.1/dataset/filesystem/manifest.yml
+++ b/dev/packages/beats/system-0.0.1/dataset/filesystem/manifest.yml
@@ -11,5 +11,5 @@ streams:
     - drop_event.when.regexp:
         system.filesystem.mount_point: ^/(sys|cgroup|proc|dev|etc|host|lib|snap)($|/)
     name: processors
-  title: System filesystem logs
+  title: System filesystem metrics
   description: Collect System filesystem metrics

--- a/dev/packages/beats/system-0.0.1/dataset/fsstat/manifest.yml
+++ b/dev/packages/beats/system-0.0.1/dataset/fsstat/manifest.yml
@@ -11,5 +11,5 @@ streams:
     - drop_event.when.regexp:
         system.filesystem.mount_point: ^/(sys|cgroup|proc|dev|etc|host|lib|snap)($|/)
     name: processors
-  title: System fsstat logs
+  title: System fsstat metrics
   description: Collect System fsstat metrics

--- a/dev/packages/beats/system-0.0.1/dataset/load/manifest.yml
+++ b/dev/packages/beats/system-0.0.1/dataset/load/manifest.yml
@@ -21,5 +21,5 @@ streams:
   - default:
     - .*
     name: processes
-  title: System load logs
+  title: System load metrics
   description: Collect System load metrics

--- a/dev/packages/beats/system-0.0.1/dataset/memory/manifest.yml
+++ b/dev/packages/beats/system-0.0.1/dataset/memory/manifest.yml
@@ -21,5 +21,5 @@ streams:
   - default:
     - .*
     name: processes
-  title: System memory logs
+  title: System memory metrics
   description: Collect System memory metrics

--- a/dev/packages/beats/system-0.0.1/dataset/network/manifest.yml
+++ b/dev/packages/beats/system-0.0.1/dataset/network/manifest.yml
@@ -21,5 +21,5 @@ streams:
   - default:
     - .*
     name: processes
-  title: System network logs
+  title: System network metrics
   description: Collect System network metrics

--- a/dev/packages/beats/system-0.0.1/dataset/network_summary/manifest.yml
+++ b/dev/packages/beats/system-0.0.1/dataset/network_summary/manifest.yml
@@ -4,5 +4,5 @@ release: beta
 type: metrics
 streams:
 - input: system/metrics
-  title: System network_summary logs
+  title: System network_summary metrics
   description: Collect System network_summary metrics

--- a/dev/packages/beats/system-0.0.1/dataset/process/manifest.yml
+++ b/dev/packages/beats/system-0.0.1/dataset/process/manifest.yml
@@ -21,5 +21,5 @@ streams:
   - default:
     - .*
     name: processes
-  title: System process logs
+  title: System process metrics
   description: Collect System process metrics

--- a/dev/packages/beats/system-0.0.1/dataset/process_summary/manifest.yml
+++ b/dev/packages/beats/system-0.0.1/dataset/process_summary/manifest.yml
@@ -21,5 +21,5 @@ streams:
   - default:
     - .*
     name: processes
-  title: System process_summary logs
+  title: System process_summary metrics
   description: Collect System process_summary metrics

--- a/dev/packages/beats/system-0.0.1/dataset/raid/manifest.yml
+++ b/dev/packages/beats/system-0.0.1/dataset/raid/manifest.yml
@@ -4,5 +4,5 @@ release: ga
 type: metrics
 streams:
 - input: system/metrics
-  title: System raid logs
+  title: System raid metrics
   description: Collect System raid metrics

--- a/dev/packages/beats/system-0.0.1/dataset/service/manifest.yml
+++ b/dev/packages/beats/system-0.0.1/dataset/service/manifest.yml
@@ -4,5 +4,5 @@ release: beta
 type: metrics
 streams:
 - input: system/metrics
-  title: System service logs
+  title: System service metrics
   description: Collect System service metrics

--- a/dev/packages/beats/system-0.0.1/dataset/socket/manifest.yml
+++ b/dev/packages/beats/system-0.0.1/dataset/socket/manifest.yml
@@ -4,5 +4,5 @@ release: ga
 type: metrics
 streams:
 - input: system/metrics
-  title: System socket logs
+  title: System socket metrics
   description: Collect System socket metrics

--- a/dev/packages/beats/system-0.0.1/dataset/socket_summary/manifest.yml
+++ b/dev/packages/beats/system-0.0.1/dataset/socket_summary/manifest.yml
@@ -21,5 +21,5 @@ streams:
   - default:
     - .*
     name: processes
-  title: System socket_summary logs
+  title: System socket_summary metrics
   description: Collect System socket_summary metrics

--- a/dev/packages/beats/system-0.0.1/dataset/uptime/manifest.yml
+++ b/dev/packages/beats/system-0.0.1/dataset/uptime/manifest.yml
@@ -17,5 +17,5 @@ streams:
   - default:
     - .*
     name: processes
-  title: System uptime logs
+  title: System uptime metrics
   description: Collect System uptime metrics

--- a/dev/packages/beats/system-0.0.1/dataset/users/manifest.yml
+++ b/dev/packages/beats/system-0.0.1/dataset/users/manifest.yml
@@ -4,5 +4,5 @@ release: beta
 type: metrics
 streams:
 - input: system/metrics
-  title: System users logs
+  title: System users metrics
   description: Collect System users metrics

--- a/dev/packages/beats/tomcat-0.0.1/dataset/cache/manifest.yml
+++ b/dev/packages/beats/tomcat-0.0.1/dataset/cache/manifest.yml
@@ -12,5 +12,5 @@ streams:
     name: path
   - default: 10s
     name: period
-  title: Tomcat cache logs
+  title: Tomcat cache metrics
   description: Collect Tomcat cache metrics

--- a/dev/packages/beats/tomcat-0.0.1/dataset/memory/manifest.yml
+++ b/dev/packages/beats/tomcat-0.0.1/dataset/memory/manifest.yml
@@ -12,5 +12,5 @@ streams:
     name: path
   - default: 10s
     name: period
-  title: Tomcat memory logs
+  title: Tomcat memory metrics
   description: Collect Tomcat memory metrics

--- a/dev/packages/beats/tomcat-0.0.1/dataset/requests/manifest.yml
+++ b/dev/packages/beats/tomcat-0.0.1/dataset/requests/manifest.yml
@@ -12,5 +12,5 @@ streams:
     name: path
   - default: 10s
     name: period
-  title: Tomcat requests logs
+  title: Tomcat requests metrics
   description: Collect Tomcat requests metrics

--- a/dev/packages/beats/tomcat-0.0.1/dataset/threading/manifest.yml
+++ b/dev/packages/beats/tomcat-0.0.1/dataset/threading/manifest.yml
@@ -12,5 +12,5 @@ streams:
     name: path
   - default: 10s
     name: period
-  title: Tomcat threading logs
+  title: Tomcat threading metrics
   description: Collect Tomcat threading metrics

--- a/dev/packages/beats/traefik-0.0.1/dataset/health/manifest.yml
+++ b/dev/packages/beats/traefik-0.0.1/dataset/health/manifest.yml
@@ -10,5 +10,5 @@ streams:
     name: hosts
   - default: 10s
     name: period
-  title: traefik health logs
+  title: traefik health metrics
   description: Collect traefik health metrics

--- a/dev/packages/beats/uwsgi-0.0.1/dataset/status/manifest.yml
+++ b/dev/packages/beats/uwsgi-0.0.1/dataset/status/manifest.yml
@@ -12,5 +12,5 @@ streams:
     name: hosts
   - default: 10s
     name: period
-  title: uwsgi status logs
+  title: uwsgi status metrics
   description: Collect uwsgi status metrics

--- a/dev/packages/beats/vsphere-0.0.1/dataset/datastore/manifest.yml
+++ b/dev/packages/beats/vsphere-0.0.1/dataset/datastore/manifest.yml
@@ -16,5 +16,5 @@ streams:
     name: period
   - default: user
     name: username
-  title: vSphere datastore logs
+  title: vSphere datastore metrics
   description: Collect vSphere datastore metrics

--- a/dev/packages/beats/vsphere-0.0.1/dataset/host/manifest.yml
+++ b/dev/packages/beats/vsphere-0.0.1/dataset/host/manifest.yml
@@ -16,5 +16,5 @@ streams:
     name: period
   - default: user
     name: username
-  title: vSphere host logs
+  title: vSphere host metrics
   description: Collect vSphere host metrics

--- a/dev/packages/beats/vsphere-0.0.1/dataset/virtualmachine/manifest.yml
+++ b/dev/packages/beats/vsphere-0.0.1/dataset/virtualmachine/manifest.yml
@@ -16,5 +16,5 @@ streams:
     name: period
   - default: user
     name: username
-  title: vSphere virtualmachine logs
+  title: vSphere virtualmachine metrics
   description: Collect vSphere virtualmachine metrics

--- a/dev/packages/beats/windows-0.0.1/dataset/perfmon/manifest.yml
+++ b/dev/packages/beats/windows-0.0.1/dataset/perfmon/manifest.yml
@@ -11,5 +11,5 @@ streams:
     name: perfmon.ignore_non_existent_counters
   - default: 10s
     name: period
-  title: Windows perfmon logs
+  title: Windows perfmon metrics
   description: Collect Windows perfmon metrics

--- a/dev/packages/beats/windows-0.0.1/dataset/service/manifest.yml
+++ b/dev/packages/beats/windows-0.0.1/dataset/service/manifest.yml
@@ -7,5 +7,5 @@ streams:
   vars:
   - default: 60s
     name: period
-  title: Windows service logs
+  title: Windows service metrics
   description: Collect Windows service metrics

--- a/dev/packages/beats/zookeeper-0.0.1/dataset/connection/manifest.yml
+++ b/dev/packages/beats/zookeeper-0.0.1/dataset/connection/manifest.yml
@@ -4,5 +4,5 @@ release: ga
 type: metrics
 streams:
 - input: zookeeper/metrics
-  title: ZooKeeper connection logs
+  title: ZooKeeper connection metrics
   description: Collect ZooKeeper connection metrics

--- a/dev/packages/beats/zookeeper-0.0.1/dataset/mntr/manifest.yml
+++ b/dev/packages/beats/zookeeper-0.0.1/dataset/mntr/manifest.yml
@@ -10,5 +10,5 @@ streams:
     name: hosts
   - default: 10s
     name: period
-  title: ZooKeeper mntr logs
+  title: ZooKeeper mntr metrics
   description: Collect ZooKeeper mntr metrics

--- a/dev/packages/beats/zookeeper-0.0.1/dataset/server/manifest.yml
+++ b/dev/packages/beats/zookeeper-0.0.1/dataset/server/manifest.yml
@@ -10,5 +10,5 @@ streams:
     name: hosts
   - default: 10s
     name: period
-  title: ZooKeeper server logs
+  title: ZooKeeper server metrics
   description: Collect ZooKeeper server metrics


### PR DESCRIPTION
Changes:
* fix invalid input stream description (logs instead of metrics)
* regenerate manifests

(spotted by @exekias during meeting today)