### PR TITLE
Fix Readme and icon links

### DIFF
--- a/docs/api/package.json
+++ b/docs/api/package.json
@@ -3,7 +3,7 @@
   "name": "example",
   "title": "Example Integration",
   "version": "1.0.0",
-  "readme": "/package/example-1.0.0/docs/README.md",
+  "readme": "/package/example/1.0.0/docs/README.md",
   "license": "basic",
   "description": "This is the example integration",
   "type": "integration",
@@ -21,12 +21,12 @@
   },
   "screenshots": [
     {
-      "src": "/package/example-1.0.0/img/kibana-iptables.png",
+      "src": "/package/example/1.0.0/img/kibana-iptables.png",
       "title": "IP Tables Overview dashboard",
       "size": "1492x1382"
     },
     {
-      "src": "/package/example-1.0.0/img/kibana-iptables-ubiquity.png",
+      "src": "/package/example/1.0.0/img/kibana-iptables-ubiquity.png",
       "title": "IP Tables Ubiquity Dashboard",
       "size": "1492x1464",
       "type": "image/png"

--- a/testdata/public/package/datasources/1.0.0/index.json
+++ b/testdata/public/package/datasources/1.0.0/index.json
@@ -3,7 +3,7 @@
   "name": "datasources",
   "title": "Default datasource Integration",
   "version": "1.0.0",
-  "readme": "/package/datasources-1.0.0/docs/README.md",
+  "readme": "/package/datasources/1.0.0/docs/README.md",
   "license": "basic",
   "description": "Package with data sources",
   "type": "integration",

--- a/testdata/public/package/default-pipeline/0.0.2/index.json
+++ b/testdata/public/package/default-pipeline/0.0.2/index.json
@@ -3,7 +3,7 @@
   "name": "default-pipeline",
   "title": "Default pipeline Integration",
   "version": "0.0.2",
-  "readme": "/package/default-pipeline-0.0.2/docs/README.md",
+  "readme": "/package/default-pipeline/0.0.2/docs/README.md",
   "license": "basic",
   "description": "Tests if no pipeline is set, it defaults to the default one",
   "type": "integration",

--- a/testdata/public/package/example/0.0.2/index.json
+++ b/testdata/public/package/example/0.0.2/index.json
@@ -3,7 +3,7 @@
   "name": "example",
   "title": "Example",
   "version": "0.0.2",
-  "readme": "/package/example-0.0.2/docs/README.md",
+  "readme": "/package/example/0.0.2/docs/README.md",
   "license": "basic",
   "description": "This is the example integration.",
   "type": "integration",

--- a/testdata/public/package/example/1.0.0/index.json
+++ b/testdata/public/package/example/1.0.0/index.json
@@ -3,7 +3,7 @@
   "name": "example",
   "title": "Example Integration",
   "version": "1.0.0",
-  "readme": "/package/example-1.0.0/docs/README.md",
+  "readme": "/package/example/1.0.0/docs/README.md",
   "license": "basic",
   "description": "This is the example integration",
   "type": "integration",
@@ -21,12 +21,12 @@
   },
   "screenshots": [
     {
-      "src": "/package/example-1.0.0/img/kibana-iptables.png",
+      "src": "/package/example/1.0.0/img/kibana-iptables.png",
       "title": "IP Tables Overview dashboard",
       "size": "1492x1382"
     },
     {
-      "src": "/package/example-1.0.0/img/kibana-iptables-ubiquity.png",
+      "src": "/package/example/1.0.0/img/kibana-iptables-ubiquity.png",
       "title": "IP Tables Ubiquity Dashboard",
       "size": "1492x1464",
       "type": "image/png"

--- a/testdata/public/package/foo/1.0.0/index.json
+++ b/testdata/public/package/foo/1.0.0/index.json
@@ -3,7 +3,7 @@
   "name": "foo",
   "title": "Foo",
   "version": "1.0.0",
-  "readme": "/package/foo-1.0.0/docs/README.md",
+  "readme": "/package/foo/1.0.0/docs/README.md",
   "license": "basic",
   "description": "This is the foo integration",
   "type": "solution",

--- a/testdata/public/package/internal/1.2.0/index.json
+++ b/testdata/public/package/internal/1.2.0/index.json
@@ -3,7 +3,7 @@
   "name": "internal",
   "title": "Internal",
   "version": "1.2.0",
-  "readme": "/package/internal-1.2.0/docs/README.md",
+  "readme": "/package/internal/1.2.0/docs/README.md",
   "license": "basic",
   "description": "Internal package",
   "type": "integration",

--- a/util/package.go
+++ b/util/package.go
@@ -85,7 +85,7 @@ type Image struct {
 }
 
 func (i Image) getPath(p *Package) string {
-	return "/package/" + p.Name + "-" + p.Version + i.Src
+	return path.Join("/package", p.Name, p.Version, i.Src)
 }
 
 // NewPackage creates a new package instances based on the given base path.
@@ -149,7 +149,7 @@ func NewPackage(basePath string) (*Package, error) {
 		if readme.IsDir() {
 			return nil, fmt.Errorf("README.md is a directory")
 		}
-		readmePathShort := "/package/" + p.Name + "-" + p.Version + "/docs/README.md"
+		readmePathShort := path.Join("/package", p.Name, p.Version, "docs", "README.md")
 		p.Readme = &readmePathShort
 	}
 


### PR DESCRIPTION
In https://github.com/elastic/package-registry/pull/300 the links to the README and icons were not correct.