### PR TITLE
Fix System Host overview dashboard

### DIFF
--- a/dev/packages/example/system-0.9.0/kibana/dashboard/79ffd6e0-faa0-11e6-947f-177f697178b8-ecs.json
+++ b/dev/packages/example/system-0.9.0/kibana/dashboard/79ffd6e0-faa0-11e6-947f-177f697178b8-ecs.json
@@ -3,15 +3,7 @@
         "description": "Overview of host metrics",
         "hits": 0,
         "kibanaSavedObjectMeta": {
-            "searchSourceJSON": {
-                "filter": [],
-                "highlightAll": true,
-                "query": {
-                    "language": "kuery",
-                    "query": "host.name:\"CHANGEME_HOSTNAME\""
-                },
-                "version": true
-            }
+            "searchSourceJSON": {}
         },
         "optionsJSON": {
             "darkTheme": false


### PR DESCRIPTION
On the Beats side, we took this dashboard and replace the hostname field with the local hostname. This had the nice onboarding experience that a user had the data directly filtered on his own host. This does not work anymore so this filter has to be removed. Instead I expect us when linking for example from an agent to a dashboard or similar, that we can apply some filters in advance.