### PR TITLE
remove lifecycle.rollover_alias from base index templates

### DIFF
--- a/dev/packages/example/base-1.0.0/elasticsearch/index-template/events-settings.json
+++ b/dev/packages/example/base-1.0.0/elasticsearch/index-template/events-settings.json
@@ -6,8 +6,7 @@
     "settings": {
         "index": {
             "lifecycle": {
-                "name": "events-default",
-                "rollover_alias": "events-generic-default"
+                "name": "events-default"
             },
             "codec": "best_compression",
             "refresh_interval": "5s",

--- a/dev/packages/example/base-1.0.0/elasticsearch/index-template/logs-settings.json
+++ b/dev/packages/example/base-1.0.0/elasticsearch/index-template/logs-settings.json
@@ -6,8 +6,7 @@
     "settings": {
         "index": {
             "lifecycle": {
-                "name": "logs-default",
-                "rollover_alias": "logs-generic-default"
+                "name": "logs-default"
             },
             "codec": "best_compression",
             "refresh_interval": "5s",

--- a/dev/packages/example/base-1.0.0/elasticsearch/index-template/metrics-settings.json
+++ b/dev/packages/example/base-1.0.0/elasticsearch/index-template/metrics-settings.json
@@ -6,8 +6,7 @@
     "settings": {
         "index": {
             "lifecycle": {
-                "name": "metrics-default",
-                "rollover_alias": "metrics-generic-default"
+                "name": "metrics-default"
             },
             "codec": "best_compression",
             "refresh_interval": "5s",


### PR DESCRIPTION
this can be removed because we are going to be using datastreams which does not require this to be configured.