### PR TITLE
Fix nginx stream template

### DIFF
--- a/dev/packages/example/nginx-1.2.0/dataset/error/agent/stream/stream.yml
+++ b/dev/packages/example/nginx-1.2.0/dataset/error/agent/stream/stream.yml
@@ -1,7 +1,3 @@
-
-# The selected input has to be passed to the stream config when processed.
-
-{{#if input == log}}
 input: log
 
 {{#each paths}}
@@ -11,13 +7,3 @@ exclude_files: [".gz$"]
 
 processors:
   - add_locale: ~
-{{/if}}
-
-
-# This is an example stream config on how multiple inputs could be supported
-
-{{#if input == syslog}}
-input: syslog
-
-# TODO: would need some more config options
-{{/if}}

--- a/dev/packages/example/nginx-1.2.0/dataset/error/agent/stream/syslog.yml
+++ b/dev/packages/example/nginx-1.2.0/dataset/error/agent/stream/syslog.yml
@@ -1,0 +1,1 @@
+input: syslog


### PR DESCRIPTION
Handlebar does not support if == statements as was used in the nginx template. This removes the if and for now only supports the log input. A follow up PR will happen which will indicate how multiple inputs will work.