### PR TITLE
Prepare basic testing environment for integrations

### DIFF
--- a/testing/environments/README.md
+++ b/testing/environments/README.md
@@ -1,0 +1,11 @@
+Firstly, refresh docker images:
+
+```bash
+$ docker-compose -f snapshot.yml pull
+```
+
+Run docker containers:
+
+```bash
+$ docker-compose -f snapshot.yml -f local.yml up --force-recreate kibana integrations-registry
+```

--- a/testing/environments/README.md
+++ b/testing/environments/README.md
@@ -7,5 +7,5 @@ $ docker-compose -f snapshot.yml pull
 Run docker containers:
 
 ```bash
-$ docker-compose -f snapshot.yml -f local.yml up --force-recreate kibana integrations-registry
+$ docker-compose -f snapshot.yml -f local.yml up --force-recreate
 ```

--- a/testing/environments/kibana.config.yml
+++ b/testing/environments/kibana.config.yml
@@ -1,0 +1,9 @@
+server.name: kibana
+server.host: "0"
+elasticsearch.hosts: [ "http://elasticsearch:9200" ]
+xpack.monitoring.ui.container.elasticsearch.enabled: true
+
+xpack.ingestManager.enabled: true
+xpack.ingestManager.epm.enabled: true
+xpack.ingestManager.fleet.enabled: true
+xpack.ingestManager.epm.registryUrl: "http://integrations-registry:8080"

--- a/testing/environments/kibana.config.yml
+++ b/testing/environments/kibana.config.yml
@@ -1,6 +1,9 @@
 server.name: kibana
 server.host: "0"
+
 elasticsearch.hosts: [ "http://elasticsearch:9200" ]
+elasticsearch.username: elastic
+elasticsearch.password: changeme
 xpack.monitoring.ui.container.elasticsearch.enabled: true
 
 xpack.ingestManager.enabled: true

--- a/testing/environments/local.yml
+++ b/testing/environments/local.yml
@@ -1,0 +1,21 @@
+# Defines if ports should be exported.
+# This is useful for testing locally with a full elastic stack setup.
+# All services can be reached through localhost like localhost:5601 for Kibana
+# This is not used for CI as otherwise ports conflicts could happen.
+version: '2.3'
+services:
+  kibana:
+    ports:
+      - "127.0.0.1:5601:5601"
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
+
+  elasticsearch:
+    ports:
+      - "127.0.0.1:9200:9200"
+
+  integrations-registry:
+    ports:
+      - "127.0.0.1:8080:8080"
+

--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -29,7 +29,7 @@ services:
       - ./kibana.config.yml:/usr/share/kibana/config/kibana.yml
 
   integrations-registry:
-    image: integrations_registry:latest
+    image: docker.elastic.co/package-registry/package-registry:master
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080"]
       retries: 300

--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -1,0 +1,34 @@
+# This should start the environment with the latest snapshots.
+
+version: '2.3'
+services:
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.0.0-SNAPSHOT
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9200"]
+      retries: 300
+      interval: 1s
+    environment:
+    - "ES_JAVA_OPTS=-Xms1g -Xmx1g"
+    - "network.host="
+    - "transport.host=127.0.0.1"
+    - "http.host=0.0.0.0"
+    - "xpack.security.enabled=false"
+    - "indices.id_field_data.enabled=true"
+    - "xpack.security.authc.api_key.enabled=true"
+
+  kibana:
+    image: docker.elastic.co/kibana/kibana:8.0.0-SNAPSHOT
+    healthcheck:
+      test: ["CMD-SHELL", 'python -c ''import urllib, json; response = urllib.urlopen("http://localhost:5601/api/status"); data = json.loads(response.read()); exit(1) if data["status"]["overall"]["state"] != "green" else exit(0);''']
+      retries: 600
+      interval: 1s
+    volumes:
+      - ./kibana.config.yml:/usr/share/kibana/config/kibana.yml
+
+  integrations-registry:
+    image: docker.elastic.co/package-registry/package-registry:c5e73d1585bbd4fcf32022ad7b088beb6c3f9467
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080"]
+      retries: 300
+      interval: 1s

--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -22,7 +22,7 @@ services:
   kibana:
     image: docker.elastic.co/kibana/kibana:8.0.0-SNAPSHOT
     healthcheck:
-      test: ["CMD-SHELL", 'python -c ''import urllib, json; response = urllib.urlopen("http://localhost:5601/api/status"); data = json.loads(response.read()); exit(1) if data["status"]["overall"]["state"] != "green" else exit(0);''']
+      test: ["CMD", "curl", "-f", "http://localhost:5601/login"]
       retries: 600
       interval: 1s
     volumes:

--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -5,7 +5,7 @@ services:
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:8.0.0-SNAPSHOT
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:9200"]
+      test: ["CMD", "curl", "-f", "-u", "elastic:changeme", "http://127.0.0.1:9200/"]
       retries: 300
       interval: 1s
     environment:
@@ -13,9 +13,11 @@ services:
     - "network.host="
     - "transport.host=127.0.0.1"
     - "http.host=0.0.0.0"
-    - "xpack.security.enabled=false"
     - "indices.id_field_data.enabled=true"
+    - "license=trial"
+    - "xpack.security.enabled=true"
     - "xpack.security.authc.api_key.enabled=true"
+    - "ELASTIC_PASSWORD=changeme"
 
   kibana:
     image: docker.elastic.co/kibana/kibana:8.0.0-SNAPSHOT
@@ -27,7 +29,7 @@ services:
       - ./kibana.config.yml:/usr/share/kibana/config/kibana.yml
 
   integrations-registry:
-    image: docker.elastic.co/package-registry/package-registry:master
+    image: integrations_registry:latest
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080"]
       retries: 300

--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -27,7 +27,7 @@ services:
       - ./kibana.config.yml:/usr/share/kibana/config/kibana.yml
 
   integrations-registry:
-    image: docker.elastic.co/package-registry/package-registry:c5e73d1585bbd4fcf32022ad7b088beb6c3f9467
+    image: docker.elastic.co/package-registry/package-registry:master
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080"]
       retries: 300


### PR DESCRIPTION
This PR prepares a basic testing environment that will boot up containers:
* Elasticsearch
* Kibana with enabled Ingest Manager
* Integrations registry

Let's consider this as grounds for the Integrations Developer Environment. I wonder if it's possible to use elastic-agent image and enroll it, so that the final setup would be ES, Kibana, Package Registry and an enrolled agent. 