### PR TITLE
Add removable config to package manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Make README.md file a required file for a package. [#287](https://github.com/elastic/integrations-registry/pull/287)
 *  Add stream fields to each dataset [#296](https://github.com/elastic/integrations-registry/pull/296)
 * Add `all` query param to return all packages. By default is set false. [#301](https://github.com/elastic/integrations-registry/pull/301)
+* Add `removable` flag to package manifest. Default is true. [#](https://github.com/elastic/integrations-registry/pull/)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Make README.md file a required file for a package. [#287](https://github.com/elastic/integrations-registry/pull/287)
 *  Add stream fields to each dataset [#296](https://github.com/elastic/integrations-registry/pull/296)
 * Add `all` query param to return all packages. By default is set false. [#301](https://github.com/elastic/integrations-registry/pull/301)
-* Add `removable` flag to package manifest. Default is true. [#](https://github.com/elastic/integrations-registry/pull/)
+* Add `removable` flag to package manifest. Default is true. [#359](https://github.com/elastic/integrations-registry/pull/359)
 
 ### Deprecated
 

--- a/dev/import-beats/variables.go
+++ b/dev/import-beats/variables.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-	"gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v2"
 
 	"github.com/elastic/package-registry/util"
 )

--- a/dev/import-beats/variables_compact.go
+++ b/dev/import-beats/variables_compact.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-	"gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v2"
 
 	"github.com/elastic/package-registry/util"
 )

--- a/dev/packages/example/base-1.0.0/manifest.yml
+++ b/dev/packages/example/base-1.0.0/manifest.yml
@@ -10,6 +10,9 @@ version: 1.0.0
 categories: []
 release: ga
 
+# The base package cannot be removed
+removable: false
+
 # The user should not see this package and not be able to install it
 internal: true
 

--- a/dev/packages/example/system-0.9.0/manifest.yml
+++ b/dev/packages/example/system-0.9.0/manifest.yml
@@ -7,6 +7,9 @@ version: 0.9.0
 categories: ["logs", "metrics"]
 release: ga
 
+# The system package cannot be removed
+removable: false
+
 requirement:
   kibana:
     versions: "<8.0.0"

--- a/docs/api/package.json
+++ b/docs/api/package.json
@@ -11,6 +11,7 @@
     "logs",
     "metrics"
   ],
+  "removable": true,
   "requirement": {
     "kibana": {
       "versions": "\u003e=7.0.0"

--- a/testdata/package/internal-1.2.0/manifest.yml
+++ b/testdata/package/internal-1.2.0/manifest.yml
@@ -6,3 +6,4 @@ version: 1.2.0
 title: Internal
 categories: []
 internal: true
+removable: false

--- a/testdata/public/package/datasources/1.0.0/index.json
+++ b/testdata/public/package/datasources/1.0.0/index.json
@@ -10,6 +10,7 @@
   "categories": [
     "logs"
   ],
+  "removable": true,
   "requirement": {
     "kibana": {},
     "elasticsearch": {}

--- a/testdata/public/package/default-pipeline/0.0.2/index.json
+++ b/testdata/public/package/default-pipeline/0.0.2/index.json
@@ -10,6 +10,7 @@
   "categories": [
     "logs"
   ],
+  "removable": true,
   "requirement": {
     "kibana": {},
     "elasticsearch": {}

--- a/testdata/public/package/example/0.0.2/index.json
+++ b/testdata/public/package/example/0.0.2/index.json
@@ -10,6 +10,7 @@
   "categories": [
     "logs"
   ],
+  "removable": true,
   "requirement": {
     "kibana": {
       "versions": "\u003e=6.0.0"

--- a/testdata/public/package/example/1.0.0/index.json
+++ b/testdata/public/package/example/1.0.0/index.json
@@ -11,6 +11,7 @@
     "logs",
     "metrics"
   ],
+  "removable": true,
   "requirement": {
     "kibana": {
       "versions": "\u003e=7.0.0"

--- a/testdata/public/package/foo/1.0.0/index.json
+++ b/testdata/public/package/foo/1.0.0/index.json
@@ -10,6 +10,7 @@
   "categories": [
     "metrics"
   ],
+  "removable": true,
   "requirement": {
     "kibana": {
       "versions": "\u003e=7.0.0"

--- a/testdata/public/package/internal/1.2.0/index.json
+++ b/testdata/public/package/internal/1.2.0/index.json
@@ -8,6 +8,7 @@
   "description": "Internal package",
   "type": "integration",
   "categories": [],
+  "removable": false,
   "requirement": {
     "kibana": {},
     "elasticsearch": {}

--- a/testdata/public/package/internal/1.2.0/manifest.yml
+++ b/testdata/public/package/internal/1.2.0/manifest.yml
@@ -6,3 +6,4 @@ version: 1.2.0
 title: Internal
 categories: []
 internal: true
+removable: false

--- a/util/package.go
+++ b/util/package.go
@@ -41,6 +41,7 @@ type Package struct {
 	Type          string       `config:"type" json:"type"`
 	Categories    []string     `config:"categories" json:"categories"`
 	Release       string       `config:"release,omitempty" json:"release,omitempty"`
+	Removable     bool         `config:"removable" json:"removable"`
 	Requirement   Requirement  `config:"requirement" json:"requirement"`
 	Screenshots   []Image      `config:"screenshots,omitempty" json:"screenshots,omitempty" yaml:"screenshots,omitempty"`
 	Icons         []Image      `config:"icons,omitempty" json:"icons,omitempty" yaml:"icons,omitempty"`
@@ -99,7 +100,8 @@ func NewPackage(basePath string) (*Package, error) {
 	}
 
 	var p = &Package{
-		BasePath: basePath,
+		BasePath:  basePath,
+		Removable: true,
 	}
 	err = manifest.Unpack(p)
 	if err != nil {


### PR DESCRIPTION
This config indicates if a package can be removed again after it is installed. There are certain packages like the system and the base package which are required for the working of the package manager and because of this cannot be removed. The default of this flag is true.