### PR TITLE
import-beats: Fix: do not encode twice

### DIFF
--- a/dev/generator/main.go
+++ b/dev/generator/main.go
@@ -266,7 +266,6 @@ var (
 // The reason is that for versioning it is much nicer to have the full
 // json so only on packaging this is changed.
 func encodedSavedObject(data []byte) (string, error) {
-
 	savedObject := MapStr{}
 	json.Unmarshal(data, &savedObject)
 
@@ -281,7 +280,7 @@ func encodedSavedObject(data []byte) (string, error) {
 		// In this case skip the encoding.
 		_, isString := out.(string)
 		if isString {
-			continue
+			return "", fmt.Errorf("expect non-string field type (fieldName: %s)", v)
 		}
 
 		// Marshal the value to encode it properly

--- a/dev/generator/main.go
+++ b/dev/generator/main.go
@@ -277,6 +277,13 @@ func encodedSavedObject(data []byte) (string, error) {
 			continue
 		}
 
+		// It may happen that some objects existing in example directory might be already encoded.
+		// In this case skip the encoding.
+		_, isString := out.(string)
+		if isString {
+			continue
+		}
+
 		// Marshal the value to encode it properly
 		r, err := json.Marshal(&out)
 		if err != nil {

--- a/dev/packages/example/endpoint-1.0.0/kibana/map/a3a3bd10-706b-11ea-9bc8-6b38f4d29a16.json
+++ b/dev/packages/example/endpoint-1.0.0/kibana/map/a3a3bd10-706b-11ea-9bc8-6b38f4d29a16.json
@@ -28,8 +28,152 @@
             "type": "Polygon"
         },
         "description": "",
-        "layerListJSON": "[{\"sourceDescriptor\":{\"type\":\"EMS_TMS\",\"isAutoSelect\":true},\"id\":\"526f1956-b031-487b-887f-15901691696a\",\"label\":null,\"minZoom\":0,\"maxZoom\":24,\"alpha\":1,\"visible\":true,\"style\":{},\"type\":\"VECTOR_TILE\"},{\"sourceDescriptor\":{\"type\":\"ES_GEO_GRID\",\"id\":\"872f1625-c279-44a8-b4d3-f698b0a5e907\",\"geoField\":\"host.geo.location\",\"requestType\":\"point\",\"resolution\":\"COARSE\",\"applyGlobalQuery\":true,\"metrics\":[{\"type\":\"cardinality\",\"label\":\"Number of Endpoints\",\"field\":\"agent.id\"}],\"indexPatternRefName\":\"layer_1_source_index_pattern\"},\"style\":{\"type\":\"VECTOR\",\"properties\":{\"fillColor\":{\"type\":\"STATIC\",\"options\":{\"color\":\"#54B399\"}},\"lineColor\":{\"type\":\"STATIC\",\"options\":{\"color\":\"#FFF\"}},\"lineWidth\":{\"type\":\"STATIC\",\"options\":{\"size\":0}},\"iconSize\":{\"type\":\"DYNAMIC\",\"options\":{\"minSize\":10,\"maxSize\":35,\"fieldMetaOptions\":{\"isEnabled\":true,\"sigma\":3},\"field\":{\"label\":\"Number of Endpoints\",\"name\":\"cardinality_of_agent.id\",\"origin\":\"source\"}}},\"iconOrientation\":{\"type\":\"STATIC\",\"options\":{\"orientation\":0}},\"labelText\":{\"type\":\"DYNAMIC\",\"options\":{\"field\":{\"label\":\"Number of Endpoints\",\"name\":\"cardinality_of_agent.id\",\"origin\":\"source\"}}},\"labelColor\":{\"type\":\"STATIC\",\"options\":{\"color\":\"#000000\"}},\"labelSize\":{\"type\":\"STATIC\",\"options\":{\"size\":14}},\"labelBorderColor\":{\"type\":\"STATIC\",\"options\":{\"color\":\"#FFFFFF\"}},\"symbol\":{\"options\":{\"symbolizeAs\":\"circle\",\"symbolId\":\"airfield\"}},\"labelBorderSize\":{\"options\":{\"size\":\"SMALL\"}}},\"isTimeAware\":true},\"id\":\"da92df53-51bf-446f-8f88-21933fea8fe3\",\"label\":\"Endpoints\",\"minZoom\":0,\"maxZoom\":24,\"alpha\":0.75,\"visible\":true,\"type\":\"VECTOR\"}]",
-        "mapStateJSON": "{\"zoom\":0.71,\"center\":{\"lon\":-72.02031,\"lat\":-18.76202},\"timeFilters\":{\"from\":\"now-15d\",\"to\":\"now\"},\"refreshConfig\":{\"isPaused\":false,\"interval\":0},\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filters\":[]}",
+        "layerListJSON": [
+            {
+                "sourceDescriptor": {
+                    "type": "EMS_TMS",
+                    "isAutoSelect": true
+                },
+                "id": "526f1956-b031-487b-887f-15901691696a",
+                "label": null,
+                "minZoom": 0,
+                "maxZoom": 24,
+                "alpha": 1,
+                "visible": true,
+                "style": {},
+                "type": "VECTOR_TILE"
+            },
+            {
+                "sourceDescriptor": {
+                    "type": "ES_GEO_GRID",
+                    "id": "872f1625-c279-44a8-b4d3-f698b0a5e907",
+                    "geoField": "host.geo.location",
+                    "requestType": "point",
+                    "resolution": "COARSE",
+                    "applyGlobalQuery": true,
+                    "metrics": [
+                        {
+                            "type": "cardinality",
+                            "label": "Number of Endpoints",
+                            "field": "agent.id"
+                        }
+                    ],
+                    "indexPatternRefName": "layer_1_source_index_pattern"
+                },
+                "style": {
+                    "type": "VECTOR",
+                    "properties": {
+                        "fillColor": {
+                            "type": "STATIC",
+                            "options": {
+                                "color": "#54B399"
+                            }
+                        },
+                        "lineColor": {
+                            "type": "STATIC",
+                            "options": {
+                                "color": "#FFF"
+                            }
+                        },
+                        "lineWidth": {
+                            "type": "STATIC",
+                            "options": {
+                                "size": 0
+                            }
+                        },
+                        "iconSize": {
+                            "type": "DYNAMIC",
+                            "options": {
+                                "minSize": 10,
+                                "maxSize": 35,
+                                "fieldMetaOptions": {
+                                    "isEnabled": true,
+                                    "sigma": 3
+                                },
+                                "field": {
+                                    "label": "Number of Endpoints",
+                                    "name": "cardinality_of_agent.id",
+                                    "origin": "source"
+                                }
+                            }
+                        },
+                        "iconOrientation": {
+                            "type": "STATIC",
+                            "options": {
+                                "orientation": 0
+                            }
+                        },
+                        "labelText": {
+                            "type": "DYNAMIC",
+                            "options": {
+                                "field": {
+                                    "label": "Number of Endpoints",
+                                    "name": "cardinality_of_agent.id",
+                                    "origin": "source"
+                                }
+                            }
+                        },
+                        "labelColor": {
+                            "type": "STATIC",
+                            "options": {
+                                "color": "#000000"
+                            }
+                        },
+                        "labelSize": {
+                            "type": "STATIC",
+                            "options": {
+                                "size": 14
+                            }
+                        },
+                        "labelBorderColor": {
+                            "type": "STATIC",
+                            "options": {
+                                "color": "#FFFFFF"
+                            }
+                        },
+                        "symbol": {
+                            "options": {
+                                "symbolizeAs": "circle",
+                                "symbolId": "airfield"
+                            }
+                        },
+                        "labelBorderSize": {
+                            "options": {
+                                "size": "SMALL"
+                            }
+                        }
+                    },
+                    "isTimeAware": true
+                },
+                "id": "da92df53-51bf-446f-8f88-21933fea8fe3",
+                "label": "Endpoints",
+                "minZoom": 0,
+                "maxZoom": 24,
+                "alpha": 0.75,
+                "visible": true,
+                "type": "VECTOR"
+            }
+        ],
+        "mapStateJSON": {
+            "zoom": 0.71,
+            "center": {
+                "lon": -72.02031,
+                "lat": -18.76202
+            },
+            "timeFilters": {
+                "from": "now-15d",
+                "to": "now"
+            },
+            "refreshConfig": {
+                "isPaused": false,
+                "interval": 0
+            },
+            "query": {
+                "query": "",
+                "language": "kuery"
+            },
+            "filters": []
+        },
         "title": "[Endpoint] Endpoint Map",
         "uiStateJSON": {
             "isLayerTOCOpen": true,


### PR DESCRIPTION
This PR fixes bug in the `generator`, which performed encoding twice on Kibana objects. Some objects (e.g. in the `example` package) are already stored in the encoded form.