### PR TITLE
Add independent Dockerfile

### DIFF
--- a/dev/release/Dockerfile
+++ b/dev/release/Dockerfile
@@ -22,13 +22,27 @@ EXPOSE 8080
 ENV GO111MODULE=on
 RUN go mod vendor
 RUN go get -u github.com/magefile/mage
+# Prepare all the packages to be built
 RUN mage build
 
-# This directory contains the packages at the moment but is only used during the build process
-# If we keep it, it means all packages exist twice.
-RUN rm -rf dev
+# Build binary
+RUN go build .
 
-ENTRYPOINT ["go", "run", "."]
+# Move all files need to run to its own directory
+# This will become useful for staged builds later on
+RUN mkdir /registry
+RUN mv package-registry /registry/
+RUN mv config.yml /registry/
+RUN mv public /registry/
+
+# Clean up files not needed
+RUN rm -rf /go/src/github.com/elastic/package-registry
+RUN rm -rf /go/package-storage
+
+# Change to new working directory
+WORKDIR /registry
+
+ENTRYPOINT ["./package-registry"]
 # Make sure it's accessible from outside the container
 CMD ["--address=0.0.0.0:8080"]
 

--- a/dev/release/Dockerfile
+++ b/dev/release/Dockerfile
@@ -1,3 +1,5 @@
+# This Dockerfile allows to build the package-registry and packages together.
+# It is decoupled from the packages and the registry even though for now both are in the same repository.
 ARG GO_VERSION=1.14.2
 FROM golang:${GO_VERSION}
 
@@ -7,10 +9,13 @@ RUN \
          zip rsync \
       && rm -rf /var/lib/apt/lists/*
 
-COPY ./ /go/src/github.com/elastic/package-registry
-EXPOSE 8080
-
+RUN go get github.com/elastic/package-registry
 WORKDIR "/go/src/github.com/elastic/package-registry"
+
+# Define which version of the packages should be checked out.
+ARG PACKAGES_VERSION=master
+RUN git checkout ${PACKAGES_VERSION}
+EXPOSE 8080
 
 ENV GO111MODULE=on
 RUN go mod vendor

--- a/dev/release/Dockerfile
+++ b/dev/release/Dockerfile
@@ -9,8 +9,10 @@ RUN \
          zip rsync \
       && rm -rf /var/lib/apt/lists/*
 
+RUN git clone https://github.com/elastic/package-storage.git
 RUN go get github.com/elastic/package-registry
 WORKDIR "/go/src/github.com/elastic/package-registry"
+RUN rsync -a /go/package-storage/packages/ dev/packages/example
 
 # Define which version of the packages should be checked out.
 ARG PACKAGES_VERSION=master


### PR DESCRIPTION
The package storage and the package registry are soon going to be decoupled. To be able to still build a docker container with both inside a Dockerfile is needed that can pull in the dependencies from an external sources instead of local files.

To get this started, a separate Dockerfile is introduced that does not load any files from the repository directly but pulls it from Github. This is to start play around with this idea.

The end goal is being able to pass in the version of the packages that should be used to built the container and the version of the registry.

Where this Dockerfile should land in the end is not clear yet but the package-registry seems to be a good place at the moment.

Other changes:

* Updated the Golang version of the container running the registry