### PR TITLE
Include fields in fields.epr.yml

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -182,6 +182,12 @@ what's been already fixed, as the script has overridden part of it).
     a field definition. The sum of fields in all present files should contain only fields that are really used, e.g.
     not all existing ECS fields.
 
+    It may happen that the ingest pipeline uses fields abstracted from ECS, but not mentioned in `fields.yml`.
+    Integrations should contain these fields and also have them documented.
+
+    See the PR https://github.com/elastic/beats/pull/17895 to understand how to add them to Beats (e.g. `event.code`,
+    `event.provider`) using the `fields.epr.yml` file.
+
 6. Metricbeat: add missing configuration options.
 
    The `import-beats` script extracts configuration options from Metricbeat module's `_meta` directory. It analyzes

--- a/dev/import-beats/fields.go
+++ b/dev/import-beats/fields.go
@@ -127,7 +127,7 @@ func loadDatasetFields(modulePath, moduleName, datasetName string) ([]fieldDefin
 	fieldsEpr := filepath.Join(modulePath, datasetName, "_meta", "fields.epr.yml")
 	efs, err := loadFieldsFile(fieldsEpr)
 	if err != nil {
-		return nil, errors.Wrapf(err, "loading dataset fields file failed")
+		return nil, errors.Wrapf(err, "loading fields.epr.yml file failed")
 	}
 
 	fs = append(fs, efs...)

--- a/dev/import-beats/fields.go
+++ b/dev/import-beats/fields.go
@@ -115,15 +115,22 @@ func loadModuleFields(modulePath string) ([]fieldDefinition, error) {
 }
 
 func loadDatasetFields(modulePath, moduleName, datasetName string) ([]fieldDefinition, error) {
-	path := filepath.Join(modulePath, datasetName, "_meta", "fields.yml")
-	fs, err := loadFieldsFile(path)
+	fieldsPath := filepath.Join(modulePath, datasetName, "_meta", "fields.yml")
+	fs, err := loadFieldsFile(fieldsPath)
+	if err != nil {
+		return nil, errors.Wrapf(err, "loading dataset fields file failed")
+	}
+	for i, f := range fs {
+		fs[i].Name = fmt.Sprintf("%s.%s", moduleName, f.Name)
+	}
+
+	fieldsEpr := filepath.Join(modulePath, datasetName, "_meta", "fields.epr.yml")
+	efs, err := loadFieldsFile(fieldsEpr)
 	if err != nil {
 		return nil, errors.Wrapf(err, "loading dataset fields file failed")
 	}
 
-	for i, f := range fs {
-		fs[i].Name = fmt.Sprintf("%s.%s", moduleName, f.Name)
-	}
+	fs = append(fs, efs...)
 	return fs, nil
 }
 

--- a/dev/packages/alpha/mysql-0.0.2/dataset/error/fields/fields.yml
+++ b/dev/packages/alpha/mysql-0.0.2/dataset/error/fields/fields.yml
@@ -1,2 +1,23 @@
 - name: mysql.error
   type: group
+- name: event.code
+  type: keyword
+  description: Identification code for this event
+- name: event.provider
+  type: keyword
+  description: Source of the event (e.g. Server)
+- name: event.created
+  type: date
+  description: Date/time when the event was first read by an agent, or by your pipeline.
+- name: event.timezone
+  type: keyword
+  description: Time zone information
+- name: event.kind
+  type: keyword
+  description: Event kind (e.g. event)
+- name: event.category
+  type: keyword
+  description: Event category (e.g. database)
+- name: event.type
+  type: keyword
+  description: Event severity (e.g. info, error)

--- a/dev/packages/alpha/mysql-0.0.2/docs/README.md
+++ b/dev/packages/alpha/mysql-0.0.2/docs/README.md
@@ -19,6 +19,13 @@ The `error` dataset collects the MySQL error logs.
 
 | Field | Description | Type |
 |---|---|---|
+| event.category | Event category (e.g. database) | keyword |
+| event.code | Identification code for this event | keyword |
+| event.created | Date/time when the event was first read by an agent, or by your pipeline. | date |
+| event.kind | Event kind (e.g. event) | keyword |
+| event.provider | Source of the event (e.g. Server) | keyword |
+| event.timezone | Time zone information | keyword |
+| event.type | Event severity (e.g. info, error) | keyword |
 | log.level | Original log level of the log event. If the source of the event provides a log level or textual severity, this is the one that goes in `log.level`. If your source doesn't specify one, you may put your event transport's severity here (e.g. Syslog severity). Some examples are `warn`, `err`, `i`, `informational`. | keyword |
 | message | For log events the message field contains the log message, optimized for viewing in a log viewer. For structured logs without an original message field, other fields can be concatenated to form a human-readable summary of the event. If multiple messages exist, they can be combined into one message. | text |
 | mysql.thread_id | The connection or thread ID for the query. | long |

--- a/dev/packages/beats/mysql-0.0.1/dataset/error/fields/fields.yml
+++ b/dev/packages/beats/mysql-0.0.1/dataset/error/fields/fields.yml
@@ -1,2 +1,23 @@
 - name: mysql.error
   type: group
+- name: event.code
+  type: keyword
+  description: Identification code for this event
+- name: event.provider
+  type: keyword
+  description: Source of the event (e.g. Server)
+- name: event.created
+  type: date
+  description: Date/time when the event was first read by an agent, or by your pipeline.
+- name: event.timezone
+  type: keyword
+  description: Time zone information
+- name: event.kind
+  type: keyword
+  description: Event kind (e.g. event)
+- name: event.category
+  type: keyword
+  description: Event category (e.g. database)
+- name: event.type
+  type: keyword
+  description: Event severity (e.g. info, error)

--- a/dev/packages/beats/mysql-0.0.1/docs/README.md
+++ b/dev/packages/beats/mysql-0.0.1/docs/README.md
@@ -19,6 +19,13 @@ The `error` dataset collects the MySQL error logs.
 
 | Field | Description | Type |
 |---|---|---|
+| event.category | Event category (e.g. database) | keyword |
+| event.code | Identification code for this event | keyword |
+| event.created | Date/time when the event was first read by an agent, or by your pipeline. | date |
+| event.kind | Event kind (e.g. event) | keyword |
+| event.provider | Source of the event (e.g. Server) | keyword |
+| event.timezone | Time zone information | keyword |
+| event.type | Event severity (e.g. info, error) | keyword |
 | log.level | Original log level of the log event. If the source of the event provides a log level or textual severity, this is the one that goes in `log.level`. If your source doesn't specify one, you may put your event transport's severity here (e.g. Syslog severity). Some examples are `warn`, `err`, `i`, `informational`. | keyword |
 | message | For log events the message field contains the log message, optimized for viewing in a log viewer. For structured logs without an original message field, other fields can be concatenated to form a human-readable summary of the event. If multiple messages exist, they can be combined into one message. | text |
 | mysql.thread_id | The connection or thread ID for the query. | long |


### PR DESCRIPTION
This PR includes fields defined in the `fields.epr.yml` file.

These fields are used in ingest pipelines, but aren't defined in fields file in beats.