### PR TITLE
import-beats: select packages to import

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,6 +123,12 @@ feel free to review the script's [README](https://github.com/elastic/package-reg
     the one you're currently working on (e.g. `dev/packages/beats/foobarbaz-0.0.1`). You can either commit this changes
     or leave them for later.
 
+    If you want to select a subgroup of packages, set the environment variable `PACKAGES` (comma-delimited list):
+
+    ```bash
+   $ PACKAGES=aws,cisco mage ImportBeats
+    ```
+
 6. Copy the package output for your integration (e.g. `dev/packages/beats/foobarbaz-0.0.1`) to the _alpha_ directory and
     raise the version manually: `dev/packages/alpha/foobarbaz-0.0.2`.
 

--- a/magefile.go
+++ b/magefile.go
@@ -73,6 +73,9 @@ func ImportBeats() error {
 	if os.Getenv("SKIP_KIBANA") == "true" {
 		args = append(args, "-skipKibana")
 	}
+	if os.Getenv("PACKAGES") != "" {
+		args = append(args, "-packages", os.Getenv("PACKAGES"))
+	}
 	args = append(args, "*.go")
 	return sh.Run("go", args...)
 }


### PR DESCRIPTION
This PR modifies the `import-beats` script to allow for selecting particular packages you're working on, e.g.:

```bash
PACKAGES=aws,cisco mage ImportBeats
``` 

It definitely shortens total time for importing, as there is no need to wait for unrelated packages to get imported. 