### PR TITLE
Add missing annotations

### DIFF
--- a/util/dataset.go
+++ b/util/dataset.go
@@ -49,8 +49,8 @@ type Stream struct {
 	Vars    []Variable `config:"vars" json:"vars,omitempty" yaml:"vars,omitempty"`
 	Dataset string     `config:"dataset" json:"dataset,omitempty" yaml:"dataset,omitempty"`
 	// TODO: This might cause issues when consuming the json as the key contains . (had been an issue in the past if I remember correctly)
-	TemplatePath    string `config:"template_path" json:"template_path,omitempty" yaml:"template-path,omitempty"`
-	TemplateContent string `json:"template,omitempty"` // This is always generated in the json output
+	TemplatePath    string `config:"template_path" json:"template_path,omitempty" yaml:"template_path,omitempty"`
+	TemplateContent string `json:"template,omitempty" yaml:"template,omitempty"` // This is always generated in the json output
 	Title           string `config:"title" json:"title,omitempty" yaml:"title,omitempty"`
 	Description     string `config:"description" json:"description,omitempty" yaml:"description,omitempty"`
 }

--- a/util/package.go
+++ b/util/package.go
@@ -62,7 +62,7 @@ type Datasource struct {
 	Description string  `config:"description" json:"description" validate:"required"`
 	Solution    string  `config:"solution" json:"solution,omitempty" yaml:"solution,omitempty"`
 	Inputs      []Input `config:"inputs" json:"inputs"`
-	Multiple    *bool   `config:"multiple" json:"multiple" yaml:"multiple"`
+	Multiple    *bool   `config:"multiple" json:"multiple,omitempty" yaml:"multiple,omitempty"`
 }
 
 type Requirement struct {


### PR DESCRIPTION
This PR adds missing annotations to structures in `util` to prevent the `import-beats` from "null" or empty fields generation.

Thank to this change no imported files are touched.