### PR TITLE
Add experimental releases for packages and datasets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add `removable` flag to package manifest. Default is true. [#359](https://github.com/elastic/integrations-registry/pull/359)
 * Add stream template to package json. [#335](https://github.com/elastic/integrations-registry/pull/335)
 * Add support for multiple inputs per dataset. [#346](https://github.com/elastic/integrations-registry/pull/346)
+* Add experimental releases for packages and datasets. [#](https://github.com/elastic/integrations-registry/pull/)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add `removable` flag to package manifest. Default is true. [#359](https://github.com/elastic/integrations-registry/pull/359)
 * Add stream template to package json. [#335](https://github.com/elastic/integrations-registry/pull/335)
 * Add support for multiple inputs per dataset. [#346](https://github.com/elastic/integrations-registry/pull/346)
-* Add experimental releases for packages and datasets. [#](https://github.com/elastic/integrations-registry/pull/)
+* Add experimental releases for packages and datasets. [#382](https://github.com/elastic/integrations-registry/pull/382)
 
 ### Deprecated
 

--- a/docs/api/categories-experimental.json
+++ b/docs/api/categories-experimental.json
@@ -1,0 +1,12 @@
+[
+  {
+    "id": "logs",
+    "title": "Logs",
+    "count": 4
+  },
+  {
+    "id": "metrics",
+    "title": "Metrics",
+    "count": 3
+  }
+]

--- a/docs/api/package.json
+++ b/docs/api/package.json
@@ -11,6 +11,7 @@
     "logs",
     "metrics"
   ],
+  "release": "ga",
   "removable": true,
   "requirement": {
     "kibana": {
@@ -59,7 +60,7 @@
     {
       "id": "bar",
       "title": "Foo",
-      "release": "beta",
+      "release": "experimental",
       "type": "logs",
       "ingest_pipeline": "pipeline-entry",
       "streams": [

--- a/docs/api/search-package-experimental.json
+++ b/docs/api/search-package-experimental.json
@@ -1,0 +1,56 @@
+[
+  {
+    "description": "Package with data sources",
+    "download": "/epr/datasources/datasources-1.0.0.tar.gz",
+    "name": "datasources",
+    "path": "/package/datasources/1.0.0",
+    "title": "Default datasource Integration",
+    "type": "integration",
+    "version": "1.0.0"
+  },
+  {
+    "description": "Tests if no pipeline is set, it defaults to the default one",
+    "download": "/epr/default-pipeline/default-pipeline-0.0.2.tar.gz",
+    "name": "default-pipeline",
+    "path": "/package/default-pipeline/0.0.2",
+    "title": "Default pipeline Integration",
+    "type": "integration",
+    "version": "0.0.2"
+  },
+  {
+    "description": "This is the example integration",
+    "download": "/epr/example/example-1.0.0.tar.gz",
+    "name": "example",
+    "path": "/package/example/1.0.0",
+    "title": "Example Integration",
+    "type": "integration",
+    "version": "1.0.0"
+  },
+  {
+    "description": "Experimental package, should be set by default",
+    "download": "/epr/experimental/experimental-0.0.1.tar.gz",
+    "name": "experimental",
+    "path": "/package/experimental/0.0.1",
+    "title": "Experimental",
+    "type": "solution",
+    "version": "0.0.1"
+  },
+  {
+    "description": "This is the foo integration",
+    "download": "/epr/foo/foo-1.0.0.tar.gz",
+    "name": "foo",
+    "path": "/package/foo/1.0.0",
+    "title": "Foo",
+    "type": "solution",
+    "version": "1.0.0"
+  },
+  {
+    "description": "Tests that multiple can be set to false",
+    "download": "/epr/multiple-false/multiple-false-0.0.1.tar.gz",
+    "name": "multiple-false",
+    "path": "/package/multiple-false/0.0.1",
+    "title": "Multiple false",
+    "type": "integration",
+    "version": "0.0.1"
+  }
+]

--- a/main_test.go
+++ b/main_test.go
@@ -39,6 +39,7 @@ func TestEndpoints(t *testing.T) {
 		{"/search", "/search", "search.json", searchHandler(packagesBasePath, testCacheTime)},
 		{"/search?all=true", "/search", "search-all.json", searchHandler(packagesBasePath, testCacheTime)},
 		{"/categories", "/categories", "categories.json", categoriesHandler(packagesBasePath, testCacheTime)},
+		{"/categories?experimental=true", "/categories", "categories-experimental.json", categoriesHandler(packagesBasePath, testCacheTime)},
 		{"/search?kibana=6.5.2", "/search", "search-kibana652.json", searchHandler(packagesBasePath, testCacheTime)},
 		{"/search?kibana=7.2.1", "/search", "search-kibana721.json", searchHandler(packagesBasePath, testCacheTime)},
 		{"/search?category=metrics", "/search", "search-category-metrics.json", searchHandler(packagesBasePath, testCacheTime)},
@@ -46,6 +47,7 @@ func TestEndpoints(t *testing.T) {
 		{"/search?package=example", "/search", "search-package-example.json", searchHandler(packagesBasePath, testCacheTime)},
 		{"/search?package=example&all=true", "/search", "search-package-example-all.json", searchHandler(packagesBasePath, testCacheTime)},
 		{"/search?internal=true", "/search", "search-package-internal.json", searchHandler(packagesBasePath, testCacheTime)},
+		{"/search?experimental=true", "/search", "search-package-experimental.json", searchHandler(packagesBasePath, testCacheTime)},
 		{"/package/example/1.0.0", "", "package.json", catchAll(publicPath, testCacheTime)},
 	}
 

--- a/search.go
+++ b/search.go
@@ -28,6 +28,7 @@ func searchHandler(packagesBasePath string, cacheTime time.Duration) func(w http
 		var packageQuery string
 		var all bool
 		var internal bool
+		var experimental bool
 		var err error
 
 		// Read query filter params which can affect the output
@@ -65,6 +66,13 @@ func searchHandler(packagesBasePath string, cacheTime time.Duration) func(w http
 					internal, _ = strconv.ParseBool(v)
 				}
 			}
+
+			if v := query.Get("experimental"); v != "" {
+				if v != "" {
+					// In case of error, keep it false
+					experimental, _ = strconv.ParseBool(v)
+				}
+			}
 		}
 
 		packages, err := util.GetPackages(packagesBasePath)
@@ -79,6 +87,11 @@ func searchHandler(packagesBasePath string, cacheTime time.Duration) func(w http
 
 			// Skip internal packages by default
 			if p.Internal && !internal {
+				continue
+			}
+
+			// Skip experimental packages if flag is not specified
+			if p.Release == util.ReleaseExperimental && !experimental {
 				continue
 			}
 

--- a/testdata/package/datasources-1.0.0/manifest.yml
+++ b/testdata/package/datasources-1.0.0/manifest.yml
@@ -7,7 +7,7 @@ title: Default datasource Integration
 categories: ["logs"]
 type: integration
 license: basic
-
+release: beta
 
 datasources:
   -

--- a/testdata/package/default-pipeline-0.0.2/manifest.yml
+++ b/testdata/package/default-pipeline-0.0.2/manifest.yml
@@ -6,6 +6,7 @@ version: 0.0.2
 title: Default pipeline Integration
 categories: ["logs"]
 type: integration
+release: beta
 
 
 datasources:

--- a/testdata/package/example-0.0.2/manifest.yml
+++ b/testdata/package/example-0.0.2/manifest.yml
@@ -5,6 +5,7 @@ title: Example
 description: This is the example integration.
 version: 0.0.2
 categories: ["logs"]
+release: beta
 
 requirement:
   elasticsearch:

--- a/testdata/package/example-1.0.0/manifest.yml
+++ b/testdata/package/example-1.0.0/manifest.yml
@@ -6,6 +6,7 @@ version: 1.0.0
 title: Example Integration
 categories: ["logs", "metrics"]
 type: integration
+release: ga
 
 requirement:
   elasticsearch:

--- a/testdata/package/experimental-0.0.1/manifest.yml
+++ b/testdata/package/experimental-0.0.1/manifest.yml
@@ -1,0 +1,10 @@
+format_version: 1.0.0
+
+name: experimental
+description: Experimental package, should be set by default
+version: 0.0.1
+title: Experimental
+categories: [metrics]
+type: solution
+
+

--- a/testdata/package/foo-1.0.0/manifest.yml
+++ b/testdata/package/foo-1.0.0/manifest.yml
@@ -6,6 +6,7 @@ version: 1.0.0
 title: Foo
 categories: [metrics]
 type: solution
+release: beta
 
 requirement:
   elasticsearch:

--- a/testdata/package/internal-1.2.0/manifest.yml
+++ b/testdata/package/internal-1.2.0/manifest.yml
@@ -7,3 +7,4 @@ title: Internal
 categories: []
 internal: true
 removable: false
+release: beta

--- a/testdata/package/multiple-false-0.0.1/manifest.yml
+++ b/testdata/package/multiple-false-0.0.1/manifest.yml
@@ -6,6 +6,7 @@ version: 0.0.1
 title: Multiple false
 categories: ["logs"]
 type: integration
+release: beta
 
 
 datasources:

--- a/testdata/public/package/datasources/1.0.0/index.json
+++ b/testdata/public/package/datasources/1.0.0/index.json
@@ -10,6 +10,7 @@
   "categories": [
     "logs"
   ],
+  "release": "beta",
   "removable": true,
   "requirement": {
     "kibana": {},
@@ -33,7 +34,7 @@
     {
       "id": "datasources.examplelog1",
       "title": "Example dataset with inputs",
-      "release": "beta",
+      "release": "experimental",
       "type": "logs",
       "streams": [
         {
@@ -80,7 +81,7 @@
     {
       "id": "datasources.examplelog2",
       "title": "Example dataset with inputs",
-      "release": "beta",
+      "release": "experimental",
       "type": "logs",
       "streams": [
         {
@@ -120,7 +121,7 @@
     {
       "id": "datasources.examplemetric",
       "title": "Example dataset with inputs",
-      "release": "beta",
+      "release": "experimental",
       "type": "metrics",
       "streams": [
         {

--- a/testdata/public/package/datasources/1.0.0/manifest.yml
+++ b/testdata/public/package/datasources/1.0.0/manifest.yml
@@ -7,7 +7,7 @@ title: Default datasource Integration
 categories: ["logs"]
 type: integration
 license: basic
-
+release: beta
 
 datasources:
   -

--- a/testdata/public/package/default-pipeline/0.0.2/index.json
+++ b/testdata/public/package/default-pipeline/0.0.2/index.json
@@ -10,6 +10,7 @@
   "categories": [
     "logs"
   ],
+  "release": "beta",
   "removable": true,
   "requirement": {
     "kibana": {},
@@ -27,7 +28,7 @@
     {
       "id": "default-pipeline.foo",
       "title": "Foo",
-      "release": "beta",
+      "release": "experimental",
       "type": "logs",
       "ingest_pipeline": "default",
       "streams": [

--- a/testdata/public/package/default-pipeline/0.0.2/manifest.yml
+++ b/testdata/public/package/default-pipeline/0.0.2/manifest.yml
@@ -6,6 +6,7 @@ version: 0.0.2
 title: Default pipeline Integration
 categories: ["logs"]
 type: integration
+release: beta
 
 
 datasources:

--- a/testdata/public/package/example/0.0.2/index.json
+++ b/testdata/public/package/example/0.0.2/index.json
@@ -10,6 +10,7 @@
   "categories": [
     "logs"
   ],
+  "release": "beta",
   "removable": true,
   "requirement": {
     "kibana": {

--- a/testdata/public/package/example/0.0.2/manifest.yml
+++ b/testdata/public/package/example/0.0.2/manifest.yml
@@ -5,6 +5,7 @@ title: Example
 description: This is the example integration.
 version: 0.0.2
 categories: ["logs"]
+release: beta
 
 requirement:
   elasticsearch:

--- a/testdata/public/package/example/1.0.0/index.json
+++ b/testdata/public/package/example/1.0.0/index.json
@@ -11,6 +11,7 @@
     "logs",
     "metrics"
   ],
+  "release": "ga",
   "removable": true,
   "requirement": {
     "kibana": {
@@ -59,7 +60,7 @@
     {
       "id": "bar",
       "title": "Foo",
-      "release": "beta",
+      "release": "experimental",
       "type": "logs",
       "ingest_pipeline": "pipeline-entry",
       "streams": [

--- a/testdata/public/package/example/1.0.0/manifest.yml
+++ b/testdata/public/package/example/1.0.0/manifest.yml
@@ -6,6 +6,7 @@ version: 1.0.0
 title: Example Integration
 categories: ["logs", "metrics"]
 type: integration
+release: ga
 
 requirement:
   elasticsearch:

--- a/testdata/public/package/experimental/0.0.1/index.json
+++ b/testdata/public/package/experimental/0.0.1/index.json
@@ -1,0 +1,25 @@
+{
+  "format_version": "1.0.0",
+  "name": "experimental",
+  "title": "Experimental",
+  "version": "0.0.1",
+  "readme": "/package/experimental/0.0.1/docs/README.md",
+  "license": "basic",
+  "description": "Experimental package, should be set by default",
+  "type": "solution",
+  "categories": [
+    "metrics"
+  ],
+  "release": "experimental",
+  "removable": true,
+  "requirement": {
+    "kibana": {},
+    "elasticsearch": {}
+  },
+  "assets": [
+    "/package/experimental/0.0.1/manifest.yml",
+    "/package/experimental/0.0.1/docs/README.md"
+  ],
+  "download": "/epr/experimental/experimental-0.0.1.tar.gz",
+  "path": "/package/experimental/0.0.1"
+}

--- a/testdata/public/package/experimental/0.0.1/manifest.yml
+++ b/testdata/public/package/experimental/0.0.1/manifest.yml
@@ -1,0 +1,10 @@
+format_version: 1.0.0
+
+name: experimental
+description: Experimental package, should be set by default
+version: 0.0.1
+title: Experimental
+categories: [metrics]
+type: solution
+
+

--- a/testdata/public/package/foo/1.0.0/index.json
+++ b/testdata/public/package/foo/1.0.0/index.json
@@ -10,6 +10,7 @@
   "categories": [
     "metrics"
   ],
+  "release": "beta",
   "removable": true,
   "requirement": {
     "kibana": {

--- a/testdata/public/package/foo/1.0.0/manifest.yml
+++ b/testdata/public/package/foo/1.0.0/manifest.yml
@@ -6,6 +6,7 @@ version: 1.0.0
 title: Foo
 categories: [metrics]
 type: solution
+release: beta
 
 requirement:
   elasticsearch:

--- a/testdata/public/package/internal/1.2.0/index.json
+++ b/testdata/public/package/internal/1.2.0/index.json
@@ -8,6 +8,7 @@
   "description": "Internal package",
   "type": "integration",
   "categories": [],
+  "release": "beta",
   "removable": false,
   "requirement": {
     "kibana": {},

--- a/testdata/public/package/internal/1.2.0/manifest.yml
+++ b/testdata/public/package/internal/1.2.0/manifest.yml
@@ -7,3 +7,4 @@ title: Internal
 categories: []
 internal: true
 removable: false
+release: beta

--- a/testdata/public/package/multiple-false/0.0.1/index.json
+++ b/testdata/public/package/multiple-false/0.0.1/index.json
@@ -10,6 +10,7 @@
   "categories": [
     "logs"
   ],
+  "release": "beta",
   "removable": true,
   "requirement": {
     "kibana": {},
@@ -27,7 +28,7 @@
     {
       "id": "multiple-false.foo",
       "title": "Foo",
-      "release": "beta",
+      "release": "experimental",
       "type": "logs",
       "ingest_pipeline": "default",
       "streams": [

--- a/testdata/public/package/multiple-false/0.0.1/manifest.yml
+++ b/testdata/public/package/multiple-false/0.0.1/manifest.yml
@@ -6,6 +6,7 @@ version: 0.0.1
 title: Multiple false
 categories: ["logs"]
 type: integration
+release: beta
 
 
 datasources:

--- a/util/dataset.go
+++ b/util/dataset.go
@@ -106,7 +106,11 @@ func NewDataset(basePath string, p *Package) (*DataSet, error) {
 	}
 
 	if d.Release == "" {
-		d.Release = "beta"
+		d.Release = DefaultRelease
+	}
+
+	if !IsValidRelase(d.Release) {
+		return nil, fmt.Errorf("invalid release: %s", d.Release)
 	}
 
 	return d, nil

--- a/util/helper.go
+++ b/util/helper.go
@@ -1,0 +1,25 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package util
+
+const (
+	ReleaseExperimental = "experimental"
+	ReleaseBeta         = "beta"
+	ReleaseGa           = "ga"
+
+	// Default release if no release is configured
+	DefaultRelease = ReleaseExperimental
+)
+
+var ReleaseTypes = map[string]interface{}{
+	ReleaseExperimental: nil,
+	ReleaseBeta:         nil,
+	ReleaseGa:           nil,
+}
+
+func IsValidRelase(release string) bool {
+	_, exists := ReleaseTypes[release]
+	return exists
+}

--- a/util/helper_test.go
+++ b/util/helper_test.go
@@ -1,0 +1,42 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var releaseTests = []struct {
+	release string
+	exists  bool
+}{
+	{
+		ReleaseBeta,
+		true,
+	},
+	{
+		"foo",
+		false,
+	},
+	{
+		ReleaseExperimental,
+		true,
+	},
+	{
+		ReleaseGa,
+		true,
+	},
+}
+
+func TestReleases(t *testing.T) {
+	for _, tt := range releaseTests {
+		t.Run(tt.release, func(t *testing.T) {
+			exists := IsValidRelase(tt.release)
+			assert.Equal(t, tt.exists, exists)
+		})
+	}
+}

--- a/util/package.go
+++ b/util/package.go
@@ -144,6 +144,14 @@ func NewPackage(basePath string) (*Package, error) {
 		}
 	}
 
+	if p.Release == "" {
+		p.Release = DefaultRelease
+	}
+
+	if !IsValidRelase(p.Release) {
+		return nil, fmt.Errorf("invalid release: %s", p.Release)
+	}
+
 	p.versionSemVer, err = semver.Parse(p.Version)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
So far the available release types were beta and ga. In this PR experimental is added to the list and set as default.

Having experimental around for packages provides some interesting options. Experimental packages are not shown in the search endpoint by default. To query for the experimental package the flag `experimental=true` has to be added. This allows to publish some packages without directly making it available to everyone.

The idea is that we introduce in EPM a setting "Experimental" that users can enable to also see and install experimental packages.

On the dataset level also experimental datasets exist. My expectation here is that these would not be shown by the Config Builder as long as Experimental:true is not enabled.