### PR TITLE
import-beats: Do not print table with no fields in README

### DIFF
--- a/dev/import-beats/docs.go
+++ b/dev/import-beats/docs.go
@@ -49,20 +49,21 @@ func renderExportedFields(packageDataset string, datasets datasetContentArray) (
 			buffer.WriteString("**Exported fields**")
 			buffer.WriteString("\n\n")
 
-			if len(dataset.fields.files) == 0 {
-				buffer.WriteString("(no fields available)")
-			} else {
-				collected, err := collectFields(dataset.fields)
-				if err != nil {
-					return "", errors.Wrapf(err, "collecting fields failed")
-				}
+			collected, err := collectFields(dataset.fields)
+			if err != nil {
+				return "", errors.Wrapf(err, "collecting fields failed")
+			}
 
-				buffer.WriteString("| Field | Description | Type |\n")
-				buffer.WriteString("|---|---|---|\n")
-				for _, c := range collected {
-					description := strings.TrimSpace(strings.ReplaceAll(c.description, "\n", " "))
-					buffer.WriteString(fmt.Sprintf("| %s | %s | %s |\n", c.name, description, c.aType))
-				}
+			if len(collected) == 0 {
+				buffer.WriteString("(no fields available)")
+				return buffer.String(), nil
+			}
+
+			buffer.WriteString("| Field | Description | Type |\n")
+			buffer.WriteString("|---|---|---|\n")
+			for _, c := range collected {
+				description := strings.TrimSpace(strings.ReplaceAll(c.description, "\n", " "))
+				buffer.WriteString(fmt.Sprintf("| %s | %s | %s |\n", c.name, description, c.aType))
 			}
 			return buffer.String(), nil
 		}


### PR DESCRIPTION
Only for consistency - if there is a dataset with no fields defined, we shouldn't print empty tables.

This PR adjusts the `import-beats` code for better user experience.