### PR TITLE
Add basic access logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add support for multiple inputs per dataset. [#346](https://github.com/elastic/integrations-registry/pull/346)
 * Add experimental releases for packages and datasets. [#382](https://github.com/elastic/integrations-registry/pull/382)
 * Handle invalid query params and return error. [#382](https://github.com/elastic/integrations-registry/pull/382)
+* Add basic access logs. [#400](https://github.com/elastic/integrations-registry/pull/400)
 
 ### Deprecated
 

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"log"
 	"net/http"
 	"os"
@@ -115,10 +116,23 @@ func getRouter(config Config, packagesBasePath string) *mux.Router {
 	router.HandleFunc("/categories", categoriesHandler(packagesBasePath, config.CacheTimeCategories))
 	router.HandleFunc("/health", healthHandler)
 	router.PathPrefix("/").HandlerFunc(catchAll(config.PublicDir, config.CacheTimeCatchAll))
-
+	router.Use(loggingMiddleware)
 	return router
 }
 
 // healthHandler is used for Docker/K8s deployments. It returns 200 if the service is live
 // In addition ?ready=true can be used for a ready request. Currently both are identical.
 func healthHandler(w http.ResponseWriter, r *http.Request) {}
+
+// logging middle to log all requests
+func loggingMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		logRequest(r)
+		next.ServeHTTP(w, r)
+	})
+}
+
+// logRequest converts a request object into a proper logging event
+func logRequest(r *http.Request) {
+	log.Println(fmt.Sprintf("source.ip: %s, url.original: %s", r.RemoteAddr, r.RequestURI))
+}


### PR DESCRIPTION
Having basic access logs make it easier to debug the registry and see what is access from Kibana.

This is a basic PR before moving to ECS logs in https://github.com/elastic/package-registry/pull/383