### PR TITLE
import-beats: Docs: define the origin of fields files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -184,8 +184,10 @@ what's been already fixed, as the script has overridden part of it).
 
     The goal of this action item is to verify if produced artifacts are correct.
 
-    The fields files (`package-fields.yml`, `fields.yml` and `ecs.yml`) in the package were created from original
-    `fields.yml` files and the ECS schema. It may happen that original sources have a typo, bad description or misses
+    The fields files (package-fields.yml, fields.yml and ecs.yml) in the package were created from original fields.yml
+    files (that may contain ECS schema fields) and fields.epr.yml (defining some other fields used in the ingest
+    pipeline).
+    It may happen that original sources have a typo, bad description or misses
     a field definition. The sum of fields in all present files should contain only fields that are really used, e.g.
     not all existing ECS fields.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -186,10 +186,9 @@ what's been already fixed, as the script has overridden part of it).
 
     The fields files (package-fields.yml, fields.yml and ecs.yml) in the package were created from original fields.yml
     files (that may contain ECS schema fields) and fields.epr.yml (defining some other fields used in the ingest
-    pipeline).
-    It may happen that original sources have a typo, bad description or misses
-    a field definition. The sum of fields in all present files should contain only fields that are really used, e.g.
-    not all existing ECS fields.
+    pipeline). It may happen that original sources have a typo, bad description or misses a field definition.
+    The sum of fields in all present files should contain only fields that are really used, e.g. not all existing ECS
+    fields.
 
     It may happen that the ingest pipeline uses fields abstracted from ECS, but not mentioned in `fields.yml`.
     Integrations should contain these fields and also have them documented.


### PR DESCRIPTION
This PR improves the "Review fields file and exported fields in docs" in the `import-beats` script docs.