### PR TITLE
Update packages to remove input definitions

### DIFF
--- a/dev/packages/alpha/mysql/0.0.2/dataset/error/agent/stream/stream.yml.hbs
+++ b/dev/packages/alpha/mysql/0.0.2/dataset/error/agent/stream/stream.yml.hbs
@@ -1,4 +1,3 @@
-input: log
 paths:
 {{#each paths}}
   - {{this}}

--- a/dev/packages/alpha/mysql/0.0.2/dataset/galera_status/agent/stream/stream.yml.hbs
+++ b/dev/packages/alpha/mysql/0.0.2/dataset/galera_status/agent/stream/stream.yml.hbs
@@ -1,4 +1,3 @@
-input: mysql/metrics
 metricsets: ["galera_status"]
 hosts:
 {{#each hosts}}

--- a/dev/packages/alpha/mysql/0.0.2/dataset/slowlog/agent/stream/stream.yml.hbs
+++ b/dev/packages/alpha/mysql/0.0.2/dataset/slowlog/agent/stream/stream.yml.hbs
@@ -1,4 +1,3 @@
-input: log
 paths:
 {{#each paths}}
   - {{this}}

--- a/dev/packages/alpha/mysql/0.0.2/dataset/status/agent/stream/stream.yml.hbs
+++ b/dev/packages/alpha/mysql/0.0.2/dataset/status/agent/stream/stream.yml.hbs
@@ -1,4 +1,3 @@
-input: mysql/metrics
 metricsets: ["status"]
 hosts:
 {{#each hosts}}

--- a/dev/packages/alpha/nginx/0.0.3/dataset/access/agent/stream/stream.yml.hbs
+++ b/dev/packages/alpha/nginx/0.0.3/dataset/access/agent/stream/stream.yml.hbs
@@ -1,4 +1,3 @@
-input: log
 paths:
 {{#each paths}}
   - {{this}}

--- a/dev/packages/alpha/nginx/0.0.3/dataset/error/agent/stream/stream.yml.hbs
+++ b/dev/packages/alpha/nginx/0.0.3/dataset/error/agent/stream/stream.yml.hbs
@@ -1,4 +1,3 @@
-input: log
 paths:
 {{#each paths}}
   - {{this}}

--- a/dev/packages/alpha/nginx/0.0.3/dataset/ingress_controller/agent/stream/stream.yml.hbs
+++ b/dev/packages/alpha/nginx/0.0.3/dataset/ingress_controller/agent/stream/stream.yml.hbs
@@ -1,4 +1,3 @@
-input: log
 paths:
 {{#each paths}}
   - {{this}}

--- a/dev/packages/alpha/nginx/0.0.3/dataset/stubstatus/agent/stream/stream.yml.hbs
+++ b/dev/packages/alpha/nginx/0.0.3/dataset/stubstatus/agent/stream/stream.yml.hbs
@@ -1,4 +1,3 @@
-input: nginx/metrics
 metricsets: ["stubstatus"]
 hosts:
 {{#each hosts}}

--- a/dev/packages/alpha/redis/0.0.2/dataset/info/agent/stream/stream.yml.hbs
+++ b/dev/packages/alpha/redis/0.0.2/dataset/info/agent/stream/stream.yml.hbs
@@ -1,4 +1,3 @@
-input: redis/metrics
 metricsets: ["info"]
 hosts:
 {{#each hosts}}

--- a/dev/packages/alpha/redis/0.0.2/dataset/key/agent/stream/stream.yml.hbs
+++ b/dev/packages/alpha/redis/0.0.2/dataset/key/agent/stream/stream.yml.hbs
@@ -1,4 +1,3 @@
-input: redis/metrics
 metricsets: ["key"]
 hosts:
 {{#each hosts}}

--- a/dev/packages/alpha/redis/0.0.2/dataset/keyspace/agent/stream/stream.yml.hbs
+++ b/dev/packages/alpha/redis/0.0.2/dataset/keyspace/agent/stream/stream.yml.hbs
@@ -1,4 +1,3 @@
-input: redis/metrics
 metricsets: ["keyspace"]
 hosts:
 {{#each hosts}}

--- a/dev/packages/alpha/redis/0.0.2/dataset/log/agent/stream/stream.yml.hbs
+++ b/dev/packages/alpha/redis/0.0.2/dataset/log/agent/stream/stream.yml.hbs
@@ -1,4 +1,3 @@
-input: log
 paths:
 {{#each paths as |path i|}}
  - {{path}}

--- a/dev/packages/alpha/redis/0.0.2/dataset/slowlog/agent/stream/stream.yml.hbs
+++ b/dev/packages/alpha/redis/0.0.2/dataset/slowlog/agent/stream/stream.yml.hbs
@@ -1,4 +1,3 @@
-input: redis
 hosts:
 {{#each hosts as |host i|}}
  - {{host}}

--- a/dev/packages/example/aws/0.0.2/dataset/billing/agent/stream/stream.yml.hbs
+++ b/dev/packages/example/aws/0.0.2/dataset/billing/agent/stream/stream.yml.hbs
@@ -1,4 +1,3 @@
-input: aws/metrics
 period: {{period}}
 metricsets: billing
 regions: {{regions}}

--- a/dev/packages/example/aws/0.0.2/dataset/cloudwatch/agent/stream/stream.yml.hbs
+++ b/dev/packages/example/aws/0.0.2/dataset/cloudwatch/agent/stream/stream.yml.hbs
@@ -1,4 +1,3 @@
-input: aws/metrics
 period: {{period}}
 metricsets: cloudwatch
 # TODO

--- a/dev/packages/example/aws/0.0.2/dataset/dynamodb/agent/stream/stream.yml.hbs
+++ b/dev/packages/example/aws/0.0.2/dataset/dynamodb/agent/stream/stream.yml.hbs
@@ -1,4 +1,3 @@
-input: aws/metrics
 period: {{period}}
 metricsets: dynamodb
 dataset: aws.dynamodb

--- a/dev/packages/example/aws/0.0.2/dataset/ebs/agent/stream/stream.yml.hbs
+++ b/dev/packages/example/aws/0.0.2/dataset/ebs/agent/stream/stream.yml.hbs
@@ -1,4 +1,3 @@
-input: aws/metrics
 period: {{period}}
 metricsets: ebs
 dataset: aws.ebs

--- a/dev/packages/example/aws/0.0.2/dataset/ec2/agent/stream/stream.yml.hbs
+++ b/dev/packages/example/aws/0.0.2/dataset/ec2/agent/stream/stream.yml.hbs
@@ -1,4 +1,3 @@
-input: aws/metrics
 period: {{period}}
 metricsets: ec2
 dataset: aws.ec2

--- a/dev/packages/example/aws/0.0.2/dataset/elb/agent/stream/stream.yml.hbs
+++ b/dev/packages/example/aws/0.0.2/dataset/elb/agent/stream/stream.yml.hbs
@@ -1,4 +1,3 @@
-input: aws/metrics
 period: {{period}}
 metricsets: elb
 dataset: aws.elb

--- a/dev/packages/example/aws/0.0.2/dataset/lambda/agent/stream/stream.yml.hbs
+++ b/dev/packages/example/aws/0.0.2/dataset/lambda/agent/stream/stream.yml.hbs
@@ -1,4 +1,3 @@
-input: aws/metrics
 period: {{period}}
 metricsets: lambda
 dataset: aws.lambda

--- a/dev/packages/example/aws/0.0.2/dataset/natgateway/agent/stream/stream.yml.hbs
+++ b/dev/packages/example/aws/0.0.2/dataset/natgateway/agent/stream/stream.yml.hbs
@@ -1,4 +1,3 @@
-input: aws/metrics
 period: {{period}}
 metricsets: natgateway
 dataset: aws.natgateway

--- a/dev/packages/example/aws/0.0.2/dataset/rds/agent/stream/stream.yml.hbs
+++ b/dev/packages/example/aws/0.0.2/dataset/rds/agent/stream/stream.yml.hbs
@@ -1,4 +1,3 @@
-input: aws/metrics
 period: {{period}}
 metricsets: rds
 dataset: aws.rds

--- a/dev/packages/example/aws/0.0.2/dataset/s3_daily_storage/agent/stream/stream.yml.hbs
+++ b/dev/packages/example/aws/0.0.2/dataset/s3_daily_storage/agent/stream/stream.yml.hbs
@@ -1,4 +1,3 @@
-input: aws/metrics
 period: {{period}}
 metricsets: s3_daily_storage
 dataset: aws.s3_daily_storage

--- a/dev/packages/example/aws/0.0.2/dataset/s3_request/agent/stream/stream.yml.hbs
+++ b/dev/packages/example/aws/0.0.2/dataset/s3_request/agent/stream/stream.yml.hbs
@@ -1,4 +1,3 @@
-input: aws/metrics
 period: {{period}}
 metricsets: s3_request
 dataset: aws.s3_request

--- a/dev/packages/example/aws/0.0.2/dataset/sns/agent/stream/stream.yml.hbs
+++ b/dev/packages/example/aws/0.0.2/dataset/sns/agent/stream/stream.yml.hbs
@@ -1,4 +1,3 @@
-input: aws/metrics
 period: {{period}}
 metricsets: sns
 dataset: aws.sns

--- a/dev/packages/example/aws/0.0.2/dataset/sqs/agent/stream/stream.yml.hbs
+++ b/dev/packages/example/aws/0.0.2/dataset/sqs/agent/stream/stream.yml.hbs
@@ -1,4 +1,3 @@
-input: aws/metrics
 period: {{period}}
 metricsets: sqs
 dataset: aws.sqs

--- a/dev/packages/example/aws/0.0.2/dataset/transitgateway/agent/stream/stream.yml.hbs
+++ b/dev/packages/example/aws/0.0.2/dataset/transitgateway/agent/stream/stream.yml.hbs
@@ -1,4 +1,3 @@
-input: aws/metrics
 period: {{period}}
 metricsets: transitgateway
 dataset: aws.transitgateway

--- a/dev/packages/example/aws/0.0.2/dataset/usage/agent/stream/stream.yml.hbs
+++ b/dev/packages/example/aws/0.0.2/dataset/usage/agent/stream/stream.yml.hbs
@@ -1,4 +1,3 @@
-input: aws/metrics
 period: {{period}}
 metricsets: usage
 dataset: aws.usage

--- a/dev/packages/example/aws/0.0.2/dataset/vpn/agent/stream/stream.yml.hbs
+++ b/dev/packages/example/aws/0.0.2/dataset/vpn/agent/stream/stream.yml.hbs
@@ -1,4 +1,3 @@
-input: aws/metrics
 period: {{period}}
 metricsets: vpn
 dataset: aws.vpn

--- a/dev/packages/example/nginx/0.0.2/dataset/access/agent/stream/stream.yml.hbs
+++ b/dev/packages/example/nginx/0.0.2/dataset/access/agent/stream/stream.yml.hbs
@@ -1,5 +1,3 @@
-
-input: log
 paths:
 {{#each paths}}
   - "{{this}}"

--- a/dev/packages/example/nginx/0.0.2/dataset/error/agent/stream/stream.yml.hbs
+++ b/dev/packages/example/nginx/0.0.2/dataset/error/agent/stream/stream.yml.hbs
@@ -1,5 +1,3 @@
-input: log
-
 {{#each paths}}
 paths: "{{this}}"
 {{/each}}

--- a/dev/packages/example/nginx/0.0.2/dataset/stubstatus/agent/stream/stream.yml.hbs
+++ b/dev/packages/example/nginx/0.0.2/dataset/stubstatus/agent/stream/stream.yml.hbs
@@ -1,5 +1,3 @@
-# Defines which input to use, should be stripped out when creating the config
-input: nginx/metrics
 metricsets: ["stubstatus"]
 period: {{period}}
 

--- a/dev/packages/example/system/0.0.2/dataset/auth/agent/stream/stream.yml.hbs
+++ b/dev/packages/example/system/0.0.2/dataset/auth/agent/stream/stream.yml.hbs
@@ -1,4 +1,3 @@
-input: log
 paths:
 {{#each paths}}
   - "{{this}}"

--- a/dev/packages/example/system/0.0.2/dataset/core/agent/stream/stream.yml.hbs
+++ b/dev/packages/example/system/0.0.2/dataset/core/agent/stream/stream.yml.hbs
@@ -1,4 +1,3 @@
-input: system/metrics
 metricset: core
 period: {{period}}
 dataset: system.core

--- a/dev/packages/example/system/0.0.2/dataset/cpu/agent/stream/stream.yml.hbs
+++ b/dev/packages/example/system/0.0.2/dataset/cpu/agent/stream/stream.yml.hbs
@@ -1,4 +1,3 @@
-input: system/metrics
 metricset: cpu
 period: {{period}}
 dataset: system.cpu

--- a/dev/packages/example/system/0.0.2/dataset/diskio/agent/stream/stream.yml.hbs
+++ b/dev/packages/example/system/0.0.2/dataset/diskio/agent/stream/stream.yml.hbs
@@ -1,4 +1,3 @@
-input: system/metrics
 metricset: diskio
 period: {{period}}
 dataset: system.diskio

--- a/dev/packages/example/system/0.0.2/dataset/entropy/agent/stream/stream.yml.hbs
+++ b/dev/packages/example/system/0.0.2/dataset/entropy/agent/stream/stream.yml.hbs
@@ -1,4 +1,3 @@
-input: system/metrics
 metricset: entropy
 period: {{period}}
 dataset: system.entropy

--- a/dev/packages/example/system/0.0.2/dataset/filesystem/agent/stream/stream.yml.hbs
+++ b/dev/packages/example/system/0.0.2/dataset/filesystem/agent/stream/stream.yml.hbs
@@ -1,4 +1,3 @@
-input: system/metrics
 metricset: filesystem
 period: {{period}}
 dataset: system.filesystem

--- a/dev/packages/example/system/0.0.2/dataset/fsstat/agent/stream/stream.yml.hbs
+++ b/dev/packages/example/system/0.0.2/dataset/fsstat/agent/stream/stream.yml.hbs
@@ -1,4 +1,3 @@
-input: system/metrics
 metricset: fsstat
 period: {{period}}
 dataset: system.fsstat

--- a/dev/packages/example/system/0.0.2/dataset/load/agent/stream/stream.yml.hbs
+++ b/dev/packages/example/system/0.0.2/dataset/load/agent/stream/stream.yml.hbs
@@ -1,4 +1,3 @@
-input: system/metrics
 metricset: load
 period: {{period}}
 dataset: system.load

--- a/dev/packages/example/system/0.0.2/dataset/memory/agent/stream/stream.yml.hbs
+++ b/dev/packages/example/system/0.0.2/dataset/memory/agent/stream/stream.yml.hbs
@@ -1,4 +1,3 @@
-input: system/metrics
 metricset: memory
 period: {{period}}
 dataset: system.memory

--- a/dev/packages/example/system/0.0.2/dataset/network/agent/stream/stream.yml.hbs
+++ b/dev/packages/example/system/0.0.2/dataset/network/agent/stream/stream.yml.hbs
@@ -1,4 +1,3 @@
-input: system/metrics
 metricset: network
 period: {{period}}
 dataset: system.network

--- a/dev/packages/example/system/0.0.2/dataset/network_summary/agent/stream/stream.yml.hbs
+++ b/dev/packages/example/system/0.0.2/dataset/network_summary/agent/stream/stream.yml.hbs
@@ -1,4 +1,3 @@
-input: system/metrics
 metricset: network_summary
 period: {{period}}
 dataset: system.network_summary

--- a/dev/packages/example/system/0.0.2/dataset/process/agent/stream/stream.yml.hbs
+++ b/dev/packages/example/system/0.0.2/dataset/process/agent/stream/stream.yml.hbs
@@ -1,4 +1,3 @@
-input: system/metrics
 metricset: process
 period: {{period}}
 dataset: system.process

--- a/dev/packages/example/system/0.0.2/dataset/process_summary/agent/stream/stream.yml.hbs
+++ b/dev/packages/example/system/0.0.2/dataset/process_summary/agent/stream/stream.yml.hbs
@@ -1,4 +1,3 @@
-input: system/metrics
 metricset: process_summary
 period: {{period}}
 dataset: system.process_summary

--- a/dev/packages/example/system/0.0.2/dataset/raid/agent/stream/stream.yml.hbs
+++ b/dev/packages/example/system/0.0.2/dataset/raid/agent/stream/stream.yml.hbs
@@ -1,4 +1,3 @@
-input: system/metrics
 metricset: raid
 period: {{period}}
 dataset: system.raid

--- a/dev/packages/example/system/0.0.2/dataset/service/agent/stream/stream.yml.hbs
+++ b/dev/packages/example/system/0.0.2/dataset/service/agent/stream/stream.yml.hbs
@@ -1,4 +1,3 @@
-input: system/metrics
 metricset: service
 period: {{period}}
 dataset: system.service

--- a/dev/packages/example/system/0.0.2/dataset/socket/agent/stream/stream.yml.hbs
+++ b/dev/packages/example/system/0.0.2/dataset/socket/agent/stream/stream.yml.hbs
@@ -1,4 +1,3 @@
-input: system/metrics
 metricset: socket
 period: {{period}}
 dataset: system.socket

--- a/dev/packages/example/system/0.0.2/dataset/socket_summary/agent/stream/stream.yml.hbs
+++ b/dev/packages/example/system/0.0.2/dataset/socket_summary/agent/stream/stream.yml.hbs
@@ -1,4 +1,3 @@
-input: system/metrics
 metricset: socket_summary
 period: {{period}}
 dataset: system.socket_summary

--- a/dev/packages/example/system/0.0.2/dataset/syslog/agent/stream/stream.yml.hbs
+++ b/dev/packages/example/system/0.0.2/dataset/syslog/agent/stream/stream.yml.hbs
@@ -1,4 +1,3 @@
-input: log
 paths:
 {{#each paths}}
   - "{{this}}"

--- a/dev/packages/example/system/0.0.2/dataset/uptime/agent/stream/stream.yml.hbs
+++ b/dev/packages/example/system/0.0.2/dataset/uptime/agent/stream/stream.yml.hbs
@@ -1,4 +1,3 @@
-input: system/metrics
 metricset: uptime
 period: {{period}}
 dataset: system.uptime

--- a/dev/packages/example/system/0.0.2/dataset/users/agent/stream/stream.yml.hbs
+++ b/dev/packages/example/system/0.0.2/dataset/users/agent/stream/stream.yml.hbs
@@ -1,4 +1,3 @@
-input: system/metrics
 metricset: users
 period: {{period}}
 dataset: system.users


### PR DESCRIPTION
The stream template should not need the input definitions as they are already availabe in the manifest.