### PR TITLE
Refactor package-registry

### DIFF
--- a/categories.go
+++ b/categories.go
@@ -26,7 +26,7 @@ func categoriesHandler(packagesBasePath string, cacheTime time.Duration) func(w 
 	return func(w http.ResponseWriter, r *http.Request) {
 		packages, err := util.GetPackages(packagesBasePath)
 		if err != nil {
-			notFound(w, err)
+			notFound(w, err.Error())
 			return
 		}
 
@@ -38,7 +38,7 @@ func categoriesHandler(packagesBasePath string, cacheTime time.Duration) func(w 
 				if v != "" {
 					experimental, err = strconv.ParseBool(v)
 					if err != nil {
-						badRequest(w, fmt.Errorf("invalid 'experimental' query param: '%s'", v))
+						badRequest(w, fmt.Sprintf("invalid 'experimental' query param: '%s'", v))
 						return
 					}
 
@@ -88,7 +88,7 @@ func categoriesHandler(packagesBasePath string, cacheTime time.Duration) func(w 
 
 		data, err := getCategoriesOutput(categories)
 		if err != nil {
-			notFound(w, err)
+			notFound(w, err.Error())
 			return
 		}
 

--- a/categories.go
+++ b/categories.go
@@ -26,7 +26,7 @@ func categoriesHandler(packagesBasePath string, cacheTime time.Duration) func(w 
 	return func(w http.ResponseWriter, r *http.Request) {
 		packages, err := util.GetPackages(packagesBasePath)
 		if err != nil {
-			notFound(w, err.Error())
+			notFoundError(w, err)
 			return
 		}
 
@@ -88,7 +88,7 @@ func categoriesHandler(packagesBasePath string, cacheTime time.Duration) func(w 
 
 		data, err := getCategoriesOutput(categories)
 		if err != nil {
-			notFound(w, err.Error())
+			notFoundError(w, err)
 			return
 		}
 

--- a/dev/generator/main.go
+++ b/dev/generator/main.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 
 	"github.com/magefile/mage/sh"
+	"github.com/pkg/errors"
 
 	"github.com/elastic/package-registry/util"
 )
@@ -59,17 +60,14 @@ func main() {
 
 	if sourceDir == "" || publicDir == "" {
 		log.Fatal("sourceDir and publicDir must be set")
-		os.Exit(1)
 	}
 
 	if err := Build(sourceDir, publicDir); err != nil {
 		log.Fatal(err)
-		os.Exit(1)
 	}
 }
 
 func Build(sourceDir, publicDir string) error {
-
 	err := BuildPackages(sourceDir, filepath.Join(publicDir, packageDirName))
 	if err != nil {
 		return err
@@ -80,8 +78,11 @@ func Build(sourceDir, publicDir string) error {
 // CopyPackage copies the files of a package to the public directory
 func CopyPackage(src, dst string) error {
 	log.Println(">> Copy package: " + src)
-	os.MkdirAll(dst, 0755)
-	err := sh.RunV("rsync", "-a", src, dst)
+	err := os.MkdirAll(dst, 0755)
+	if err != nil {
+		return err
+	}
+	err = sh.RunV("rsync", "-a", src, dst)
 	if err != nil {
 		return err
 	}
@@ -91,7 +92,6 @@ func CopyPackage(src, dst string) error {
 
 // BuildPackage rebuilds the zip files inside packages
 func BuildPackages(sourceDir, packagesPath string) error {
-
 	list, err := filepath.Glob(sourceDir + "/*/*")
 	if err != nil {
 		return err
@@ -135,7 +135,6 @@ func BuildPackages(sourceDir, packagesPath string) error {
 }
 
 func buildPackage(packagesBasePath string, p util.Package) error {
-
 	// Change path to simplify tar command
 	currentPath, err := os.Getwd()
 	if err != nil {
@@ -145,7 +144,7 @@ func buildPackage(packagesBasePath string, p util.Package) error {
 	// Checks if the package is valid
 	err = p.Validate()
 	if err != nil {
-		return fmt.Errorf("Invalid package: %s: %s", p.GetPath(), err)
+		return errors.Wrapf(err, "package validation failed (path: %s", p.GetPath())
 	}
 
 	p.BasePath = filepath.Join(currentPath, packagesBasePath, p.GetPath())
@@ -221,7 +220,7 @@ func buildPackage(packagesBasePath string, p util.Package) error {
 		}
 
 		tarGzName := p.Name + "-" + p.Version
-		copiedPackagePath := filepath.Join(tarGzDirPath, tarGzName)
+		dst := filepath.Join(tarGzDirPath, tarGzName)
 
 		// As the package directories are now {packagename}/{version} when just running tar, the dir inside
 		// the package had the wrong name. Using `-s` or `--transform` for some reason worked on the command line
@@ -229,17 +228,18 @@ func buildPackage(packagesBasePath string, p util.Package) error {
 		// and then run tar on it.
 		// This could become even useful in the future as things like images or videos should potentially not be part of
 		// a tar.gz to keep it small.
-		err := CopyPackage(packagesBasePath+"/"+p.Name+"/"+p.Version+"/", copiedPackagePath)
+		src := packagesBasePath + "/" + p.Name + "/" + p.Version + "/"
+		err := CopyPackage(src, dst)
 		if err != nil {
-			return err
+			return errors.Wrapf(err, "copying package content failed (path: %s)", p.GetPath())
 		}
 
 		err = sh.RunV("tar", "czf", filepath.Join(packagesBasePath, "..", "epr", p.Name, tarGzName+".tar.gz"), "-C", tarGzDirPath, tarGzName+"/")
 		if err != nil {
-			return fmt.Errorf("Error creating package: %s: %s", p.GetPath(), err)
+			return errors.Wrapf(err, "compressing package failed (path: %s)", p.GetPath())
 		}
 
-		err = os.RemoveAll(copiedPackagePath)
+		err = os.RemoveAll(dst)
 		if err != nil {
 			return err
 		}
@@ -275,7 +275,10 @@ var (
 // json so only on packaging this is changed.
 func encodedSavedObject(data []byte) (string, error) {
 	savedObject := MapStr{}
-	json.Unmarshal(data, &savedObject)
+	err := json.Unmarshal(data, &savedObject)
+	if err != nil {
+		return "", errors.Wrapf(err, "unmarshalling saved object failed")
+	}
 
 	for _, v := range fieldsToEncode {
 		out, err := savedObject.GetValue(v)
@@ -296,7 +299,11 @@ func encodedSavedObject(data []byte) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		savedObject.Put(v, string(r))
+		_, err = savedObject.Put(v, string(r))
+		if err != nil {
+			return "", errors.Wrapf(err, "can't put value to the saved object")
+		}
+
 	}
 
 	return savedObject.StringToPrint(), nil

--- a/handler.go
+++ b/handler.go
@@ -5,107 +5,80 @@
 package main
 
 import (
+	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
-	"os"
 	"path/filepath"
 	"time"
 )
 
-func notFound(w http.ResponseWriter, err error) {
-	errString := ""
-	if err != nil {
-		errString = err.Error()
-	}
-
-	http.Error(w, errString, http.StatusNotFound)
+func notFound(w http.ResponseWriter, errorMessage string) {
+	http.Error(w, errorMessage, http.StatusNotFound)
 }
 
-func badRequest(w http.ResponseWriter, err error) {
-	errString := ""
-	if err != nil {
-		errString = err.Error()
-	}
-
-	http.Error(w, errString, http.StatusBadRequest)
+func notFoundError(w http.ResponseWriter, err error) {
+	http.Error(w, err.Error(), http.StatusNotFound)
 }
 
-func catchAll(publicPath string, cacheTime time.Duration) func(w http.ResponseWriter, r *http.Request) {
+func badRequest(w http.ResponseWriter, errorMessage string) {
+	http.Error(w, errorMessage, http.StatusBadRequest)
+}
+
+func catchAll(public http.FileSystem, cacheTime time.Duration) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
-
-		path := r.RequestURI
-
-		file, err := os.Stat(publicPath + path)
-		if os.IsNotExist(err) {
-			notFound(w, fmt.Errorf("404 Page Not Found Error"))
-			return
-		}
-
-		// Handles if it's a directory or last char is a / (also a directory)
-		// It then opens index.json by default (if it exists)
-		if len(path) == 0 {
-			path = "/index.json"
-		} else if path[len(path)-1:] == "/" {
-			path = path + "index.json"
-		} else if file.IsDir() {
-			path = path + "/index.json"
-		}
-
-		file, err = os.Stat(publicPath + path)
-		if os.IsNotExist(err) {
-			notFound(w, fmt.Errorf("404 Page Not Found Error"))
-			return
-		}
-
-		data, err := ioutil.ReadFile(publicPath + path)
+		path, err := determineResourcePath(r, public)
 		if err != nil {
-			notFound(w, fmt.Errorf("404 Page Not Found Error"))
+			notFoundError(w, err)
 			return
 		}
 
 		cacheHeaders(w, cacheTime)
-		sendHeader(w, r)
-		w.Write(data)
+
+		fs := http.FileServer(public)
+		r.URL.Path = path
+		fs.ServeHTTP(w, r)
 	}
 }
 
-func jsonHeader(w http.ResponseWriter) {
-	w.Header().Set("Content-Type", "application/json")
-}
+func determineResourcePath(r *http.Request, public http.FileSystem) (string, error) {
+	path := r.RequestURI
 
-func sendHeader(w http.ResponseWriter, r *http.Request) {
-	extension := filepath.Ext(r.RequestURI)
+	// Handles if it's a directory or last char is a / (also a directory)
+	// It then opens index.json by default (if it exists)
+	if len(path) == 0 || path == "/" {
+		path = "index.json"
+	} else if path[len(path)-1:] == "/" {
+		path = filepath.Join(path, "index.json")
+	} else {
+		f, err := public.Open(path)
+		if err != nil { // catch all errors, including "forbidden access"
+			return "", errors.New("404 Page Not Found Error")
+		}
+		defer f.Close()
 
-	switch extension {
-	// No extension is always json
-	case "":
-		w.Header().Set("Content-Type", "application/json")
-	case ".asciidoc":
-		w.Header().Set("Content-Type", "text/asciidoc; charset=UTF-8")
-	case ".gz":
-		w.Header().Set("Content-Type", "application/gzip")
-	case ".ico":
-		w.Header().Set("Content-Type", "image/x-icon")
-	case ".jpg":
-	case ".jpeg":
-		w.Header().Set("Content-Type", "image/jpeg")
-	case ".md":
-		w.Header().Set("Content-Type", "text/markdown; charset=UTF-8")
-	case ".png":
-		w.Header().Set("Content-Type", "image/png")
-	case ".svg":
-		w.Header().Set("Content-Type", "image/svg+xml")
-	case ".yml":
-		w.Header().Set("Content-Type", "text/yaml; charset=UTF-8")
-	default:
-		// Using json as the default header
-		w.Header().Set("Content-Type", "application/json")
+		stat, err := f.Stat()
+		if err != nil {
+			return "", errors.New("404 Page Not Found Error")
+		}
+
+		if stat.IsDir() {
+			path = path + "/index.json"
+			dirIndexFile, err := public.Open(path)
+			if err != nil { // catch all errors, including "forbidden access"
+				return "", errors.New("404 Page Not Found Error")
+			}
+			defer dirIndexFile.Close()
+		}
 	}
+	return path, nil
 }
 
 func cacheHeaders(w http.ResponseWriter, cacheTime time.Duration) {
 	maxAge := fmt.Sprintf("max-age=%.0f", cacheTime.Seconds())
 	w.Header().Add("Cache-Control", maxAge)
 	w.Header().Add("Cache-Control", "public")
+}
+
+func jsonHeader(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json")
 }

--- a/handler.go
+++ b/handler.go
@@ -25,6 +25,7 @@ func badRequest(w http.ResponseWriter, errorMessage string) {
 }
 
 func catchAll(public http.FileSystem, cacheTime time.Duration) func(w http.ResponseWriter, r *http.Request) {
+	fileServer := http.FileServer(public)
 	return func(w http.ResponseWriter, r *http.Request) {
 		path, err := determineResourcePath(r, public)
 		if err != nil {
@@ -34,9 +35,8 @@ func catchAll(public http.FileSystem, cacheTime time.Duration) func(w http.Respo
 
 		cacheHeaders(w, cacheTime)
 
-		fs := http.FileServer(public)
 		r.URL.Path = path
-		fs.ServeHTTP(w, r)
+		fileServer.ServeHTTP(w, r)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -115,7 +115,7 @@ func getRouter(config Config, packagesBasePath string) *mux.Router {
 	router.HandleFunc("/search", searchHandler(packagesBasePath, config.CacheTimeSearch))
 	router.HandleFunc("/categories", categoriesHandler(packagesBasePath, config.CacheTimeCategories))
 	router.HandleFunc("/health", healthHandler)
-	router.PathPrefix("/").HandlerFunc(catchAll(config.PublicDir, config.CacheTimeCatchAll))
+	router.PathPrefix("/").HandlerFunc(catchAll(http.Dir(config.PublicDir), config.CacheTimeCatchAll))
 	router.Use(loggingMiddleware)
 	return router
 }

--- a/main_test.go
+++ b/main_test.go
@@ -35,7 +35,7 @@ func TestEndpoints(t *testing.T) {
 		file     string
 		handler  func(w http.ResponseWriter, r *http.Request)
 	}{
-		{"/", "", "info.json", catchAll(publicPath, testCacheTime)},
+		{"/", "", "info.json", catchAll(http.Dir(publicPath), testCacheTime)},
 		{"/search", "/search", "search.json", searchHandler(packagesBasePath, testCacheTime)},
 		{"/search?all=true", "/search", "search-all.json", searchHandler(packagesBasePath, testCacheTime)},
 		{"/categories", "/categories", "categories.json", categoriesHandler(packagesBasePath, testCacheTime)},
@@ -51,7 +51,7 @@ func TestEndpoints(t *testing.T) {
 		{"/search?internal=bar", "/search", "search-package-internal-error.json", searchHandler(packagesBasePath, testCacheTime)},
 		{"/search?experimental=true", "/search", "search-package-experimental.json", searchHandler(packagesBasePath, testCacheTime)},
 		{"/search?experimental=foo", "/search", "search-package-experimental-error.json", searchHandler(packagesBasePath, testCacheTime)},
-		{"/package/example/1.0.0", "", "package.json", catchAll(publicPath, testCacheTime)},
+		{"/package/example/1.0.0", "", "package.json", catchAll(http.Dir(publicPath), testCacheTime)},
 	}
 
 	for _, test := range tests {

--- a/search.go
+++ b/search.go
@@ -13,9 +13,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pkg/errors"
-
 	"github.com/blang/semver"
+	"github.com/pkg/errors"
 
 	"github.com/elastic/package-registry/util"
 )

--- a/search.go
+++ b/search.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pkg/errors"
+
 	"github.com/blang/semver"
 
 	"github.com/elastic/package-registry/util"
@@ -36,7 +38,7 @@ func searchHandler(packagesBasePath string, cacheTime time.Duration) func(w http
 			if v := query.Get("kibana"); v != "" {
 				kibanaVersion, err = semver.New(v)
 				if err != nil {
-					badRequest(w, fmt.Errorf("invalid Kibana version '%s': %s", v, err))
+					badRequest(w, fmt.Sprintf("invalid Kibana version '%s': %s", v, err))
 					return
 				}
 			}
@@ -58,7 +60,7 @@ func searchHandler(packagesBasePath string, cacheTime time.Duration) func(w http
 					// Default is false, also on error
 					all, err = strconv.ParseBool(v)
 					if err != nil {
-						badRequest(w, fmt.Errorf("invalid 'all' query param: '%s'", v))
+						badRequest(w, fmt.Sprintf("invalid 'all' query param: '%s'", v))
 						return
 					}
 				}
@@ -69,7 +71,7 @@ func searchHandler(packagesBasePath string, cacheTime time.Duration) func(w http
 					// In case of error, keep it false
 					internal, err = strconv.ParseBool(v)
 					if err != nil {
-						badRequest(w, fmt.Errorf("invalid 'internal' query param: '%s'", v))
+						badRequest(w, fmt.Sprintf("invalid 'internal' query param: '%s'", v))
 						return
 					}
 				}
@@ -80,7 +82,7 @@ func searchHandler(packagesBasePath string, cacheTime time.Duration) func(w http
 					// In case of error, keep it false
 					experimental, err = strconv.ParseBool(v)
 					if err != nil {
-						badRequest(w, fmt.Errorf("invalid 'experimental' query param: '%s'", v))
+						badRequest(w, fmt.Sprintf("invalid 'experimental' query param: '%s'", v))
 						return
 					}
 				}
@@ -89,7 +91,7 @@ func searchHandler(packagesBasePath string, cacheTime time.Duration) func(w http
 
 		packages, err := util.GetPackages(packagesBasePath)
 		if err != nil {
-			notFound(w, fmt.Errorf("problem fetching packages: %s", err))
+			notFoundError(w, errors.Wrapf(err, "fetching package failed"))
 			return
 		}
 		packagesList := map[string]map[string]util.Package{}
@@ -150,7 +152,7 @@ func searchHandler(packagesBasePath string, cacheTime time.Duration) func(w http
 
 		data, err := getPackageOutput(packagesList)
 		if err != nil {
-			notFound(w, err)
+			notFoundError(w, err)
 			return
 		}
 


### PR DESCRIPTION
Changes:
- remove redundant os.Exit after log.Fatal
- check errors on generator commands
- use Go http logic for serving content: prevent any path traversal bugs, detect content-type automatically
- use http.FileServer for package content (support for If-Modified-Since, range queries)