### PR TITLE
Add experimental URLs to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ The following endpoints exist:
 * prod, CDN: https://epr.elastic.co
 * staging, no CDN: https://epr-staging.ea-web.elastic.dev
 * staging, CDN: https://epr-staging.elastic.co
+* experimental, no CDN: https://epr-experimental.ea-web.elastic.dev/
+* experimental, CDN: https://epr-experimental.elastic.co/
 
 An dev registry is running on `https://epr-staging.elastic.co/`. This is updated from time to time to be in sync with master.
 


### PR DESCRIPTION
For the first release, we have a special registry. This adds the links to this registry to the docs.