### PR TITLE
Introduce PACKAGE_PATHS env variable select paths to build

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -38,6 +38,11 @@ var (
 
 func Build() error {
 
+	packagePathsEnv := os.Getenv("PACKAGE_PATHS")
+	if packagePathsEnv != "" {
+		packagePaths = strings.Split(packagePathsEnv, ",")
+	}
+
 	err := os.RemoveAll(publicDir)
 	if err != nil {
 		return err


### PR DESCRIPTION
The `PACKAGE_PATHS` environment variables allows to overwrite the package paths which are set by default. This becomes useful for example in a Docker container if only one of the directories should be built.