### PR TITLE
Verify I/O, system errors while loading packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bugfixes
 
 ### Added
+* Use filepath.Walk to find valid package content data. [#438](https://github.com/elastic/package-registry/pull/438)
 
 ### Deprecated
 


### PR DESCRIPTION
Changes:
* I found this bug once misconfigured a docker volume. It loaded an empty registry without reporting any issues.
"glob" skips all potential errors like system, IO, etc. so refactored to use `filepath.Walk`.
* adjusted some log.Prints.
* properly handle HTTP server errors (port used, binding issues, etc.)

Output:
```
./package-registry
2020/05/06 10:28:19 Package registry started.
2020/05/06 10:28:19 Cache time for /search:  10m0s
2020/05/06 10:28:19 Cache time for /categories:  10m0s
2020/05/06 10:28:19 Cache time for all others:  10m0s
2020/05/06 10:28:19 List packages in public/package
2020/05/06 10:28:19 aws                              0.0.2      public/package/aws/0.0.2
2020/05/06 10:28:19 base                             1.0.0      public/package/base/1.0.0
2020/05/06 10:28:19 endpoint                         1.0.0      public/package/endpoint/1.0.0
2020/05/06 10:28:19 log                              0.9.0      public/package/log/0.9.0
2020/05/06 10:28:19 longdocs                         1.0.4      public/package/longdocs/1.0.4
2020/05/06 10:28:19 metricsonly                      2.0.1      public/package/metricsonly/2.0.1
2020/05/06 10:28:19 multiversion                     1.0.3      public/package/multiversion/1.0.3
2020/05/06 10:28:19 multiversion                     1.0.4      public/package/multiversion/1.0.4
2020/05/06 10:28:19 multiversion                     1.1.0      public/package/multiversion/1.1.0
2020/05/06 10:28:19 mysql                            0.0.2      public/package/mysql/0.0.2
2020/05/06 10:28:19 nginx                            0.0.3      public/package/nginx/0.0.3
2020/05/06 10:28:19 redis                            0.0.2      public/package/redis/0.0.2
2020/05/06 10:28:19 reference                        1.0.0      public/package/reference/1.0.0
2020/05/06 10:28:19 system                           0.0.2      public/package/system/0.0.2
2020/05/06 10:28:19 yamlpipeline                     1.0.0      public/package/yamlpipeline/1.0.0
2020/05/06 10:28:19 15 package manifests loaded into memory.
``` 