### PR TITLE
Add support for datastreams on base templates

### DIFF
--- a/dev/packages/example/base/0.2.0/docs/README.md
+++ b/dev/packages/example/base/0.2.0/docs/README.md
@@ -1,0 +1,3 @@
+# Base package
+
+This is installed in the background by EPM to setup the Elastic Stack.

--- a/dev/packages/example/base/0.2.0/elasticsearch/component-template/events-mappings.json
+++ b/dev/packages/example/base/0.2.0/elasticsearch/component-template/events-mappings.json
@@ -1,0 +1,148 @@
+{
+    "template": {
+        "mappings": {
+            "_meta": {
+            },
+            "dynamic_templates": [
+                {
+                    "strings_as_keyword": {
+                        "mapping": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "match_mapping_type": "string"
+                    }
+                }
+            ],
+            "date_detection": false,
+            "properties": {
+                "@timestamp": {
+                    "type": "date"
+                },
+                "stream": {
+                    "properties": {
+                        "type": {
+                            "type": "constant_keyword"
+                        },
+                        "dataset": {
+                            "type": "constant_keyword"
+                        },
+                        "namespace": {
+                            "type": "constant_keyword"
+                        }
+                    }
+                },
+                "agent": {
+                    "properties": {
+                        "hostname": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "name": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "id": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "ephemeral_id": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "type": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "version": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        }
+                    }
+                },
+                "ecs": {
+                    "properties": {
+                        "version": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        }
+                    }
+                },
+                "host": {
+                    "properties": {
+                        "hostname": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "os": {
+                            "properties": {
+                                "build": {
+                                    "ignore_above": 1024,
+                                    "type": "keyword"
+                                },
+                                "kernel": {
+                                    "ignore_above": 1024,
+                                    "type": "keyword"
+                                },
+                                "codename": {
+                                    "ignore_above": 1024,
+                                    "type": "keyword"
+                                },
+                                "name": {
+                                    "ignore_above": 1024,
+                                    "type": "keyword"
+                                },
+                                "family": {
+                                    "ignore_above": 1024,
+                                    "type": "keyword"
+                                },
+                                "version": {
+                                    "ignore_above": 1024,
+                                    "type": "keyword"
+                                },
+                                "platform": {
+                                    "ignore_above": 1024,
+                                    "type": "keyword"
+                                },
+                                "full": {
+                                    "ignore_above": 1024,
+                                    "type": "keyword"
+                                }
+                            }
+                        },
+                        "ip": {
+                            "type": "ip"
+                        },
+                        "containerized": {
+                            "type": "boolean"
+                        },
+                        "name": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "id": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "type": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "mac": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "architecture": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        }
+                    }
+                },
+                "message": {
+                    "type": "text"
+                }
+            }
+        },
+        "aliases": {}
+    }
+}

--- a/dev/packages/example/base/0.2.0/elasticsearch/component-template/events-settings.json
+++ b/dev/packages/example/base/0.2.0/elasticsearch/component-template/events-settings.json
@@ -1,0 +1,21 @@
+{
+    "template": {
+        "settings": {
+            "index": {
+                "lifecycle": {
+                    "name": "events-default"
+                },
+                "codec": "best_compression",
+                "refresh_interval": "5s",
+                "number_of_shards": "1",
+                "query": {
+                    "default_field": [
+                        "message"
+                    ]
+                },
+                "number_of_routing_shards": "30"
+            }
+        },
+        "aliases": {}
+    }
+}

--- a/dev/packages/example/base/0.2.0/elasticsearch/component-template/logs-mappings.json
+++ b/dev/packages/example/base/0.2.0/elasticsearch/component-template/logs-mappings.json
@@ -1,0 +1,148 @@
+{
+    "template": {
+        "mappings": {
+            "_meta": {
+            },
+            "dynamic_templates": [
+                {
+                    "strings_as_keyword": {
+                        "mapping": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "match_mapping_type": "string"
+                    }
+                }
+            ],
+            "date_detection": false,
+            "properties": {
+                "@timestamp": {
+                    "type": "date"
+                },
+                "stream": {
+                    "properties": {
+                        "type": {
+                            "type": "constant_keyword"
+                        },
+                        "dataset": {
+                            "type": "constant_keyword"
+                        },
+                        "namespace": {
+                            "type": "constant_keyword"
+                        }
+                    }
+                },
+                "agent": {
+                    "properties": {
+                        "hostname": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "name": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "id": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "ephemeral_id": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "type": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "version": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        }
+                    }
+                },
+                "ecs": {
+                    "properties": {
+                        "version": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        }
+                    }
+                },
+                "host": {
+                    "properties": {
+                        "hostname": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "os": {
+                            "properties": {
+                                "build": {
+                                    "ignore_above": 1024,
+                                    "type": "keyword"
+                                },
+                                "kernel": {
+                                    "ignore_above": 1024,
+                                    "type": "keyword"
+                                },
+                                "codename": {
+                                    "ignore_above": 1024,
+                                    "type": "keyword"
+                                },
+                                "name": {
+                                    "ignore_above": 1024,
+                                    "type": "keyword"
+                                },
+                                "family": {
+                                    "ignore_above": 1024,
+                                    "type": "keyword"
+                                },
+                                "version": {
+                                    "ignore_above": 1024,
+                                    "type": "keyword"
+                                },
+                                "platform": {
+                                    "ignore_above": 1024,
+                                    "type": "keyword"
+                                },
+                                "full": {
+                                    "ignore_above": 1024,
+                                    "type": "keyword"
+                                }
+                            }
+                        },
+                        "ip": {
+                            "type": "ip"
+                        },
+                        "containerized": {
+                            "type": "boolean"
+                        },
+                        "name": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "id": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "type": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "mac": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "architecture": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        }
+                    }
+                },
+                "message": {
+                    "type": "text"
+                }
+            }
+        },
+        "aliases": {}
+    }
+}

--- a/dev/packages/example/base/0.2.0/elasticsearch/component-template/logs-settings.json
+++ b/dev/packages/example/base/0.2.0/elasticsearch/component-template/logs-settings.json
@@ -1,0 +1,21 @@
+{
+    "template": {
+        "settings": {
+            "index": {
+                "lifecycle": {
+                    "name": "logs-default"
+                },
+                "codec": "best_compression",
+                "refresh_interval": "5s",
+                "number_of_shards": "1",
+                "query": {
+                    "default_field": [
+                        "message"
+                    ]
+                },
+                "number_of_routing_shards": "30"
+            }
+        },
+        "aliases": {}
+    }
+}

--- a/dev/packages/example/base/0.2.0/elasticsearch/component-template/metrics-mappings.json
+++ b/dev/packages/example/base/0.2.0/elasticsearch/component-template/metrics-mappings.json
@@ -1,0 +1,145 @@
+{
+    "template": {
+        "mappings": {
+            "_meta": {
+            },
+            "dynamic_templates": [
+                {
+                    "strings_as_keyword": {
+                        "mapping": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "match_mapping_type": "string"
+                    }
+                }
+            ],
+            "date_detection": false,
+            "properties": {
+                "@timestamp": {
+                    "type": "date"
+                },
+                "stream": {
+                    "properties": {
+                        "type": {
+                            "type": "constant_keyword"
+                        },
+                        "dataset": {
+                            "type": "constant_keyword"
+                        },
+                        "namespace": {
+                            "type": "constant_keyword"
+                        }
+                    }
+                },
+                "agent": {
+                    "properties": {
+                        "hostname": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "name": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "id": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "ephemeral_id": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "type": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "version": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        }
+                    }
+                },
+                "ecs": {
+                    "properties": {
+                        "version": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        }
+                    }
+                },
+                "host": {
+                    "properties": {
+                        "hostname": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "os": {
+                            "properties": {
+                                "build": {
+                                    "ignore_above": 1024,
+                                    "type": "keyword"
+                                },
+                                "kernel": {
+                                    "ignore_above": 1024,
+                                    "type": "keyword"
+                                },
+                                "codename": {
+                                    "ignore_above": 1024,
+                                    "type": "keyword"
+                                },
+                                "name": {
+                                    "ignore_above": 1024,
+                                    "type": "keyword"
+                                },
+                                "family": {
+                                    "ignore_above": 1024,
+                                    "type": "keyword"
+                                },
+                                "version": {
+                                    "ignore_above": 1024,
+                                    "type": "keyword"
+                                },
+                                "platform": {
+                                    "ignore_above": 1024,
+                                    "type": "keyword"
+                                },
+                                "full": {
+                                    "ignore_above": 1024,
+                                    "type": "keyword"
+                                }
+                            }
+                        },
+                        "ip": {
+                            "type": "ip"
+                        },
+                        "containerized": {
+                            "type": "boolean"
+                        },
+                        "name": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "id": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "type": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "mac": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "architecture": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        }
+                    }
+                }
+            }
+        },
+        "aliases": {}
+    }
+}

--- a/dev/packages/example/base/0.2.0/elasticsearch/component-template/metrics-settings.json
+++ b/dev/packages/example/base/0.2.0/elasticsearch/component-template/metrics-settings.json
@@ -1,0 +1,21 @@
+{
+    "template": {
+        "settings": {
+            "index": {
+                "lifecycle": {
+                    "name": "metrics-default"
+                },
+                "codec": "best_compression",
+                "refresh_interval": "5s",
+                "number_of_shards": "1",
+                "query": {
+                    "default_field": [
+                        "message"
+                    ]
+                },
+                "number_of_routing_shards": "30"
+            }
+        },
+        "aliases": {}
+    }
+}

--- a/dev/packages/example/base/0.2.0/elasticsearch/ilm-policy/events-default.json
+++ b/dev/packages/example/base/0.2.0/elasticsearch/ilm-policy/events-default.json
@@ -1,0 +1,15 @@
+{
+    "policy": {
+        "phases": {
+            "hot": {
+                "min_age": "0ms",
+                "actions": {
+                    "rollover": {
+                        "max_size": "50gb",
+                        "max_age": "30d"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/dev/packages/example/base/0.2.0/elasticsearch/ilm-policy/logs-default.json
+++ b/dev/packages/example/base/0.2.0/elasticsearch/ilm-policy/logs-default.json
@@ -1,0 +1,15 @@
+{
+        "policy": {
+            "phases": {
+                "hot": {
+                    "min_age": "0ms",
+                    "actions": {
+                        "rollover": {
+                            "max_size": "50gb",
+                            "max_age": "30d"
+                        }
+                    }
+                }
+            }
+        }
+}

--- a/dev/packages/example/base/0.2.0/elasticsearch/ilm-policy/metrics-default.json
+++ b/dev/packages/example/base/0.2.0/elasticsearch/ilm-policy/metrics-default.json
@@ -1,0 +1,15 @@
+{
+    "policy": {
+        "phases": {
+            "hot": {
+                "min_age": "0ms",
+                "actions": {
+                    "rollover": {
+                        "max_size": "50gb",
+                        "max_age": "30d"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/dev/packages/example/base/0.2.0/elasticsearch/index-template/events.json
+++ b/dev/packages/example/base/0.2.0/elasticsearch/index-template/events.json
@@ -1,0 +1,13 @@
+{
+    "index_patterns": [
+        "events-*-*"
+    ],
+    "priority": 0,
+    "data_stream": {
+        "timestamp_field": "@timestamp"
+    },
+    "composed_of": [
+        "events-mappings",
+        "events-settings"
+    ]
+}

--- a/dev/packages/example/base/0.2.0/elasticsearch/index-template/logs.json
+++ b/dev/packages/example/base/0.2.0/elasticsearch/index-template/logs.json
@@ -1,0 +1,13 @@
+{
+    "index_patterns": [
+        "logs-*-*"
+    ],
+    "priority": 0,
+    "data_stream": {
+        "timestamp_field": "@timestamp"
+    },
+    "composed_of": [
+        "logs-mappings",
+        "logs-settings"
+    ]
+}

--- a/dev/packages/example/base/0.2.0/elasticsearch/index-template/metrics.json
+++ b/dev/packages/example/base/0.2.0/elasticsearch/index-template/metrics.json
@@ -1,0 +1,13 @@
+{
+    "index_patterns": [
+        "metrics-*-*"
+    ],
+    "priority": 0,
+    "data_stream": {
+        "timestamp_field": "@timestamp"
+    },
+    "composed_of": [
+        "metrics-mappings",
+        "metrics-settings"
+    ]
+}

--- a/dev/packages/example/base/0.2.0/manifest.yml
+++ b/dev/packages/example/base/0.2.0/manifest.yml
@@ -1,0 +1,30 @@
+format_version: 1.0.0
+
+name: base
+title: Base package
+description: >
+  The base package contains assets which are needed for the basic setup of the stack.
+
+  It contains the default ILM policies.
+version: 0.2.0
+categories: []
+release: ga
+
+# The base package cannot be removed
+removable: false
+
+# The user should not see this package and not be able to install it
+internal: true
+
+license: basic
+# This is called type integration because it is required for all the integration packages
+type: integration
+
+requirement:
+  elasticsearch:
+    # Requires ILM which was released in 6.6.
+    versions: ">6.6.0"
+
+# No icons
+icons:
+


### PR DESCRIPTION
The v2 templates are updated to use datastreams. This means now moving forward all data is ingested using datastreams. This requires at least Elasticesarch 7.9.

The data_stream config is put into the template itself and not one of the components as this part should never change.

In this PR, the base package is readded to the repository as currently no other place exists for development and testing.