### PR TITLE
Fix checkout issues when using 'experimental' branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,4 @@ package-registry
 build
 public/*
 
-.package-storage
 /dev/packages/storage

--- a/magefile.go
+++ b/magefile.go
@@ -33,7 +33,7 @@ var (
 	publicDir      = "./public"
 	buildDir       = "./build"
 	storageDir     = "./dev/packages/storage"
-	storageRepoDir = "./.package-storage"
+	storageRepoDir = filepath.Join(buildDir, ".package-storage")
 	packagePaths   = []string{storageDir, "./dev/packages/example/"}
 	tarGz          = true
 )
@@ -100,7 +100,11 @@ func fetchPackageStorage() error {
 		packageStorageRevision = "master"
 	}
 
-	err = sh.Run("git", "--git-dir", filepath.Join(storageRepoDir, ".git"), "checkout", packageStorageRevision)
+	err = sh.Run("git",
+		"--git-dir", filepath.Join(storageRepoDir, ".git"),
+		"--work-tree", storageRepoDir,
+		"checkout",
+		packageStorageRevision)
 	if err != nil {
 		return err
 	}
@@ -261,12 +265,7 @@ func Clean() error {
 	if err != nil {
 		return err
 	}
-
-	err = os.RemoveAll(storageDir)
-	if err != nil {
-		return err
-	}
-	return os.Remove("package-registry")
+	return os.RemoveAll("package-registry")
 }
 
 func Vendor() error {

--- a/magefile.go
+++ b/magefile.go
@@ -33,7 +33,7 @@ var (
 	publicDir      = "./public"
 	buildDir       = "./build"
 	storageDir     = "./dev/packages/storage"
-	storageRepoDir = filepath.Join(buildDir, ".package-storage")
+	storageRepoDir = filepath.Join(buildDir, "package-storage")
 	packagePaths   = []string{storageDir, "./dev/packages/example/"}
 	tarGz          = true
 )


### PR DESCRIPTION
This PR fixes problems with checkout "experimental" branch of the package-storage.

Also, used "build" directory and changed `os.Remove` to `os.RemoveAll` when deleting `package-registry` (doesn't fail when the file is missing).