### PR TITLE
ci: trigger the master job on changes on the master package registry

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -24,6 +24,7 @@ pipeline {
   }
   triggers {
     issueCommentTrigger('(?i).*(?:jenkins\\W+)?run\\W+(?:the\\W+)?tests(?:\\W+please)?.*')
+    upstream 'Beats/package-storage/master'
   }
   stages {
     /**

--- a/.ci/jobs/package-registry.yml
+++ b/.ci/jobs/package-registry.yml
@@ -1,7 +1,7 @@
 ---
 - job:
     name: Beats/package-registry
-    display-name: Package Registry (JJBB)
+    display-name: Package Registry
     description: Jenkins pipeline for the Package Registry project
     view: Beats
     project-type: multibranch


### PR DESCRIPTION
It adds a new trigger to build the master branch on changes on the master branch of the package storage.

related to https://github.com/elastic/package-storage/pull/15