### PR TITLE
Add constant_keyword value to base templates

### DIFF
--- a/dev/packages/example/base/0.2.0/elasticsearch/component-template/events-mappings.json
+++ b/dev/packages/example/base/0.2.0/elasticsearch/component-template/events-mappings.json
@@ -22,7 +22,8 @@
                 "stream": {
                     "properties": {
                         "type": {
-                            "type": "constant_keyword"
+                            "type": "constant_keyword",
+                            "value": "events"
                         },
                         "dataset": {
                             "type": "constant_keyword"

--- a/dev/packages/example/base/0.2.0/elasticsearch/component-template/logs-mappings.json
+++ b/dev/packages/example/base/0.2.0/elasticsearch/component-template/logs-mappings.json
@@ -22,7 +22,8 @@
                 "stream": {
                     "properties": {
                         "type": {
-                            "type": "constant_keyword"
+                            "type": "constant_keyword",
+                            "value": "logs"
                         },
                         "dataset": {
                             "type": "constant_keyword"

--- a/dev/packages/example/base/0.2.0/elasticsearch/component-template/metrics-mappings.json
+++ b/dev/packages/example/base/0.2.0/elasticsearch/component-template/metrics-mappings.json
@@ -22,7 +22,8 @@
                 "stream": {
                     "properties": {
                         "type": {
-                            "type": "constant_keyword"
+                            "type": "constant_keyword",
+                            "value": "metrics"
                         },
                         "dataset": {
                             "type": "constant_keyword"


### PR DESCRIPTION
The mapping of constant_keyword allows to set the field value in advance in the template. With this the value can be enforced. As we already know in the base template the values in advance, we can set it.