### PR TITLE
chore: add team label to any PR

### DIFF
--- a/.github/paths-labeller.yml
+++ b/.github/paths-labeller.yml
@@ -1,0 +1,3 @@
+---
+- "Team:Ingest Management":
+    - "*"


### PR DESCRIPTION
## What does this PR do?
It adds the descriptor that the botelastic probot needs to monitor this repo, labelling any PR modifying any file in the repo.

## Why is important?
Less manual work :robot:

## Considerations
For the bot to monitor the repo, it's required that the `Elastic Employees` role has Write access to the repo