### PR TITLE
Do not compress archived data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Generate index.json file. [#470](https://github.com/elastic/package-registry/pull/470)
 * Stream archived package content. [#472](https://github.com/elastic/package-registry/pull/472)
 * Generate package index.json files. [#479](https://github.com/elastic/package-registry/pull/479)
+* Do not compress archived data. [#484](https://github.com/elastic/package-registry/pull/484)
 
 ### Deprecated
 

--- a/archiver/archive.go
+++ b/archiver/archive.go
@@ -29,7 +29,11 @@ type PackageProperties struct {
 
 // ArchivePackage method builds and streams an archive with package content.
 func ArchivePackage(w io.Writer, properties PackageProperties) (err error) {
-	gzipWriter := gzip.NewWriter(w)
+	gzipWriter, err := gzip.NewWriterLevel(w, gzip.NoCompression)
+	if err != nil {
+		return errors.Wrapf(err, "creating gzip writer failed")
+	}
+
 	tarWriter := tar.NewWriter(gzipWriter)
 	defer func() {
 		var multiErr multierror.Errors


### PR DESCRIPTION
This PR disables compressing on-the-fly for archived data. Even though the heaviest method on the request path is `LoadAssets()`, it will speed up processing.