### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ For each commit we have two docker image tags, one with the commit as tag
 
 `docker.elastic.co/package-registry/package-registry:f999b7a84d977cd19a379f0cec802aa1ef7ca379`
 
-An another Docker tag with the git branch or tag name
+Another Docker tag with the git branch or tag name
 
 * `docker.elastic.co/package-registry/package-registry:master`
 * `docker.elastic.co/package-registry/package-registry:pr-111`


### PR DESCRIPTION
This is also to check if CI is going red because of an invalid package or not.