### PR TITLE
Cleanup naming of docker container

### DIFF
--- a/testing/environments/kibana.config.yml
+++ b/testing/environments/kibana.config.yml
@@ -7,7 +7,5 @@ elasticsearch.password: changeme
 xpack.monitoring.ui.container.elasticsearch.enabled: true
 
 xpack.ingestManager.enabled: true
-xpack.ingestManager.epm.enabled: true
-xpack.ingestManager.fleet.enabled: true
 xpack.ingestManager.fleet.tlsCheckDisabled: true
-xpack.ingestManager.epm.registryUrl: "http://integrations-registry:8080"
+xpack.ingestManager.epm.registryUrl: "http://package-registry:8080"

--- a/testing/environments/local.yml
+++ b/testing/environments/local.yml
@@ -15,7 +15,7 @@ services:
     ports:
       - "127.0.0.1:9200:9200"
 
-  integrations-registry:
+  package-registry:
     build: ../..
     image: docker.elastic.co/package-registry/package-registry:master
     ports:

--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -28,7 +28,7 @@ services:
     volumes:
       - ./kibana.config.yml:/usr/share/kibana/config/kibana.yml
 
-  integrations-registry:
+  package-registry:
     image: docker.elastic.co/package-registry/package-registry:master
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080"]


### PR DESCRIPTION
Clean up the names to be consistent with this repository and remove flags not required anymore in the docker compose files.