### PR TITLE
Remove solution entry in package manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Breaking changes
 
 * Change stream.* fields to dataset.* fields. [#492](https://github.com/elastic/package-registry/pull/492)
+* Remove `solution` entry support in package manfiest. [#504](https://github.com/elastic/package-registry/pull/504)
 
 ### Bugfixes
 

--- a/util/package.go
+++ b/util/package.go
@@ -59,7 +59,6 @@ type Datasource struct {
 	Name        string  `config:"name" json:"name" validate:"required"`
 	Title       string  `config:"title" json:"title" validate:"required"`
 	Description string  `config:"description" json:"description" validate:"required"`
-	Solution    string  `config:"solution" json:"solution,omitempty" yaml:"solution,omitempty"`
 	Inputs      []Input `config:"inputs" json:"inputs"`
 	Multiple    *bool   `config:"multiple" json:"multiple,omitempty" yaml:"multiple,omitempty"`
 }


### PR DESCRIPTION
Based on the discussion in https://github.com/elastic/kibana/issues/67939 it seems like we do not need the solution entry in the manifest. This removes it.