### PR TITLE
Add list of downloads to /search endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add support for owner field in package manifest. [#536](https://github.com/elastic/package-registry/pull/536)
 * Introduce development mode. [#543](https://github.com/elastic/package-registry/pull/543)
 * Add additional supported categories to package. [#533](https://github.com/elastic/package-registry/pull/533)
+* Add list of downloads to /search endpoint. [#512](https://github.com/elastic/package-registry/pull/512)
 
 ### Deprecated
 

--- a/docs/api/package.json
+++ b/docs/api/package.json
@@ -33,6 +33,12 @@
       "type": "image/png"
     }
   ],
+  "downloads": [
+    {
+      "path": "/epr/example/example-1.0.0.tar.gz",
+      "type": "tar.gz"
+    }
+  ],
   "assets": [
     "/package/example/1.0.0/manifest.yml",
     "/package/example/1.0.0/docs/README.md",

--- a/docs/api/package.json
+++ b/docs/api/package.json
@@ -8,7 +8,7 @@
   "downloads": [
     {
       "path": "/epr/example/example-1.0.0.tar.gz",
-      "type": "tar.gz"
+      "type": "tar"
     }
   ],
   "path": "/package/example/1.0.0",

--- a/docs/api/package.json
+++ b/docs/api/package.json
@@ -5,6 +5,12 @@
   "description": "This is the example integration",
   "type": "integration",
   "download": "/epr/example/example-1.0.0.tar.gz",
+  "downloads": [
+    {
+      "path": "/epr/example/example-1.0.0.tar.gz",
+      "type": "tar.gz"
+    }
+  ],
   "path": "/package/example/1.0.0",
   "format_version": "1.0.0",
   "readme": "/package/example/1.0.0/docs/README.md",
@@ -31,12 +37,6 @@
       "title": "IP Tables Ubiquity Dashboard",
       "size": "1492x1464",
       "type": "image/png"
-    }
-  ],
-  "downloads": [
-    {
-      "path": "/epr/example/example-1.0.0.tar.gz",
-      "type": "tar.gz"
     }
   ],
   "assets": [

--- a/docs/api/package/datasources/1.0.0/index.json
+++ b/docs/api/package/datasources/1.0.0/index.json
@@ -5,6 +5,12 @@
   "description": "Package with data sources",
   "type": "integration",
   "download": "/epr/datasources/datasources-1.0.0.tar.gz",
+  "downloads": [
+    {
+      "path": "/epr/datasources/datasources-1.0.0.tar.gz",
+      "type": "tar.gz"
+    }
+  ],
   "path": "/package/datasources/1.0.0",
   "format_version": "1.0.0",
   "readme": "/package/datasources/1.0.0/docs/README.md",

--- a/docs/api/package/datasources/1.0.0/index.json
+++ b/docs/api/package/datasources/1.0.0/index.json
@@ -8,7 +8,7 @@
   "downloads": [
     {
       "path": "/epr/datasources/datasources-1.0.0.tar.gz",
-      "type": "tar.gz"
+      "type": "tar"
     }
   ],
   "path": "/package/datasources/1.0.0",

--- a/docs/api/package/default_pipeline/0.0.2/index.json
+++ b/docs/api/package/default_pipeline/0.0.2/index.json
@@ -5,6 +5,12 @@
   "description": "Tests if no pipeline is set, it defaults to the default one",
   "type": "integration",
   "download": "/epr/default_pipeline/default_pipeline-0.0.2.tar.gz",
+  "downloads": [
+    {
+      "path": "/epr/default_pipeline/default_pipeline-0.0.2.tar.gz",
+      "type": "tar.gz"
+    }
+  ],
   "path": "/package/default_pipeline/0.0.2",
   "format_version": "1.0.0",
   "readme": "/package/default_pipeline/0.0.2/docs/README.md",

--- a/docs/api/package/default_pipeline/0.0.2/index.json
+++ b/docs/api/package/default_pipeline/0.0.2/index.json
@@ -8,7 +8,7 @@
   "downloads": [
     {
       "path": "/epr/default_pipeline/default_pipeline-0.0.2.tar.gz",
-      "type": "tar.gz"
+      "type": "tar"
     }
   ],
   "path": "/package/default_pipeline/0.0.2",

--- a/docs/api/package/ecs_style_dataset/0.0.1/index.json
+++ b/docs/api/package/ecs_style_dataset/0.0.1/index.json
@@ -8,7 +8,7 @@
   "downloads": [
     {
       "path": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.tar.gz",
-      "type": "tar.gz"
+      "type": "tar"
     }
   ],
   "path": "/package/ecs_style_dataset/0.0.1",

--- a/docs/api/package/ecs_style_dataset/0.0.1/index.json
+++ b/docs/api/package/ecs_style_dataset/0.0.1/index.json
@@ -5,6 +5,12 @@
   "description": "Tests the registry validations works for dataset fields using the ecs style format",
   "type": "integration",
   "download": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.tar.gz",
+  "downloads": [
+    {
+      "path": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.tar.gz",
+      "type": "tar.gz"
+    }
+  ],
   "path": "/package/ecs_style_dataset/0.0.1",
   "format_version": "1.0.0",
   "readme": "/package/ecs_style_dataset/0.0.1/docs/README.md",

--- a/docs/api/package/example/0.0.2/index.json
+++ b/docs/api/package/example/0.0.2/index.json
@@ -8,7 +8,7 @@
   "downloads": [
     {
       "path": "/epr/example/example-0.0.2.tar.gz",
-      "type": "tar.gz"
+      "type": "tar"
     }
   ],
   "path": "/package/example/0.0.2",

--- a/docs/api/package/example/0.0.2/index.json
+++ b/docs/api/package/example/0.0.2/index.json
@@ -5,6 +5,12 @@
   "description": "This is the example integration.",
   "type": "integration",
   "download": "/epr/example/example-0.0.2.tar.gz",
+  "downloads": [
+    {
+      "path": "/epr/example/example-0.0.2.tar.gz",
+      "type": "tar.gz"
+    }
+  ],
   "path": "/package/example/0.0.2",
   "format_version": "1.0.0",
   "readme": "/package/example/0.0.2/docs/README.md",

--- a/docs/api/package/example/1.0.0/index.json
+++ b/docs/api/package/example/1.0.0/index.json
@@ -5,6 +5,12 @@
   "description": "This is the example integration",
   "type": "integration",
   "download": "/epr/example/example-1.0.0.tar.gz",
+  "downloads": [
+    {
+      "path": "/epr/example/example-1.0.0.tar.gz",
+      "type": "tar.gz"
+    }
+  ],
   "path": "/package/example/1.0.0",
   "format_version": "1.0.0",
   "readme": "/package/example/1.0.0/docs/README.md",

--- a/docs/api/package/example/1.0.0/index.json
+++ b/docs/api/package/example/1.0.0/index.json
@@ -8,7 +8,7 @@
   "downloads": [
     {
       "path": "/epr/example/example-1.0.0.tar.gz",
-      "type": "tar.gz"
+      "type": "tar"
     }
   ],
   "path": "/package/example/1.0.0",

--- a/docs/api/package/experimental/0.0.1/index.json
+++ b/docs/api/package/experimental/0.0.1/index.json
@@ -5,6 +5,12 @@
   "description": "Experimental package, should be set by default",
   "type": "solution",
   "download": "/epr/experimental/experimental-0.0.1.tar.gz",
+  "downloads": [
+    {
+      "path": "/epr/experimental/experimental-0.0.1.tar.gz",
+      "type": "tar.gz"
+    }
+  ],
   "path": "/package/experimental/0.0.1",
   "format_version": "1.0.0",
   "readme": "/package/experimental/0.0.1/docs/README.md",

--- a/docs/api/package/experimental/0.0.1/index.json
+++ b/docs/api/package/experimental/0.0.1/index.json
@@ -8,7 +8,7 @@
   "downloads": [
     {
       "path": "/epr/experimental/experimental-0.0.1.tar.gz",
-      "type": "tar.gz"
+      "type": "tar"
     }
   ],
   "path": "/package/experimental/0.0.1",

--- a/docs/api/package/foo/1.0.0/index.json
+++ b/docs/api/package/foo/1.0.0/index.json
@@ -8,7 +8,7 @@
   "downloads": [
     {
       "path": "/epr/foo/foo-1.0.0.tar.gz",
-      "type": "tar.gz"
+      "type": "tar"
     }
   ],
   "path": "/package/foo/1.0.0",

--- a/docs/api/package/foo/1.0.0/index.json
+++ b/docs/api/package/foo/1.0.0/index.json
@@ -5,6 +5,12 @@
   "description": "This is the foo integration",
   "type": "solution",
   "download": "/epr/foo/foo-1.0.0.tar.gz",
+  "downloads": [
+    {
+      "path": "/epr/foo/foo-1.0.0.tar.gz",
+      "type": "tar.gz"
+    }
+  ],
   "path": "/package/foo/1.0.0",
   "format_version": "1.0.0",
   "readme": "/package/foo/1.0.0/docs/README.md",

--- a/docs/api/package/internal/1.2.0/index.json
+++ b/docs/api/package/internal/1.2.0/index.json
@@ -8,7 +8,7 @@
   "downloads": [
     {
       "path": "/epr/internal/internal-1.2.0.tar.gz",
-      "type": "tar.gz"
+      "type": "tar"
     }
   ],
   "path": "/package/internal/1.2.0",

--- a/docs/api/package/internal/1.2.0/index.json
+++ b/docs/api/package/internal/1.2.0/index.json
@@ -5,6 +5,12 @@
   "description": "Internal package",
   "type": "integration",
   "download": "/epr/internal/internal-1.2.0.tar.gz",
+  "downloads": [
+    {
+      "path": "/epr/internal/internal-1.2.0.tar.gz",
+      "type": "tar.gz"
+    }
+  ],
   "path": "/package/internal/1.2.0",
   "internal": true,
   "format_version": "1.0.0",

--- a/docs/api/package/multiple_false/0.0.1/index.json
+++ b/docs/api/package/multiple_false/0.0.1/index.json
@@ -5,6 +5,12 @@
   "description": "Tests that multiple can be set to false",
   "type": "integration",
   "download": "/epr/multiple_false/multiple_false-0.0.1.tar.gz",
+  "downloads": [
+    {
+      "path": "/epr/multiple_false/multiple_false-0.0.1.tar.gz",
+      "type": "tar.gz"
+    }
+  ],
   "path": "/package/multiple_false/0.0.1",
   "format_version": "1.0.0",
   "readme": "/package/multiple_false/0.0.1/docs/README.md",

--- a/docs/api/package/multiple_false/0.0.1/index.json
+++ b/docs/api/package/multiple_false/0.0.1/index.json
@@ -8,7 +8,7 @@
   "downloads": [
     {
       "path": "/epr/multiple_false/multiple_false-0.0.1.tar.gz",
-      "type": "tar.gz"
+      "type": "tar"
     }
   ],
   "path": "/package/multiple_false/0.0.1",

--- a/docs/api/package/no_stream_configs/1.0.0/index.json
+++ b/docs/api/package/no_stream_configs/1.0.0/index.json
@@ -5,6 +5,12 @@
   "description": "This package does contain a dataset but not stream configs.\n",
   "type": "integration",
   "download": "/epr/no_stream_configs/no_stream_configs-1.0.0.tar.gz",
+  "downloads": [
+    {
+      "path": "/epr/no_stream_configs/no_stream_configs-1.0.0.tar.gz",
+      "type": "tar.gz"
+    }
+  ],
   "path": "/package/no_stream_configs/1.0.0",
   "format_version": "1.0.0",
   "readme": "/package/no_stream_configs/1.0.0/docs/README.md",

--- a/docs/api/package/no_stream_configs/1.0.0/index.json
+++ b/docs/api/package/no_stream_configs/1.0.0/index.json
@@ -8,7 +8,7 @@
   "downloads": [
     {
       "path": "/epr/no_stream_configs/no_stream_configs-1.0.0.tar.gz",
-      "type": "tar.gz"
+      "type": "tar"
     }
   ],
   "path": "/package/no_stream_configs/1.0.0",

--- a/docs/api/search-all.json
+++ b/docs/api/search-all.json
@@ -1,5 +1,16 @@
 [
   {
+<<<<<<< HEAD
+=======
+    "description": "Package with data sources",
+    "download": "/epr/datasources/datasources-1.0.0.tar.gz",
+    "downloads": [
+      {
+        "path": "/epr/datasources/datasources-1.0.0.tar.gz",
+        "type": "tar.gz"
+      }
+    ],
+>>>>>>> f5fea69e... Add list of downloads to /search endpoint
     "name": "datasources",
     "title": "Default datasource Integration",
     "version": "1.0.0",
@@ -9,6 +20,17 @@
     "path": "/package/datasources/1.0.0"
   },
   {
+<<<<<<< HEAD
+=======
+    "description": "Tests if no pipeline is set, it defaults to the default one",
+    "download": "/epr/default_pipeline/default_pipeline-0.0.2.tar.gz",
+    "downloads": [
+      {
+        "path": "/epr/default_pipeline/default_pipeline-0.0.2.tar.gz",
+        "type": "tar.gz"
+      }
+    ],
+>>>>>>> f5fea69e... Add list of downloads to /search endpoint
     "name": "default_pipeline",
     "title": "Default pipeline Integration",
     "version": "0.0.2",
@@ -18,6 +40,17 @@
     "path": "/package/default_pipeline/0.0.2"
   },
   {
+<<<<<<< HEAD
+=======
+    "description": "Tests the registry validations works for dataset fields using the ecs style format",
+    "download": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.tar.gz",
+    "downloads": [
+      {
+        "path": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.tar.gz",
+        "type": "tar.gz"
+      }
+    ],
+>>>>>>> f5fea69e... Add list of downloads to /search endpoint
     "name": "ecs_style_dataset",
     "title": "Default pipeline Integration",
     "version": "0.0.1",
@@ -27,6 +60,17 @@
     "path": "/package/ecs_style_dataset/0.0.1"
   },
   {
+<<<<<<< HEAD
+=======
+    "description": "This is the example integration.",
+    "download": "/epr/example/example-0.0.2.tar.gz",
+    "downloads": [
+      {
+        "path": "/epr/example/example-0.0.2.tar.gz",
+        "type": "tar.gz"
+      }
+    ],
+>>>>>>> f5fea69e... Add list of downloads to /search endpoint
     "name": "example",
     "title": "Example",
     "version": "0.0.2",
@@ -36,6 +80,17 @@
     "path": "/package/example/0.0.2"
   },
   {
+<<<<<<< HEAD
+=======
+    "description": "This is the example integration",
+    "download": "/epr/example/example-1.0.0.tar.gz",
+    "downloads": [
+      {
+        "path": "/epr/example/example-1.0.0.tar.gz",
+        "type": "tar.gz"
+      }
+    ],
+>>>>>>> f5fea69e... Add list of downloads to /search endpoint
     "name": "example",
     "title": "Example Integration",
     "version": "1.0.0",
@@ -45,6 +100,17 @@
     "path": "/package/example/1.0.0"
   },
   {
+<<<<<<< HEAD
+=======
+    "description": "This is the foo integration",
+    "download": "/epr/foo/foo-1.0.0.tar.gz",
+    "downloads": [
+      {
+        "path": "/epr/foo/foo-1.0.0.tar.gz",
+        "type": "tar.gz"
+      }
+    ],
+>>>>>>> f5fea69e... Add list of downloads to /search endpoint
     "name": "foo",
     "title": "Foo",
     "version": "1.0.0",
@@ -54,6 +120,17 @@
     "path": "/package/foo/1.0.0"
   },
   {
+<<<<<<< HEAD
+=======
+    "description": "Tests that multiple can be set to false",
+    "download": "/epr/multiple_false/multiple_false-0.0.1.tar.gz",
+    "downloads": [
+      {
+        "path": "/epr/multiple_false/multiple_false-0.0.1.tar.gz",
+        "type": "tar.gz"
+      }
+    ],
+>>>>>>> f5fea69e... Add list of downloads to /search endpoint
     "name": "multiple_false",
     "title": "Multiple false",
     "version": "0.0.1",
@@ -63,6 +140,17 @@
     "path": "/package/multiple_false/0.0.1"
   },
   {
+<<<<<<< HEAD
+=======
+    "description": "This package does contain a dataset but not stream configs.\n",
+    "download": "/epr/no_stream_configs/no_stream_configs-1.0.0.tar.gz",
+    "downloads": [
+      {
+        "path": "/epr/no_stream_configs/no_stream_configs-1.0.0.tar.gz",
+        "type": "tar.gz"
+      }
+    ],
+>>>>>>> f5fea69e... Add list of downloads to /search endpoint
     "name": "no_stream_configs",
     "title": "No Stream configs",
     "version": "1.0.0",

--- a/docs/api/search-all.json
+++ b/docs/api/search-all.json
@@ -1,8 +1,10 @@
 [
   {
-<<<<<<< HEAD
-=======
+    "name": "datasources",
+    "title": "Default datasource Integration",
+    "version": "1.0.0",
     "description": "Package with data sources",
+    "type": "integration",
     "download": "/epr/datasources/datasources-1.0.0.tar.gz",
     "downloads": [
       {
@@ -10,19 +12,14 @@
         "type": "tar.gz"
       }
     ],
->>>>>>> f5fea69e... Add list of downloads to /search endpoint
-    "name": "datasources",
-    "title": "Default datasource Integration",
-    "version": "1.0.0",
-    "description": "Package with data sources",
-    "type": "integration",
-    "download": "/epr/datasources/datasources-1.0.0.tar.gz",
     "path": "/package/datasources/1.0.0"
   },
   {
-<<<<<<< HEAD
-=======
+    "name": "default_pipeline",
+    "title": "Default pipeline Integration",
+    "version": "0.0.2",
     "description": "Tests if no pipeline is set, it defaults to the default one",
+    "type": "integration",
     "download": "/epr/default_pipeline/default_pipeline-0.0.2.tar.gz",
     "downloads": [
       {
@@ -30,19 +27,14 @@
         "type": "tar.gz"
       }
     ],
->>>>>>> f5fea69e... Add list of downloads to /search endpoint
-    "name": "default_pipeline",
-    "title": "Default pipeline Integration",
-    "version": "0.0.2",
-    "description": "Tests if no pipeline is set, it defaults to the default one",
-    "type": "integration",
-    "download": "/epr/default_pipeline/default_pipeline-0.0.2.tar.gz",
     "path": "/package/default_pipeline/0.0.2"
   },
   {
-<<<<<<< HEAD
-=======
+    "name": "ecs_style_dataset",
+    "title": "Default pipeline Integration",
+    "version": "0.0.1",
     "description": "Tests the registry validations works for dataset fields using the ecs style format",
+    "type": "integration",
     "download": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.tar.gz",
     "downloads": [
       {
@@ -50,19 +42,14 @@
         "type": "tar.gz"
       }
     ],
->>>>>>> f5fea69e... Add list of downloads to /search endpoint
-    "name": "ecs_style_dataset",
-    "title": "Default pipeline Integration",
-    "version": "0.0.1",
-    "description": "Tests the registry validations works for dataset fields using the ecs style format",
-    "type": "integration",
-    "download": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.tar.gz",
     "path": "/package/ecs_style_dataset/0.0.1"
   },
   {
-<<<<<<< HEAD
-=======
+    "name": "example",
+    "title": "Example",
+    "version": "0.0.2",
     "description": "This is the example integration.",
+    "type": "integration",
     "download": "/epr/example/example-0.0.2.tar.gz",
     "downloads": [
       {
@@ -70,19 +57,14 @@
         "type": "tar.gz"
       }
     ],
->>>>>>> f5fea69e... Add list of downloads to /search endpoint
-    "name": "example",
-    "title": "Example",
-    "version": "0.0.2",
-    "description": "This is the example integration.",
-    "type": "integration",
-    "download": "/epr/example/example-0.0.2.tar.gz",
     "path": "/package/example/0.0.2"
   },
   {
-<<<<<<< HEAD
-=======
+    "name": "example",
+    "title": "Example Integration",
+    "version": "1.0.0",
     "description": "This is the example integration",
+    "type": "integration",
     "download": "/epr/example/example-1.0.0.tar.gz",
     "downloads": [
       {
@@ -90,19 +72,14 @@
         "type": "tar.gz"
       }
     ],
->>>>>>> f5fea69e... Add list of downloads to /search endpoint
-    "name": "example",
-    "title": "Example Integration",
-    "version": "1.0.0",
-    "description": "This is the example integration",
-    "type": "integration",
-    "download": "/epr/example/example-1.0.0.tar.gz",
     "path": "/package/example/1.0.0"
   },
   {
-<<<<<<< HEAD
-=======
+    "name": "foo",
+    "title": "Foo",
+    "version": "1.0.0",
     "description": "This is the foo integration",
+    "type": "solution",
     "download": "/epr/foo/foo-1.0.0.tar.gz",
     "downloads": [
       {
@@ -110,19 +87,14 @@
         "type": "tar.gz"
       }
     ],
->>>>>>> f5fea69e... Add list of downloads to /search endpoint
-    "name": "foo",
-    "title": "Foo",
-    "version": "1.0.0",
-    "description": "This is the foo integration",
-    "type": "solution",
-    "download": "/epr/foo/foo-1.0.0.tar.gz",
     "path": "/package/foo/1.0.0"
   },
   {
-<<<<<<< HEAD
-=======
+    "name": "multiple_false",
+    "title": "Multiple false",
+    "version": "0.0.1",
     "description": "Tests that multiple can be set to false",
+    "type": "integration",
     "download": "/epr/multiple_false/multiple_false-0.0.1.tar.gz",
     "downloads": [
       {
@@ -130,19 +102,14 @@
         "type": "tar.gz"
       }
     ],
->>>>>>> f5fea69e... Add list of downloads to /search endpoint
-    "name": "multiple_false",
-    "title": "Multiple false",
-    "version": "0.0.1",
-    "description": "Tests that multiple can be set to false",
-    "type": "integration",
-    "download": "/epr/multiple_false/multiple_false-0.0.1.tar.gz",
     "path": "/package/multiple_false/0.0.1"
   },
   {
-<<<<<<< HEAD
-=======
+    "name": "no_stream_configs",
+    "title": "No Stream configs",
+    "version": "1.0.0",
     "description": "This package does contain a dataset but not stream configs.\n",
+    "type": "integration",
     "download": "/epr/no_stream_configs/no_stream_configs-1.0.0.tar.gz",
     "downloads": [
       {
@@ -150,13 +117,6 @@
         "type": "tar.gz"
       }
     ],
->>>>>>> f5fea69e... Add list of downloads to /search endpoint
-    "name": "no_stream_configs",
-    "title": "No Stream configs",
-    "version": "1.0.0",
-    "description": "This package does contain a dataset but not stream configs.\n",
-    "type": "integration",
-    "download": "/epr/no_stream_configs/no_stream_configs-1.0.0.tar.gz",
     "path": "/package/no_stream_configs/1.0.0"
   }
 ]

--- a/docs/api/search-all.json
+++ b/docs/api/search-all.json
@@ -9,7 +9,7 @@
     "downloads": [
       {
         "path": "/epr/datasources/datasources-1.0.0.tar.gz",
-        "type": "tar.gz"
+        "type": "tar"
       }
     ],
     "path": "/package/datasources/1.0.0"
@@ -24,7 +24,7 @@
     "downloads": [
       {
         "path": "/epr/default_pipeline/default_pipeline-0.0.2.tar.gz",
-        "type": "tar.gz"
+        "type": "tar"
       }
     ],
     "path": "/package/default_pipeline/0.0.2"
@@ -39,7 +39,7 @@
     "downloads": [
       {
         "path": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.tar.gz",
-        "type": "tar.gz"
+        "type": "tar"
       }
     ],
     "path": "/package/ecs_style_dataset/0.0.1"
@@ -54,7 +54,7 @@
     "downloads": [
       {
         "path": "/epr/example/example-0.0.2.tar.gz",
-        "type": "tar.gz"
+        "type": "tar"
       }
     ],
     "path": "/package/example/0.0.2"
@@ -69,7 +69,7 @@
     "downloads": [
       {
         "path": "/epr/example/example-1.0.0.tar.gz",
-        "type": "tar.gz"
+        "type": "tar"
       }
     ],
     "path": "/package/example/1.0.0"
@@ -84,7 +84,7 @@
     "downloads": [
       {
         "path": "/epr/foo/foo-1.0.0.tar.gz",
-        "type": "tar.gz"
+        "type": "tar"
       }
     ],
     "path": "/package/foo/1.0.0"
@@ -99,7 +99,7 @@
     "downloads": [
       {
         "path": "/epr/multiple_false/multiple_false-0.0.1.tar.gz",
-        "type": "tar.gz"
+        "type": "tar"
       }
     ],
     "path": "/package/multiple_false/0.0.1"
@@ -114,7 +114,7 @@
     "downloads": [
       {
         "path": "/epr/no_stream_configs/no_stream_configs-1.0.0.tar.gz",
-        "type": "tar.gz"
+        "type": "tar"
       }
     ],
     "path": "/package/no_stream_configs/1.0.0"

--- a/docs/api/search-category-logs.json
+++ b/docs/api/search-category-logs.json
@@ -1,5 +1,16 @@
 [
   {
+<<<<<<< HEAD
+=======
+    "description": "Package with data sources",
+    "download": "/epr/datasources/datasources-1.0.0.tar.gz",
+    "downloads": [
+      {
+        "path": "/epr/datasources/datasources-1.0.0.tar.gz",
+        "type": "tar.gz"
+      }
+    ],
+>>>>>>> f5fea69e... Add list of downloads to /search endpoint
     "name": "datasources",
     "title": "Default datasource Integration",
     "version": "1.0.0",
@@ -9,6 +20,17 @@
     "path": "/package/datasources/1.0.0"
   },
   {
+<<<<<<< HEAD
+=======
+    "description": "Tests if no pipeline is set, it defaults to the default one",
+    "download": "/epr/default_pipeline/default_pipeline-0.0.2.tar.gz",
+    "downloads": [
+      {
+        "path": "/epr/default_pipeline/default_pipeline-0.0.2.tar.gz",
+        "type": "tar.gz"
+      }
+    ],
+>>>>>>> f5fea69e... Add list of downloads to /search endpoint
     "name": "default_pipeline",
     "title": "Default pipeline Integration",
     "version": "0.0.2",
@@ -18,6 +40,17 @@
     "path": "/package/default_pipeline/0.0.2"
   },
   {
+<<<<<<< HEAD
+=======
+    "description": "Tests the registry validations works for dataset fields using the ecs style format",
+    "download": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.tar.gz",
+    "downloads": [
+      {
+        "path": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.tar.gz",
+        "type": "tar.gz"
+      }
+    ],
+>>>>>>> f5fea69e... Add list of downloads to /search endpoint
     "name": "ecs_style_dataset",
     "title": "Default pipeline Integration",
     "version": "0.0.1",
@@ -27,6 +60,17 @@
     "path": "/package/ecs_style_dataset/0.0.1"
   },
   {
+<<<<<<< HEAD
+=======
+    "description": "This is the example integration",
+    "download": "/epr/example/example-1.0.0.tar.gz",
+    "downloads": [
+      {
+        "path": "/epr/example/example-1.0.0.tar.gz",
+        "type": "tar.gz"
+      }
+    ],
+>>>>>>> f5fea69e... Add list of downloads to /search endpoint
     "name": "example",
     "title": "Example Integration",
     "version": "1.0.0",
@@ -36,6 +80,17 @@
     "path": "/package/example/1.0.0"
   },
   {
+<<<<<<< HEAD
+=======
+    "description": "Tests that multiple can be set to false",
+    "download": "/epr/multiple_false/multiple_false-0.0.1.tar.gz",
+    "downloads": [
+      {
+        "path": "/epr/multiple_false/multiple_false-0.0.1.tar.gz",
+        "type": "tar.gz"
+      }
+    ],
+>>>>>>> f5fea69e... Add list of downloads to /search endpoint
     "name": "multiple_false",
     "title": "Multiple false",
     "version": "0.0.1",
@@ -45,6 +100,17 @@
     "path": "/package/multiple_false/0.0.1"
   },
   {
+<<<<<<< HEAD
+=======
+    "description": "This package does contain a dataset but not stream configs.\n",
+    "download": "/epr/no_stream_configs/no_stream_configs-1.0.0.tar.gz",
+    "downloads": [
+      {
+        "path": "/epr/no_stream_configs/no_stream_configs-1.0.0.tar.gz",
+        "type": "tar.gz"
+      }
+    ],
+>>>>>>> f5fea69e... Add list of downloads to /search endpoint
     "name": "no_stream_configs",
     "title": "No Stream configs",
     "version": "1.0.0",

--- a/docs/api/search-category-logs.json
+++ b/docs/api/search-category-logs.json
@@ -9,7 +9,7 @@
     "downloads": [
       {
         "path": "/epr/datasources/datasources-1.0.0.tar.gz",
-        "type": "tar.gz"
+        "type": "tar"
       }
     ],
     "path": "/package/datasources/1.0.0"
@@ -24,7 +24,7 @@
     "downloads": [
       {
         "path": "/epr/default_pipeline/default_pipeline-0.0.2.tar.gz",
-        "type": "tar.gz"
+        "type": "tar"
       }
     ],
     "path": "/package/default_pipeline/0.0.2"
@@ -39,7 +39,7 @@
     "downloads": [
       {
         "path": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.tar.gz",
-        "type": "tar.gz"
+        "type": "tar"
       }
     ],
     "path": "/package/ecs_style_dataset/0.0.1"
@@ -54,7 +54,7 @@
     "downloads": [
       {
         "path": "/epr/example/example-1.0.0.tar.gz",
-        "type": "tar.gz"
+        "type": "tar"
       }
     ],
     "path": "/package/example/1.0.0"
@@ -69,7 +69,7 @@
     "downloads": [
       {
         "path": "/epr/multiple_false/multiple_false-0.0.1.tar.gz",
-        "type": "tar.gz"
+        "type": "tar"
       }
     ],
     "path": "/package/multiple_false/0.0.1"
@@ -84,7 +84,7 @@
     "downloads": [
       {
         "path": "/epr/no_stream_configs/no_stream_configs-1.0.0.tar.gz",
-        "type": "tar.gz"
+        "type": "tar"
       }
     ],
     "path": "/package/no_stream_configs/1.0.0"

--- a/docs/api/search-category-logs.json
+++ b/docs/api/search-category-logs.json
@@ -1,8 +1,10 @@
 [
   {
-<<<<<<< HEAD
-=======
+    "name": "datasources",
+    "title": "Default datasource Integration",
+    "version": "1.0.0",
     "description": "Package with data sources",
+    "type": "integration",
     "download": "/epr/datasources/datasources-1.0.0.tar.gz",
     "downloads": [
       {
@@ -10,19 +12,14 @@
         "type": "tar.gz"
       }
     ],
->>>>>>> f5fea69e... Add list of downloads to /search endpoint
-    "name": "datasources",
-    "title": "Default datasource Integration",
-    "version": "1.0.0",
-    "description": "Package with data sources",
-    "type": "integration",
-    "download": "/epr/datasources/datasources-1.0.0.tar.gz",
     "path": "/package/datasources/1.0.0"
   },
   {
-<<<<<<< HEAD
-=======
+    "name": "default_pipeline",
+    "title": "Default pipeline Integration",
+    "version": "0.0.2",
     "description": "Tests if no pipeline is set, it defaults to the default one",
+    "type": "integration",
     "download": "/epr/default_pipeline/default_pipeline-0.0.2.tar.gz",
     "downloads": [
       {
@@ -30,19 +27,14 @@
         "type": "tar.gz"
       }
     ],
->>>>>>> f5fea69e... Add list of downloads to /search endpoint
-    "name": "default_pipeline",
-    "title": "Default pipeline Integration",
-    "version": "0.0.2",
-    "description": "Tests if no pipeline is set, it defaults to the default one",
-    "type": "integration",
-    "download": "/epr/default_pipeline/default_pipeline-0.0.2.tar.gz",
     "path": "/package/default_pipeline/0.0.2"
   },
   {
-<<<<<<< HEAD
-=======
+    "name": "ecs_style_dataset",
+    "title": "Default pipeline Integration",
+    "version": "0.0.1",
     "description": "Tests the registry validations works for dataset fields using the ecs style format",
+    "type": "integration",
     "download": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.tar.gz",
     "downloads": [
       {
@@ -50,19 +42,14 @@
         "type": "tar.gz"
       }
     ],
->>>>>>> f5fea69e... Add list of downloads to /search endpoint
-    "name": "ecs_style_dataset",
-    "title": "Default pipeline Integration",
-    "version": "0.0.1",
-    "description": "Tests the registry validations works for dataset fields using the ecs style format",
-    "type": "integration",
-    "download": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.tar.gz",
     "path": "/package/ecs_style_dataset/0.0.1"
   },
   {
-<<<<<<< HEAD
-=======
+    "name": "example",
+    "title": "Example Integration",
+    "version": "1.0.0",
     "description": "This is the example integration",
+    "type": "integration",
     "download": "/epr/example/example-1.0.0.tar.gz",
     "downloads": [
       {
@@ -70,19 +57,14 @@
         "type": "tar.gz"
       }
     ],
->>>>>>> f5fea69e... Add list of downloads to /search endpoint
-    "name": "example",
-    "title": "Example Integration",
-    "version": "1.0.0",
-    "description": "This is the example integration",
-    "type": "integration",
-    "download": "/epr/example/example-1.0.0.tar.gz",
     "path": "/package/example/1.0.0"
   },
   {
-<<<<<<< HEAD
-=======
+    "name": "multiple_false",
+    "title": "Multiple false",
+    "version": "0.0.1",
     "description": "Tests that multiple can be set to false",
+    "type": "integration",
     "download": "/epr/multiple_false/multiple_false-0.0.1.tar.gz",
     "downloads": [
       {
@@ -90,19 +72,14 @@
         "type": "tar.gz"
       }
     ],
->>>>>>> f5fea69e... Add list of downloads to /search endpoint
-    "name": "multiple_false",
-    "title": "Multiple false",
-    "version": "0.0.1",
-    "description": "Tests that multiple can be set to false",
-    "type": "integration",
-    "download": "/epr/multiple_false/multiple_false-0.0.1.tar.gz",
     "path": "/package/multiple_false/0.0.1"
   },
   {
-<<<<<<< HEAD
-=======
+    "name": "no_stream_configs",
+    "title": "No Stream configs",
+    "version": "1.0.0",
     "description": "This package does contain a dataset but not stream configs.\n",
+    "type": "integration",
     "download": "/epr/no_stream_configs/no_stream_configs-1.0.0.tar.gz",
     "downloads": [
       {
@@ -110,13 +87,6 @@
         "type": "tar.gz"
       }
     ],
->>>>>>> f5fea69e... Add list of downloads to /search endpoint
-    "name": "no_stream_configs",
-    "title": "No Stream configs",
-    "version": "1.0.0",
-    "description": "This package does contain a dataset but not stream configs.\n",
-    "type": "integration",
-    "download": "/epr/no_stream_configs/no_stream_configs-1.0.0.tar.gz",
     "path": "/package/no_stream_configs/1.0.0"
   }
 ]

--- a/docs/api/search-category-metrics.json
+++ b/docs/api/search-category-metrics.json
@@ -9,7 +9,7 @@
     "downloads": [
       {
         "path": "/epr/example/example-1.0.0.tar.gz",
-        "type": "tar.gz"
+        "type": "tar"
       }
     ],
     "path": "/package/example/1.0.0"
@@ -24,7 +24,7 @@
     "downloads": [
       {
         "path": "/epr/foo/foo-1.0.0.tar.gz",
-        "type": "tar.gz"
+        "type": "tar"
       }
     ],
     "path": "/package/foo/1.0.0"

--- a/docs/api/search-category-metrics.json
+++ b/docs/api/search-category-metrics.json
@@ -1,8 +1,10 @@
 [
   {
-<<<<<<< HEAD
-=======
+    "name": "example",
+    "title": "Example Integration",
+    "version": "1.0.0",
     "description": "This is the example integration",
+    "type": "integration",
     "download": "/epr/example/example-1.0.0.tar.gz",
     "downloads": [
       {
@@ -10,19 +12,14 @@
         "type": "tar.gz"
       }
     ],
->>>>>>> f5fea69e... Add list of downloads to /search endpoint
-    "name": "example",
-    "title": "Example Integration",
-    "version": "1.0.0",
-    "description": "This is the example integration",
-    "type": "integration",
-    "download": "/epr/example/example-1.0.0.tar.gz",
     "path": "/package/example/1.0.0"
   },
   {
-<<<<<<< HEAD
-=======
+    "name": "foo",
+    "title": "Foo",
+    "version": "1.0.0",
     "description": "This is the foo integration",
+    "type": "solution",
     "download": "/epr/foo/foo-1.0.0.tar.gz",
     "downloads": [
       {
@@ -30,13 +27,6 @@
         "type": "tar.gz"
       }
     ],
->>>>>>> f5fea69e... Add list of downloads to /search endpoint
-    "name": "foo",
-    "title": "Foo",
-    "version": "1.0.0",
-    "description": "This is the foo integration",
-    "type": "solution",
-    "download": "/epr/foo/foo-1.0.0.tar.gz",
     "path": "/package/foo/1.0.0"
   }
 ]

--- a/docs/api/search-category-metrics.json
+++ b/docs/api/search-category-metrics.json
@@ -1,5 +1,16 @@
 [
   {
+<<<<<<< HEAD
+=======
+    "description": "This is the example integration",
+    "download": "/epr/example/example-1.0.0.tar.gz",
+    "downloads": [
+      {
+        "path": "/epr/example/example-1.0.0.tar.gz",
+        "type": "tar.gz"
+      }
+    ],
+>>>>>>> f5fea69e... Add list of downloads to /search endpoint
     "name": "example",
     "title": "Example Integration",
     "version": "1.0.0",
@@ -9,6 +20,17 @@
     "path": "/package/example/1.0.0"
   },
   {
+<<<<<<< HEAD
+=======
+    "description": "This is the foo integration",
+    "download": "/epr/foo/foo-1.0.0.tar.gz",
+    "downloads": [
+      {
+        "path": "/epr/foo/foo-1.0.0.tar.gz",
+        "type": "tar.gz"
+      }
+    ],
+>>>>>>> f5fea69e... Add list of downloads to /search endpoint
     "name": "foo",
     "title": "Foo",
     "version": "1.0.0",

--- a/docs/api/search-kibana652.json
+++ b/docs/api/search-kibana652.json
@@ -1,8 +1,10 @@
 [
   {
-<<<<<<< HEAD
-=======
+    "name": "datasources",
+    "title": "Default datasource Integration",
+    "version": "1.0.0",
     "description": "Package with data sources",
+    "type": "integration",
     "download": "/epr/datasources/datasources-1.0.0.tar.gz",
     "downloads": [
       {
@@ -10,19 +12,14 @@
         "type": "tar.gz"
       }
     ],
->>>>>>> f5fea69e... Add list of downloads to /search endpoint
-    "name": "datasources",
-    "title": "Default datasource Integration",
-    "version": "1.0.0",
-    "description": "Package with data sources",
-    "type": "integration",
-    "download": "/epr/datasources/datasources-1.0.0.tar.gz",
     "path": "/package/datasources/1.0.0"
   },
   {
-<<<<<<< HEAD
-=======
+    "name": "default_pipeline",
+    "title": "Default pipeline Integration",
+    "version": "0.0.2",
     "description": "Tests if no pipeline is set, it defaults to the default one",
+    "type": "integration",
     "download": "/epr/default_pipeline/default_pipeline-0.0.2.tar.gz",
     "downloads": [
       {
@@ -30,19 +27,14 @@
         "type": "tar.gz"
       }
     ],
->>>>>>> f5fea69e... Add list of downloads to /search endpoint
-    "name": "default_pipeline",
-    "title": "Default pipeline Integration",
-    "version": "0.0.2",
-    "description": "Tests if no pipeline is set, it defaults to the default one",
-    "type": "integration",
-    "download": "/epr/default_pipeline/default_pipeline-0.0.2.tar.gz",
     "path": "/package/default_pipeline/0.0.2"
   },
   {
-<<<<<<< HEAD
-=======
+    "name": "ecs_style_dataset",
+    "title": "Default pipeline Integration",
+    "version": "0.0.1",
     "description": "Tests the registry validations works for dataset fields using the ecs style format",
+    "type": "integration",
     "download": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.tar.gz",
     "downloads": [
       {
@@ -50,19 +42,14 @@
         "type": "tar.gz"
       }
     ],
->>>>>>> f5fea69e... Add list of downloads to /search endpoint
-    "name": "ecs_style_dataset",
-    "title": "Default pipeline Integration",
-    "version": "0.0.1",
-    "description": "Tests the registry validations works for dataset fields using the ecs style format",
-    "type": "integration",
-    "download": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.tar.gz",
     "path": "/package/ecs_style_dataset/0.0.1"
   },
   {
-<<<<<<< HEAD
-=======
+    "name": "example",
+    "title": "Example",
+    "version": "0.0.2",
     "description": "This is the example integration.",
+    "type": "integration",
     "download": "/epr/example/example-0.0.2.tar.gz",
     "downloads": [
       {
@@ -70,19 +57,14 @@
         "type": "tar.gz"
       }
     ],
->>>>>>> f5fea69e... Add list of downloads to /search endpoint
-    "name": "example",
-    "title": "Example",
-    "version": "0.0.2",
-    "description": "This is the example integration.",
-    "type": "integration",
-    "download": "/epr/example/example-0.0.2.tar.gz",
     "path": "/package/example/0.0.2"
   },
   {
-<<<<<<< HEAD
-=======
+    "name": "multiple_false",
+    "title": "Multiple false",
+    "version": "0.0.1",
     "description": "Tests that multiple can be set to false",
+    "type": "integration",
     "download": "/epr/multiple_false/multiple_false-0.0.1.tar.gz",
     "downloads": [
       {
@@ -90,19 +72,14 @@
         "type": "tar.gz"
       }
     ],
->>>>>>> f5fea69e... Add list of downloads to /search endpoint
-    "name": "multiple_false",
-    "title": "Multiple false",
-    "version": "0.0.1",
-    "description": "Tests that multiple can be set to false",
-    "type": "integration",
-    "download": "/epr/multiple_false/multiple_false-0.0.1.tar.gz",
     "path": "/package/multiple_false/0.0.1"
   },
   {
-<<<<<<< HEAD
-=======
+    "name": "no_stream_configs",
+    "title": "No Stream configs",
+    "version": "1.0.0",
     "description": "This package does contain a dataset but not stream configs.\n",
+    "type": "integration",
     "download": "/epr/no_stream_configs/no_stream_configs-1.0.0.tar.gz",
     "downloads": [
       {
@@ -110,13 +87,6 @@
         "type": "tar.gz"
       }
     ],
->>>>>>> f5fea69e... Add list of downloads to /search endpoint
-    "name": "no_stream_configs",
-    "title": "No Stream configs",
-    "version": "1.0.0",
-    "description": "This package does contain a dataset but not stream configs.\n",
-    "type": "integration",
-    "download": "/epr/no_stream_configs/no_stream_configs-1.0.0.tar.gz",
     "path": "/package/no_stream_configs/1.0.0"
   }
 ]

--- a/docs/api/search-kibana652.json
+++ b/docs/api/search-kibana652.json
@@ -9,7 +9,7 @@
     "downloads": [
       {
         "path": "/epr/datasources/datasources-1.0.0.tar.gz",
-        "type": "tar.gz"
+        "type": "tar"
       }
     ],
     "path": "/package/datasources/1.0.0"
@@ -24,7 +24,7 @@
     "downloads": [
       {
         "path": "/epr/default_pipeline/default_pipeline-0.0.2.tar.gz",
-        "type": "tar.gz"
+        "type": "tar"
       }
     ],
     "path": "/package/default_pipeline/0.0.2"
@@ -39,7 +39,7 @@
     "downloads": [
       {
         "path": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.tar.gz",
-        "type": "tar.gz"
+        "type": "tar"
       }
     ],
     "path": "/package/ecs_style_dataset/0.0.1"
@@ -54,7 +54,7 @@
     "downloads": [
       {
         "path": "/epr/example/example-0.0.2.tar.gz",
-        "type": "tar.gz"
+        "type": "tar"
       }
     ],
     "path": "/package/example/0.0.2"
@@ -69,7 +69,7 @@
     "downloads": [
       {
         "path": "/epr/multiple_false/multiple_false-0.0.1.tar.gz",
-        "type": "tar.gz"
+        "type": "tar"
       }
     ],
     "path": "/package/multiple_false/0.0.1"
@@ -84,7 +84,7 @@
     "downloads": [
       {
         "path": "/epr/no_stream_configs/no_stream_configs-1.0.0.tar.gz",
-        "type": "tar.gz"
+        "type": "tar"
       }
     ],
     "path": "/package/no_stream_configs/1.0.0"

--- a/docs/api/search-kibana652.json
+++ b/docs/api/search-kibana652.json
@@ -1,5 +1,16 @@
 [
   {
+<<<<<<< HEAD
+=======
+    "description": "Package with data sources",
+    "download": "/epr/datasources/datasources-1.0.0.tar.gz",
+    "downloads": [
+      {
+        "path": "/epr/datasources/datasources-1.0.0.tar.gz",
+        "type": "tar.gz"
+      }
+    ],
+>>>>>>> f5fea69e... Add list of downloads to /search endpoint
     "name": "datasources",
     "title": "Default datasource Integration",
     "version": "1.0.0",
@@ -9,6 +20,17 @@
     "path": "/package/datasources/1.0.0"
   },
   {
+<<<<<<< HEAD
+=======
+    "description": "Tests if no pipeline is set, it defaults to the default one",
+    "download": "/epr/default_pipeline/default_pipeline-0.0.2.tar.gz",
+    "downloads": [
+      {
+        "path": "/epr/default_pipeline/default_pipeline-0.0.2.tar.gz",
+        "type": "tar.gz"
+      }
+    ],
+>>>>>>> f5fea69e... Add list of downloads to /search endpoint
     "name": "default_pipeline",
     "title": "Default pipeline Integration",
     "version": "0.0.2",
@@ -18,6 +40,17 @@
     "path": "/package/default_pipeline/0.0.2"
   },
   {
+<<<<<<< HEAD
+=======
+    "description": "Tests the registry validations works for dataset fields using the ecs style format",
+    "download": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.tar.gz",
+    "downloads": [
+      {
+        "path": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.tar.gz",
+        "type": "tar.gz"
+      }
+    ],
+>>>>>>> f5fea69e... Add list of downloads to /search endpoint
     "name": "ecs_style_dataset",
     "title": "Default pipeline Integration",
     "version": "0.0.1",
@@ -27,6 +60,17 @@
     "path": "/package/ecs_style_dataset/0.0.1"
   },
   {
+<<<<<<< HEAD
+=======
+    "description": "This is the example integration.",
+    "download": "/epr/example/example-0.0.2.tar.gz",
+    "downloads": [
+      {
+        "path": "/epr/example/example-0.0.2.tar.gz",
+        "type": "tar.gz"
+      }
+    ],
+>>>>>>> f5fea69e... Add list of downloads to /search endpoint
     "name": "example",
     "title": "Example",
     "version": "0.0.2",
@@ -36,6 +80,17 @@
     "path": "/package/example/0.0.2"
   },
   {
+<<<<<<< HEAD
+=======
+    "description": "Tests that multiple can be set to false",
+    "download": "/epr/multiple_false/multiple_false-0.0.1.tar.gz",
+    "downloads": [
+      {
+        "path": "/epr/multiple_false/multiple_false-0.0.1.tar.gz",
+        "type": "tar.gz"
+      }
+    ],
+>>>>>>> f5fea69e... Add list of downloads to /search endpoint
     "name": "multiple_false",
     "title": "Multiple false",
     "version": "0.0.1",
@@ -45,6 +100,17 @@
     "path": "/package/multiple_false/0.0.1"
   },
   {
+<<<<<<< HEAD
+=======
+    "description": "This package does contain a dataset but not stream configs.\n",
+    "download": "/epr/no_stream_configs/no_stream_configs-1.0.0.tar.gz",
+    "downloads": [
+      {
+        "path": "/epr/no_stream_configs/no_stream_configs-1.0.0.tar.gz",
+        "type": "tar.gz"
+      }
+    ],
+>>>>>>> f5fea69e... Add list of downloads to /search endpoint
     "name": "no_stream_configs",
     "title": "No Stream configs",
     "version": "1.0.0",

--- a/docs/api/search-kibana721.json
+++ b/docs/api/search-kibana721.json
@@ -1,8 +1,10 @@
 [
   {
-<<<<<<< HEAD
-=======
+    "name": "datasources",
+    "title": "Default datasource Integration",
+    "version": "1.0.0",
     "description": "Package with data sources",
+    "type": "integration",
     "download": "/epr/datasources/datasources-1.0.0.tar.gz",
     "downloads": [
       {
@@ -10,19 +12,14 @@
         "type": "tar.gz"
       }
     ],
->>>>>>> f5fea69e... Add list of downloads to /search endpoint
-    "name": "datasources",
-    "title": "Default datasource Integration",
-    "version": "1.0.0",
-    "description": "Package with data sources",
-    "type": "integration",
-    "download": "/epr/datasources/datasources-1.0.0.tar.gz",
     "path": "/package/datasources/1.0.0"
   },
   {
-<<<<<<< HEAD
-=======
+    "name": "default_pipeline",
+    "title": "Default pipeline Integration",
+    "version": "0.0.2",
     "description": "Tests if no pipeline is set, it defaults to the default one",
+    "type": "integration",
     "download": "/epr/default_pipeline/default_pipeline-0.0.2.tar.gz",
     "downloads": [
       {
@@ -30,19 +27,14 @@
         "type": "tar.gz"
       }
     ],
->>>>>>> f5fea69e... Add list of downloads to /search endpoint
-    "name": "default_pipeline",
-    "title": "Default pipeline Integration",
-    "version": "0.0.2",
-    "description": "Tests if no pipeline is set, it defaults to the default one",
-    "type": "integration",
-    "download": "/epr/default_pipeline/default_pipeline-0.0.2.tar.gz",
     "path": "/package/default_pipeline/0.0.2"
   },
   {
-<<<<<<< HEAD
-=======
+    "name": "ecs_style_dataset",
+    "title": "Default pipeline Integration",
+    "version": "0.0.1",
     "description": "Tests the registry validations works for dataset fields using the ecs style format",
+    "type": "integration",
     "download": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.tar.gz",
     "downloads": [
       {
@@ -50,19 +42,14 @@
         "type": "tar.gz"
       }
     ],
->>>>>>> f5fea69e... Add list of downloads to /search endpoint
-    "name": "ecs_style_dataset",
-    "title": "Default pipeline Integration",
-    "version": "0.0.1",
-    "description": "Tests the registry validations works for dataset fields using the ecs style format",
-    "type": "integration",
-    "download": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.tar.gz",
     "path": "/package/ecs_style_dataset/0.0.1"
   },
   {
-<<<<<<< HEAD
-=======
+    "name": "example",
+    "title": "Example Integration",
+    "version": "1.0.0",
     "description": "This is the example integration",
+    "type": "integration",
     "download": "/epr/example/example-1.0.0.tar.gz",
     "downloads": [
       {
@@ -70,19 +57,14 @@
         "type": "tar.gz"
       }
     ],
->>>>>>> f5fea69e... Add list of downloads to /search endpoint
-    "name": "example",
-    "title": "Example Integration",
-    "version": "1.0.0",
-    "description": "This is the example integration",
-    "type": "integration",
-    "download": "/epr/example/example-1.0.0.tar.gz",
     "path": "/package/example/1.0.0"
   },
   {
-<<<<<<< HEAD
-=======
+    "name": "foo",
+    "title": "Foo",
+    "version": "1.0.0",
     "description": "This is the foo integration",
+    "type": "solution",
     "download": "/epr/foo/foo-1.0.0.tar.gz",
     "downloads": [
       {
@@ -90,19 +72,14 @@
         "type": "tar.gz"
       }
     ],
->>>>>>> f5fea69e... Add list of downloads to /search endpoint
-    "name": "foo",
-    "title": "Foo",
-    "version": "1.0.0",
-    "description": "This is the foo integration",
-    "type": "solution",
-    "download": "/epr/foo/foo-1.0.0.tar.gz",
     "path": "/package/foo/1.0.0"
   },
   {
-<<<<<<< HEAD
-=======
+    "name": "multiple_false",
+    "title": "Multiple false",
+    "version": "0.0.1",
     "description": "Tests that multiple can be set to false",
+    "type": "integration",
     "download": "/epr/multiple_false/multiple_false-0.0.1.tar.gz",
     "downloads": [
       {
@@ -110,19 +87,14 @@
         "type": "tar.gz"
       }
     ],
->>>>>>> f5fea69e... Add list of downloads to /search endpoint
-    "name": "multiple_false",
-    "title": "Multiple false",
-    "version": "0.0.1",
-    "description": "Tests that multiple can be set to false",
-    "type": "integration",
-    "download": "/epr/multiple_false/multiple_false-0.0.1.tar.gz",
     "path": "/package/multiple_false/0.0.1"
   },
   {
-<<<<<<< HEAD
-=======
+    "name": "no_stream_configs",
+    "title": "No Stream configs",
+    "version": "1.0.0",
     "description": "This package does contain a dataset but not stream configs.\n",
+    "type": "integration",
     "download": "/epr/no_stream_configs/no_stream_configs-1.0.0.tar.gz",
     "downloads": [
       {
@@ -130,13 +102,6 @@
         "type": "tar.gz"
       }
     ],
->>>>>>> f5fea69e... Add list of downloads to /search endpoint
-    "name": "no_stream_configs",
-    "title": "No Stream configs",
-    "version": "1.0.0",
-    "description": "This package does contain a dataset but not stream configs.\n",
-    "type": "integration",
-    "download": "/epr/no_stream_configs/no_stream_configs-1.0.0.tar.gz",
     "path": "/package/no_stream_configs/1.0.0"
   }
 ]

--- a/docs/api/search-kibana721.json
+++ b/docs/api/search-kibana721.json
@@ -1,5 +1,16 @@
 [
   {
+<<<<<<< HEAD
+=======
+    "description": "Package with data sources",
+    "download": "/epr/datasources/datasources-1.0.0.tar.gz",
+    "downloads": [
+      {
+        "path": "/epr/datasources/datasources-1.0.0.tar.gz",
+        "type": "tar.gz"
+      }
+    ],
+>>>>>>> f5fea69e... Add list of downloads to /search endpoint
     "name": "datasources",
     "title": "Default datasource Integration",
     "version": "1.0.0",
@@ -9,6 +20,17 @@
     "path": "/package/datasources/1.0.0"
   },
   {
+<<<<<<< HEAD
+=======
+    "description": "Tests if no pipeline is set, it defaults to the default one",
+    "download": "/epr/default_pipeline/default_pipeline-0.0.2.tar.gz",
+    "downloads": [
+      {
+        "path": "/epr/default_pipeline/default_pipeline-0.0.2.tar.gz",
+        "type": "tar.gz"
+      }
+    ],
+>>>>>>> f5fea69e... Add list of downloads to /search endpoint
     "name": "default_pipeline",
     "title": "Default pipeline Integration",
     "version": "0.0.2",
@@ -18,6 +40,17 @@
     "path": "/package/default_pipeline/0.0.2"
   },
   {
+<<<<<<< HEAD
+=======
+    "description": "Tests the registry validations works for dataset fields using the ecs style format",
+    "download": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.tar.gz",
+    "downloads": [
+      {
+        "path": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.tar.gz",
+        "type": "tar.gz"
+      }
+    ],
+>>>>>>> f5fea69e... Add list of downloads to /search endpoint
     "name": "ecs_style_dataset",
     "title": "Default pipeline Integration",
     "version": "0.0.1",
@@ -27,6 +60,17 @@
     "path": "/package/ecs_style_dataset/0.0.1"
   },
   {
+<<<<<<< HEAD
+=======
+    "description": "This is the example integration",
+    "download": "/epr/example/example-1.0.0.tar.gz",
+    "downloads": [
+      {
+        "path": "/epr/example/example-1.0.0.tar.gz",
+        "type": "tar.gz"
+      }
+    ],
+>>>>>>> f5fea69e... Add list of downloads to /search endpoint
     "name": "example",
     "title": "Example Integration",
     "version": "1.0.0",
@@ -36,6 +80,17 @@
     "path": "/package/example/1.0.0"
   },
   {
+<<<<<<< HEAD
+=======
+    "description": "This is the foo integration",
+    "download": "/epr/foo/foo-1.0.0.tar.gz",
+    "downloads": [
+      {
+        "path": "/epr/foo/foo-1.0.0.tar.gz",
+        "type": "tar.gz"
+      }
+    ],
+>>>>>>> f5fea69e... Add list of downloads to /search endpoint
     "name": "foo",
     "title": "Foo",
     "version": "1.0.0",
@@ -45,6 +100,17 @@
     "path": "/package/foo/1.0.0"
   },
   {
+<<<<<<< HEAD
+=======
+    "description": "Tests that multiple can be set to false",
+    "download": "/epr/multiple_false/multiple_false-0.0.1.tar.gz",
+    "downloads": [
+      {
+        "path": "/epr/multiple_false/multiple_false-0.0.1.tar.gz",
+        "type": "tar.gz"
+      }
+    ],
+>>>>>>> f5fea69e... Add list of downloads to /search endpoint
     "name": "multiple_false",
     "title": "Multiple false",
     "version": "0.0.1",
@@ -54,6 +120,17 @@
     "path": "/package/multiple_false/0.0.1"
   },
   {
+<<<<<<< HEAD
+=======
+    "description": "This package does contain a dataset but not stream configs.\n",
+    "download": "/epr/no_stream_configs/no_stream_configs-1.0.0.tar.gz",
+    "downloads": [
+      {
+        "path": "/epr/no_stream_configs/no_stream_configs-1.0.0.tar.gz",
+        "type": "tar.gz"
+      }
+    ],
+>>>>>>> f5fea69e... Add list of downloads to /search endpoint
     "name": "no_stream_configs",
     "title": "No Stream configs",
     "version": "1.0.0",

--- a/docs/api/search-kibana721.json
+++ b/docs/api/search-kibana721.json
@@ -9,7 +9,7 @@
     "downloads": [
       {
         "path": "/epr/datasources/datasources-1.0.0.tar.gz",
-        "type": "tar.gz"
+        "type": "tar"
       }
     ],
     "path": "/package/datasources/1.0.0"
@@ -24,7 +24,7 @@
     "downloads": [
       {
         "path": "/epr/default_pipeline/default_pipeline-0.0.2.tar.gz",
-        "type": "tar.gz"
+        "type": "tar"
       }
     ],
     "path": "/package/default_pipeline/0.0.2"
@@ -39,7 +39,7 @@
     "downloads": [
       {
         "path": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.tar.gz",
-        "type": "tar.gz"
+        "type": "tar"
       }
     ],
     "path": "/package/ecs_style_dataset/0.0.1"
@@ -54,7 +54,7 @@
     "downloads": [
       {
         "path": "/epr/example/example-1.0.0.tar.gz",
-        "type": "tar.gz"
+        "type": "tar"
       }
     ],
     "path": "/package/example/1.0.0"
@@ -69,7 +69,7 @@
     "downloads": [
       {
         "path": "/epr/foo/foo-1.0.0.tar.gz",
-        "type": "tar.gz"
+        "type": "tar"
       }
     ],
     "path": "/package/foo/1.0.0"
@@ -84,7 +84,7 @@
     "downloads": [
       {
         "path": "/epr/multiple_false/multiple_false-0.0.1.tar.gz",
-        "type": "tar.gz"
+        "type": "tar"
       }
     ],
     "path": "/package/multiple_false/0.0.1"
@@ -99,7 +99,7 @@
     "downloads": [
       {
         "path": "/epr/no_stream_configs/no_stream_configs-1.0.0.tar.gz",
-        "type": "tar.gz"
+        "type": "tar"
       }
     ],
     "path": "/package/no_stream_configs/1.0.0"

--- a/docs/api/search-package-example-all.json
+++ b/docs/api/search-package-example-all.json
@@ -1,5 +1,16 @@
 [
   {
+<<<<<<< HEAD
+=======
+    "description": "This is the example integration.",
+    "download": "/epr/example/example-0.0.2.tar.gz",
+    "downloads": [
+      {
+        "path": "/epr/example/example-0.0.2.tar.gz",
+        "type": "tar.gz"
+      }
+    ],
+>>>>>>> f5fea69e... Add list of downloads to /search endpoint
     "name": "example",
     "title": "Example",
     "version": "0.0.2",
@@ -9,6 +20,17 @@
     "path": "/package/example/0.0.2"
   },
   {
+<<<<<<< HEAD
+=======
+    "description": "This is the example integration",
+    "download": "/epr/example/example-1.0.0.tar.gz",
+    "downloads": [
+      {
+        "path": "/epr/example/example-1.0.0.tar.gz",
+        "type": "tar.gz"
+      }
+    ],
+>>>>>>> f5fea69e... Add list of downloads to /search endpoint
     "name": "example",
     "title": "Example Integration",
     "version": "1.0.0",

--- a/docs/api/search-package-example-all.json
+++ b/docs/api/search-package-example-all.json
@@ -9,7 +9,7 @@
     "downloads": [
       {
         "path": "/epr/example/example-0.0.2.tar.gz",
-        "type": "tar.gz"
+        "type": "tar"
       }
     ],
     "path": "/package/example/0.0.2"
@@ -24,7 +24,7 @@
     "downloads": [
       {
         "path": "/epr/example/example-1.0.0.tar.gz",
-        "type": "tar.gz"
+        "type": "tar"
       }
     ],
     "path": "/package/example/1.0.0"

--- a/docs/api/search-package-example-all.json
+++ b/docs/api/search-package-example-all.json
@@ -1,8 +1,10 @@
 [
   {
-<<<<<<< HEAD
-=======
+    "name": "example",
+    "title": "Example",
+    "version": "0.0.2",
     "description": "This is the example integration.",
+    "type": "integration",
     "download": "/epr/example/example-0.0.2.tar.gz",
     "downloads": [
       {
@@ -10,19 +12,14 @@
         "type": "tar.gz"
       }
     ],
->>>>>>> f5fea69e... Add list of downloads to /search endpoint
-    "name": "example",
-    "title": "Example",
-    "version": "0.0.2",
-    "description": "This is the example integration.",
-    "type": "integration",
-    "download": "/epr/example/example-0.0.2.tar.gz",
     "path": "/package/example/0.0.2"
   },
   {
-<<<<<<< HEAD
-=======
+    "name": "example",
+    "title": "Example Integration",
+    "version": "1.0.0",
     "description": "This is the example integration",
+    "type": "integration",
     "download": "/epr/example/example-1.0.0.tar.gz",
     "downloads": [
       {
@@ -30,13 +27,6 @@
         "type": "tar.gz"
       }
     ],
->>>>>>> f5fea69e... Add list of downloads to /search endpoint
-    "name": "example",
-    "title": "Example Integration",
-    "version": "1.0.0",
-    "description": "This is the example integration",
-    "type": "integration",
-    "download": "/epr/example/example-1.0.0.tar.gz",
     "path": "/package/example/1.0.0"
   }
 ]

--- a/docs/api/search-package-example.json
+++ b/docs/api/search-package-example.json
@@ -1,8 +1,10 @@
 [
   {
-<<<<<<< HEAD
-=======
+    "name": "example",
+    "title": "Example Integration",
+    "version": "1.0.0",
     "description": "This is the example integration",
+    "type": "integration",
     "download": "/epr/example/example-1.0.0.tar.gz",
     "downloads": [
       {
@@ -10,13 +12,6 @@
         "type": "tar.gz"
       }
     ],
->>>>>>> f5fea69e... Add list of downloads to /search endpoint
-    "name": "example",
-    "title": "Example Integration",
-    "version": "1.0.0",
-    "description": "This is the example integration",
-    "type": "integration",
-    "download": "/epr/example/example-1.0.0.tar.gz",
     "path": "/package/example/1.0.0"
   }
 ]

--- a/docs/api/search-package-example.json
+++ b/docs/api/search-package-example.json
@@ -9,7 +9,7 @@
     "downloads": [
       {
         "path": "/epr/example/example-1.0.0.tar.gz",
-        "type": "tar.gz"
+        "type": "tar"
       }
     ],
     "path": "/package/example/1.0.0"

--- a/docs/api/search-package-example.json
+++ b/docs/api/search-package-example.json
@@ -1,5 +1,16 @@
 [
   {
+<<<<<<< HEAD
+=======
+    "description": "This is the example integration",
+    "download": "/epr/example/example-1.0.0.tar.gz",
+    "downloads": [
+      {
+        "path": "/epr/example/example-1.0.0.tar.gz",
+        "type": "tar.gz"
+      }
+    ],
+>>>>>>> f5fea69e... Add list of downloads to /search endpoint
     "name": "example",
     "title": "Example Integration",
     "version": "1.0.0",

--- a/docs/api/search-package-experimental.json
+++ b/docs/api/search-package-experimental.json
@@ -9,7 +9,7 @@
     "downloads": [
       {
         "path": "/epr/datasources/datasources-1.0.0.tar.gz",
-        "type": "tar.gz"
+        "type": "tar"
       }
     ],
     "path": "/package/datasources/1.0.0"
@@ -24,7 +24,7 @@
     "downloads": [
       {
         "path": "/epr/default_pipeline/default_pipeline-0.0.2.tar.gz",
-        "type": "tar.gz"
+        "type": "tar"
       }
     ],
     "path": "/package/default_pipeline/0.0.2"
@@ -39,7 +39,7 @@
     "downloads": [
       {
         "path": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.tar.gz",
-        "type": "tar.gz"
+        "type": "tar"
       }
     ],
     "path": "/package/ecs_style_dataset/0.0.1"
@@ -54,7 +54,7 @@
     "downloads": [
       {
         "path": "/epr/example/example-1.0.0.tar.gz",
-        "type": "tar.gz"
+        "type": "tar"
       }
     ],
     "path": "/package/example/1.0.0"
@@ -69,7 +69,7 @@
     "downloads": [
       {
         "path": "/epr/experimental/experimental-0.0.1.tar.gz",
-        "type": "tar.gz"
+        "type": "tar"
       }
     ],
     "path": "/package/experimental/0.0.1"
@@ -84,7 +84,7 @@
     "downloads": [
       {
         "path": "/epr/foo/foo-1.0.0.tar.gz",
-        "type": "tar.gz"
+        "type": "tar"
       }
     ],
     "path": "/package/foo/1.0.0"
@@ -99,7 +99,7 @@
     "downloads": [
       {
         "path": "/epr/multiple_false/multiple_false-0.0.1.tar.gz",
-        "type": "tar.gz"
+        "type": "tar"
       }
     ],
     "path": "/package/multiple_false/0.0.1"
@@ -114,7 +114,7 @@
     "downloads": [
       {
         "path": "/epr/no_stream_configs/no_stream_configs-1.0.0.tar.gz",
-        "type": "tar.gz"
+        "type": "tar"
       }
     ],
     "path": "/package/no_stream_configs/1.0.0"

--- a/docs/api/search-package-experimental.json
+++ b/docs/api/search-package-experimental.json
@@ -1,5 +1,16 @@
 [
   {
+<<<<<<< HEAD
+=======
+    "description": "Package with data sources",
+    "download": "/epr/datasources/datasources-1.0.0.tar.gz",
+    "downloads": [
+      {
+        "path": "/epr/datasources/datasources-1.0.0.tar.gz",
+        "type": "tar.gz"
+      }
+    ],
+>>>>>>> f5fea69e... Add list of downloads to /search endpoint
     "name": "datasources",
     "title": "Default datasource Integration",
     "version": "1.0.0",
@@ -9,6 +20,17 @@
     "path": "/package/datasources/1.0.0"
   },
   {
+<<<<<<< HEAD
+=======
+    "description": "Tests if no pipeline is set, it defaults to the default one",
+    "download": "/epr/default_pipeline/default_pipeline-0.0.2.tar.gz",
+    "downloads": [
+      {
+        "path": "/epr/default_pipeline/default_pipeline-0.0.2.tar.gz",
+        "type": "tar.gz"
+      }
+    ],
+>>>>>>> f5fea69e... Add list of downloads to /search endpoint
     "name": "default_pipeline",
     "title": "Default pipeline Integration",
     "version": "0.0.2",
@@ -18,6 +40,17 @@
     "path": "/package/default_pipeline/0.0.2"
   },
   {
+<<<<<<< HEAD
+=======
+    "description": "Tests the registry validations works for dataset fields using the ecs style format",
+    "download": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.tar.gz",
+    "downloads": [
+      {
+        "path": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.tar.gz",
+        "type": "tar.gz"
+      }
+    ],
+>>>>>>> f5fea69e... Add list of downloads to /search endpoint
     "name": "ecs_style_dataset",
     "title": "Default pipeline Integration",
     "version": "0.0.1",
@@ -27,6 +60,17 @@
     "path": "/package/ecs_style_dataset/0.0.1"
   },
   {
+<<<<<<< HEAD
+=======
+    "description": "This is the example integration",
+    "download": "/epr/example/example-1.0.0.tar.gz",
+    "downloads": [
+      {
+        "path": "/epr/example/example-1.0.0.tar.gz",
+        "type": "tar.gz"
+      }
+    ],
+>>>>>>> f5fea69e... Add list of downloads to /search endpoint
     "name": "example",
     "title": "Example Integration",
     "version": "1.0.0",
@@ -36,6 +80,17 @@
     "path": "/package/example/1.0.0"
   },
   {
+<<<<<<< HEAD
+=======
+    "description": "Experimental package, should be set by default",
+    "download": "/epr/experimental/experimental-0.0.1.tar.gz",
+    "downloads": [
+      {
+        "path": "/epr/experimental/experimental-0.0.1.tar.gz",
+        "type": "tar.gz"
+      }
+    ],
+>>>>>>> f5fea69e... Add list of downloads to /search endpoint
     "name": "experimental",
     "title": "Experimental",
     "version": "0.0.1",
@@ -45,6 +100,17 @@
     "path": "/package/experimental/0.0.1"
   },
   {
+<<<<<<< HEAD
+=======
+    "description": "This is the foo integration",
+    "download": "/epr/foo/foo-1.0.0.tar.gz",
+    "downloads": [
+      {
+        "path": "/epr/foo/foo-1.0.0.tar.gz",
+        "type": "tar.gz"
+      }
+    ],
+>>>>>>> f5fea69e... Add list of downloads to /search endpoint
     "name": "foo",
     "title": "Foo",
     "version": "1.0.0",
@@ -54,6 +120,17 @@
     "path": "/package/foo/1.0.0"
   },
   {
+<<<<<<< HEAD
+=======
+    "description": "Tests that multiple can be set to false",
+    "download": "/epr/multiple_false/multiple_false-0.0.1.tar.gz",
+    "downloads": [
+      {
+        "path": "/epr/multiple_false/multiple_false-0.0.1.tar.gz",
+        "type": "tar.gz"
+      }
+    ],
+>>>>>>> f5fea69e... Add list of downloads to /search endpoint
     "name": "multiple_false",
     "title": "Multiple false",
     "version": "0.0.1",
@@ -63,6 +140,17 @@
     "path": "/package/multiple_false/0.0.1"
   },
   {
+<<<<<<< HEAD
+=======
+    "description": "This package does contain a dataset but not stream configs.\n",
+    "download": "/epr/no_stream_configs/no_stream_configs-1.0.0.tar.gz",
+    "downloads": [
+      {
+        "path": "/epr/no_stream_configs/no_stream_configs-1.0.0.tar.gz",
+        "type": "tar.gz"
+      }
+    ],
+>>>>>>> f5fea69e... Add list of downloads to /search endpoint
     "name": "no_stream_configs",
     "title": "No Stream configs",
     "version": "1.0.0",

--- a/docs/api/search-package-experimental.json
+++ b/docs/api/search-package-experimental.json
@@ -1,8 +1,10 @@
 [
   {
-<<<<<<< HEAD
-=======
+    "name": "datasources",
+    "title": "Default datasource Integration",
+    "version": "1.0.0",
     "description": "Package with data sources",
+    "type": "integration",
     "download": "/epr/datasources/datasources-1.0.0.tar.gz",
     "downloads": [
       {
@@ -10,19 +12,14 @@
         "type": "tar.gz"
       }
     ],
->>>>>>> f5fea69e... Add list of downloads to /search endpoint
-    "name": "datasources",
-    "title": "Default datasource Integration",
-    "version": "1.0.0",
-    "description": "Package with data sources",
-    "type": "integration",
-    "download": "/epr/datasources/datasources-1.0.0.tar.gz",
     "path": "/package/datasources/1.0.0"
   },
   {
-<<<<<<< HEAD
-=======
+    "name": "default_pipeline",
+    "title": "Default pipeline Integration",
+    "version": "0.0.2",
     "description": "Tests if no pipeline is set, it defaults to the default one",
+    "type": "integration",
     "download": "/epr/default_pipeline/default_pipeline-0.0.2.tar.gz",
     "downloads": [
       {
@@ -30,19 +27,14 @@
         "type": "tar.gz"
       }
     ],
->>>>>>> f5fea69e... Add list of downloads to /search endpoint
-    "name": "default_pipeline",
-    "title": "Default pipeline Integration",
-    "version": "0.0.2",
-    "description": "Tests if no pipeline is set, it defaults to the default one",
-    "type": "integration",
-    "download": "/epr/default_pipeline/default_pipeline-0.0.2.tar.gz",
     "path": "/package/default_pipeline/0.0.2"
   },
   {
-<<<<<<< HEAD
-=======
+    "name": "ecs_style_dataset",
+    "title": "Default pipeline Integration",
+    "version": "0.0.1",
     "description": "Tests the registry validations works for dataset fields using the ecs style format",
+    "type": "integration",
     "download": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.tar.gz",
     "downloads": [
       {
@@ -50,19 +42,14 @@
         "type": "tar.gz"
       }
     ],
->>>>>>> f5fea69e... Add list of downloads to /search endpoint
-    "name": "ecs_style_dataset",
-    "title": "Default pipeline Integration",
-    "version": "0.0.1",
-    "description": "Tests the registry validations works for dataset fields using the ecs style format",
-    "type": "integration",
-    "download": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.tar.gz",
     "path": "/package/ecs_style_dataset/0.0.1"
   },
   {
-<<<<<<< HEAD
-=======
+    "name": "example",
+    "title": "Example Integration",
+    "version": "1.0.0",
     "description": "This is the example integration",
+    "type": "integration",
     "download": "/epr/example/example-1.0.0.tar.gz",
     "downloads": [
       {
@@ -70,19 +57,14 @@
         "type": "tar.gz"
       }
     ],
->>>>>>> f5fea69e... Add list of downloads to /search endpoint
-    "name": "example",
-    "title": "Example Integration",
-    "version": "1.0.0",
-    "description": "This is the example integration",
-    "type": "integration",
-    "download": "/epr/example/example-1.0.0.tar.gz",
     "path": "/package/example/1.0.0"
   },
   {
-<<<<<<< HEAD
-=======
+    "name": "experimental",
+    "title": "Experimental",
+    "version": "0.0.1",
     "description": "Experimental package, should be set by default",
+    "type": "solution",
     "download": "/epr/experimental/experimental-0.0.1.tar.gz",
     "downloads": [
       {
@@ -90,19 +72,14 @@
         "type": "tar.gz"
       }
     ],
->>>>>>> f5fea69e... Add list of downloads to /search endpoint
-    "name": "experimental",
-    "title": "Experimental",
-    "version": "0.0.1",
-    "description": "Experimental package, should be set by default",
-    "type": "solution",
-    "download": "/epr/experimental/experimental-0.0.1.tar.gz",
     "path": "/package/experimental/0.0.1"
   },
   {
-<<<<<<< HEAD
-=======
+    "name": "foo",
+    "title": "Foo",
+    "version": "1.0.0",
     "description": "This is the foo integration",
+    "type": "solution",
     "download": "/epr/foo/foo-1.0.0.tar.gz",
     "downloads": [
       {
@@ -110,19 +87,14 @@
         "type": "tar.gz"
       }
     ],
->>>>>>> f5fea69e... Add list of downloads to /search endpoint
-    "name": "foo",
-    "title": "Foo",
-    "version": "1.0.0",
-    "description": "This is the foo integration",
-    "type": "solution",
-    "download": "/epr/foo/foo-1.0.0.tar.gz",
     "path": "/package/foo/1.0.0"
   },
   {
-<<<<<<< HEAD
-=======
+    "name": "multiple_false",
+    "title": "Multiple false",
+    "version": "0.0.1",
     "description": "Tests that multiple can be set to false",
+    "type": "integration",
     "download": "/epr/multiple_false/multiple_false-0.0.1.tar.gz",
     "downloads": [
       {
@@ -130,19 +102,14 @@
         "type": "tar.gz"
       }
     ],
->>>>>>> f5fea69e... Add list of downloads to /search endpoint
-    "name": "multiple_false",
-    "title": "Multiple false",
-    "version": "0.0.1",
-    "description": "Tests that multiple can be set to false",
-    "type": "integration",
-    "download": "/epr/multiple_false/multiple_false-0.0.1.tar.gz",
     "path": "/package/multiple_false/0.0.1"
   },
   {
-<<<<<<< HEAD
-=======
+    "name": "no_stream_configs",
+    "title": "No Stream configs",
+    "version": "1.0.0",
     "description": "This package does contain a dataset but not stream configs.\n",
+    "type": "integration",
     "download": "/epr/no_stream_configs/no_stream_configs-1.0.0.tar.gz",
     "downloads": [
       {
@@ -150,13 +117,6 @@
         "type": "tar.gz"
       }
     ],
->>>>>>> f5fea69e... Add list of downloads to /search endpoint
-    "name": "no_stream_configs",
-    "title": "No Stream configs",
-    "version": "1.0.0",
-    "description": "This package does contain a dataset but not stream configs.\n",
-    "type": "integration",
-    "download": "/epr/no_stream_configs/no_stream_configs-1.0.0.tar.gz",
     "path": "/package/no_stream_configs/1.0.0"
   }
 ]

--- a/docs/api/search-package-internal.json
+++ b/docs/api/search-package-internal.json
@@ -9,7 +9,7 @@
     "downloads": [
       {
         "path": "/epr/datasources/datasources-1.0.0.tar.gz",
-        "type": "tar.gz"
+        "type": "tar"
       }
     ],
     "path": "/package/datasources/1.0.0"
@@ -24,7 +24,7 @@
     "downloads": [
       {
         "path": "/epr/default_pipeline/default_pipeline-0.0.2.tar.gz",
-        "type": "tar.gz"
+        "type": "tar"
       }
     ],
     "path": "/package/default_pipeline/0.0.2"
@@ -39,7 +39,7 @@
     "downloads": [
       {
         "path": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.tar.gz",
-        "type": "tar.gz"
+        "type": "tar"
       }
     ],
     "path": "/package/ecs_style_dataset/0.0.1"
@@ -54,7 +54,7 @@
     "downloads": [
       {
         "path": "/epr/example/example-1.0.0.tar.gz",
-        "type": "tar.gz"
+        "type": "tar"
       }
     ],
     "path": "/package/example/1.0.0"
@@ -69,7 +69,7 @@
     "downloads": [
       {
         "path": "/epr/foo/foo-1.0.0.tar.gz",
-        "type": "tar.gz"
+        "type": "tar"
       }
     ],
     "path": "/package/foo/1.0.0"
@@ -84,7 +84,7 @@
     "downloads": [
       {
         "path": "/epr/internal/internal-1.2.0.tar.gz",
-        "type": "tar.gz"
+        "type": "tar"
       }
     ],
     "path": "/package/internal/1.2.0",
@@ -100,7 +100,7 @@
     "downloads": [
       {
         "path": "/epr/multiple_false/multiple_false-0.0.1.tar.gz",
-        "type": "tar.gz"
+        "type": "tar"
       }
     ],
     "path": "/package/multiple_false/0.0.1"
@@ -115,7 +115,7 @@
     "downloads": [
       {
         "path": "/epr/no_stream_configs/no_stream_configs-1.0.0.tar.gz",
-        "type": "tar.gz"
+        "type": "tar"
       }
     ],
     "path": "/package/no_stream_configs/1.0.0"

--- a/docs/api/search-package-internal.json
+++ b/docs/api/search-package-internal.json
@@ -1,5 +1,16 @@
 [
   {
+<<<<<<< HEAD
+=======
+    "description": "Package with data sources",
+    "download": "/epr/datasources/datasources-1.0.0.tar.gz",
+    "downloads": [
+      {
+        "path": "/epr/datasources/datasources-1.0.0.tar.gz",
+        "type": "tar.gz"
+      }
+    ],
+>>>>>>> f5fea69e... Add list of downloads to /search endpoint
     "name": "datasources",
     "title": "Default datasource Integration",
     "version": "1.0.0",
@@ -9,6 +20,17 @@
     "path": "/package/datasources/1.0.0"
   },
   {
+<<<<<<< HEAD
+=======
+    "description": "Tests if no pipeline is set, it defaults to the default one",
+    "download": "/epr/default_pipeline/default_pipeline-0.0.2.tar.gz",
+    "downloads": [
+      {
+        "path": "/epr/default_pipeline/default_pipeline-0.0.2.tar.gz",
+        "type": "tar.gz"
+      }
+    ],
+>>>>>>> f5fea69e... Add list of downloads to /search endpoint
     "name": "default_pipeline",
     "title": "Default pipeline Integration",
     "version": "0.0.2",
@@ -18,6 +40,17 @@
     "path": "/package/default_pipeline/0.0.2"
   },
   {
+<<<<<<< HEAD
+=======
+    "description": "Tests the registry validations works for dataset fields using the ecs style format",
+    "download": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.tar.gz",
+    "downloads": [
+      {
+        "path": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.tar.gz",
+        "type": "tar.gz"
+      }
+    ],
+>>>>>>> f5fea69e... Add list of downloads to /search endpoint
     "name": "ecs_style_dataset",
     "title": "Default pipeline Integration",
     "version": "0.0.1",
@@ -27,6 +60,17 @@
     "path": "/package/ecs_style_dataset/0.0.1"
   },
   {
+<<<<<<< HEAD
+=======
+    "description": "This is the example integration",
+    "download": "/epr/example/example-1.0.0.tar.gz",
+    "downloads": [
+      {
+        "path": "/epr/example/example-1.0.0.tar.gz",
+        "type": "tar.gz"
+      }
+    ],
+>>>>>>> f5fea69e... Add list of downloads to /search endpoint
     "name": "example",
     "title": "Example Integration",
     "version": "1.0.0",
@@ -36,6 +80,17 @@
     "path": "/package/example/1.0.0"
   },
   {
+<<<<<<< HEAD
+=======
+    "description": "This is the foo integration",
+    "download": "/epr/foo/foo-1.0.0.tar.gz",
+    "downloads": [
+      {
+        "path": "/epr/foo/foo-1.0.0.tar.gz",
+        "type": "tar.gz"
+      }
+    ],
+>>>>>>> f5fea69e... Add list of downloads to /search endpoint
     "name": "foo",
     "title": "Foo",
     "version": "1.0.0",
@@ -45,6 +100,18 @@
     "path": "/package/foo/1.0.0"
   },
   {
+<<<<<<< HEAD
+=======
+    "description": "Internal package",
+    "download": "/epr/internal/internal-1.2.0.tar.gz",
+    "downloads": [
+      {
+        "path": "/epr/internal/internal-1.2.0.tar.gz",
+        "type": "tar.gz"
+      }
+    ],
+    "internal": true,
+>>>>>>> f5fea69e... Add list of downloads to /search endpoint
     "name": "internal",
     "title": "Internal",
     "version": "1.2.0",
@@ -55,6 +122,17 @@
     "internal": true
   },
   {
+<<<<<<< HEAD
+=======
+    "description": "Tests that multiple can be set to false",
+    "download": "/epr/multiple_false/multiple_false-0.0.1.tar.gz",
+    "downloads": [
+      {
+        "path": "/epr/multiple_false/multiple_false-0.0.1.tar.gz",
+        "type": "tar.gz"
+      }
+    ],
+>>>>>>> f5fea69e... Add list of downloads to /search endpoint
     "name": "multiple_false",
     "title": "Multiple false",
     "version": "0.0.1",
@@ -64,6 +142,17 @@
     "path": "/package/multiple_false/0.0.1"
   },
   {
+<<<<<<< HEAD
+=======
+    "description": "This package does contain a dataset but not stream configs.\n",
+    "download": "/epr/no_stream_configs/no_stream_configs-1.0.0.tar.gz",
+    "downloads": [
+      {
+        "path": "/epr/no_stream_configs/no_stream_configs-1.0.0.tar.gz",
+        "type": "tar.gz"
+      }
+    ],
+>>>>>>> f5fea69e... Add list of downloads to /search endpoint
     "name": "no_stream_configs",
     "title": "No Stream configs",
     "version": "1.0.0",

--- a/docs/api/search-package-internal.json
+++ b/docs/api/search-package-internal.json
@@ -1,8 +1,10 @@
 [
   {
-<<<<<<< HEAD
-=======
+    "name": "datasources",
+    "title": "Default datasource Integration",
+    "version": "1.0.0",
     "description": "Package with data sources",
+    "type": "integration",
     "download": "/epr/datasources/datasources-1.0.0.tar.gz",
     "downloads": [
       {
@@ -10,19 +12,14 @@
         "type": "tar.gz"
       }
     ],
->>>>>>> f5fea69e... Add list of downloads to /search endpoint
-    "name": "datasources",
-    "title": "Default datasource Integration",
-    "version": "1.0.0",
-    "description": "Package with data sources",
-    "type": "integration",
-    "download": "/epr/datasources/datasources-1.0.0.tar.gz",
     "path": "/package/datasources/1.0.0"
   },
   {
-<<<<<<< HEAD
-=======
+    "name": "default_pipeline",
+    "title": "Default pipeline Integration",
+    "version": "0.0.2",
     "description": "Tests if no pipeline is set, it defaults to the default one",
+    "type": "integration",
     "download": "/epr/default_pipeline/default_pipeline-0.0.2.tar.gz",
     "downloads": [
       {
@@ -30,19 +27,14 @@
         "type": "tar.gz"
       }
     ],
->>>>>>> f5fea69e... Add list of downloads to /search endpoint
-    "name": "default_pipeline",
-    "title": "Default pipeline Integration",
-    "version": "0.0.2",
-    "description": "Tests if no pipeline is set, it defaults to the default one",
-    "type": "integration",
-    "download": "/epr/default_pipeline/default_pipeline-0.0.2.tar.gz",
     "path": "/package/default_pipeline/0.0.2"
   },
   {
-<<<<<<< HEAD
-=======
+    "name": "ecs_style_dataset",
+    "title": "Default pipeline Integration",
+    "version": "0.0.1",
     "description": "Tests the registry validations works for dataset fields using the ecs style format",
+    "type": "integration",
     "download": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.tar.gz",
     "downloads": [
       {
@@ -50,19 +42,14 @@
         "type": "tar.gz"
       }
     ],
->>>>>>> f5fea69e... Add list of downloads to /search endpoint
-    "name": "ecs_style_dataset",
-    "title": "Default pipeline Integration",
-    "version": "0.0.1",
-    "description": "Tests the registry validations works for dataset fields using the ecs style format",
-    "type": "integration",
-    "download": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.tar.gz",
     "path": "/package/ecs_style_dataset/0.0.1"
   },
   {
-<<<<<<< HEAD
-=======
+    "name": "example",
+    "title": "Example Integration",
+    "version": "1.0.0",
     "description": "This is the example integration",
+    "type": "integration",
     "download": "/epr/example/example-1.0.0.tar.gz",
     "downloads": [
       {
@@ -70,19 +57,14 @@
         "type": "tar.gz"
       }
     ],
->>>>>>> f5fea69e... Add list of downloads to /search endpoint
-    "name": "example",
-    "title": "Example Integration",
-    "version": "1.0.0",
-    "description": "This is the example integration",
-    "type": "integration",
-    "download": "/epr/example/example-1.0.0.tar.gz",
     "path": "/package/example/1.0.0"
   },
   {
-<<<<<<< HEAD
-=======
+    "name": "foo",
+    "title": "Foo",
+    "version": "1.0.0",
     "description": "This is the foo integration",
+    "type": "solution",
     "download": "/epr/foo/foo-1.0.0.tar.gz",
     "downloads": [
       {
@@ -90,19 +72,14 @@
         "type": "tar.gz"
       }
     ],
->>>>>>> f5fea69e... Add list of downloads to /search endpoint
-    "name": "foo",
-    "title": "Foo",
-    "version": "1.0.0",
-    "description": "This is the foo integration",
-    "type": "solution",
-    "download": "/epr/foo/foo-1.0.0.tar.gz",
     "path": "/package/foo/1.0.0"
   },
   {
-<<<<<<< HEAD
-=======
+    "name": "internal",
+    "title": "Internal",
+    "version": "1.2.0",
     "description": "Internal package",
+    "type": "integration",
     "download": "/epr/internal/internal-1.2.0.tar.gz",
     "downloads": [
       {
@@ -110,21 +87,15 @@
         "type": "tar.gz"
       }
     ],
-    "internal": true,
->>>>>>> f5fea69e... Add list of downloads to /search endpoint
-    "name": "internal",
-    "title": "Internal",
-    "version": "1.2.0",
-    "description": "Internal package",
-    "type": "integration",
-    "download": "/epr/internal/internal-1.2.0.tar.gz",
     "path": "/package/internal/1.2.0",
     "internal": true
   },
   {
-<<<<<<< HEAD
-=======
+    "name": "multiple_false",
+    "title": "Multiple false",
+    "version": "0.0.1",
     "description": "Tests that multiple can be set to false",
+    "type": "integration",
     "download": "/epr/multiple_false/multiple_false-0.0.1.tar.gz",
     "downloads": [
       {
@@ -132,19 +103,14 @@
         "type": "tar.gz"
       }
     ],
->>>>>>> f5fea69e... Add list of downloads to /search endpoint
-    "name": "multiple_false",
-    "title": "Multiple false",
-    "version": "0.0.1",
-    "description": "Tests that multiple can be set to false",
-    "type": "integration",
-    "download": "/epr/multiple_false/multiple_false-0.0.1.tar.gz",
     "path": "/package/multiple_false/0.0.1"
   },
   {
-<<<<<<< HEAD
-=======
+    "name": "no_stream_configs",
+    "title": "No Stream configs",
+    "version": "1.0.0",
     "description": "This package does contain a dataset but not stream configs.\n",
+    "type": "integration",
     "download": "/epr/no_stream_configs/no_stream_configs-1.0.0.tar.gz",
     "downloads": [
       {
@@ -152,13 +118,6 @@
         "type": "tar.gz"
       }
     ],
->>>>>>> f5fea69e... Add list of downloads to /search endpoint
-    "name": "no_stream_configs",
-    "title": "No Stream configs",
-    "version": "1.0.0",
-    "description": "This package does contain a dataset but not stream configs.\n",
-    "type": "integration",
-    "download": "/epr/no_stream_configs/no_stream_configs-1.0.0.tar.gz",
     "path": "/package/no_stream_configs/1.0.0"
   }
 ]

--- a/docs/api/search.json
+++ b/docs/api/search.json
@@ -1,8 +1,10 @@
 [
   {
-<<<<<<< HEAD
-=======
+    "name": "datasources",
+    "title": "Default datasource Integration",
+    "version": "1.0.0",
     "description": "Package with data sources",
+    "type": "integration",
     "download": "/epr/datasources/datasources-1.0.0.tar.gz",
     "downloads": [
       {
@@ -10,19 +12,14 @@
         "type": "tar.gz"
       }
     ],
->>>>>>> f5fea69e... Add list of downloads to /search endpoint
-    "name": "datasources",
-    "title": "Default datasource Integration",
-    "version": "1.0.0",
-    "description": "Package with data sources",
-    "type": "integration",
-    "download": "/epr/datasources/datasources-1.0.0.tar.gz",
     "path": "/package/datasources/1.0.0"
   },
   {
-<<<<<<< HEAD
-=======
+    "name": "default_pipeline",
+    "title": "Default pipeline Integration",
+    "version": "0.0.2",
     "description": "Tests if no pipeline is set, it defaults to the default one",
+    "type": "integration",
     "download": "/epr/default_pipeline/default_pipeline-0.0.2.tar.gz",
     "downloads": [
       {
@@ -30,19 +27,14 @@
         "type": "tar.gz"
       }
     ],
->>>>>>> f5fea69e... Add list of downloads to /search endpoint
-    "name": "default_pipeline",
-    "title": "Default pipeline Integration",
-    "version": "0.0.2",
-    "description": "Tests if no pipeline is set, it defaults to the default one",
-    "type": "integration",
-    "download": "/epr/default_pipeline/default_pipeline-0.0.2.tar.gz",
     "path": "/package/default_pipeline/0.0.2"
   },
   {
-<<<<<<< HEAD
-=======
+    "name": "ecs_style_dataset",
+    "title": "Default pipeline Integration",
+    "version": "0.0.1",
     "description": "Tests the registry validations works for dataset fields using the ecs style format",
+    "type": "integration",
     "download": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.tar.gz",
     "downloads": [
       {
@@ -50,19 +42,14 @@
         "type": "tar.gz"
       }
     ],
->>>>>>> f5fea69e... Add list of downloads to /search endpoint
-    "name": "ecs_style_dataset",
-    "title": "Default pipeline Integration",
-    "version": "0.0.1",
-    "description": "Tests the registry validations works for dataset fields using the ecs style format",
-    "type": "integration",
-    "download": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.tar.gz",
     "path": "/package/ecs_style_dataset/0.0.1"
   },
   {
-<<<<<<< HEAD
-=======
+    "name": "example",
+    "title": "Example Integration",
+    "version": "1.0.0",
     "description": "This is the example integration",
+    "type": "integration",
     "download": "/epr/example/example-1.0.0.tar.gz",
     "downloads": [
       {
@@ -70,19 +57,14 @@
         "type": "tar.gz"
       }
     ],
->>>>>>> f5fea69e... Add list of downloads to /search endpoint
-    "name": "example",
-    "title": "Example Integration",
-    "version": "1.0.0",
-    "description": "This is the example integration",
-    "type": "integration",
-    "download": "/epr/example/example-1.0.0.tar.gz",
     "path": "/package/example/1.0.0"
   },
   {
-<<<<<<< HEAD
-=======
+    "name": "foo",
+    "title": "Foo",
+    "version": "1.0.0",
     "description": "This is the foo integration",
+    "type": "solution",
     "download": "/epr/foo/foo-1.0.0.tar.gz",
     "downloads": [
       {
@@ -90,19 +72,14 @@
         "type": "tar.gz"
       }
     ],
->>>>>>> f5fea69e... Add list of downloads to /search endpoint
-    "name": "foo",
-    "title": "Foo",
-    "version": "1.0.0",
-    "description": "This is the foo integration",
-    "type": "solution",
-    "download": "/epr/foo/foo-1.0.0.tar.gz",
     "path": "/package/foo/1.0.0"
   },
   {
-<<<<<<< HEAD
-=======
+    "name": "multiple_false",
+    "title": "Multiple false",
+    "version": "0.0.1",
     "description": "Tests that multiple can be set to false",
+    "type": "integration",
     "download": "/epr/multiple_false/multiple_false-0.0.1.tar.gz",
     "downloads": [
       {
@@ -110,19 +87,14 @@
         "type": "tar.gz"
       }
     ],
->>>>>>> f5fea69e... Add list of downloads to /search endpoint
-    "name": "multiple_false",
-    "title": "Multiple false",
-    "version": "0.0.1",
-    "description": "Tests that multiple can be set to false",
-    "type": "integration",
-    "download": "/epr/multiple_false/multiple_false-0.0.1.tar.gz",
     "path": "/package/multiple_false/0.0.1"
   },
   {
-<<<<<<< HEAD
-=======
+    "name": "no_stream_configs",
+    "title": "No Stream configs",
+    "version": "1.0.0",
     "description": "This package does contain a dataset but not stream configs.\n",
+    "type": "integration",
     "download": "/epr/no_stream_configs/no_stream_configs-1.0.0.tar.gz",
     "downloads": [
       {
@@ -130,13 +102,6 @@
         "type": "tar.gz"
       }
     ],
->>>>>>> f5fea69e... Add list of downloads to /search endpoint
-    "name": "no_stream_configs",
-    "title": "No Stream configs",
-    "version": "1.0.0",
-    "description": "This package does contain a dataset but not stream configs.\n",
-    "type": "integration",
-    "download": "/epr/no_stream_configs/no_stream_configs-1.0.0.tar.gz",
     "path": "/package/no_stream_configs/1.0.0"
   }
 ]

--- a/docs/api/search.json
+++ b/docs/api/search.json
@@ -1,5 +1,16 @@
 [
   {
+<<<<<<< HEAD
+=======
+    "description": "Package with data sources",
+    "download": "/epr/datasources/datasources-1.0.0.tar.gz",
+    "downloads": [
+      {
+        "path": "/epr/datasources/datasources-1.0.0.tar.gz",
+        "type": "tar.gz"
+      }
+    ],
+>>>>>>> f5fea69e... Add list of downloads to /search endpoint
     "name": "datasources",
     "title": "Default datasource Integration",
     "version": "1.0.0",
@@ -9,6 +20,17 @@
     "path": "/package/datasources/1.0.0"
   },
   {
+<<<<<<< HEAD
+=======
+    "description": "Tests if no pipeline is set, it defaults to the default one",
+    "download": "/epr/default_pipeline/default_pipeline-0.0.2.tar.gz",
+    "downloads": [
+      {
+        "path": "/epr/default_pipeline/default_pipeline-0.0.2.tar.gz",
+        "type": "tar.gz"
+      }
+    ],
+>>>>>>> f5fea69e... Add list of downloads to /search endpoint
     "name": "default_pipeline",
     "title": "Default pipeline Integration",
     "version": "0.0.2",
@@ -18,6 +40,17 @@
     "path": "/package/default_pipeline/0.0.2"
   },
   {
+<<<<<<< HEAD
+=======
+    "description": "Tests the registry validations works for dataset fields using the ecs style format",
+    "download": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.tar.gz",
+    "downloads": [
+      {
+        "path": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.tar.gz",
+        "type": "tar.gz"
+      }
+    ],
+>>>>>>> f5fea69e... Add list of downloads to /search endpoint
     "name": "ecs_style_dataset",
     "title": "Default pipeline Integration",
     "version": "0.0.1",
@@ -27,6 +60,17 @@
     "path": "/package/ecs_style_dataset/0.0.1"
   },
   {
+<<<<<<< HEAD
+=======
+    "description": "This is the example integration",
+    "download": "/epr/example/example-1.0.0.tar.gz",
+    "downloads": [
+      {
+        "path": "/epr/example/example-1.0.0.tar.gz",
+        "type": "tar.gz"
+      }
+    ],
+>>>>>>> f5fea69e... Add list of downloads to /search endpoint
     "name": "example",
     "title": "Example Integration",
     "version": "1.0.0",
@@ -36,6 +80,17 @@
     "path": "/package/example/1.0.0"
   },
   {
+<<<<<<< HEAD
+=======
+    "description": "This is the foo integration",
+    "download": "/epr/foo/foo-1.0.0.tar.gz",
+    "downloads": [
+      {
+        "path": "/epr/foo/foo-1.0.0.tar.gz",
+        "type": "tar.gz"
+      }
+    ],
+>>>>>>> f5fea69e... Add list of downloads to /search endpoint
     "name": "foo",
     "title": "Foo",
     "version": "1.0.0",
@@ -45,6 +100,17 @@
     "path": "/package/foo/1.0.0"
   },
   {
+<<<<<<< HEAD
+=======
+    "description": "Tests that multiple can be set to false",
+    "download": "/epr/multiple_false/multiple_false-0.0.1.tar.gz",
+    "downloads": [
+      {
+        "path": "/epr/multiple_false/multiple_false-0.0.1.tar.gz",
+        "type": "tar.gz"
+      }
+    ],
+>>>>>>> f5fea69e... Add list of downloads to /search endpoint
     "name": "multiple_false",
     "title": "Multiple false",
     "version": "0.0.1",
@@ -54,6 +120,17 @@
     "path": "/package/multiple_false/0.0.1"
   },
   {
+<<<<<<< HEAD
+=======
+    "description": "This package does contain a dataset but not stream configs.\n",
+    "download": "/epr/no_stream_configs/no_stream_configs-1.0.0.tar.gz",
+    "downloads": [
+      {
+        "path": "/epr/no_stream_configs/no_stream_configs-1.0.0.tar.gz",
+        "type": "tar.gz"
+      }
+    ],
+>>>>>>> f5fea69e... Add list of downloads to /search endpoint
     "name": "no_stream_configs",
     "title": "No Stream configs",
     "version": "1.0.0",

--- a/docs/api/search.json
+++ b/docs/api/search.json
@@ -9,7 +9,7 @@
     "downloads": [
       {
         "path": "/epr/datasources/datasources-1.0.0.tar.gz",
-        "type": "tar.gz"
+        "type": "tar"
       }
     ],
     "path": "/package/datasources/1.0.0"
@@ -24,7 +24,7 @@
     "downloads": [
       {
         "path": "/epr/default_pipeline/default_pipeline-0.0.2.tar.gz",
-        "type": "tar.gz"
+        "type": "tar"
       }
     ],
     "path": "/package/default_pipeline/0.0.2"
@@ -39,7 +39,7 @@
     "downloads": [
       {
         "path": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.tar.gz",
-        "type": "tar.gz"
+        "type": "tar"
       }
     ],
     "path": "/package/ecs_style_dataset/0.0.1"
@@ -54,7 +54,7 @@
     "downloads": [
       {
         "path": "/epr/example/example-1.0.0.tar.gz",
-        "type": "tar.gz"
+        "type": "tar"
       }
     ],
     "path": "/package/example/1.0.0"
@@ -69,7 +69,7 @@
     "downloads": [
       {
         "path": "/epr/foo/foo-1.0.0.tar.gz",
-        "type": "tar.gz"
+        "type": "tar"
       }
     ],
     "path": "/package/foo/1.0.0"
@@ -84,7 +84,7 @@
     "downloads": [
       {
         "path": "/epr/multiple_false/multiple_false-0.0.1.tar.gz",
-        "type": "tar.gz"
+        "type": "tar"
       }
     ],
     "path": "/package/multiple_false/0.0.1"
@@ -99,7 +99,7 @@
     "downloads": [
       {
         "path": "/epr/no_stream_configs/no_stream_configs-1.0.0.tar.gz",
-        "type": "tar.gz"
+        "type": "tar"
       }
     ],
     "path": "/package/no_stream_configs/1.0.0"

--- a/util/package.go
+++ b/util/package.go
@@ -137,7 +137,7 @@ func NewDownload(p Package, t string) Download {
 }
 
 func getDownloadPath(p Package, t string) string {
-	return path.Join("/epr", p.Name, p.Name+"-"+p.Version+"."+t)
+	return path.Join("/epr", p.Name, p.Name+"-"+p.Version+".tar.gz")
 }
 
 // NewPackage creates a new package instances based on the given base path.
@@ -186,7 +186,7 @@ func NewPackage(basePath string) (*Package, error) {
 		}
 	}
 
-	p.Downloads = []Download{NewDownload(*p, "tar.gz")}
+	p.Downloads = []Download{NewDownload(*p, "tar")}
 
 	if p.Requirement.Kibana.Versions != "" {
 		p.Requirement.Kibana.semVerRange, err = semver.NewConstraint(p.Requirement.Kibana.Versions)


### PR DESCRIPTION
As discussed in https://github.com/elastic/package-registry/issues/474 in the future we might have more then one format to download a package. To be prepared for this, downloads becomes an array.

At the moment download and downloads is available but as soon as Kibana switched over, the old endpoint should be removed.