### PR TITLE
Remove support for Elasticsearch requirement

### DIFF
--- a/ASSETS.md
+++ b/ASSETS.md
@@ -35,12 +35,8 @@ compatibility: [1.0.2, 2.0.1]
 os.platform: [darwin, freebsd, linux, macos, openbsd, windows]
 
 requirement:
-  elasticsearch:
-    versions: >7.0
   kibana:
     versions: >7.0
-  agent:
-    versions: >7.1
 
 # The order of the items listed here is the order they show up in the package overview.
 screenshots:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Change stream.* fields to dataset.* fields. [#492](https://github.com/elastic/package-registry/pull/492)
 * Remove `solution` entry support in package manfiest. [#504](https://github.com/elastic/package-registry/pull/504)
+* Remove support for Elasticsearch requirements [#516](https://github.com/elastic/package-registry/pull/516)
 
 ### Bugfixes
 

--- a/dev/packages/example/base/0.2.0/manifest.yml
+++ b/dev/packages/example/base/0.2.0/manifest.yml
@@ -21,9 +21,9 @@ license: basic
 type: integration
 
 requirement:
-  elasticsearch:
+  kibana:
     # Requires ILM which was released in 6.6.
-    versions: ">6.6.0"
+    versions: ">7.9"
 
 # No icons
 icons:

--- a/dev/packages/example/base/0.2.0/manifest.yml
+++ b/dev/packages/example/base/0.2.0/manifest.yml
@@ -23,7 +23,7 @@ type: integration
 requirement:
   kibana:
     # Requires ILM which was released in 6.6.
-    versions: ">7.9"
+    versions: ">7.9.0"
 
 # No icons
 icons:

--- a/dev/packages/example/longdocs/1.0.4/manifest.yml
+++ b/dev/packages/example/longdocs/1.0.4/manifest.yml
@@ -16,8 +16,6 @@ license: basic
 requirement:
   kibana:
     versions: ">6.7.0"
-  elasticsearch:
-    versions: ">7.0.1"
 
 icons:
 - src: "/img/icon.svg"

--- a/dev/packages/example/multiversion/1.0.3/manifest.yml
+++ b/dev/packages/example/multiversion/1.0.3/manifest.yml
@@ -12,8 +12,6 @@ license: basic
 requirement:
   kibana:
     versions: ">6.7.0"
-  elasticsearch:
-    versions: ">7.0.1"
 
 icons:
 - src: "/img/icon.svg"

--- a/dev/packages/example/multiversion/1.0.4/manifest.yml
+++ b/dev/packages/example/multiversion/1.0.4/manifest.yml
@@ -13,8 +13,6 @@ type: integration
 requirement:
   kibana:
     versions: ">6.7.0"
-  elasticsearch:
-    versions: ">7.0.1"
 
 icons:
 - src: "/img/icon.svg"

--- a/dev/packages/example/multiversion/1.1.0/manifest.yml
+++ b/dev/packages/example/multiversion/1.1.0/manifest.yml
@@ -12,8 +12,6 @@ license: basic
 requirement:
   kibana:
     versions: ">6.7.0"
-  elasticsearch:
-    versions: ">7.0.1"
 
 icons:
 - src: "/img/icon.svg"

--- a/dev/packages/example/yamlpipeline/1.0.0/manifest.yml
+++ b/dev/packages/example/yamlpipeline/1.0.0/manifest.yml
@@ -11,10 +11,6 @@ release: beta
 license: basic
 type: integration
 
-requirement:
-  elasticsearch:
-    version.min: 7.0.0
-
 # No icons
 icons:
 

--- a/docs/api/example-0.0.2.tar.gz-preview.txt
+++ b/docs/api/example-0.0.2.tar.gz-preview.txt
@@ -23,4 +23,4 @@
 1995 example-0.0.2/kibana/visualization/7e4084e0-5c99-11e9-8477-077ec9664dbd.json
 1849 example-0.0.2/kibana/visualization/80844540-5c97-11e9-8477-077ec9664dbd.json
 1920 example-0.0.2/kibana/visualization/ab48c3f0-5ca6-11e9-8477-077ec9664dbd.json
-319 example-0.0.2/manifest.yml
+196 example-0.0.2/manifest.yml

--- a/docs/api/package.json
+++ b/docs/api/package.json
@@ -16,9 +16,6 @@
   "requirement": {
     "kibana": {
       "versions": "\u003e=7.0.0"
-    },
-    "elasticsearch": {
-      "versions": "\u003e=7.0.0 \u003c=7.5.0"
     }
   },
   "screenshots": [

--- a/testdata/package/example/0.0.2/manifest.yml
+++ b/testdata/package/example/0.0.2/manifest.yml
@@ -8,11 +8,5 @@ categories: ["logs"]
 release: beta
 
 requirement:
-  elasticsearch:
-    versions: ">=6.0.0 <=6.8.0"
   kibana:
     versions: ">=6.0.0"
-  metricbeat:
-    versions: ">=6.1.0"
-  filebeat:
-    versions: ">=6.2.0"

--- a/testdata/package/example/1.0.0/manifest.yml
+++ b/testdata/package/example/1.0.0/manifest.yml
@@ -9,14 +9,8 @@ type: integration
 release: ga
 
 requirement:
-  elasticsearch:
-    versions: ">=7.0.0 <=7.5.0"
   kibana:
     versions: ">=7.0.0"
-  metricbeat:
-    versions: ">=7.1.0"
-  filebeat:
-    versions: ">=7.2.0"
 
 screenshots:
   - src: /img/kibana-iptables.png

--- a/testdata/package/foo/1.0.0/manifest.yml
+++ b/testdata/package/foo/1.0.0/manifest.yml
@@ -9,12 +9,6 @@ type: solution
 release: beta
 
 requirement:
-  elasticsearch:
-    versions: ">=7.0.0 <=7.5.0"
   kibana:
     versions: ">=7.0.0"
-  metricbeat:
-    versions: ">=7.1.0"
-  filebeat:
-    versions: ">=7.2.0"
 

--- a/testdata/public/package/example/0.0.2/manifest.yml
+++ b/testdata/public/package/example/0.0.2/manifest.yml
@@ -8,11 +8,5 @@ categories: ["logs"]
 release: beta
 
 requirement:
-  elasticsearch:
-    versions: ">=6.0.0 <=6.8.0"
   kibana:
     versions: ">=6.0.0"
-  metricbeat:
-    versions: ">=6.1.0"
-  filebeat:
-    versions: ">=6.2.0"

--- a/testdata/public/package/example/1.0.0/manifest.yml
+++ b/testdata/public/package/example/1.0.0/manifest.yml
@@ -9,14 +9,8 @@ type: integration
 release: ga
 
 requirement:
-  elasticsearch:
-    versions: ">=7.0.0 <=7.5.0"
   kibana:
     versions: ">=7.0.0"
-  metricbeat:
-    versions: ">=7.1.0"
-  filebeat:
-    versions: ">=7.2.0"
 
 screenshots:
   - src: /img/kibana-iptables.png

--- a/testdata/public/package/foo/1.0.0/manifest.yml
+++ b/testdata/public/package/foo/1.0.0/manifest.yml
@@ -9,12 +9,6 @@ type: solution
 release: beta
 
 requirement:
-  elasticsearch:
-    versions: ">=7.0.0 <=7.5.0"
   kibana:
     versions: ">=7.0.0"
-  metricbeat:
-    versions: ">=7.1.0"
-  filebeat:
-    versions: ">=7.2.0"
 

--- a/util/package.go
+++ b/util/package.go
@@ -64,8 +64,7 @@ type Datasource struct {
 }
 
 type Requirement struct {
-	Kibana        ProductRequirement `config:"kibana" json:"kibana,omitempty" yaml:"kibana"`
-	Elasticsearch ProductRequirement `config:"elasticsearch" json:"elasticsearch,omitempty" yaml:"elasticsearch"`
+	Kibana ProductRequirement `config:"kibana" json:"kibana,omitempty" yaml:"kibana"`
 }
 
 type ProductRequirement struct {
@@ -298,13 +297,6 @@ func (p *Package) Validate() error {
 
 	if p.Description == "" {
 		return fmt.Errorf("no description set")
-	}
-
-	if p.Requirement.Elasticsearch.Versions != "" {
-		_, err := semver.NewConstraint(p.Requirement.Elasticsearch.Versions)
-		if err != nil {
-			return fmt.Errorf("invalid Elasticsearch versions: %s, %s", p.Requirement.Elasticsearch.Versions, err)
-		}
 	}
 
 	if p.Requirement.Kibana.Versions != "" {


### PR DESCRIPTION
So far I have not seen a package that would need to specify requirements for an Elasticsearch version as the Elasticsearch and Kibana version are tied together in the minor. Because of this removing support for Elasticsearch requirements for now. We can readd it later if we need.

This also cleans up the existing packages to remove the mention of Elasticsearch and some other examples that were still around.

As a follow up, integrations packages should be updated to get rid of the requirement. But more changes will happen to the requirements after https://github.com/elastic/package-registry/pull/515 is merged so perhaps we rather wait with this a bit more.

This change should not break any existing packages.