### PR TITLE
Rename `kibana` query param to `kibana.version`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Change stream.* fields to dataset.* fields. [#492](https://github.com/elastic/package-registry/pull/492)
 * Remove `solution` entry support in package manifest. [#504](https://github.com/elastic/package-registry/pull/504)
-* Rename `kibana` query param to `kibana.version. [#``](https://github.com/elastic/package-registry/pull/)
+* Rename `kibana` query param to `kibana.version`. [#518](https://github.com/elastic/package-registry/pull/518)
 
 ### Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Breaking changes
 
 * Change stream.* fields to dataset.* fields. [#492](https://github.com/elastic/package-registry/pull/492)
-* Remove `solution` entry support in package manfiest. [#504](https://github.com/elastic/package-registry/pull/504)
+* Remove `solution` entry support in package manifest. [#504](https://github.com/elastic/package-registry/pull/504)
+* Rename `kibana` query param to `kibana.version. [#``](https://github.com/elastic/package-registry/pull/)
 
 ### Bugfixes
 

--- a/categories.go
+++ b/categories.go
@@ -35,13 +35,10 @@ func categoriesHandler(packagesBasePath string, cacheTime time.Duration) func(w 
 		// Read query filter params which can affect the output
 		if len(query) > 0 {
 			if v := query.Get("experimental"); v != "" {
-				if v != "" {
-					experimental, err = strconv.ParseBool(v)
-					if err != nil {
-						badRequest(w, fmt.Sprintf("invalid 'experimental' query param: '%s'", v))
-						return
-					}
-
+				experimental, err = strconv.ParseBool(v)
+				if err != nil {
+					badRequest(w, fmt.Sprintf("invalid 'experimental' query param: '%s'", v))
+					return
 				}
 			}
 		}

--- a/main_test.go
+++ b/main_test.go
@@ -18,11 +18,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/gorilla/mux"
-
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -53,8 +51,8 @@ func TestEndpoints(t *testing.T) {
 		{"/categories", "/categories", "categories.json", categoriesHandler(packagesBasePath, testCacheTime)},
 		{"/categories?experimental=true", "/categories", "categories-experimental.json", categoriesHandler(packagesBasePath, testCacheTime)},
 		{"/categories?experimental=foo", "/categories", "categories-experimental-error.json", categoriesHandler(packagesBasePath, testCacheTime)},
-		{"/search?kibana=6.5.2", "/search", "search-kibana652.json", searchHandler(packagesBasePath, testCacheTime)},
-		{"/search?kibana=7.2.1", "/search", "search-kibana721.json", searchHandler(packagesBasePath, testCacheTime)},
+		{"/search?kibana.version=6.5.2", "/search", "search-kibana652.json", searchHandler(packagesBasePath, testCacheTime)},
+		{"/search?kibana.version=7.2.1", "/search", "search-kibana721.json", searchHandler(packagesBasePath, testCacheTime)},
 		{"/search?category=metrics", "/search", "search-category-metrics.json", searchHandler(packagesBasePath, testCacheTime)},
 		{"/search?category=logs", "/search", "search-category-logs.json", searchHandler(packagesBasePath, testCacheTime)},
 		{"/search?package=example", "/search", "search-package-example.json", searchHandler(packagesBasePath, testCacheTime)},

--- a/search.go
+++ b/search.go
@@ -34,7 +34,7 @@ func searchHandler(packagesBasePath string, cacheTime time.Duration) func(w http
 
 		// Read query filter params which can affect the output
 		if len(query) > 0 {
-			if v := query.Get("kibana"); v != "" {
+			if v := query.Get("kibana.version"); v != "" {
 				kibanaVersion, err = semver.NewVersion(v)
 				if err != nil {
 					badRequest(w, fmt.Sprintf("invalid Kibana version '%s': %s", v, err))
@@ -43,47 +43,37 @@ func searchHandler(packagesBasePath string, cacheTime time.Duration) func(w http
 			}
 
 			if v := query.Get("category"); v != "" {
-				if v != "" {
-					category = v
-				}
+				category = v
 			}
 
 			if v := query.Get("package"); v != "" {
-				if v != "" {
-					packageQuery = v
-				}
+				packageQuery = v
 			}
 
 			if v := query.Get("all"); v != "" {
-				if v != "" {
-					// Default is false, also on error
-					all, err = strconv.ParseBool(v)
-					if err != nil {
-						badRequest(w, fmt.Sprintf("invalid 'all' query param: '%s'", v))
-						return
-					}
+				// Default is false, also on error
+				all, err = strconv.ParseBool(v)
+				if err != nil {
+					badRequest(w, fmt.Sprintf("invalid 'all' query param: '%s'", v))
+					return
 				}
 			}
 
 			if v := query.Get("internal"); v != "" {
-				if v != "" {
-					// In case of error, keep it false
-					internal, err = strconv.ParseBool(v)
-					if err != nil {
-						badRequest(w, fmt.Sprintf("invalid 'internal' query param: '%s'", v))
-						return
-					}
+				// In case of error, keep it false
+				internal, err = strconv.ParseBool(v)
+				if err != nil {
+					badRequest(w, fmt.Sprintf("invalid 'internal' query param: '%s'", v))
+					return
 				}
 			}
 
 			if v := query.Get("experimental"); v != "" {
-				if v != "" {
-					// In case of error, keep it false
-					experimental, err = strconv.ParseBool(v)
-					if err != nil {
-						badRequest(w, fmt.Sprintf("invalid 'experimental' query param: '%s'", v))
-						return
-					}
+				// In case of error, keep it false
+				experimental, err = strconv.ParseBool(v)
+				if err != nil {
+					badRequest(w, fmt.Sprintf("invalid 'experimental' query param: '%s'", v))
+					return
 				}
 			}
 		}


### PR DESCRIPTION
The `/search` query param was renamed from `kibana` to `kibana.version`. There are two reasons for this. The first one is to align the naming inside requirements in the manifest with the actual query param. The second is to make sure in case we have other criterias related to kibana in the future, there is space for this.

As Kibana does not use this query today, this should not affect any parts yet.

More changes:
* Cleaned up some duplicated if clauses spotted during an other PR review