### PR TITLE
Add conditions as future replacement of requirements 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add list of downloads to /search endpoint. [#512](https://github.com/elastic/package-registry/pull/512)
 * Apply rule: first package found served. [#546](https://github.com/elastic/package-registry/pull/546)
 * Implement package watcher. [#553](https://github.com/elastic/package-registry/pull/553)
+* Add conditions as future replacement of requirements. [#519](https://github.com/elastic/package-registry/pull/519)
 
 ### Deprecated
 

--- a/testdata/generated/package.json
+++ b/testdata/generated/package.json
@@ -25,6 +25,9 @@
       "versions": "\u003e=7.0.0"
     }
   },
+  "conditions": {
+    "kibana.version": "~7.x.x"
+  },
   "screenshots": [
     {
       "src": "/package/example/1.0.0/img/kibana-iptables.png",

--- a/testdata/generated/package.json
+++ b/testdata/generated/package.json
@@ -20,13 +20,13 @@
     "metrics"
   ],
   "release": "ga",
+  "conditions": {
+    "kibana.version": "~7.x.x"
+  },
   "requirement": {
     "kibana": {
       "versions": "\u003e=7.0.0"
     }
-  },
-  "conditions": {
-    "kibana.version": "~7.x.x"
   },
   "screenshots": [
     {

--- a/testdata/generated/package/base/0.2.0/index.json
+++ b/testdata/generated/package/base/0.2.0/index.json
@@ -23,6 +23,9 @@
       "versions": "\u003e7.9.0"
     }
   },
+  "conditions": {
+    "kibana.version": "\u003e7.9.0"
+  },
   "assets": [
     "/package/base/0.2.0/manifest.yml",
     "/package/base/0.2.0/docs/README.md",

--- a/testdata/generated/package/base/0.2.0/index.json
+++ b/testdata/generated/package/base/0.2.0/index.json
@@ -18,13 +18,13 @@
   "license": "basic",
   "categories": [],
   "release": "ga",
+  "conditions": {
+    "kibana.version": "\u003e7.9.0"
+  },
   "requirement": {
     "kibana": {
       "versions": "\u003e7.9.0"
     }
-  },
-  "conditions": {
-    "kibana.version": "\u003e7.9.0"
   },
   "assets": [
     "/package/base/0.2.0/manifest.yml",

--- a/testdata/generated/package/example/0.0.2/index.json
+++ b/testdata/generated/package/example/0.0.2/index.json
@@ -24,6 +24,9 @@
       "versions": "\u003e=6.0.0"
     }
   },
+  "conditions": {
+    "kibana.version": "\u003e=6.0.0"
+  },
   "assets": [
     "/package/example/0.0.2/manifest.yml",
     "/package/example/0.0.2/docs/README.md",

--- a/testdata/generated/package/example/0.0.2/index.json
+++ b/testdata/generated/package/example/0.0.2/index.json
@@ -19,13 +19,13 @@
     "logs"
   ],
   "release": "beta",
+  "conditions": {
+    "kibana.version": "\u003e=6.0.0"
+  },
   "requirement": {
     "kibana": {
       "versions": "\u003e=6.0.0"
     }
-  },
-  "conditions": {
-    "kibana.version": "\u003e=6.0.0"
   },
   "assets": [
     "/package/example/0.0.2/manifest.yml",

--- a/testdata/generated/package/example/1.0.0/index.json
+++ b/testdata/generated/package/example/1.0.0/index.json
@@ -25,6 +25,9 @@
       "versions": "\u003e=7.0.0"
     }
   },
+  "conditions": {
+    "kibana.version": "~7.x.x"
+  },
   "screenshots": [
     {
       "src": "/package/example/1.0.0/img/kibana-iptables.png",

--- a/testdata/generated/package/example/1.0.0/index.json
+++ b/testdata/generated/package/example/1.0.0/index.json
@@ -20,13 +20,13 @@
     "metrics"
   ],
   "release": "ga",
+  "conditions": {
+    "kibana.version": "~7.x.x"
+  },
   "requirement": {
     "kibana": {
       "versions": "\u003e=7.0.0"
     }
-  },
-  "conditions": {
-    "kibana.version": "~7.x.x"
   },
   "screenshots": [
     {

--- a/testdata/generated/package/foo/1.0.0/index.json
+++ b/testdata/generated/package/foo/1.0.0/index.json
@@ -24,6 +24,9 @@
       "versions": "\u003e=7.0.0"
     }
   },
+  "conditions": {
+    "kibana.version": "\u003e=7.0.0"
+  },
   "assets": [
     "/package/foo/1.0.0/manifest.yml",
     "/package/foo/1.0.0/docs/README.md"

--- a/testdata/generated/package/foo/1.0.0/index.json
+++ b/testdata/generated/package/foo/1.0.0/index.json
@@ -19,13 +19,13 @@
     "metrics"
   ],
   "release": "beta",
+  "conditions": {
+    "kibana.version": "\u003e=7.0.0"
+  },
   "requirement": {
     "kibana": {
       "versions": "\u003e=7.0.0"
     }
-  },
-  "conditions": {
-    "kibana.version": "\u003e=7.0.0"
   },
   "assets": [
     "/package/foo/1.0.0/manifest.yml",

--- a/testdata/generated/package/longdocs/1.0.4/index.json
+++ b/testdata/generated/package/longdocs/1.0.4/index.json
@@ -26,13 +26,13 @@
     "metrics"
   ],
   "release": "ga",
+  "conditions": {
+    "kibana.version": "\u003e6.7.0"
+  },
   "requirement": {
     "kibana": {
       "versions": "\u003e6.7.0"
     }
-  },
-  "conditions": {
-    "kibana.version": "\u003e6.7.0"
   },
   "assets": [
     "/package/longdocs/1.0.4/manifest.yml",

--- a/testdata/generated/package/longdocs/1.0.4/index.json
+++ b/testdata/generated/package/longdocs/1.0.4/index.json
@@ -31,6 +31,9 @@
       "versions": "\u003e6.7.0"
     }
   },
+  "conditions": {
+    "kibana.version": "\u003e6.7.0"
+  },
   "assets": [
     "/package/longdocs/1.0.4/manifest.yml",
     "/package/longdocs/1.0.4/docs/README.md",

--- a/testdata/generated/package/multiversion/1.0.3/index.json
+++ b/testdata/generated/package/multiversion/1.0.3/index.json
@@ -31,6 +31,9 @@
       "versions": "\u003e6.7.0"
     }
   },
+  "conditions": {
+    "kibana.version": "\u003e6.7.0"
+  },
   "assets": [
     "/package/multiversion/1.0.3/changelog.yml",
     "/package/multiversion/1.0.3/manifest.yml",

--- a/testdata/generated/package/multiversion/1.0.3/index.json
+++ b/testdata/generated/package/multiversion/1.0.3/index.json
@@ -26,13 +26,13 @@
     "metrics"
   ],
   "release": "ga",
+  "conditions": {
+    "kibana.version": "\u003e6.7.0"
+  },
   "requirement": {
     "kibana": {
       "versions": "\u003e6.7.0"
     }
-  },
-  "conditions": {
-    "kibana.version": "\u003e6.7.0"
   },
   "assets": [
     "/package/multiversion/1.0.3/changelog.yml",

--- a/testdata/generated/package/multiversion/1.0.4/index.json
+++ b/testdata/generated/package/multiversion/1.0.4/index.json
@@ -26,13 +26,13 @@
     "metrics"
   ],
   "release": "ga",
+  "conditions": {
+    "kibana.version": "\u003e6.7.0"
+  },
   "requirement": {
     "kibana": {
       "versions": "\u003e6.7.0"
     }
-  },
-  "conditions": {
-    "kibana.version": "\u003e6.7.0"
   },
   "assets": [
     "/package/multiversion/1.0.4/changelog.yml",

--- a/testdata/generated/package/multiversion/1.0.4/index.json
+++ b/testdata/generated/package/multiversion/1.0.4/index.json
@@ -31,6 +31,9 @@
       "versions": "\u003e6.7.0"
     }
   },
+  "conditions": {
+    "kibana.version": "\u003e6.7.0"
+  },
   "assets": [
     "/package/multiversion/1.0.4/changelog.yml",
     "/package/multiversion/1.0.4/manifest.yml",

--- a/testdata/generated/package/multiversion/1.1.0/index.json
+++ b/testdata/generated/package/multiversion/1.1.0/index.json
@@ -26,13 +26,13 @@
     "metrics"
   ],
   "release": "ga",
+  "conditions": {
+    "kibana.version": "\u003e6.7.0"
+  },
   "requirement": {
     "kibana": {
       "versions": "\u003e6.7.0"
     }
-  },
-  "conditions": {
-    "kibana.version": "\u003e6.7.0"
   },
   "assets": [
     "/package/multiversion/1.1.0/changelog.yml",

--- a/testdata/generated/package/multiversion/1.1.0/index.json
+++ b/testdata/generated/package/multiversion/1.1.0/index.json
@@ -31,6 +31,9 @@
       "versions": "\u003e6.7.0"
     }
   },
+  "conditions": {
+    "kibana.version": "\u003e6.7.0"
+  },
   "assets": [
     "/package/multiversion/1.1.0/changelog.yml",
     "/package/multiversion/1.1.0/manifest.yml",

--- a/testdata/generated/package/reference/1.0.0/index.json
+++ b/testdata/generated/package/reference/1.0.0/index.json
@@ -27,13 +27,13 @@
     "metrics"
   ],
   "release": "ga",
+  "conditions": {
+    "kibana.version": "\u003e6.7.0  \u003c7.6.0"
+  },
   "requirement": {
     "kibana": {
       "versions": "\u003e6.7.0  \u003c7.6.0"
     }
-  },
-  "conditions": {
-    "kibana.version": "\u003e6.7.0  \u003c7.6.0"
   },
   "assets": [
     "/package/reference/1.0.0/changelog.yml",

--- a/testdata/generated/package/reference/1.0.0/index.json
+++ b/testdata/generated/package/reference/1.0.0/index.json
@@ -32,6 +32,9 @@
       "versions": "\u003e6.7.0  \u003c7.6.0"
     }
   },
+  "conditions": {
+    "kibana.version": "\u003e6.7.0  \u003c7.6.0"
+  },
   "assets": [
     "/package/reference/1.0.0/changelog.yml",
     "/package/reference/1.0.0/manifest.yml",

--- a/testdata/package/example/1.0.0/manifest.yml
+++ b/testdata/package/example/1.0.0/manifest.yml
@@ -10,6 +10,9 @@ release: ga
 
 owner.github: "ruflin"
 
+conditions:
+  kibana.version: "~7.x.x"
+
 requirement:
   kibana:
     versions: ">=7.0.0"

--- a/testdata/package/reference/1.0.0/manifest.yml
+++ b/testdata/package/reference/1.0.0/manifest.yml
@@ -33,6 +33,9 @@ type: integration
 owner:
   github: "ruflin"
 
+conditions:
+  kibana.version: ">6.7.0  <7.6.0"
+
 requirement:
   kibana:
     versions: ">6.7.0  <7.6.0"

--- a/util/package.go
+++ b/util/package.go
@@ -60,6 +60,7 @@ type Package struct {
 	versionSemVer   *semver.Version
 	Categories      []string         `config:"categories" json:"categories"`
 	Release         string           `config:"release,omitempty" json:"release,omitempty"`
+	Conditions      *Conditions      `config:"conditions,omitempty" json:"conditions,omitempty" yaml:"conditions,omitempty"`
 	Requirement     Requirement      `config:"requirement" json:"requirement"`
 	Screenshots     []Image          `config:"screenshots,omitempty" json:"screenshots,omitempty" yaml:"screenshots,omitempty"`
 	Assets          []string         `config:"assets,omitempty" json:"assets,omitempty" yaml:"assets,omitempty"`
@@ -95,6 +96,11 @@ type ConfigTemplate struct {
 
 type Requirement struct {
 	Kibana ProductRequirement `config:"kibana" json:"kibana,omitempty" yaml:"kibana"`
+}
+
+type Conditions struct {
+	KibanaVersion string `config:"kibana.version,omitempty" json:"kibana.version,omitempty" yaml:"kibana.version,omitempty"`
+	kibanaVersion *semver.Constraints
 }
 
 type ProductRequirement struct {
@@ -150,7 +156,7 @@ func NewPackage(basePath string) (*Package, error) {
 	var p = &Package{
 		BasePath: basePath,
 	}
-	err = manifest.Unpack(p)
+	err = manifest.Unpack(p, ucfg.PathSep("."))
 	if err != nil {
 		return nil, err
 	}
@@ -185,8 +191,18 @@ func NewPackage(basePath string) (*Package, error) {
 
 	p.Downloads = []Download{NewDownload(*p, "tar")}
 
-	if p.Requirement.Kibana.Versions != "" {
-		p.Requirement.Kibana.semVerRange, err = semver.NewConstraint(p.Requirement.Kibana.Versions)
+	// If the new conditions are used, select them over the requirements
+	if p.Conditions != nil && p.Conditions.KibanaVersion != "" {
+		p.Conditions.kibanaVersion, err = semver.NewConstraint(p.Conditions.KibanaVersion)
+		if err != nil {
+			return nil, errors.Wrapf(err, "invalid Kibana versions range: %s", p.Requirement.Kibana.Versions)
+		}
+		// TODO: remove legacy part
+	} else if p.Requirement.Kibana.Versions != "" {
+		p.Conditions = &Conditions{
+			KibanaVersion: p.Requirement.Kibana.Versions,
+		}
+		p.Conditions.kibanaVersion, err = semver.NewConstraint(p.Requirement.Kibana.Versions)
 		if err != nil {
 			return nil, errors.Wrapf(err, "invalid Kibana versions range: %s", p.Requirement.Kibana.Versions)
 		}
@@ -253,16 +269,11 @@ func (p *Package) HasCategory(category string) bool {
 func (p *Package) HasKibanaVersion(version *semver.Version) bool {
 
 	// If the version is not specified, it is for all versions
-	if p.Requirement.Kibana.Versions == "" {
+	if p.Conditions == nil || version == nil {
 		return true
 	}
 
-	if version != nil {
-		if !p.Requirement.Kibana.semVerRange.Check(version) {
-			return false
-		}
-	}
-	return true
+	return p.Conditions.kibanaVersion.Check(version)
 }
 
 func (p *Package) IsNewerOrEqual(pp Package) bool {

--- a/util/package.go
+++ b/util/package.go
@@ -99,8 +99,8 @@ type Requirement struct {
 }
 
 type Conditions struct {
-	KibanaVersion string `config:"kibana.version,omitempty" json:"kibana.version,omitempty" yaml:"kibana.version,omitempty"`
-	kibanaVersion *semver.Constraints
+	KibanaVersion    string `config:"kibana.version,omitempty" json:"kibana.version,omitempty" yaml:"kibana.version,omitempty"`
+	kibanaConstraint *semver.Constraints
 }
 
 type ProductRequirement struct {
@@ -193,7 +193,7 @@ func NewPackage(basePath string) (*Package, error) {
 
 	// If the new conditions are used, select them over the requirements
 	if p.Conditions != nil && p.Conditions.KibanaVersion != "" {
-		p.Conditions.kibanaVersion, err = semver.NewConstraint(p.Conditions.KibanaVersion)
+		p.Conditions.kibanaConstraint, err = semver.NewConstraint(p.Conditions.KibanaVersion)
 		if err != nil {
 			return nil, errors.Wrapf(err, "invalid Kibana versions range: %s", p.Requirement.Kibana.Versions)
 		}
@@ -202,7 +202,7 @@ func NewPackage(basePath string) (*Package, error) {
 		p.Conditions = &Conditions{
 			KibanaVersion: p.Requirement.Kibana.Versions,
 		}
-		p.Conditions.kibanaVersion, err = semver.NewConstraint(p.Requirement.Kibana.Versions)
+		p.Conditions.kibanaConstraint, err = semver.NewConstraint(p.Requirement.Kibana.Versions)
 		if err != nil {
 			return nil, errors.Wrapf(err, "invalid Kibana versions range: %s", p.Requirement.Kibana.Versions)
 		}
@@ -273,7 +273,7 @@ func (p *Package) HasKibanaVersion(version *semver.Version) bool {
 		return true
 	}
 
-	return p.Conditions.kibanaVersion.Check(version)
+	return p.Conditions.kibanaConstraint.Check(version)
 }
 
 func (p *Package) IsNewerOrEqual(pp Package) bool {

--- a/util/package.go
+++ b/util/package.go
@@ -195,7 +195,7 @@ func NewPackage(basePath string) (*Package, error) {
 	if p.Conditions != nil && p.Conditions.KibanaVersion != "" {
 		p.Conditions.kibanaConstraint, err = semver.NewConstraint(p.Conditions.KibanaVersion)
 		if err != nil {
-			return nil, errors.Wrapf(err, "invalid Kibana versions range: %s", p.Requirement.Kibana.Versions)
+			return nil, errors.Wrapf(err, "invalid Kibana versions range: %s", p.Conditions.KibanaVersion)
 		}
 		// TODO: remove legacy part
 	} else if p.Requirement.Kibana.Versions != "" {

--- a/util/package_test.go
+++ b/util/package_test.go
@@ -5,8 +5,10 @@
 package util
 
 import (
+	"log"
 	"testing"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -123,6 +125,74 @@ func TestValidate(t *testing.T) {
 			} else {
 				assert.True(t, tt.valid)
 			}
+		})
+	}
+}
+
+var kibanaVersionPackageTests = []struct {
+	description   string
+	constraint    string
+	kibanaVersion string
+	check         bool
+}{
+	{
+		"last major",
+		">= 7.0.0",
+		"6.7.0",
+		false,
+	},
+	{
+		"next minor",
+		">= 7.0.0",
+		"7.1.0",
+		true,
+	},
+	{
+		"next minor tilde",
+		"~7",
+		"7.1.0",
+		true,
+	},
+	{
+		"next minor tilde, x",
+		"~7.x.x",
+		"7.1.0",
+		true,
+	},
+	{
+		"next minor tilde, not matching",
+		"~7.0.0",
+		"7.1.0",
+		false,
+	},
+	{
+		"next minor tilde, matching",
+		"~7.0.x",
+		"7.0.2",
+		true,
+	},
+}
+
+func TestHasKibanaVersion(t *testing.T) {
+	for _, tt := range kibanaVersionPackageTests {
+		t.Run(tt.description, func(t *testing.T) {
+
+			constraint, err := semver.NewConstraint(tt.constraint)
+			assert.NoError(t, err)
+
+			p := Package{
+				Conditions: &Conditions{
+					kibanaVersion: constraint,
+				},
+			}
+
+			kibanaVersion, err := semver.NewVersion(tt.kibanaVersion)
+			assert.NoError(t, err)
+
+			check := p.HasKibanaVersion(kibanaVersion)
+			log.Println(check)
+			assert.Equal(t, tt.check, check)
+
 		})
 	}
 }

--- a/util/package_test.go
+++ b/util/package_test.go
@@ -171,6 +171,18 @@ var kibanaVersionPackageTests = []struct {
 		"7.0.2",
 		true,
 	},
+	{
+		"inside major, not",
+		"^7.6.0",
+		"7.0.2",
+		false,
+	},
+	{
+		"inside major",
+		"^7.6.0",
+		"7.12.2",
+		true,
+	},
 }
 
 func TestHasKibanaVersion(t *testing.T) {

--- a/util/package_test.go
+++ b/util/package_test.go
@@ -182,7 +182,7 @@ func TestHasKibanaVersion(t *testing.T) {
 
 			p := Package{
 				Conditions: &Conditions{
-					kibanaVersion: constraint,
+					kibanaConstraint: constraint,
 				},
 			}
 


### PR DESCRIPTION
This change adds `conditions` as part of the package manifest to align with other parts in the stack. Currently it adds the future of conditions and does not remove requirements yet. Requirements will be removed as soon as packages are updated.