### PR TITLE
Generate package index.json files for testing

### DIFF
--- a/docs/api/artifact-not-found.txt
+++ b/docs/api/artifact-not-found.txt
@@ -1,1 +1,0 @@
-artifact not found

--- a/docs/api/package-invalid-version.txt
+++ b/docs/api/package-invalid-version.txt
@@ -1,1 +1,0 @@
-invalid package version

--- a/docs/api/package-missing.txt
+++ b/docs/api/package-missing.txt
@@ -1,1 +1,0 @@
-artifact not found

--- a/docs/api/package/datasources/1.0.0/index.json
+++ b/docs/api/package/datasources/1.0.0/index.json
@@ -1,0 +1,313 @@
+{
+  "format_version": "1.0.0",
+  "name": "datasources",
+  "title": "Default datasource Integration",
+  "version": "1.0.0",
+  "readme": "/package/datasources/1.0.0/docs/README.md",
+  "license": "basic",
+  "description": "Package with data sources",
+  "type": "integration",
+  "categories": [
+    "logs"
+  ],
+  "release": "beta",
+  "removable": true,
+  "requirement": {
+    "kibana": {}
+  },
+  "assets": [
+    "/package/datasources/1.0.0/manifest.yml",
+    "/package/datasources/1.0.0/docs/README.md",
+    "/package/datasources/1.0.0/dataset/examplelog1/manifest.yml",
+    "/package/datasources/1.0.0/dataset/examplelog2/manifest.yml",
+    "/package/datasources/1.0.0/dataset/examplemetric/manifest.yml",
+    "/package/datasources/1.0.0/dataset/examplelog1/fields/base-fields.yml",
+    "/package/datasources/1.0.0/dataset/examplelog2/fields/base-fields.yml",
+    "/package/datasources/1.0.0/dataset/examplemetric/fields/base-fields.yml",
+    "/package/datasources/1.0.0/dataset/examplelog1/agent/stream/logs.yml",
+    "/package/datasources/1.0.0/dataset/examplelog1/agent/stream/syslog.yml",
+    "/package/datasources/1.0.0/dataset/examplelog2/agent/stream/stream.yml.hbs",
+    "/package/datasources/1.0.0/dataset/examplemetric/agent/stream/stream.yml.hbs"
+  ],
+  "datasets": [
+    {
+      "id": "datasources.examplelog1",
+      "title": "Example dataset with inputs",
+      "release": "experimental",
+      "type": "logs",
+      "streams": [
+        {
+          "input": "logs",
+          "vars": [
+            {
+              "name": "paths",
+              "type": "text",
+              "description": "Paths to the nginx error log file.",
+              "multi": true,
+              "required": true,
+              "show_user": false,
+              "default": [
+                "/var/log/nginx/error.log*"
+              ],
+              "os": {
+                "darwin": {
+                  "default": [
+                    "/usr/local/var/log/nginx/error.log*"
+                  ]
+                },
+                "windows": {
+                  "default": [
+                    "c:/programdata/nginx/logs/*error.log*"
+                  ]
+                }
+              }
+            }
+          ],
+          "template_path": "logs.yml",
+          "title": "Title of the stream",
+          "description": "Description of the stream with more details.",
+          "enabled": true
+        },
+        {
+          "input": "syslog",
+          "template_path": "syslog.yml",
+          "title": "Title of the stream",
+          "description": "Description of the stream with more details.",
+          "enabled": true
+        }
+      ],
+      "package": "datasources",
+      "path": "examplelog1"
+    },
+    {
+      "id": "datasources.examplelog2",
+      "title": "Example dataset with inputs",
+      "release": "experimental",
+      "type": "logs",
+      "streams": [
+        {
+          "input": "logs",
+          "vars": [
+            {
+              "name": "paths",
+              "type": "text",
+              "description": "Paths to the nginx access log file.",
+              "multi": true,
+              "required": true,
+              "show_user": false,
+              "default": [
+                "/var/log/nginx/access.log*"
+              ],
+              "os": {
+                "darwin": {
+                  "default": [
+                    "/usr/local/var/log/nginx/access.log*"
+                  ]
+                },
+                "windows": {
+                  "default": [
+                    "c:/programdata/nginx/logs/*access.log*"
+                  ]
+                }
+              }
+            }
+          ],
+          "title": "Title of the stream",
+          "description": "Description of the stream with more details.",
+          "enabled": true
+        }
+      ],
+      "package": "datasources",
+      "path": "examplelog2"
+    },
+    {
+      "id": "datasources.examplemetric",
+      "title": "Example dataset with inputs",
+      "release": "experimental",
+      "type": "metrics",
+      "streams": [
+        {
+          "input": "nginx/metrics",
+          "vars": [
+            {
+              "name": "url",
+              "type": "text",
+              "description": "Paths to the nginx access log file.",
+              "multi": false,
+              "required": true,
+              "show_user": false,
+              "default": "localhost"
+            }
+          ],
+          "title": "Title of the stream",
+          "description": "Not enabled data source.",
+          "enabled": false
+        }
+      ],
+      "package": "datasources",
+      "path": "examplemetric"
+    }
+  ],
+  "datasources": [
+    {
+      "name": "nginx",
+      "title": "Datasource title",
+      "description": "Details about the data source.",
+      "inputs": [
+        {
+          "type": "nginx/metrics",
+          "vars": [
+            {
+              "name": "hosts",
+              "type": "text",
+              "description": "Nginx hosts",
+              "multi": true,
+              "required": true,
+              "show_user": false,
+              "default": [
+                "http://127.0.0.1"
+              ]
+            },
+            {
+              "name": "period",
+              "type": "duration",
+              "description": "Collection period. Valid values: 10s, 5m, 2h",
+              "multi": false,
+              "required": false,
+              "show_user": false,
+              "default": "10s"
+            },
+            {
+              "name": "username",
+              "type": "text",
+              "multi": false,
+              "required": false,
+              "show_user": false
+            },
+            {
+              "name": "password",
+              "type": "password",
+              "multi": false,
+              "required": false,
+              "show_user": false
+            }
+          ],
+          "description": "Collecting metrics for nginx.",
+          "streams": [
+            {
+              "input": "nginx/metrics",
+              "vars": [
+                {
+                  "name": "url",
+                  "type": "text",
+                  "description": "Paths to the nginx access log file.",
+                  "multi": false,
+                  "required": true,
+                  "show_user": false,
+                  "default": "localhost"
+                }
+              ],
+              "dataset": "datasources.examplemetric",
+              "template_path": "stream.yml.hbs",
+              "template": "metric: foo\n",
+              "title": "Title of the stream",
+              "description": "Not enabled data source.",
+              "enabled": false
+            }
+          ]
+        },
+        {
+          "type": "logs",
+          "description": "Collect nginx logs.",
+          "streams": [
+            {
+              "input": "logs",
+              "vars": [
+                {
+                  "name": "paths",
+                  "type": "text",
+                  "description": "Paths to the nginx error log file.",
+                  "multi": true,
+                  "required": true,
+                  "show_user": false,
+                  "default": [
+                    "/var/log/nginx/error.log*"
+                  ],
+                  "os": {
+                    "darwin": {
+                      "default": [
+                        "/usr/local/var/log/nginx/error.log*"
+                      ]
+                    },
+                    "windows": {
+                      "default": [
+                        "c:/programdata/nginx/logs/*error.log*"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "dataset": "datasources.examplelog1",
+              "template_path": "logs.yml",
+              "template": "foo: bar\n",
+              "title": "Title of the stream",
+              "description": "Description of the stream with more details.",
+              "enabled": true
+            },
+            {
+              "input": "logs",
+              "vars": [
+                {
+                  "name": "paths",
+                  "type": "text",
+                  "description": "Paths to the nginx access log file.",
+                  "multi": true,
+                  "required": true,
+                  "show_user": false,
+                  "default": [
+                    "/var/log/nginx/access.log*"
+                  ],
+                  "os": {
+                    "darwin": {
+                      "default": [
+                        "/usr/local/var/log/nginx/access.log*"
+                      ]
+                    },
+                    "windows": {
+                      "default": [
+                        "c:/programdata/nginx/logs/*access.log*"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "dataset": "datasources.examplelog2",
+              "template_path": "stream.yml.hbs",
+              "template": "foo: bar\n",
+              "title": "Title of the stream",
+              "description": "Description of the stream with more details.",
+              "enabled": true
+            }
+          ]
+        },
+        {
+          "type": "syslog",
+          "streams": [
+            {
+              "input": "syslog",
+              "dataset": "datasources.examplelog1",
+              "template_path": "syslog.yml",
+              "template": "syslog: bar\n",
+              "title": "Title of the stream",
+              "description": "Description of the stream with more details.",
+              "enabled": true
+            }
+          ]
+        }
+      ],
+      "multiple": true
+    }
+  ],
+  "download": "/epr/datasources/datasources-1.0.0.tar.gz",
+  "path": "/package/datasources/1.0.0"
+}

--- a/docs/api/package/datasources/1.0.0/index.json
+++ b/docs/api/package/datasources/1.0.0/index.json
@@ -1,12 +1,14 @@
 {
-  "format_version": "1.0.0",
   "name": "datasources",
   "title": "Default datasource Integration",
   "version": "1.0.0",
-  "readme": "/package/datasources/1.0.0/docs/README.md",
-  "license": "basic",
   "description": "Package with data sources",
   "type": "integration",
+  "download": "/epr/datasources/datasources-1.0.0.tar.gz",
+  "path": "/package/datasources/1.0.0",
+  "format_version": "1.0.0",
+  "readme": "/package/datasources/1.0.0/docs/README.md",
+  "license": "basic",
   "categories": [
     "logs"
   ],
@@ -307,7 +309,5 @@
       ],
       "multiple": true
     }
-  ],
-  "download": "/epr/datasources/datasources-1.0.0.tar.gz",
-  "path": "/package/datasources/1.0.0"
+  ]
 }

--- a/docs/api/package/default_pipeline/0.0.2/index.json
+++ b/docs/api/package/default_pipeline/0.0.2/index.json
@@ -1,12 +1,14 @@
 {
-  "format_version": "1.0.0",
   "name": "default_pipeline",
   "title": "Default pipeline Integration",
   "version": "0.0.2",
-  "readme": "/package/default_pipeline/0.0.2/docs/README.md",
-  "license": "basic",
   "description": "Tests if no pipeline is set, it defaults to the default one",
   "type": "integration",
+  "download": "/epr/default_pipeline/default_pipeline-0.0.2.tar.gz",
+  "path": "/package/default_pipeline/0.0.2",
+  "format_version": "1.0.0",
+  "readme": "/package/default_pipeline/0.0.2/docs/README.md",
+  "license": "basic",
   "categories": [
     "logs"
   ],
@@ -81,7 +83,5 @@
       ],
       "multiple": true
     }
-  ],
-  "download": "/epr/default_pipeline/default_pipeline-0.0.2.tar.gz",
-  "path": "/package/default_pipeline/0.0.2"
+  ]
 }

--- a/docs/api/package/default_pipeline/0.0.2/index.json
+++ b/docs/api/package/default_pipeline/0.0.2/index.json
@@ -1,0 +1,87 @@
+{
+  "format_version": "1.0.0",
+  "name": "default_pipeline",
+  "title": "Default pipeline Integration",
+  "version": "0.0.2",
+  "readme": "/package/default_pipeline/0.0.2/docs/README.md",
+  "license": "basic",
+  "description": "Tests if no pipeline is set, it defaults to the default one",
+  "type": "integration",
+  "categories": [
+    "logs"
+  ],
+  "release": "beta",
+  "removable": true,
+  "requirement": {
+    "kibana": {}
+  },
+  "assets": [
+    "/package/default_pipeline/0.0.2/manifest.yml",
+    "/package/default_pipeline/0.0.2/docs/README.md",
+    "/package/default_pipeline/0.0.2/dataset/foo/manifest.yml",
+    "/package/default_pipeline/0.0.2/dataset/foo/fields/base-fields.yml",
+    "/package/default_pipeline/0.0.2/dataset/foo/agent/stream/stream.yml.hbs",
+    "/package/default_pipeline/0.0.2/dataset/foo/elasticsearch/ingest-pipeline/default.json"
+  ],
+  "datasets": [
+    {
+      "id": "default_pipeline.foo",
+      "title": "Foo",
+      "release": "experimental",
+      "type": "logs",
+      "ingest_pipeline": "default",
+      "streams": [
+        {
+          "input": "logs",
+          "vars": [
+            {
+              "name": "paths",
+              "type": "text",
+              "description": "Path to log files to be collected",
+              "multi": true,
+              "required": true,
+              "show_user": false
+            }
+          ],
+          "enabled": true
+        }
+      ],
+      "package": "default_pipeline",
+      "path": "foo"
+    }
+  ],
+  "datasources": [
+    {
+      "name": "logs",
+      "title": "Logs datasource",
+      "description": "Datasource for your log files.",
+      "inputs": [
+        {
+          "type": "logs",
+          "streams": [
+            {
+              "input": "logs",
+              "vars": [
+                {
+                  "name": "paths",
+                  "type": "text",
+                  "description": "Path to log files to be collected",
+                  "multi": true,
+                  "required": true,
+                  "show_user": false
+                }
+              ],
+              "dataset": "default_pipeline.foo",
+              "template_path": "stream.yml.hbs",
+              "template": "foo: bar\n",
+              "enabled": true
+            }
+          ]
+        }
+      ],
+      "multiple": true
+    }
+  ],
+  "download": "/epr/default_pipeline/default_pipeline-0.0.2.tar.gz",
+  "path": "/package/default_pipeline/0.0.2"
+}

--- a/docs/api/package/ecs_style_dataset/0.0.1/index.json
+++ b/docs/api/package/ecs_style_dataset/0.0.1/index.json
@@ -1,0 +1,49 @@
+{
+  "format_version": "1.0.0",
+  "name": "ecs_style_dataset",
+  "title": "Default pipeline Integration",
+  "version": "0.0.1",
+  "readme": "/package/ecs_style_dataset/0.0.1/docs/README.md",
+  "license": "basic",
+  "description": "Tests the registry validations works for dataset fields using the ecs style format",
+  "type": "integration",
+  "categories": [
+    "logs"
+  ],
+  "release": "beta",
+  "removable": true,
+  "requirement": {
+    "kibana": {}
+  },
+  "assets": [
+    "/package/ecs_style_dataset/0.0.1/manifest.yml",
+    "/package/ecs_style_dataset/0.0.1/docs/README.md",
+    "/package/ecs_style_dataset/0.0.1/dataset/foo/manifest.yml",
+    "/package/ecs_style_dataset/0.0.1/dataset/foo/fields/fields.yml"
+  ],
+  "datasets": [
+    {
+      "id": "ecs_style_dataset.foo",
+      "title": "Foo",
+      "release": "experimental",
+      "type": "logs",
+      "package": "ecs_style_dataset",
+      "path": "foo"
+    }
+  ],
+  "datasources": [
+    {
+      "name": "logs",
+      "title": "Logs datasource",
+      "description": "Datasource for your log files.",
+      "inputs": [
+        {
+          "type": "logs"
+        }
+      ],
+      "multiple": true
+    }
+  ],
+  "download": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.tar.gz",
+  "path": "/package/ecs_style_dataset/0.0.1"
+}

--- a/docs/api/package/ecs_style_dataset/0.0.1/index.json
+++ b/docs/api/package/ecs_style_dataset/0.0.1/index.json
@@ -1,12 +1,14 @@
 {
-  "format_version": "1.0.0",
   "name": "ecs_style_dataset",
   "title": "Default pipeline Integration",
   "version": "0.0.1",
-  "readme": "/package/ecs_style_dataset/0.0.1/docs/README.md",
-  "license": "basic",
   "description": "Tests the registry validations works for dataset fields using the ecs style format",
   "type": "integration",
+  "download": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.tar.gz",
+  "path": "/package/ecs_style_dataset/0.0.1",
+  "format_version": "1.0.0",
+  "readme": "/package/ecs_style_dataset/0.0.1/docs/README.md",
+  "license": "basic",
   "categories": [
     "logs"
   ],
@@ -43,7 +45,5 @@
       ],
       "multiple": true
     }
-  ],
-  "download": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.tar.gz",
-  "path": "/package/ecs_style_dataset/0.0.1"
+  ]
 }

--- a/docs/api/package/example/0.0.2/index.json
+++ b/docs/api/package/example/0.0.2/index.json
@@ -1,0 +1,41 @@
+{
+  "format_version": "1.0.0",
+  "name": "example",
+  "title": "Example",
+  "version": "0.0.2",
+  "readme": "/package/example/0.0.2/docs/README.md",
+  "license": "basic",
+  "description": "This is the example integration.",
+  "type": "integration",
+  "categories": [
+    "logs"
+  ],
+  "release": "beta",
+  "removable": true,
+  "requirement": {
+    "kibana": {
+      "versions": "\u003e=6.0.0"
+    }
+  },
+  "assets": [
+    "/package/example/0.0.2/manifest.yml",
+    "/package/example/0.0.2/docs/README.md",
+    "/package/example/0.0.2/img/kibana-envoyproxy.jpg",
+    "/package/example/0.0.2/elasticsearch/ingest-pipeline/pipeline-entry.json",
+    "/package/example/0.0.2/elasticsearch/ingest-pipeline/pipeline-http.json",
+    "/package/example/0.0.2/elasticsearch/ingest-pipeline/pipeline-json.json",
+    "/package/example/0.0.2/elasticsearch/ingest-pipeline/pipeline-plaintext.json",
+    "/package/example/0.0.2/elasticsearch/ingest-pipeline/pipeline-tcp.json",
+    "/package/example/0.0.2/kibana/dashboard/0c610510-5cbd-11e9-8477-077ec9664dbd.json",
+    "/package/example/0.0.2/kibana/index-pattern/filebeat.json",
+    "/package/example/0.0.2/kibana/infrastructure-ui-source/default.json",
+    "/package/example/0.0.2/kibana/visualization/0a994af0-5c9d-11e9-8477-077ec9664dbd.json",
+    "/package/example/0.0.2/kibana/visualization/36f872a0-5c03-11e9-85b4-19d0072eb4f2.json",
+    "/package/example/0.0.2/kibana/visualization/38f96190-5c99-11e9-8477-077ec9664dbd.json",
+    "/package/example/0.0.2/kibana/visualization/7e4084e0-5c99-11e9-8477-077ec9664dbd.json",
+    "/package/example/0.0.2/kibana/visualization/80844540-5c97-11e9-8477-077ec9664dbd.json",
+    "/package/example/0.0.2/kibana/visualization/ab48c3f0-5ca6-11e9-8477-077ec9664dbd.json"
+  ],
+  "download": "/epr/example/example-0.0.2.tar.gz",
+  "path": "/package/example/0.0.2"
+}

--- a/docs/api/package/example/0.0.2/index.json
+++ b/docs/api/package/example/0.0.2/index.json
@@ -1,12 +1,14 @@
 {
-  "format_version": "1.0.0",
   "name": "example",
   "title": "Example",
   "version": "0.0.2",
-  "readme": "/package/example/0.0.2/docs/README.md",
-  "license": "basic",
   "description": "This is the example integration.",
   "type": "integration",
+  "download": "/epr/example/example-0.0.2.tar.gz",
+  "path": "/package/example/0.0.2",
+  "format_version": "1.0.0",
+  "readme": "/package/example/0.0.2/docs/README.md",
+  "license": "basic",
   "categories": [
     "logs"
   ],
@@ -35,7 +37,5 @@
     "/package/example/0.0.2/kibana/visualization/7e4084e0-5c99-11e9-8477-077ec9664dbd.json",
     "/package/example/0.0.2/kibana/visualization/80844540-5c97-11e9-8477-077ec9664dbd.json",
     "/package/example/0.0.2/kibana/visualization/ab48c3f0-5ca6-11e9-8477-077ec9664dbd.json"
-  ],
-  "download": "/epr/example/example-0.0.2.tar.gz",
-  "path": "/package/example/0.0.2"
+  ]
 }

--- a/docs/api/package/example/1.0.0/index.json
+++ b/docs/api/package/example/1.0.0/index.json
@@ -1,12 +1,14 @@
 {
-  "format_version": "1.0.0",
   "name": "example",
   "title": "Example Integration",
   "version": "1.0.0",
-  "readme": "/package/example/1.0.0/docs/README.md",
-  "license": "basic",
   "description": "This is the example integration",
   "type": "integration",
+  "download": "/epr/example/example-1.0.0.tar.gz",
+  "path": "/package/example/1.0.0",
+  "format_version": "1.0.0",
+  "readme": "/package/example/1.0.0/docs/README.md",
+  "license": "basic",
   "categories": [
     "logs",
     "metrics"
@@ -111,7 +113,5 @@
       ],
       "multiple": true
     }
-  ],
-  "download": "/epr/example/example-1.0.0.tar.gz",
-  "path": "/package/example/1.0.0"
+  ]
 }

--- a/docs/api/package/example/1.0.0/index.json
+++ b/docs/api/package/example/1.0.0/index.json
@@ -1,0 +1,117 @@
+{
+  "format_version": "1.0.0",
+  "name": "example",
+  "title": "Example Integration",
+  "version": "1.0.0",
+  "readme": "/package/example/1.0.0/docs/README.md",
+  "license": "basic",
+  "description": "This is the example integration",
+  "type": "integration",
+  "categories": [
+    "logs",
+    "metrics"
+  ],
+  "release": "ga",
+  "removable": true,
+  "requirement": {
+    "kibana": {
+      "versions": "\u003e=7.0.0"
+    }
+  },
+  "screenshots": [
+    {
+      "src": "/package/example/1.0.0/img/kibana-iptables.png",
+      "title": "IP Tables Overview dashboard",
+      "size": "1492x1382"
+    },
+    {
+      "src": "/package/example/1.0.0/img/kibana-iptables-ubiquity.png",
+      "title": "IP Tables Ubiquity Dashboard",
+      "size": "1492x1464",
+      "type": "image/png"
+    }
+  ],
+  "assets": [
+    "/package/example/1.0.0/manifest.yml",
+    "/package/example/1.0.0/docs/README.md",
+    "/package/example/1.0.0/img/icon.png",
+    "/package/example/1.0.0/img/kibana-envoyproxy.jpg",
+    "/package/example/1.0.0/dataset/foo/manifest.yml",
+    "/package/example/1.0.0/kibana/dashboard/0c610510-5cbd-11e9-8477-077ec9664dbd.json",
+    "/package/example/1.0.0/kibana/index-pattern/filebeat.json",
+    "/package/example/1.0.0/kibana/visualization/0a994af0-5c9d-11e9-8477-077ec9664dbd.json",
+    "/package/example/1.0.0/kibana/visualization/36f872a0-5c03-11e9-85b4-19d0072eb4f2.json",
+    "/package/example/1.0.0/kibana/visualization/38f96190-5c99-11e9-8477-077ec9664dbd.json",
+    "/package/example/1.0.0/kibana/visualization/7e4084e0-5c99-11e9-8477-077ec9664dbd.json",
+    "/package/example/1.0.0/kibana/visualization/80844540-5c97-11e9-8477-077ec9664dbd.json",
+    "/package/example/1.0.0/kibana/visualization/ab48c3f0-5ca6-11e9-8477-077ec9664dbd.json",
+    "/package/example/1.0.0/dataset/foo/fields/base-fields.yml",
+    "/package/example/1.0.0/dataset/foo/agent/stream/stream.yml.hbs",
+    "/package/example/1.0.0/dataset/foo/elasticsearch/ingest-pipeline/pipeline-entry.json",
+    "/package/example/1.0.0/dataset/foo/elasticsearch/ingest-pipeline/pipeline-http.json",
+    "/package/example/1.0.0/dataset/foo/elasticsearch/ingest-pipeline/pipeline-json.json",
+    "/package/example/1.0.0/dataset/foo/elasticsearch/ingest-pipeline/pipeline-plaintext.json",
+    "/package/example/1.0.0/dataset/foo/elasticsearch/ingest-pipeline/pipeline-tcp.json"
+  ],
+  "datasets": [
+    {
+      "id": "bar",
+      "title": "Foo",
+      "release": "experimental",
+      "type": "logs",
+      "ingest_pipeline": "pipeline-entry",
+      "streams": [
+        {
+          "input": "foo",
+          "vars": [
+            {
+              "name": "paths",
+              "type": "text",
+              "description": "Path to log files to be collected",
+              "multi": true,
+              "required": true,
+              "show_user": false
+            }
+          ],
+          "enabled": true
+        }
+      ],
+      "package": "example",
+      "path": "foo"
+    }
+  ],
+  "datasources": [
+    {
+      "name": "logs",
+      "title": "Logs datasource",
+      "description": "Datasource for your log files.",
+      "inputs": [
+        {
+          "type": "foo",
+          "streams": [
+            {
+              "input": "foo",
+              "vars": [
+                {
+                  "name": "paths",
+                  "type": "text",
+                  "description": "Path to log files to be collected",
+                  "multi": true,
+                  "required": true,
+                  "show_user": false
+                }
+              ],
+              "dataset": "bar",
+              "template_path": "stream.yml.hbs",
+              "template": "foo: bar\n",
+              "enabled": true
+            }
+          ]
+        }
+      ],
+      "multiple": true
+    }
+  ],
+  "download": "/epr/example/example-1.0.0.tar.gz",
+  "path": "/package/example/1.0.0"
+}

--- a/docs/api/package/experimental/0.0.1/index.json
+++ b/docs/api/package/experimental/0.0.1/index.json
@@ -1,12 +1,14 @@
 {
-  "format_version": "1.0.0",
   "name": "experimental",
   "title": "Experimental",
   "version": "0.0.1",
-  "readme": "/package/experimental/0.0.1/docs/README.md",
-  "license": "basic",
   "description": "Experimental package, should be set by default",
   "type": "solution",
+  "download": "/epr/experimental/experimental-0.0.1.tar.gz",
+  "path": "/package/experimental/0.0.1",
+  "format_version": "1.0.0",
+  "readme": "/package/experimental/0.0.1/docs/README.md",
+  "license": "basic",
   "categories": [
     "metrics"
   ],
@@ -18,7 +20,5 @@
   "assets": [
     "/package/experimental/0.0.1/manifest.yml",
     "/package/experimental/0.0.1/docs/README.md"
-  ],
-  "download": "/epr/experimental/experimental-0.0.1.tar.gz",
-  "path": "/package/experimental/0.0.1"
+  ]
 }

--- a/docs/api/package/experimental/0.0.1/index.json
+++ b/docs/api/package/experimental/0.0.1/index.json
@@ -1,0 +1,24 @@
+{
+  "format_version": "1.0.0",
+  "name": "experimental",
+  "title": "Experimental",
+  "version": "0.0.1",
+  "readme": "/package/experimental/0.0.1/docs/README.md",
+  "license": "basic",
+  "description": "Experimental package, should be set by default",
+  "type": "solution",
+  "categories": [
+    "metrics"
+  ],
+  "release": "experimental",
+  "removable": true,
+  "requirement": {
+    "kibana": {}
+  },
+  "assets": [
+    "/package/experimental/0.0.1/manifest.yml",
+    "/package/experimental/0.0.1/docs/README.md"
+  ],
+  "download": "/epr/experimental/experimental-0.0.1.tar.gz",
+  "path": "/package/experimental/0.0.1"
+}

--- a/docs/api/package/foo/1.0.0/index.json
+++ b/docs/api/package/foo/1.0.0/index.json
@@ -1,12 +1,14 @@
 {
-  "format_version": "1.0.0",
   "name": "foo",
   "title": "Foo",
   "version": "1.0.0",
-  "readme": "/package/foo/1.0.0/docs/README.md",
-  "license": "basic",
   "description": "This is the foo integration",
   "type": "solution",
+  "download": "/epr/foo/foo-1.0.0.tar.gz",
+  "path": "/package/foo/1.0.0",
+  "format_version": "1.0.0",
+  "readme": "/package/foo/1.0.0/docs/README.md",
+  "license": "basic",
   "categories": [
     "metrics"
   ],
@@ -20,7 +22,5 @@
   "assets": [
     "/package/foo/1.0.0/manifest.yml",
     "/package/foo/1.0.0/docs/README.md"
-  ],
-  "download": "/epr/foo/foo-1.0.0.tar.gz",
-  "path": "/package/foo/1.0.0"
+  ]
 }

--- a/docs/api/package/foo/1.0.0/index.json
+++ b/docs/api/package/foo/1.0.0/index.json
@@ -1,0 +1,26 @@
+{
+  "format_version": "1.0.0",
+  "name": "foo",
+  "title": "Foo",
+  "version": "1.0.0",
+  "readme": "/package/foo/1.0.0/docs/README.md",
+  "license": "basic",
+  "description": "This is the foo integration",
+  "type": "solution",
+  "categories": [
+    "metrics"
+  ],
+  "release": "beta",
+  "removable": true,
+  "requirement": {
+    "kibana": {
+      "versions": "\u003e=7.0.0"
+    }
+  },
+  "assets": [
+    "/package/foo/1.0.0/manifest.yml",
+    "/package/foo/1.0.0/docs/README.md"
+  ],
+  "download": "/epr/foo/foo-1.0.0.tar.gz",
+  "path": "/package/foo/1.0.0"
+}

--- a/docs/api/package/internal/1.2.0/index.json
+++ b/docs/api/package/internal/1.2.0/index.json
@@ -1,12 +1,15 @@
 {
-  "format_version": "1.0.0",
   "name": "internal",
   "title": "Internal",
   "version": "1.2.0",
-  "readme": "/package/internal/1.2.0/docs/README.md",
-  "license": "basic",
   "description": "Internal package",
   "type": "integration",
+  "download": "/epr/internal/internal-1.2.0.tar.gz",
+  "path": "/package/internal/1.2.0",
+  "internal": true,
+  "format_version": "1.0.0",
+  "readme": "/package/internal/1.2.0/docs/README.md",
+  "license": "basic",
   "categories": [],
   "release": "beta",
   "removable": false,
@@ -16,8 +19,5 @@
   "assets": [
     "/package/internal/1.2.0/manifest.yml",
     "/package/internal/1.2.0/docs/README.md"
-  ],
-  "internal": true,
-  "download": "/epr/internal/internal-1.2.0.tar.gz",
-  "path": "/package/internal/1.2.0"
+  ]
 }

--- a/docs/api/package/internal/1.2.0/index.json
+++ b/docs/api/package/internal/1.2.0/index.json
@@ -1,0 +1,23 @@
+{
+  "format_version": "1.0.0",
+  "name": "internal",
+  "title": "Internal",
+  "version": "1.2.0",
+  "readme": "/package/internal/1.2.0/docs/README.md",
+  "license": "basic",
+  "description": "Internal package",
+  "type": "integration",
+  "categories": [],
+  "release": "beta",
+  "removable": false,
+  "requirement": {
+    "kibana": {}
+  },
+  "assets": [
+    "/package/internal/1.2.0/manifest.yml",
+    "/package/internal/1.2.0/docs/README.md"
+  ],
+  "internal": true,
+  "download": "/epr/internal/internal-1.2.0.tar.gz",
+  "path": "/package/internal/1.2.0"
+}

--- a/docs/api/package/multiple_false/0.0.1/index.json
+++ b/docs/api/package/multiple_false/0.0.1/index.json
@@ -1,0 +1,87 @@
+{
+  "format_version": "1.0.0",
+  "name": "multiple_false",
+  "title": "Multiple false",
+  "version": "0.0.1",
+  "readme": "/package/multiple_false/0.0.1/docs/README.md",
+  "license": "basic",
+  "description": "Tests that multiple can be set to false",
+  "type": "integration",
+  "categories": [
+    "logs"
+  ],
+  "release": "beta",
+  "removable": true,
+  "requirement": {
+    "kibana": {}
+  },
+  "assets": [
+    "/package/multiple_false/0.0.1/manifest.yml",
+    "/package/multiple_false/0.0.1/docs/README.md",
+    "/package/multiple_false/0.0.1/dataset/foo/manifest.yml",
+    "/package/multiple_false/0.0.1/dataset/foo/fields/base-fields.yml",
+    "/package/multiple_false/0.0.1/dataset/foo/agent/stream/stream.yml.hbs",
+    "/package/multiple_false/0.0.1/dataset/foo/elasticsearch/ingest-pipeline/default.json"
+  ],
+  "datasets": [
+    {
+      "id": "multiple_false.foo",
+      "title": "Foo",
+      "release": "experimental",
+      "type": "logs",
+      "ingest_pipeline": "default",
+      "streams": [
+        {
+          "input": "logs",
+          "vars": [
+            {
+              "name": "paths",
+              "type": "text",
+              "description": "Path to log files to be collected",
+              "multi": true,
+              "required": true,
+              "show_user": false
+            }
+          ],
+          "enabled": true
+        }
+      ],
+      "package": "multiple_false",
+      "path": "foo"
+    }
+  ],
+  "datasources": [
+    {
+      "name": "logs",
+      "title": "Logs datasource",
+      "description": "Datasource for your log files.",
+      "inputs": [
+        {
+          "type": "logs",
+          "streams": [
+            {
+              "input": "logs",
+              "vars": [
+                {
+                  "name": "paths",
+                  "type": "text",
+                  "description": "Path to log files to be collected",
+                  "multi": true,
+                  "required": true,
+                  "show_user": false
+                }
+              ],
+              "dataset": "multiple_false.foo",
+              "template_path": "stream.yml.hbs",
+              "template": "foo: bar\n",
+              "enabled": true
+            }
+          ]
+        }
+      ],
+      "multiple": false
+    }
+  ],
+  "download": "/epr/multiple_false/multiple_false-0.0.1.tar.gz",
+  "path": "/package/multiple_false/0.0.1"
+}

--- a/docs/api/package/multiple_false/0.0.1/index.json
+++ b/docs/api/package/multiple_false/0.0.1/index.json
@@ -1,12 +1,14 @@
 {
-  "format_version": "1.0.0",
   "name": "multiple_false",
   "title": "Multiple false",
   "version": "0.0.1",
-  "readme": "/package/multiple_false/0.0.1/docs/README.md",
-  "license": "basic",
   "description": "Tests that multiple can be set to false",
   "type": "integration",
+  "download": "/epr/multiple_false/multiple_false-0.0.1.tar.gz",
+  "path": "/package/multiple_false/0.0.1",
+  "format_version": "1.0.0",
+  "readme": "/package/multiple_false/0.0.1/docs/README.md",
+  "license": "basic",
   "categories": [
     "logs"
   ],
@@ -81,7 +83,5 @@
       ],
       "multiple": false
     }
-  ],
-  "download": "/epr/multiple_false/multiple_false-0.0.1.tar.gz",
-  "path": "/package/multiple_false/0.0.1"
+  ]
 }

--- a/docs/api/package/no_stream_configs/1.0.0/index.json
+++ b/docs/api/package/no_stream_configs/1.0.0/index.json
@@ -1,12 +1,14 @@
 {
-  "format_version": "1.0.0",
   "name": "no_stream_configs",
   "title": "No Stream configs",
   "version": "1.0.0",
-  "readme": "/package/no_stream_configs/1.0.0/docs/README.md",
-  "license": "basic",
   "description": "This package does contain a dataset but not stream configs.\n",
   "type": "integration",
+  "download": "/epr/no_stream_configs/no_stream_configs-1.0.0.tar.gz",
+  "path": "/package/no_stream_configs/1.0.0",
+  "format_version": "1.0.0",
+  "readme": "/package/no_stream_configs/1.0.0/docs/README.md",
+  "license": "basic",
   "categories": [
     "logs"
   ],
@@ -31,7 +33,5 @@
       "package": "no_stream_configs",
       "path": "log"
     }
-  ],
-  "download": "/epr/no_stream_configs/no_stream_configs-1.0.0.tar.gz",
-  "path": "/package/no_stream_configs/1.0.0"
+  ]
 }

--- a/docs/api/package/no_stream_configs/1.0.0/index.json
+++ b/docs/api/package/no_stream_configs/1.0.0/index.json
@@ -1,0 +1,37 @@
+{
+  "format_version": "1.0.0",
+  "name": "no_stream_configs",
+  "title": "No Stream configs",
+  "version": "1.0.0",
+  "readme": "/package/no_stream_configs/1.0.0/docs/README.md",
+  "license": "basic",
+  "description": "This package does contain a dataset but not stream configs.\n",
+  "type": "integration",
+  "categories": [
+    "logs"
+  ],
+  "release": "beta",
+  "removable": true,
+  "requirement": {
+    "kibana": {}
+  },
+  "assets": [
+    "/package/no_stream_configs/1.0.0/manifest.yml",
+    "/package/no_stream_configs/1.0.0/docs/README.md",
+    "/package/no_stream_configs/1.0.0/dataset/log/manifest.yml",
+    "/package/no_stream_configs/1.0.0/dataset/log/fields/base-fields.yml",
+    "/package/no_stream_configs/1.0.0/dataset/log/fields/ecs.yml"
+  ],
+  "datasets": [
+    {
+      "id": "no_stream_configs.log",
+      "title": "Log Yaml pipeline",
+      "release": "experimental",
+      "type": "logs",
+      "package": "no_stream_configs",
+      "path": "log"
+    }
+  ],
+  "download": "/epr/no_stream_configs/no_stream_configs-1.0.0.tar.gz",
+  "path": "/package/no_stream_configs/1.0.0"
+}

--- a/main_test.go
+++ b/main_test.go
@@ -122,14 +122,18 @@ func TestPackageIndex(t *testing.T) {
 
 // TestAllPackageIndex generates and compares all index.json files for the test packages
 func TestAllPackageIndex(t *testing.T) {
-	publicPath := "./testdata/public"
-	packagesBasePath := []string{publicPath + "/package"}
+	testPackagePath := filepath.Join("testdata", "package")
 
+	packagesBasePath := []string{testPackagePath}
 	packageIndexHandler := packageIndexHandler(packagesBasePath, testCacheTime)
 
 	// find all packages
-	dirs, err := filepath.Glob(packagesBasePath[0] + "/*/*")
-	assert.NoError(t, err)
+	var dirs []string
+	for _, path := range packagesBasePath {
+		d, err := filepath.Glob(path + "/*/*")
+		assert.NoError(t, err)
+		dirs = append(dirs, d...)
+	}
 
 	type Test struct {
 		packageName    string

--- a/main_test.go
+++ b/main_test.go
@@ -123,12 +123,12 @@ func TestPackageIndex(t *testing.T) {
 // TestAllPackageIndex generates and compares all index.json files for the test packages
 func TestAllPackageIndex(t *testing.T) {
 	publicPath := "./testdata/public"
-	packagesBasePath := publicPath + "/package"
+	packagesBasePath := []string{publicPath + "/package"}
 
 	packageIndexHandler := packageIndexHandler(packagesBasePath, testCacheTime)
 
 	// find all packages
-	dirs, err := filepath.Glob(packagesBasePath + "/*/*")
+	dirs, err := filepath.Glob(packagesBasePath[0] + "/*/*")
 	assert.NoError(t, err)
 
 	type Test struct {


### PR DESCRIPTION
We got rid of the generated files so we are able to get rid of the public directory and the build step. But on the testing side this removed one useful tool to show changes in our generated output. To get this back, I added a test that creates all index.json files for the testdata packages.

Doing this change I found also some generated files we don't use anymore. After this is merged, I want to clean up a bit on where we put our golden files and make sure we clean it up.