### PR TITLE
Use BasePackage for search output data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Validate version consistency. [#510](https://github.com/elastic/package-registry/pull/510)
 * Remove package code generator. [#513](https://github.com/elastic/package-registry/pull/513)
 * Added support for ecs style validation for dataset fields. [#520](https://github.com/elastic/package-registry/pull/520)
+* Use BasePackage for search output data. [#529](https://github.com/elastic/package-registry/pull/529)
 
 ### Deprecated
 

--- a/docs/api/package.json
+++ b/docs/api/package.json
@@ -1,12 +1,14 @@
 {
-  "format_version": "1.0.0",
   "name": "example",
   "title": "Example Integration",
   "version": "1.0.0",
-  "readme": "/package/example/1.0.0/docs/README.md",
-  "license": "basic",
   "description": "This is the example integration",
   "type": "integration",
+  "download": "/epr/example/example-1.0.0.tar.gz",
+  "path": "/package/example/1.0.0",
+  "format_version": "1.0.0",
+  "readme": "/package/example/1.0.0/docs/README.md",
+  "license": "basic",
   "categories": [
     "logs",
     "metrics"
@@ -111,7 +113,5 @@
       ],
       "multiple": true
     }
-  ],
-  "download": "/epr/example/example-1.0.0.tar.gz",
-  "path": "/package/example/1.0.0"
+  ]
 }

--- a/docs/api/search-all.json
+++ b/docs/api/search-all.json
@@ -1,74 +1,74 @@
 [
   {
-    "description": "Package with data sources",
-    "download": "/epr/datasources/datasources-1.0.0.tar.gz",
     "name": "datasources",
-    "path": "/package/datasources/1.0.0",
     "title": "Default datasource Integration",
+    "version": "1.0.0",
+    "description": "Package with data sources",
     "type": "integration",
-    "version": "1.0.0"
+    "download": "/epr/datasources/datasources-1.0.0.tar.gz",
+    "path": "/package/datasources/1.0.0"
   },
   {
-    "description": "Tests if no pipeline is set, it defaults to the default one",
-    "download": "/epr/default_pipeline/default_pipeline-0.0.2.tar.gz",
     "name": "default_pipeline",
-    "path": "/package/default_pipeline/0.0.2",
     "title": "Default pipeline Integration",
+    "version": "0.0.2",
+    "description": "Tests if no pipeline is set, it defaults to the default one",
     "type": "integration",
-    "version": "0.0.2"
+    "download": "/epr/default_pipeline/default_pipeline-0.0.2.tar.gz",
+    "path": "/package/default_pipeline/0.0.2"
   },
   {
-    "description": "Tests the registry validations works for dataset fields using the ecs style format",
-    "download": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.tar.gz",
     "name": "ecs_style_dataset",
-    "path": "/package/ecs_style_dataset/0.0.1",
     "title": "Default pipeline Integration",
+    "version": "0.0.1",
+    "description": "Tests the registry validations works for dataset fields using the ecs style format",
     "type": "integration",
-    "version": "0.0.1"
+    "download": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.tar.gz",
+    "path": "/package/ecs_style_dataset/0.0.1"
   },
   {
-    "description": "This is the example integration.",
-    "download": "/epr/example/example-0.0.2.tar.gz",
     "name": "example",
-    "path": "/package/example/0.0.2",
     "title": "Example",
+    "version": "0.0.2",
+    "description": "This is the example integration.",
     "type": "integration",
-    "version": "0.0.2"
+    "download": "/epr/example/example-0.0.2.tar.gz",
+    "path": "/package/example/0.0.2"
   },
   {
-    "description": "This is the example integration",
-    "download": "/epr/example/example-1.0.0.tar.gz",
     "name": "example",
-    "path": "/package/example/1.0.0",
     "title": "Example Integration",
+    "version": "1.0.0",
+    "description": "This is the example integration",
     "type": "integration",
-    "version": "1.0.0"
+    "download": "/epr/example/example-1.0.0.tar.gz",
+    "path": "/package/example/1.0.0"
   },
   {
-    "description": "This is the foo integration",
-    "download": "/epr/foo/foo-1.0.0.tar.gz",
     "name": "foo",
-    "path": "/package/foo/1.0.0",
     "title": "Foo",
+    "version": "1.0.0",
+    "description": "This is the foo integration",
     "type": "solution",
-    "version": "1.0.0"
+    "download": "/epr/foo/foo-1.0.0.tar.gz",
+    "path": "/package/foo/1.0.0"
   },
   {
-    "description": "Tests that multiple can be set to false",
-    "download": "/epr/multiple_false/multiple_false-0.0.1.tar.gz",
     "name": "multiple_false",
-    "path": "/package/multiple_false/0.0.1",
     "title": "Multiple false",
+    "version": "0.0.1",
+    "description": "Tests that multiple can be set to false",
     "type": "integration",
-    "version": "0.0.1"
+    "download": "/epr/multiple_false/multiple_false-0.0.1.tar.gz",
+    "path": "/package/multiple_false/0.0.1"
   },
   {
-    "description": "This package does contain a dataset but not stream configs.\n",
-    "download": "/epr/no_stream_configs/no_stream_configs-1.0.0.tar.gz",
     "name": "no_stream_configs",
-    "path": "/package/no_stream_configs/1.0.0",
     "title": "No Stream configs",
+    "version": "1.0.0",
+    "description": "This package does contain a dataset but not stream configs.\n",
     "type": "integration",
-    "version": "1.0.0"
+    "download": "/epr/no_stream_configs/no_stream_configs-1.0.0.tar.gz",
+    "path": "/package/no_stream_configs/1.0.0"
   }
 ]

--- a/docs/api/search-category-logs.json
+++ b/docs/api/search-category-logs.json
@@ -1,56 +1,56 @@
 [
   {
-    "description": "Package with data sources",
-    "download": "/epr/datasources/datasources-1.0.0.tar.gz",
     "name": "datasources",
-    "path": "/package/datasources/1.0.0",
     "title": "Default datasource Integration",
+    "version": "1.0.0",
+    "description": "Package with data sources",
     "type": "integration",
-    "version": "1.0.0"
+    "download": "/epr/datasources/datasources-1.0.0.tar.gz",
+    "path": "/package/datasources/1.0.0"
   },
   {
-    "description": "Tests if no pipeline is set, it defaults to the default one",
-    "download": "/epr/default_pipeline/default_pipeline-0.0.2.tar.gz",
     "name": "default_pipeline",
-    "path": "/package/default_pipeline/0.0.2",
     "title": "Default pipeline Integration",
+    "version": "0.0.2",
+    "description": "Tests if no pipeline is set, it defaults to the default one",
     "type": "integration",
-    "version": "0.0.2"
+    "download": "/epr/default_pipeline/default_pipeline-0.0.2.tar.gz",
+    "path": "/package/default_pipeline/0.0.2"
   },
   {
-    "description": "Tests the registry validations works for dataset fields using the ecs style format",
-    "download": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.tar.gz",
     "name": "ecs_style_dataset",
-    "path": "/package/ecs_style_dataset/0.0.1",
     "title": "Default pipeline Integration",
+    "version": "0.0.1",
+    "description": "Tests the registry validations works for dataset fields using the ecs style format",
     "type": "integration",
-    "version": "0.0.1"
+    "download": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.tar.gz",
+    "path": "/package/ecs_style_dataset/0.0.1"
   },
   {
-    "description": "This is the example integration",
-    "download": "/epr/example/example-1.0.0.tar.gz",
     "name": "example",
-    "path": "/package/example/1.0.0",
     "title": "Example Integration",
+    "version": "1.0.0",
+    "description": "This is the example integration",
     "type": "integration",
-    "version": "1.0.0"
+    "download": "/epr/example/example-1.0.0.tar.gz",
+    "path": "/package/example/1.0.0"
   },
   {
-    "description": "Tests that multiple can be set to false",
-    "download": "/epr/multiple_false/multiple_false-0.0.1.tar.gz",
     "name": "multiple_false",
-    "path": "/package/multiple_false/0.0.1",
     "title": "Multiple false",
+    "version": "0.0.1",
+    "description": "Tests that multiple can be set to false",
     "type": "integration",
-    "version": "0.0.1"
+    "download": "/epr/multiple_false/multiple_false-0.0.1.tar.gz",
+    "path": "/package/multiple_false/0.0.1"
   },
   {
-    "description": "This package does contain a dataset but not stream configs.\n",
-    "download": "/epr/no_stream_configs/no_stream_configs-1.0.0.tar.gz",
     "name": "no_stream_configs",
-    "path": "/package/no_stream_configs/1.0.0",
     "title": "No Stream configs",
+    "version": "1.0.0",
+    "description": "This package does contain a dataset but not stream configs.\n",
     "type": "integration",
-    "version": "1.0.0"
+    "download": "/epr/no_stream_configs/no_stream_configs-1.0.0.tar.gz",
+    "path": "/package/no_stream_configs/1.0.0"
   }
 ]

--- a/docs/api/search-category-metrics.json
+++ b/docs/api/search-category-metrics.json
@@ -1,20 +1,20 @@
 [
   {
-    "description": "This is the example integration",
-    "download": "/epr/example/example-1.0.0.tar.gz",
     "name": "example",
-    "path": "/package/example/1.0.0",
     "title": "Example Integration",
+    "version": "1.0.0",
+    "description": "This is the example integration",
     "type": "integration",
-    "version": "1.0.0"
+    "download": "/epr/example/example-1.0.0.tar.gz",
+    "path": "/package/example/1.0.0"
   },
   {
-    "description": "This is the foo integration",
-    "download": "/epr/foo/foo-1.0.0.tar.gz",
     "name": "foo",
-    "path": "/package/foo/1.0.0",
     "title": "Foo",
+    "version": "1.0.0",
+    "description": "This is the foo integration",
     "type": "solution",
-    "version": "1.0.0"
+    "download": "/epr/foo/foo-1.0.0.tar.gz",
+    "path": "/package/foo/1.0.0"
   }
 ]

--- a/docs/api/search-kibana652.json
+++ b/docs/api/search-kibana652.json
@@ -1,56 +1,56 @@
 [
   {
-    "description": "Package with data sources",
-    "download": "/epr/datasources/datasources-1.0.0.tar.gz",
     "name": "datasources",
-    "path": "/package/datasources/1.0.0",
     "title": "Default datasource Integration",
+    "version": "1.0.0",
+    "description": "Package with data sources",
     "type": "integration",
-    "version": "1.0.0"
+    "download": "/epr/datasources/datasources-1.0.0.tar.gz",
+    "path": "/package/datasources/1.0.0"
   },
   {
-    "description": "Tests if no pipeline is set, it defaults to the default one",
-    "download": "/epr/default_pipeline/default_pipeline-0.0.2.tar.gz",
     "name": "default_pipeline",
-    "path": "/package/default_pipeline/0.0.2",
     "title": "Default pipeline Integration",
+    "version": "0.0.2",
+    "description": "Tests if no pipeline is set, it defaults to the default one",
     "type": "integration",
-    "version": "0.0.2"
+    "download": "/epr/default_pipeline/default_pipeline-0.0.2.tar.gz",
+    "path": "/package/default_pipeline/0.0.2"
   },
   {
-    "description": "Tests the registry validations works for dataset fields using the ecs style format",
-    "download": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.tar.gz",
     "name": "ecs_style_dataset",
-    "path": "/package/ecs_style_dataset/0.0.1",
     "title": "Default pipeline Integration",
+    "version": "0.0.1",
+    "description": "Tests the registry validations works for dataset fields using the ecs style format",
     "type": "integration",
-    "version": "0.0.1"
+    "download": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.tar.gz",
+    "path": "/package/ecs_style_dataset/0.0.1"
   },
   {
-    "description": "This is the example integration.",
-    "download": "/epr/example/example-0.0.2.tar.gz",
     "name": "example",
-    "path": "/package/example/0.0.2",
     "title": "Example",
+    "version": "0.0.2",
+    "description": "This is the example integration.",
     "type": "integration",
-    "version": "0.0.2"
+    "download": "/epr/example/example-0.0.2.tar.gz",
+    "path": "/package/example/0.0.2"
   },
   {
-    "description": "Tests that multiple can be set to false",
-    "download": "/epr/multiple_false/multiple_false-0.0.1.tar.gz",
     "name": "multiple_false",
-    "path": "/package/multiple_false/0.0.1",
     "title": "Multiple false",
+    "version": "0.0.1",
+    "description": "Tests that multiple can be set to false",
     "type": "integration",
-    "version": "0.0.1"
+    "download": "/epr/multiple_false/multiple_false-0.0.1.tar.gz",
+    "path": "/package/multiple_false/0.0.1"
   },
   {
-    "description": "This package does contain a dataset but not stream configs.\n",
-    "download": "/epr/no_stream_configs/no_stream_configs-1.0.0.tar.gz",
     "name": "no_stream_configs",
-    "path": "/package/no_stream_configs/1.0.0",
     "title": "No Stream configs",
+    "version": "1.0.0",
+    "description": "This package does contain a dataset but not stream configs.\n",
     "type": "integration",
-    "version": "1.0.0"
+    "download": "/epr/no_stream_configs/no_stream_configs-1.0.0.tar.gz",
+    "path": "/package/no_stream_configs/1.0.0"
   }
 ]

--- a/docs/api/search-kibana721.json
+++ b/docs/api/search-kibana721.json
@@ -1,65 +1,65 @@
 [
   {
-    "description": "Package with data sources",
-    "download": "/epr/datasources/datasources-1.0.0.tar.gz",
     "name": "datasources",
-    "path": "/package/datasources/1.0.0",
     "title": "Default datasource Integration",
+    "version": "1.0.0",
+    "description": "Package with data sources",
     "type": "integration",
-    "version": "1.0.0"
+    "download": "/epr/datasources/datasources-1.0.0.tar.gz",
+    "path": "/package/datasources/1.0.0"
   },
   {
-    "description": "Tests if no pipeline is set, it defaults to the default one",
-    "download": "/epr/default_pipeline/default_pipeline-0.0.2.tar.gz",
     "name": "default_pipeline",
-    "path": "/package/default_pipeline/0.0.2",
     "title": "Default pipeline Integration",
+    "version": "0.0.2",
+    "description": "Tests if no pipeline is set, it defaults to the default one",
     "type": "integration",
-    "version": "0.0.2"
+    "download": "/epr/default_pipeline/default_pipeline-0.0.2.tar.gz",
+    "path": "/package/default_pipeline/0.0.2"
   },
   {
-    "description": "Tests the registry validations works for dataset fields using the ecs style format",
-    "download": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.tar.gz",
     "name": "ecs_style_dataset",
-    "path": "/package/ecs_style_dataset/0.0.1",
     "title": "Default pipeline Integration",
+    "version": "0.0.1",
+    "description": "Tests the registry validations works for dataset fields using the ecs style format",
     "type": "integration",
-    "version": "0.0.1"
+    "download": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.tar.gz",
+    "path": "/package/ecs_style_dataset/0.0.1"
   },
   {
-    "description": "This is the example integration",
-    "download": "/epr/example/example-1.0.0.tar.gz",
     "name": "example",
-    "path": "/package/example/1.0.0",
     "title": "Example Integration",
+    "version": "1.0.0",
+    "description": "This is the example integration",
     "type": "integration",
-    "version": "1.0.0"
+    "download": "/epr/example/example-1.0.0.tar.gz",
+    "path": "/package/example/1.0.0"
   },
   {
-    "description": "This is the foo integration",
-    "download": "/epr/foo/foo-1.0.0.tar.gz",
     "name": "foo",
-    "path": "/package/foo/1.0.0",
     "title": "Foo",
+    "version": "1.0.0",
+    "description": "This is the foo integration",
     "type": "solution",
-    "version": "1.0.0"
+    "download": "/epr/foo/foo-1.0.0.tar.gz",
+    "path": "/package/foo/1.0.0"
   },
   {
-    "description": "Tests that multiple can be set to false",
-    "download": "/epr/multiple_false/multiple_false-0.0.1.tar.gz",
     "name": "multiple_false",
-    "path": "/package/multiple_false/0.0.1",
     "title": "Multiple false",
+    "version": "0.0.1",
+    "description": "Tests that multiple can be set to false",
     "type": "integration",
-    "version": "0.0.1"
+    "download": "/epr/multiple_false/multiple_false-0.0.1.tar.gz",
+    "path": "/package/multiple_false/0.0.1"
   },
   {
-    "description": "This package does contain a dataset but not stream configs.\n",
-    "download": "/epr/no_stream_configs/no_stream_configs-1.0.0.tar.gz",
     "name": "no_stream_configs",
-    "path": "/package/no_stream_configs/1.0.0",
     "title": "No Stream configs",
+    "version": "1.0.0",
+    "description": "This package does contain a dataset but not stream configs.\n",
     "type": "integration",
-    "version": "1.0.0"
+    "download": "/epr/no_stream_configs/no_stream_configs-1.0.0.tar.gz",
+    "path": "/package/no_stream_configs/1.0.0"
   }
 ]

--- a/docs/api/search-package-example-all.json
+++ b/docs/api/search-package-example-all.json
@@ -1,20 +1,20 @@
 [
   {
-    "description": "This is the example integration.",
-    "download": "/epr/example/example-0.0.2.tar.gz",
     "name": "example",
-    "path": "/package/example/0.0.2",
     "title": "Example",
+    "version": "0.0.2",
+    "description": "This is the example integration.",
     "type": "integration",
-    "version": "0.0.2"
+    "download": "/epr/example/example-0.0.2.tar.gz",
+    "path": "/package/example/0.0.2"
   },
   {
-    "description": "This is the example integration",
-    "download": "/epr/example/example-1.0.0.tar.gz",
     "name": "example",
-    "path": "/package/example/1.0.0",
     "title": "Example Integration",
+    "version": "1.0.0",
+    "description": "This is the example integration",
     "type": "integration",
-    "version": "1.0.0"
+    "download": "/epr/example/example-1.0.0.tar.gz",
+    "path": "/package/example/1.0.0"
   }
 ]

--- a/docs/api/search-package-example.json
+++ b/docs/api/search-package-example.json
@@ -1,11 +1,11 @@
 [
   {
-    "description": "This is the example integration",
-    "download": "/epr/example/example-1.0.0.tar.gz",
     "name": "example",
-    "path": "/package/example/1.0.0",
     "title": "Example Integration",
+    "version": "1.0.0",
+    "description": "This is the example integration",
     "type": "integration",
-    "version": "1.0.0"
+    "download": "/epr/example/example-1.0.0.tar.gz",
+    "path": "/package/example/1.0.0"
   }
 ]

--- a/docs/api/search-package-experimental.json
+++ b/docs/api/search-package-experimental.json
@@ -1,74 +1,74 @@
 [
   {
-    "description": "Package with data sources",
-    "download": "/epr/datasources/datasources-1.0.0.tar.gz",
     "name": "datasources",
-    "path": "/package/datasources/1.0.0",
     "title": "Default datasource Integration",
+    "version": "1.0.0",
+    "description": "Package with data sources",
     "type": "integration",
-    "version": "1.0.0"
+    "download": "/epr/datasources/datasources-1.0.0.tar.gz",
+    "path": "/package/datasources/1.0.0"
   },
   {
-    "description": "Tests if no pipeline is set, it defaults to the default one",
-    "download": "/epr/default_pipeline/default_pipeline-0.0.2.tar.gz",
     "name": "default_pipeline",
-    "path": "/package/default_pipeline/0.0.2",
     "title": "Default pipeline Integration",
+    "version": "0.0.2",
+    "description": "Tests if no pipeline is set, it defaults to the default one",
     "type": "integration",
-    "version": "0.0.2"
+    "download": "/epr/default_pipeline/default_pipeline-0.0.2.tar.gz",
+    "path": "/package/default_pipeline/0.0.2"
   },
   {
-    "description": "Tests the registry validations works for dataset fields using the ecs style format",
-    "download": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.tar.gz",
     "name": "ecs_style_dataset",
-    "path": "/package/ecs_style_dataset/0.0.1",
     "title": "Default pipeline Integration",
+    "version": "0.0.1",
+    "description": "Tests the registry validations works for dataset fields using the ecs style format",
     "type": "integration",
-    "version": "0.0.1"
+    "download": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.tar.gz",
+    "path": "/package/ecs_style_dataset/0.0.1"
   },
   {
-    "description": "This is the example integration",
-    "download": "/epr/example/example-1.0.0.tar.gz",
     "name": "example",
-    "path": "/package/example/1.0.0",
     "title": "Example Integration",
+    "version": "1.0.0",
+    "description": "This is the example integration",
     "type": "integration",
-    "version": "1.0.0"
+    "download": "/epr/example/example-1.0.0.tar.gz",
+    "path": "/package/example/1.0.0"
   },
   {
-    "description": "Experimental package, should be set by default",
-    "download": "/epr/experimental/experimental-0.0.1.tar.gz",
     "name": "experimental",
-    "path": "/package/experimental/0.0.1",
     "title": "Experimental",
+    "version": "0.0.1",
+    "description": "Experimental package, should be set by default",
     "type": "solution",
-    "version": "0.0.1"
+    "download": "/epr/experimental/experimental-0.0.1.tar.gz",
+    "path": "/package/experimental/0.0.1"
   },
   {
-    "description": "This is the foo integration",
-    "download": "/epr/foo/foo-1.0.0.tar.gz",
     "name": "foo",
-    "path": "/package/foo/1.0.0",
     "title": "Foo",
+    "version": "1.0.0",
+    "description": "This is the foo integration",
     "type": "solution",
-    "version": "1.0.0"
+    "download": "/epr/foo/foo-1.0.0.tar.gz",
+    "path": "/package/foo/1.0.0"
   },
   {
-    "description": "Tests that multiple can be set to false",
-    "download": "/epr/multiple_false/multiple_false-0.0.1.tar.gz",
     "name": "multiple_false",
-    "path": "/package/multiple_false/0.0.1",
     "title": "Multiple false",
+    "version": "0.0.1",
+    "description": "Tests that multiple can be set to false",
     "type": "integration",
-    "version": "0.0.1"
+    "download": "/epr/multiple_false/multiple_false-0.0.1.tar.gz",
+    "path": "/package/multiple_false/0.0.1"
   },
   {
-    "description": "This package does contain a dataset but not stream configs.\n",
-    "download": "/epr/no_stream_configs/no_stream_configs-1.0.0.tar.gz",
     "name": "no_stream_configs",
-    "path": "/package/no_stream_configs/1.0.0",
     "title": "No Stream configs",
+    "version": "1.0.0",
+    "description": "This package does contain a dataset but not stream configs.\n",
     "type": "integration",
-    "version": "1.0.0"
+    "download": "/epr/no_stream_configs/no_stream_configs-1.0.0.tar.gz",
+    "path": "/package/no_stream_configs/1.0.0"
   }
 ]

--- a/docs/api/search-package-internal.json
+++ b/docs/api/search-package-internal.json
@@ -1,75 +1,75 @@
 [
   {
-    "description": "Package with data sources",
-    "download": "/epr/datasources/datasources-1.0.0.tar.gz",
     "name": "datasources",
-    "path": "/package/datasources/1.0.0",
     "title": "Default datasource Integration",
+    "version": "1.0.0",
+    "description": "Package with data sources",
     "type": "integration",
-    "version": "1.0.0"
+    "download": "/epr/datasources/datasources-1.0.0.tar.gz",
+    "path": "/package/datasources/1.0.0"
   },
   {
-    "description": "Tests if no pipeline is set, it defaults to the default one",
-    "download": "/epr/default_pipeline/default_pipeline-0.0.2.tar.gz",
     "name": "default_pipeline",
-    "path": "/package/default_pipeline/0.0.2",
     "title": "Default pipeline Integration",
+    "version": "0.0.2",
+    "description": "Tests if no pipeline is set, it defaults to the default one",
     "type": "integration",
-    "version": "0.0.2"
+    "download": "/epr/default_pipeline/default_pipeline-0.0.2.tar.gz",
+    "path": "/package/default_pipeline/0.0.2"
   },
   {
-    "description": "Tests the registry validations works for dataset fields using the ecs style format",
-    "download": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.tar.gz",
     "name": "ecs_style_dataset",
-    "path": "/package/ecs_style_dataset/0.0.1",
     "title": "Default pipeline Integration",
+    "version": "0.0.1",
+    "description": "Tests the registry validations works for dataset fields using the ecs style format",
     "type": "integration",
-    "version": "0.0.1"
+    "download": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.tar.gz",
+    "path": "/package/ecs_style_dataset/0.0.1"
   },
   {
-    "description": "This is the example integration",
-    "download": "/epr/example/example-1.0.0.tar.gz",
     "name": "example",
-    "path": "/package/example/1.0.0",
     "title": "Example Integration",
+    "version": "1.0.0",
+    "description": "This is the example integration",
     "type": "integration",
-    "version": "1.0.0"
+    "download": "/epr/example/example-1.0.0.tar.gz",
+    "path": "/package/example/1.0.0"
   },
   {
-    "description": "This is the foo integration",
-    "download": "/epr/foo/foo-1.0.0.tar.gz",
     "name": "foo",
-    "path": "/package/foo/1.0.0",
     "title": "Foo",
+    "version": "1.0.0",
+    "description": "This is the foo integration",
     "type": "solution",
-    "version": "1.0.0"
+    "download": "/epr/foo/foo-1.0.0.tar.gz",
+    "path": "/package/foo/1.0.0"
   },
   {
-    "description": "Internal package",
-    "download": "/epr/internal/internal-1.2.0.tar.gz",
-    "internal": true,
     "name": "internal",
-    "path": "/package/internal/1.2.0",
     "title": "Internal",
+    "version": "1.2.0",
+    "description": "Internal package",
     "type": "integration",
-    "version": "1.2.0"
+    "download": "/epr/internal/internal-1.2.0.tar.gz",
+    "path": "/package/internal/1.2.0",
+    "internal": true
   },
   {
-    "description": "Tests that multiple can be set to false",
-    "download": "/epr/multiple_false/multiple_false-0.0.1.tar.gz",
     "name": "multiple_false",
-    "path": "/package/multiple_false/0.0.1",
     "title": "Multiple false",
+    "version": "0.0.1",
+    "description": "Tests that multiple can be set to false",
     "type": "integration",
-    "version": "0.0.1"
+    "download": "/epr/multiple_false/multiple_false-0.0.1.tar.gz",
+    "path": "/package/multiple_false/0.0.1"
   },
   {
-    "description": "This package does contain a dataset but not stream configs.\n",
-    "download": "/epr/no_stream_configs/no_stream_configs-1.0.0.tar.gz",
     "name": "no_stream_configs",
-    "path": "/package/no_stream_configs/1.0.0",
     "title": "No Stream configs",
+    "version": "1.0.0",
+    "description": "This package does contain a dataset but not stream configs.\n",
     "type": "integration",
-    "version": "1.0.0"
+    "download": "/epr/no_stream_configs/no_stream_configs-1.0.0.tar.gz",
+    "path": "/package/no_stream_configs/1.0.0"
   }
 ]

--- a/docs/api/search.json
+++ b/docs/api/search.json
@@ -1,65 +1,65 @@
 [
   {
-    "description": "Package with data sources",
-    "download": "/epr/datasources/datasources-1.0.0.tar.gz",
     "name": "datasources",
-    "path": "/package/datasources/1.0.0",
     "title": "Default datasource Integration",
+    "version": "1.0.0",
+    "description": "Package with data sources",
     "type": "integration",
-    "version": "1.0.0"
+    "download": "/epr/datasources/datasources-1.0.0.tar.gz",
+    "path": "/package/datasources/1.0.0"
   },
   {
-    "description": "Tests if no pipeline is set, it defaults to the default one",
-    "download": "/epr/default_pipeline/default_pipeline-0.0.2.tar.gz",
     "name": "default_pipeline",
-    "path": "/package/default_pipeline/0.0.2",
     "title": "Default pipeline Integration",
+    "version": "0.0.2",
+    "description": "Tests if no pipeline is set, it defaults to the default one",
     "type": "integration",
-    "version": "0.0.2"
+    "download": "/epr/default_pipeline/default_pipeline-0.0.2.tar.gz",
+    "path": "/package/default_pipeline/0.0.2"
   },
   {
-    "description": "Tests the registry validations works for dataset fields using the ecs style format",
-    "download": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.tar.gz",
     "name": "ecs_style_dataset",
-    "path": "/package/ecs_style_dataset/0.0.1",
     "title": "Default pipeline Integration",
+    "version": "0.0.1",
+    "description": "Tests the registry validations works for dataset fields using the ecs style format",
     "type": "integration",
-    "version": "0.0.1"
+    "download": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.tar.gz",
+    "path": "/package/ecs_style_dataset/0.0.1"
   },
   {
-    "description": "This is the example integration",
-    "download": "/epr/example/example-1.0.0.tar.gz",
     "name": "example",
-    "path": "/package/example/1.0.0",
     "title": "Example Integration",
+    "version": "1.0.0",
+    "description": "This is the example integration",
     "type": "integration",
-    "version": "1.0.0"
+    "download": "/epr/example/example-1.0.0.tar.gz",
+    "path": "/package/example/1.0.0"
   },
   {
-    "description": "This is the foo integration",
-    "download": "/epr/foo/foo-1.0.0.tar.gz",
     "name": "foo",
-    "path": "/package/foo/1.0.0",
     "title": "Foo",
+    "version": "1.0.0",
+    "description": "This is the foo integration",
     "type": "solution",
-    "version": "1.0.0"
+    "download": "/epr/foo/foo-1.0.0.tar.gz",
+    "path": "/package/foo/1.0.0"
   },
   {
-    "description": "Tests that multiple can be set to false",
-    "download": "/epr/multiple_false/multiple_false-0.0.1.tar.gz",
     "name": "multiple_false",
-    "path": "/package/multiple_false/0.0.1",
     "title": "Multiple false",
+    "version": "0.0.1",
+    "description": "Tests that multiple can be set to false",
     "type": "integration",
-    "version": "0.0.1"
+    "download": "/epr/multiple_false/multiple_false-0.0.1.tar.gz",
+    "path": "/package/multiple_false/0.0.1"
   },
   {
-    "description": "This package does contain a dataset but not stream configs.\n",
-    "download": "/epr/no_stream_configs/no_stream_configs-1.0.0.tar.gz",
     "name": "no_stream_configs",
-    "path": "/package/no_stream_configs/1.0.0",
     "title": "No Stream configs",
+    "version": "1.0.0",
+    "description": "This package does contain a dataset but not stream configs.\n",
     "type": "integration",
-    "version": "1.0.0"
+    "download": "/epr/no_stream_configs/no_stream_configs-1.0.0.tar.gz",
+    "path": "/package/no_stream_configs/1.0.0"
   }
 ]

--- a/search.go
+++ b/search.go
@@ -163,28 +163,12 @@ func getPackageOutput(packagesList map[string]map[string]util.Package) ([]byte, 
 	}
 	sort.Strings(keys)
 
-	var output []map[string]interface{}
+	var output []util.BasePackage
 
 	for _, k := range keys {
 		parts := strings.Split(k, separator)
 		m := packagesList[parts[0]][parts[1]]
-		data := map[string]interface{}{
-			"name":        m.Name,
-			"description": m.Description,
-			"version":     m.Version,
-			"type":        m.Type,
-			"download":    m.GetDownloadPath(),
-			"path":        m.GetUrlPath(),
-		}
-		if m.Title != nil {
-			data["title"] = *m.Title
-		}
-		if m.Icons != nil {
-			data["icons"] = m.Icons
-		}
-		if m.Internal {
-			data["internal"] = true
-		}
+		data := m.BasePackage
 		output = append(output, data)
 	}
 

--- a/util/package.go
+++ b/util/package.go
@@ -28,31 +28,36 @@ var CategoryTitles = map[string]string{
 }
 
 type Package struct {
+	BasePackage   `config:",inline" json:",inline" yaml:",inline"`
 	FormatVersion string `config:"format_version" json:"format_version" yaml:"format_version"`
 
-	Name          string  `config:"name" json:"name"`
-	Title         *string `config:"title,omitempty" json:"title,omitempty" yaml:"title,omitempty"`
-	Version       string  `config:"version" json:"version"`
 	Readme        *string `config:"readme,omitempty" json:"readme,omitempty" yaml:"readme,omitempty"`
 	License       string  `config:"license,omitempty" json:"license,omitempty" yaml:"license,omitempty"`
 	versionSemVer *semver.Version
-	Description   string       `config:"description" json:"description"`
-	Type          string       `config:"type" json:"type"`
 	Categories    []string     `config:"categories" json:"categories"`
 	Release       string       `config:"release,omitempty" json:"release,omitempty"`
 	Removable     bool         `config:"removable" json:"removable"`
 	Requirement   Requirement  `config:"requirement" json:"requirement"`
 	Screenshots   []Image      `config:"screenshots,omitempty" json:"screenshots,omitempty" yaml:"screenshots,omitempty"`
-	Icons         []Image      `config:"icons,omitempty" json:"icons,omitempty" yaml:"icons,omitempty"`
 	Assets        []string     `config:"assets,omitempty" json:"assets,omitempty" yaml:"assets,omitempty"`
-	Internal      bool         `config:"internal,omitempty" json:"internal,omitempty" yaml:"internal,omitempty"`
 	DataSets      []*DataSet   `config:"datasets,omitempty" json:"datasets,omitempty" yaml:"datasets,omitempty"`
 	Datasources   []Datasource `config:"datasources,omitempty" json:"datasources,omitempty" yaml:"datasources,omitempty"`
-	Download      string       `json:"download" yaml:"download,omitempty"`
-	Path          string       `json:"path" yaml:"path,omitempty"`
 
 	// Local path to the package dir
 	BasePath string `json:"-" yaml:"-"`
+}
+
+// BasePackage is used for the output of the package info in the /search endpoint
+type BasePackage struct {
+	Name        string  `config:"name" json:"name"`
+	Title       *string `config:"title,omitempty" json:"title,omitempty" yaml:"title,omitempty"`
+	Version     string  `config:"version" json:"version"`
+	Description string  `config:"description" json:"description"`
+	Type        string  `config:"type" json:"type"`
+	Download    string  `json:"download" yaml:"download,omitempty"`
+	Path        string  `json:"path" yaml:"path,omitempty"`
+	Icons       []Image `config:"icons,omitempty" json:"icons,omitempty" yaml:"icons,omitempty"`
+	Internal    bool    `config:"internal,omitempty" json:"internal,omitempty" yaml:"internal,omitempty"`
 }
 
 type Datasource struct {

--- a/util/package_test.go
+++ b/util/package_test.go
@@ -25,14 +25,18 @@ var packageTests = []struct {
 	},
 	{
 		Package{
-			Title: &title,
+			BasePackage: BasePackage{
+				Title: &title,
+			},
 		},
 		false,
 		"missing description",
 	},
 	{
 		Package{
-			Title: &title,
+			BasePackage: BasePackage{
+				Title: &title,
+			},
 			Requirement: Requirement{
 				Kibana: ProductRequirement{
 					Versions: "bar",
@@ -44,8 +48,10 @@ var packageTests = []struct {
 	},
 	{
 		Package{
-			Title:       &title,
-			Description: "my description",
+			BasePackage: BasePackage{
+				Title:       &title,
+				Description: "my description",
+			},
 			Requirement: Requirement{
 				Kibana: ProductRequirement{
 					Versions: ">=1.2.3 <=4.5.6",
@@ -58,17 +64,21 @@ var packageTests = []struct {
 	},
 	{
 		Package{
-			Title:       &title,
-			Description: "my description",
-			Categories:  []string{"metrics", "logs"},
+			BasePackage: BasePackage{
+				Title:       &title,
+				Description: "my description",
+			},
+			Categories: []string{"metrics", "logs"},
 		},
 		false,
 		"missing format_version",
 	},
 	{
 		Package{
-			Title:         &title,
-			Description:   "my description",
+			BasePackage: BasePackage{
+				Title:       &title,
+				Description: "my description",
+			},
 			Categories:    []string{"metrics", "logs"},
 			FormatVersion: "1.0",
 		},
@@ -77,22 +87,26 @@ var packageTests = []struct {
 	},
 	{
 		Package{
-			Title:         &title,
-			Description:   "my description",
+			BasePackage: BasePackage{
+				Title:       &title,
+				Description: "my description",
+				Version:     "1.0",
+			},
 			Categories:    []string{"metrics", "logs"},
 			FormatVersion: "1.0.0",
-			Version:       "1.0",
 		},
 		false,
 		"invalid package version",
 	},
 	{
 		Package{
-			Title:         &title,
-			Description:   "my description",
+			BasePackage: BasePackage{
+				Title:       &title,
+				Description: "my description",
+				Version:     "1.2.3",
+			},
 			Categories:    []string{"metrics", "logs"},
 			FormatVersion: "1.0.0",
-			Version:       "1.2.3",
 		},
 		true,
 		"complete",


### PR DESCRIPTION
So far the `/search` output was manually built. This had the risk that the format of the package output and search output diverge but they should not. To prevent this, a BasePackage is introduced. The package is composed out of this BasePackage with additional fields.

This change does not affect the output, only the order of the output.