### PR TITLE
Add additional categories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Use BasePackage for search output data. [#529](https://github.com/elastic/package-registry/pull/529)
 * Add support for owner field in package manifest. [#536](https://github.com/elastic/package-registry/pull/536)
 * Introduce development mode. [#543](https://github.com/elastic/package-registry/pull/543)
+* Add additional supported categories to package. [#533](https://github.com/elastic/package-registry/pull/533)
 
 ### Deprecated
 

--- a/docs/api/categories-experimental.json
+++ b/docs/api/categories-experimental.json
@@ -5,6 +5,11 @@
     "count": 6
   },
   {
+    "id": "message_queue",
+    "title": "Message Queue",
+    "count": 1
+  },
+  {
     "id": "metrics",
     "title": "Metrics",
     "count": 3

--- a/docs/api/categories.json
+++ b/docs/api/categories.json
@@ -5,6 +5,11 @@
     "count": 6
   },
   {
+    "id": "message_queue",
+    "title": "Message Queue",
+    "count": 1
+  },
+  {
     "id": "metrics",
     "title": "Metrics",
     "count": 2

--- a/docs/api/package/default_pipeline/0.0.2/index.json
+++ b/docs/api/package/default_pipeline/0.0.2/index.json
@@ -10,7 +10,8 @@
   "readme": "/package/default_pipeline/0.0.2/docs/README.md",
   "license": "basic",
   "categories": [
-    "logs"
+    "logs",
+    "message_queue"
   ],
   "release": "beta",
   "removable": true,

--- a/testdata/package/default_pipeline/0.0.2/manifest.yml
+++ b/testdata/package/default_pipeline/0.0.2/manifest.yml
@@ -4,7 +4,7 @@ name: default_pipeline
 description: Tests if no pipeline is set, it defaults to the default one
 version: 0.0.2
 title: Default pipeline Integration
-categories: ["logs"]
+categories: ["logs", "message_queue"]
 type: integration
 release: beta
 

--- a/util/package.go
+++ b/util/package.go
@@ -26,7 +26,6 @@ var CategoryTitles = map[string]string{
 	"azure":             "Azure",
 	"cloud":             "Cloud",
 	"config_management": "Config management",
-	"container":         "Container",
 	"containers":        "Containers",
 	"crm":               "CRM",
 	"Custom":            "Custom",

--- a/util/package.go
+++ b/util/package.go
@@ -22,9 +22,35 @@ import (
 const defaultType = "integration"
 
 var CategoryTitles = map[string]string{
-	"logs":     "Logs",
-	"metrics":  "Metrics",
-	"security": "Security",
+	"aws":               "AWS",
+	"azure":             "Azure",
+	"cloud":             "Cloud",
+	"config_management": "Config management",
+	"container":         "Container",
+	"containers":        "Containers",
+	"crm":               "CRM",
+	"Custom":            "Custom",
+	"datastore":         "Datastore",
+	"elastic_stack":     "Elastic Stack",
+	"google_loud":       "Google Cloud",
+	"kubernetes":        "Kubernetes",
+	"languages":         "Languages",
+	"message_queue":     "Message Queue",
+	"monitoring":        "Monitoring",
+	"network":           "Network",
+	"notification":      "Notification",
+	"os_system":         "OS & System",
+	"productivity":      "Productivity",
+	"security":          "Security",
+	"support":           "Support",
+	"ticketing":         "Ticketing",
+	"version_control":   "Version Control",
+	"web":               "Web",
+
+	// Old categories, to be removed
+	"logs":    "Logs",
+	"metrics": "Metrics",
+	//"security": "Security",
 }
 
 type Package struct {

--- a/util/package.go
+++ b/util/package.go
@@ -28,7 +28,7 @@ var CategoryTitles = map[string]string{
 	"config_management": "Config management",
 	"containers":        "Containers",
 	"crm":               "CRM",
-	"Custom":            "Custom",
+	"custom":            "Custom",
 	"datastore":         "Datastore",
 	"elastic_stack":     "Elastic Stack",
 	"google_loud":       "Google Cloud",


### PR DESCRIPTION
In the process of defining our integrations page, additional categories were defined: https://www.elastic.co/integrations This PR adds these categories to the registry.

It must be followed up to update all existing packages and then remove the old category definitions.