### PR TITLE
Add validation for screenshots and icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bugfixes
 
 ### Added
+* Add validation for icons and screenshots. [#537](https://github.com/elastic/package-registry/pull/537)
 
 ### Deprecated
 

--- a/testdata/generated/package.json
+++ b/testdata/generated/package.json
@@ -19,14 +19,8 @@
   },
   "screenshots": [
     {
-      "src": "/img/kibana-iptables.png",
-      "path": "/package/example/1.0.0/img/kibana-iptables.png",
-      "title": "IP Tables Overview dashboard",
-      "size": "1492x1382"
-    },
-    {
-      "src": "/img/kibana-iptables-ubiquity.png",
-      "path": "/package/example/1.0.0/img/kibana-iptables-ubiquity.png",
+      "src": "/img/kibana-envoyproxy.jpg",
+      "path": "/package/example/1.0.0/img/kibana-envoyproxy.jpg",
       "title": "IP Tables Ubiquity Dashboard",
       "size": "1492x1464",
       "type": "image/png"

--- a/testdata/generated/package/example/1.0.0/index.json
+++ b/testdata/generated/package/example/1.0.0/index.json
@@ -19,14 +19,8 @@
   },
   "screenshots": [
     {
-      "src": "/img/kibana-iptables.png",
-      "path": "/package/example/1.0.0/img/kibana-iptables.png",
-      "title": "IP Tables Overview dashboard",
-      "size": "1492x1382"
-    },
-    {
-      "src": "/img/kibana-iptables-ubiquity.png",
-      "path": "/package/example/1.0.0/img/kibana-iptables-ubiquity.png",
+      "src": "/img/kibana-envoyproxy.jpg",
+      "path": "/package/example/1.0.0/img/kibana-envoyproxy.jpg",
       "title": "IP Tables Ubiquity Dashboard",
       "size": "1492x1464",
       "type": "image/png"

--- a/testdata/package/example/1.0.0/manifest.yml
+++ b/testdata/package/example/1.0.0/manifest.yml
@@ -14,10 +14,7 @@ conditions:
   kibana.version: "~7.x.x"
 
 screenshots:
-  - src: /img/kibana-iptables.png
-    title: IP Tables Overview dashboard
-    size: 1492x1382
-  - src: /img/kibana-iptables-ubiquity.png
+  - src: /img/kibana-envoyproxy.jpg
     title: IP Tables Ubiquity Dashboard
     size: 1492x1464
     type: image/png

--- a/util/package.go
+++ b/util/package.go
@@ -106,7 +106,9 @@ type Owner struct {
 }
 
 type Image struct {
-	Src   string `config:"src" json:"src" validate:"required"`
+	// Src is relative inside the package
+	Src string `config:"src" json:"src" validate:"required"`
+	// Path is the absolute path in the url
 	Path  string `config:"path" json:"path"`
 	Title string `config:"title" json:"title,omitempty"`
 	Size  string `config:"size" json:"size,omitempty"`
@@ -337,6 +339,20 @@ func (p *Package) Validate() error {
 	p.versionSemVer, err = semver.StrictNewVersion(p.Version)
 	if err != nil {
 		return errors.Wrap(err, "invalid package version")
+	}
+
+	for _, i := range p.Icons {
+		_, err := os.Stat(filepath.Join(p.BasePath, i.Src))
+		if err != nil {
+			return err
+		}
+	}
+
+	for _, s := range p.Screenshots {
+		_, err := os.Stat(filepath.Join(p.BasePath, s.Src))
+		if err != nil {
+			return err
+		}
 	}
 
 	err = p.validateVersionConsistency()


### PR DESCRIPTION
This validates all the defined icons and screenshots and errors out, if a src is not found. Some testing packages needed updating because of this.