### PR TITLE
Apply rule: first package found served

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Use BasePackage for search output data. [#529](https://github.com/elastic/package-registry/pull/529)
 * Add support for owner field in package manifest. [#536](https://github.com/elastic/package-registry/pull/536)
 * Introduce development mode. [#543](https://github.com/elastic/package-registry/pull/543)
+* Apply rule: first package found served. [#546](https://github.com/elastic/package-registry/pull/546)
 
 ### Deprecated
 

--- a/categories.go
+++ b/categories.go
@@ -58,12 +58,12 @@ func categoriesHandler(packagesBasePaths []string, cacheTime time.Duration) func
 			}
 
 			// Check if the version exists and if it should be added or not.
-			if pp, ok := packageList[p.Name]; ok {
-				// If the package in the list is newer, do nothing. Otherwise delete and later add the new one.
-				if pp.IsNewer(p) {
-					continue
-				}
+			// If the package in the list is newer or equal, do nothing.
+			if pp, ok := packageList[p.Name]; ok && pp.IsNewerOrEqual(p) {
+				continue
 			}
+
+			// Otherwise delete and later add the new one.
 			packageList[p.Name] = p
 		}
 

--- a/search.go
+++ b/search.go
@@ -122,11 +122,12 @@ func searchHandler(packagesBasePaths []string, cacheTime time.Duration) func(w h
 					for _, pp := range versions {
 						if pp.Name == p.Name {
 
-							// If the package in the list is newer, do nothing. Otherwise delete and later add the new one.
-							if pp.IsNewer(p) {
+							// If the package in the list is newer or equal, do nothing.
+							if pp.IsNewerOrEqual(p) {
 								continue
 							}
 
+							// Otherwise delete and later add the new one.
 							delete(packagesList[pp.Name], pp.Version)
 						}
 					}

--- a/util/package.go
+++ b/util/package.go
@@ -229,8 +229,8 @@ func (p *Package) HasKibanaVersion(version *semver.Version) bool {
 	return true
 }
 
-func (p *Package) IsNewer(pp Package) bool {
-	return p.versionSemVer.GreaterThan(pp.versionSemVer)
+func (p *Package) IsNewerOrEqual(pp Package) bool {
+	return !p.versionSemVer.LessThan(pp.versionSemVer)
 }
 
 // LoadAssets (re)loads all the assets of the package


### PR DESCRIPTION
This PR modified the EPR to serve package contents from the first found package path.

Sample: if the integrations project loads another path with packages, it should have priority comparing to the package-storage.