### PR TITLE
Remove os specific config examples and code

### DIFF
--- a/testdata/generated/package/datasources/1.0.0/index.json
+++ b/testdata/generated/package/datasources/1.0.0/index.json
@@ -56,19 +56,7 @@
               "show_user": false,
               "default": [
                 "/var/log/nginx/error.log*"
-              ],
-              "os": {
-                "darwin": {
-                  "default": [
-                    "/usr/local/var/log/nginx/error.log*"
-                  ]
-                },
-                "windows": {
-                  "default": [
-                    "c:/programdata/nginx/logs/*error.log*"
-                  ]
-                }
-              }
+              ]
             }
           ],
           "template_path": "logs.yml",
@@ -105,19 +93,7 @@
               "show_user": false,
               "default": [
                 "/var/log/nginx/access.log*"
-              ],
-              "os": {
-                "darwin": {
-                  "default": [
-                    "/usr/local/var/log/nginx/access.log*"
-                  ]
-                },
-                "windows": {
-                  "default": [
-                    "c:/programdata/nginx/logs/*access.log*"
-                  ]
-                }
-              }
+              ]
             }
           ],
           "title": "Title of the stream",
@@ -240,19 +216,7 @@
                   "show_user": false,
                   "default": [
                     "/var/log/nginx/error.log*"
-                  ],
-                  "os": {
-                    "darwin": {
-                      "default": [
-                        "/usr/local/var/log/nginx/error.log*"
-                      ]
-                    },
-                    "windows": {
-                      "default": [
-                        "c:/programdata/nginx/logs/*error.log*"
-                      ]
-                    }
-                  }
+                  ]
                 }
               ],
               "dataset": "datasources.examplelog1",
@@ -274,19 +238,7 @@
                   "show_user": false,
                   "default": [
                     "/var/log/nginx/access.log*"
-                  ],
-                  "os": {
-                    "darwin": {
-                      "default": [
-                        "/usr/local/var/log/nginx/access.log*"
-                      ]
-                    },
-                    "windows": {
-                      "default": [
-                        "c:/programdata/nginx/logs/*access.log*"
-                      ]
-                    }
-                  }
+                  ]
                 }
               ],
               "dataset": "datasources.examplelog2",

--- a/testdata/package/datasources/1.0.0/dataset/examplelog1/manifest.yml
+++ b/testdata/package/datasources/1.0.0/dataset/examplelog1/manifest.yml
@@ -14,14 +14,6 @@ streams:
         multi: true
         default:
           - /var/log/nginx/error.log*
-        # I suggest to use ECS fields for this config options here: https://github.com/elastic/ecs/blob/master/schemas/os.yml
-        # This would need to be based on a predefined definition on what can be filtered on
-        os.darwin:
-          default:
-            - /usr/local/var/log/nginx/error.log*
-        os.windows:
-          default:
-            - c:/programdata/nginx/logs/*error.log*
 
   - input: syslog
     title: Title of the stream

--- a/testdata/package/datasources/1.0.0/dataset/examplelog2/manifest.yml
+++ b/testdata/package/datasources/1.0.0/dataset/examplelog2/manifest.yml
@@ -14,11 +14,3 @@ streams:
         multi: true
         default:
           - /var/log/nginx/access.log*
-        # I suggest to use ECS fields for this config options here: https://github.com/elastic/ecs/blob/master/schemas/os.yml
-        # This would need to be based on a predefined definition on what can be filtered on
-        os.darwin:
-          default:
-            - /usr/local/var/log/nginx/access.log*
-        os.windows:
-          default:
-            - c:/programdata/nginx/logs/*access.log*

--- a/util/dataset.go
+++ b/util/dataset.go
@@ -76,12 +76,6 @@ type Variable struct {
 	Required    bool        `config:"required" json:"required" yaml:"required"`
 	ShowUser    bool        `config:"show_user" json:"show_user" yaml:"show_user"`
 	Default     interface{} `config:"default" json:"default,omitempty" yaml:"default,omitempty"`
-	Os          *Os         `config:"os" json:"os,omitempty" yaml:"os,omitempty"`
-}
-
-type Os struct {
-	Darwin  interface{} `config:"darwin" json:"darwin,omitempty" yaml:"darwin,omitempty"`
-	Windows interface{} `config:"windows" json:"windows,omitempty" yaml:"windows,omitempty"`
 }
 
 type fieldEntry struct {


### PR DESCRIPTION
As discussed in https://github.com/elastic/package-registry/issues/533 the os specific configs should be removed from now.