### PR TITLE
Add support for ES index-template configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Files to be loaded into the Elastic Stack:
 {service}/{type}/{filename}
 ```
 
-Service in the above can be `elasticsearch`, `kibana` or any other component in the Elastic Stack. The type is specific to each service. In the case of Elasticsearch it can be `ingest-pipeline`, `index-template` or could also be `index` data. For Kibana it could be `dashboard`, `visualization` or any other saved object type or other types. The names are taken from the API endpoints in each service. The file name needs to be unique inside the directory and best has a descriptive nature or unique id.
+Service in the above can be `elasticsearch`, `kibana` or any other component in the Elastic Stack. The type is specific to each service. In the case of Elasticsearch it can be `ingest_pipeline`, `index_template` or could also be `index` data. For Kibana it could be `dashboard`, `visualization` or any other saved object type or other types. The names are taken from the API endpoints in each service. The file name needs to be unique inside the directory and best has a descriptive nature or unique id.
 
 Each package can contain 2 additional directories:
 

--- a/testdata/generated/package/reference/1.0.0/index.json
+++ b/testdata/generated/package/reference/1.0.0/index.json
@@ -40,7 +40,53 @@
     "/package/reference/1.0.0/dataset/reference/manifest.yml",
     "/package/reference/1.0.0/dataset/reference/fields/base-fields.yml"
   ],
+<<<<<<< HEAD
   "config_templates": [
+=======
+  "datasets": [
+    {
+      "id": "reference.reference",
+      "title": "Reference Logs Title",
+      "release": "beta",
+      "type": "logs",
+      "streams": [
+        {
+          "input": "logs",
+          "vars": [
+            {
+              "name": "paths",
+              "type": "text",
+              "title": "Example variable title",
+              "description": "Description around how a variable should be used, what values it can contain and it can even contain **Markdown** or links.\n",
+              "multi": true,
+              "required": true,
+              "show_user": false,
+              "default": "foo"
+            }
+          ],
+          "title": "Title reference stream",
+          "description": "Collecting the nginx access logs from file.",
+          "enabled": true
+        }
+      ],
+      "package": "reference",
+      "elasticsearch": {
+        "index-template.settings": {
+          "index": {
+            "lifecycle": {
+              "name": "reference"
+            }
+          }
+        },
+        "index-template.mappings": {
+          "dynamic": false
+        }
+      },
+      "path": "reference"
+    }
+  ],
+  "datasources": [
+>>>>>>> be22aea6... Add support for ES index-template configs
     {
       "name": "nginx",
       "title": "Nginx logs and metrics.",

--- a/testdata/generated/package/reference/1.0.0/index.json
+++ b/testdata/generated/package/reference/1.0.0/index.json
@@ -40,53 +40,7 @@
     "/package/reference/1.0.0/dataset/reference/manifest.yml",
     "/package/reference/1.0.0/dataset/reference/fields/base-fields.yml"
   ],
-<<<<<<< HEAD
   "config_templates": [
-=======
-  "datasets": [
-    {
-      "id": "reference.reference",
-      "title": "Reference Logs Title",
-      "release": "beta",
-      "type": "logs",
-      "streams": [
-        {
-          "input": "logs",
-          "vars": [
-            {
-              "name": "paths",
-              "type": "text",
-              "title": "Example variable title",
-              "description": "Description around how a variable should be used, what values it can contain and it can even contain **Markdown** or links.\n",
-              "multi": true,
-              "required": true,
-              "show_user": false,
-              "default": "foo"
-            }
-          ],
-          "title": "Title reference stream",
-          "description": "Collecting the nginx access logs from file.",
-          "enabled": true
-        }
-      ],
-      "package": "reference",
-      "elasticsearch": {
-        "index_template.settings": {
-          "index": {
-            "lifecycle": {
-              "name": "reference"
-            }
-          }
-        },
-        "index_template.mappings": {
-          "dynamic": false
-        }
-      },
-      "path": "reference"
-    }
-  ],
-  "datasources": [
->>>>>>> be22aea6... Add support for ES index-template configs
     {
       "name": "nginx",
       "title": "Nginx logs and metrics.",
@@ -143,6 +97,18 @@
         }
       ],
       "package": "reference",
+      "elasticsearch": {
+        "index_template.settings": {
+          "index": {
+            "lifecycle": {
+              "name": "reference"
+            }
+          }
+        },
+        "index_template.mappings": {
+          "dynamic": false
+        }
+      },
       "path": "reference"
     }
   ],

--- a/testdata/generated/package/reference/1.0.0/index.json
+++ b/testdata/generated/package/reference/1.0.0/index.json
@@ -71,14 +71,14 @@
       ],
       "package": "reference",
       "elasticsearch": {
-        "index-template.settings": {
+        "index_template.settings": {
           "index": {
             "lifecycle": {
               "name": "reference"
             }
           }
         },
-        "index-template.mappings": {
+        "index_template.mappings": {
           "dynamic": false
         }
       },

--- a/testdata/generated/package/yamlpipeline/1.0.0/index.json
+++ b/testdata/generated/package/yamlpipeline/1.0.0/index.json
@@ -59,14 +59,14 @@
       ],
       "package": "yamlpipeline",
       "elasticsearch": {
-        "index-template.settings": {
+        "index_template.settings": {
           "index": {
             "lifecycle": {
               "name": "reference"
             }
           }
         },
-        "index-template.mappings": {
+        "index_template.mappings": {
           "dynamic": false
         }
       },

--- a/testdata/generated/package/yamlpipeline/1.0.0/index.json
+++ b/testdata/generated/package/yamlpipeline/1.0.0/index.json
@@ -58,6 +58,18 @@
         }
       ],
       "package": "yamlpipeline",
+      "elasticsearch": {
+        "index-template.settings": {
+          "index": {
+            "lifecycle": {
+              "name": "reference"
+            }
+          }
+        },
+        "index-template.mappings": {
+          "dynamic": false
+        }
+      },
       "path": "log"
     }
   ]

--- a/testdata/package/reference/1.0.0/dataset/reference/manifest.yml
+++ b/testdata/package/reference/1.0.0/dataset/reference/manifest.yml
@@ -10,9 +10,9 @@ release: beta
 type: logs
 
 elasticsearch:
-  index-template.mappings:
+  index_template.mappings:
     dynamic: false
-  index-template.settings:
+  index_template.settings:
     index.lifecycle.name: reference
 
 # This is the ingest pipeline which should be used. If none is define,

--- a/testdata/package/reference/1.0.0/dataset/reference/manifest.yml
+++ b/testdata/package/reference/1.0.0/dataset/reference/manifest.yml
@@ -9,6 +9,12 @@ release: beta
 # Allowed values: logs, metrics, events
 type: logs
 
+elasticsearch:
+  index-template.mappings:
+    dynamic: false
+  index-template.settings:
+    index.lifecycle.name: reference
+
 # This is the ingest pipeline which should be used. If none is define,
 # it checks if a default pipeline exists.
 #ingest_pipeline: default

--- a/testdata/package/yamlpipeline/1.0.0/dataset/log/manifest.yml
+++ b/testdata/package/yamlpipeline/1.0.0/dataset/log/manifest.yml
@@ -5,7 +5,7 @@ type: logs
 ingest_pipeline: pipeline-entry
 
 elasticsearch:
-  index-template:
+  index_template:
     mappings:
       dynamic: false
     settings:

--- a/testdata/package/yamlpipeline/1.0.0/dataset/log/manifest.yml
+++ b/testdata/package/yamlpipeline/1.0.0/dataset/log/manifest.yml
@@ -4,6 +4,13 @@ type: logs
 
 ingest_pipeline: pipeline-entry
 
+elasticsearch:
+  index-template:
+    mappings:
+      dynamic: false
+    settings:
+      index.lifecycle.name: reference
+
 streams:
   - input: logs
     title: Yamlpipline example logs

--- a/util/dataset.go
+++ b/util/dataset.go
@@ -36,11 +36,12 @@ type Dataset struct {
 	Type string `config:"type" json:"type" validate:"required"`
 	Name string `config:"name" json:"name,omitempty" yaml:"name,omitempty"`
 
-	Title          string   `config:"title" json:"title" validate:"required"`
-	Release        string   `config:"release" json:"release"`
-	IngestPipeline string   `config:"ingest_pipeline,omitempty" config:"ingest_pipeline" json:"ingest_pipeline,omitempty" yaml:"ingest_pipeline,omitempty"`
-	Streams        []Stream `config:"streams" json:"streams,omitempty" yaml:"streams,omitempty" `
-	Package        string   `json:"package,omitempty" yaml:"package,omitempty"`
+	Title          string         `config:"title" json:"title" validate:"required"`
+	Release        string         `config:"release" json:"release"`
+	IngestPipeline string         `config:"ingest_pipeline,omitempty" config:"ingest_pipeline" json:"ingest_pipeline,omitempty" yaml:"ingest_pipeline,omitempty"`
+	Streams        []Stream       `config:"streams" json:"streams,omitempty" yaml:"streams,omitempty" `
+	Package        string         `json:"package,omitempty" yaml:"package,omitempty"`
+	Elasticsearch  *Elasticsearch `config:"elasticsearch,omitempty" json:"elasticsearch,omitempty" yaml:"elasticsearch,omitempty"`
 
 	// Generated fields
 	Path string `json:"path,omitempty" yaml:"path,omitempty"`
@@ -79,6 +80,11 @@ type Variable struct {
 	Default     interface{} `config:"default" json:"default,omitempty" yaml:"default,omitempty"`
 }
 
+type Elasticsearch struct {
+	IndexTemplateSettings map[string]interface{} `config:"index-template.settings" json:"index-template.settings,omitempty" yaml:"index-template.settings,omitempty"`
+	IndexTemplateMappings map[string]interface{} `config:"index-template.mappings" json:"index-template.mappings,omitempty" yaml:"index-template.mappings,omitempty"`
+}
+
 type fieldEntry struct {
 	name  string
 	aType string
@@ -106,7 +112,7 @@ func NewDataset(basePath string, p *Package) (*Dataset, error) {
 	}
 
 	// go-ucfg automatically calls the `Validate` method on the Dataset object here
-	err = manifest.Unpack(d)
+	err = manifest.Unpack(d, ucfg.PathSep("."))
 	if err != nil {
 		return nil, errors.Wrapf(err, "error building dataset (path: %s) in package: %s", datasetPath, p.Name)
 	}

--- a/util/dataset.go
+++ b/util/dataset.go
@@ -81,8 +81,8 @@ type Variable struct {
 }
 
 type Elasticsearch struct {
-	IndexTemplateSettings map[string]interface{} `config:"index-template.settings" json:"index-template.settings,omitempty" yaml:"index-template.settings,omitempty"`
-	IndexTemplateMappings map[string]interface{} `config:"index-template.mappings" json:"index-template.mappings,omitempty" yaml:"index-template.mappings,omitempty"`
+	IndexTemplateSettings map[string]interface{} `config:"index_template.settings" json:"index_template.settings,omitempty" yaml:"index_template.settings,omitempty"`
+	IndexTemplateMappings map[string]interface{} `config:"index_template.mappings" json:"index_template.mappings,omitempty" yaml:"index_template.mappings,omitempty"`
 }
 
 type fieldEntry struct {


### PR DESCRIPTION
In some cases, the Elasticsearch index template for a dataset needs more configuration options then just the mappings that can be shipped as the fields.yml. To make this possible, this introduces the option to configure some settings in the dataset manifest. The naming is `elasticsearch.index-template` to be in line with the directory names. Inside settings and mappings are supported as free form. Anything else is ignored.

This is not supported yet on the Kibana side. There this should either be put into a separate component template or merge on creation.