### PR TITLE
Fix package caching

### DIFF
--- a/util/packages.go
+++ b/util/packages.go
@@ -24,7 +24,8 @@ func GetPackages(packagesBasePaths []string) ([]Package, error) {
 		return packageList, nil
 	}
 
-	packageList, err := getPackagesFromFilesystem(packagesBasePaths)
+	var err error
+	packageList, err = getPackagesFromFilesystem(packagesBasePaths)
 	if err != nil {
 		return nil, errors.Wrapf(err, "reading packages from filesystem failed")
 	}


### PR DESCRIPTION
In a recent change, the package caching went lost as a local instance of `packageList` was created. This fixes it.