### PR TITLE
Add a very simple benchmark tests for NewPackage

### DIFF
--- a/util/package_test.go
+++ b/util/package_test.go
@@ -126,3 +126,10 @@ func TestValidate(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkNewPackage(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_, err := NewPackage("../testdata/package/reference/1.0.0")
+		assert.NoError(b, err)
+	}
+}


### PR DESCRIPTION
I plan to play around a bit with the package creation and I am curious on what impact these changes might have on the benchmarks, because of this adding a simple one here.

Current output on my machine:

```
pkg: github.com/elastic/package-registry/util
BenchmarkNewPackage-8               1624            729592 ns/op
PASS
ok      github.com/elastic/package-registry/util        1.411s
````