### PR TITLE
Cache build .tar.gz file

### DIFF
--- a/artifacts.go
+++ b/artifacts.go
@@ -5,8 +5,11 @@
 package main
 
 import (
+	"io/ioutil"
 	"log"
 	"net/http"
+	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/Masterminds/semver/v3"
@@ -56,14 +59,42 @@ func artifactsHandler(packagesBasePaths []string, cacheTime time.Duration) func(
 		w.Header().Set("Content-Type", "application/gzip")
 		cacheHeaders(w, cacheTime)
 
-		err = archiver.ArchivePackage(w, archiver.PackageProperties{
+		properties := archiver.PackageProperties{
 			Name:    packageName,
 			Version: packageVersion,
 			Path:    packagePath,
-		})
-		if err != nil {
-			log.Printf("archiving package path '%s' failed: %v", packagePath, err)
+		}
+		// TODO: find proper directory, make it a config option
+		basePath := "/tmp/epr"
+		path := basePath + "/" + properties.Name + "-" + properties.Version + ".tar.gz"
+
+		// TODO: Add dev option to skipt caching part
+		// The nice thing here is that it also works across restarts, meaning pre-building
+		// is an option.
+		_, err = os.Stat(path)
+		// If file does not exists, it builds the tar.gz and throws it into a file so it can be served again later.
+		if os.IsNotExist(err) {
+			os.MkdirAll(filepath.Dir(path), 0755)
+			f, err := os.Create(path)
+			if err != nil {
+				http.Error(w, "error creating cache file", http.StatusInternalServerError)
+				return
+			}
+
+			err = archiver.ArchivePackage(f, properties)
+			if err != nil {
+				log.Printf("archiving package path '%s' failed: %v", packagePath, err)
+				return
+			}
+
+			f.Sync()
+		} else if err != nil {
+			log.Printf("checking file path '%s' failed: %v", packagePath, err)
 			return
 		}
+
+		// TODO: Good idea to load it all into memory?
+		content, err := ioutil.ReadFile(path)
+		w.Write(content)
 	}
 }


### PR DESCRIPTION
This introduced a cache for the tar.gz files. The code is not finished yet and hacky but it works. This also helps with https://github.com/elastic/package-registry/issues/535

Few additional notest to the code. Having the .tar.gz cached also means they could be prebuilt. This could be used during a "warmup" of the registry or in case an external storage is mounted in, the prebuilt .tar.gz could be used instead. Also these are cached across restarts.