### PR TITLE
Introduce `elasticsearch.ingest_pipeline.name` as config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Apply rule: first package found served. [#546](https://github.com/elastic/package-registry/pull/546)
 * Implement package watcher. [#553](https://github.com/elastic/package-registry/pull/553)
 * Add conditions as future replacement of requirements. [#519](https://github.com/elastic/package-registry/pull/519)
+* Introduce `elasticsearch.ingest_pipeline.name` as config option. [#](https://github.com/elastic/package-registry/pull/)
 
 ### Deprecated
 

--- a/util/dataset.go
+++ b/util/dataset.go
@@ -83,6 +83,10 @@ type Elasticsearch struct {
 	IndexTemplateMappings map[string]interface{} `config:"index_template.mappings" json:"index_template.mappings,omitempty" yaml:"index_template.mappings,omitempty"`
 }
 
+type Elasticsearch struct {
+	IngestPipelineName string `config:"ingest_pipeline.name,omitempty" json:"ingest_pipeline.name,omitempty" yaml:"ingest_pipeline.name,omitempty"`
+}
+
 type fieldEntry struct {
 	name  string
 	aType string
@@ -157,7 +161,18 @@ func (d *Dataset) Validate() error {
 		return fmt.Errorf("type is not valid: %s", d.Type)
 	}
 
-	if d.IngestPipeline == "" {
+	if d.Elasticsearch != nil && d.Elasticsearch.IngestPipelineName == "" {
+		// Check that no ingest pipeline exists in the directory except default
+		for _, path := range paths {
+			if filepath.Base(path) == "default.json" || filepath.Base(path) == "default.yml" {
+				d.Elasticsearch.IngestPipelineName = "default"
+				// TODO: remove because of legacy
+				d.IngestPipeline = "default"
+				break
+			}
+		}
+		// TODO: Remove, only here for legacy
+	} else if d.IngestPipeline == "" {
 		// Check that no ingest pipeline exists in the directory except default
 		for _, path := range paths {
 			if filepath.Base(path) == "default.json" || filepath.Base(path) == "default.yml" {

--- a/util/dataset.go
+++ b/util/dataset.go
@@ -87,10 +87,7 @@ type Variable struct {
 type Elasticsearch struct {
 	IndexTemplateSettings map[string]interface{} `config:"index_template.settings" json:"index_template.settings,omitempty" yaml:"index_template.settings,omitempty"`
 	IndexTemplateMappings map[string]interface{} `config:"index_template.mappings" json:"index_template.mappings,omitempty" yaml:"index_template.mappings,omitempty"`
-}
-
-type Elasticsearch struct {
-	IngestPipelineName string `config:"ingest_pipeline.name,omitempty" json:"ingest_pipeline.name,omitempty" yaml:"ingest_pipeline.name,omitempty"`
+	IngestPipelineName    string                 `config:"ingest_pipeline.name,omitempty" json:"ingest_pipeline.name,omitempty" yaml:"ingest_pipeline.name,omitempty"`
 }
 
 type fieldEntry struct {

--- a/util/dataset.go
+++ b/util/dataset.go
@@ -22,6 +22,10 @@ import (
 
 const (
 	DirIngestPipeline = "ingest-pipeline"
+
+	DefaultPipelineName     = "default"
+	DefaultPipelineNameJSON = "default.json"
+	DefaultPipelineNameYAML = "default.yaml"
 )
 
 var validTypes = map[string]string{
@@ -34,8 +38,10 @@ type Dataset struct {
 	Type string `config:"type" json:"type" validate:"required"`
 	Name string `config:"name" json:"name,omitempty" yaml:"name,omitempty"`
 
-	Title          string         `config:"title" json:"title" validate:"required"`
-	Release        string         `config:"release" json:"release"`
+	Title   string `config:"title" json:"title" validate:"required"`
+	Release string `config:"release" json:"release"`
+
+	// Deprecated: Replaced by elasticsearch.ingest_pipeline.name
 	IngestPipeline string         `config:"ingest_pipeline,omitempty" config:"ingest_pipeline" json:"ingest_pipeline,omitempty" yaml:"ingest_pipeline,omitempty"`
 	Streams        []Stream       `config:"streams" json:"streams,omitempty" yaml:"streams,omitempty" `
 	Package        string         `json:"package,omitempty" yaml:"package,omitempty"`
@@ -164,10 +170,10 @@ func (d *Dataset) Validate() error {
 	if d.Elasticsearch != nil && d.Elasticsearch.IngestPipelineName == "" {
 		// Check that no ingest pipeline exists in the directory except default
 		for _, path := range paths {
-			if filepath.Base(path) == "default.json" || filepath.Base(path) == "default.yml" {
-				d.Elasticsearch.IngestPipelineName = "default"
+			if filepath.Base(path) == DefaultPipelineNameJSON || filepath.Base(path) == DefaultPipelineNameYAML {
+				d.Elasticsearch.IngestPipelineName = DefaultPipelineName
 				// TODO: remove because of legacy
-				d.IngestPipeline = "default"
+				d.IngestPipeline = DefaultPipelineName
 				break
 			}
 		}
@@ -175,8 +181,8 @@ func (d *Dataset) Validate() error {
 	} else if d.IngestPipeline == "" {
 		// Check that no ingest pipeline exists in the directory except default
 		for _, path := range paths {
-			if filepath.Base(path) == "default.json" || filepath.Base(path) == "default.yml" {
-				d.IngestPipeline = "default"
+			if filepath.Base(path) == DefaultPipelineNameJSON || filepath.Base(path) == DefaultPipelineNameYAML {
+				d.IngestPipeline = DefaultPipelineName
 				break
 			}
 		}


### PR DESCRIPTION
In https://github.com/elastic/package-registry/pull/552 `elasticsearch` as config block is introduced. As discussed there, it also makes sense to use this for the Ingest Pipeline config to have all Elasticsearch related parts in one place.

For now no package uses this change and Kibana does not support it. As both ways are supported, this is not a breaking change yet. As a follow up, the package generation must be updated to adjust for this option and Kibana must be adapted to only support the new option.