### PR TITLE
Remove `dataset.type: event` as supported type.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Remove `removable` flag from package manifest. [#532](https://github.com/elastic/package-registry/pull/532)
 * Rename `datasources` to `config_templates` in dataset manifest. [#570](https://github.com/elastic/package-registry/pull/570)
 * Remove support for logs and metrics category. [#571](https://github.com/elastic/package-registry/pull/571)
+* Remove `dataset.type: event` as suported type. [#](https://github.com/elastic/package-registry/pull/)
 
 ### Bugfixes
 

--- a/util/dataset.go
+++ b/util/dataset.go
@@ -27,8 +27,6 @@ const (
 var validTypes = map[string]string{
 	"logs":    "Logs",
 	"metrics": "Metrics",
-	// TODO: Remove as soon as endpoint package does not use it anymore
-	"events": "Events",
 }
 
 type Dataset struct {


### PR DESCRIPTION
This event type was only used by the endpoint package and it got removed. Because of this, it can be removed from the list.