### PR TITLE
Cleanup: Packages and package naming

### DIFF
--- a/package_index.go
+++ b/package_index.go
@@ -60,7 +60,7 @@ func packageIndexHandler(packagesBasePaths []string, cacheTime time.Duration) fu
 		w.Header().Set("Content-Type", "application/json")
 		cacheHeaders(w, cacheTime)
 
-		aPackage, err := util.NewPackageWithResources(packagePath)
+		p, err := util.NewPackageWithResources(packagePath)
 		if err != nil {
 			log.Printf("loading package from path '%s' failed: %v", packagePath, err)
 
@@ -68,7 +68,7 @@ func packageIndexHandler(packagesBasePaths []string, cacheTime time.Duration) fu
 			return
 		}
 
-		body, err := json.MarshalIndent(aPackage, "", "  ")
+		body, err := json.MarshalIndent(p, "", "  ")
 		if err != nil {
 			log.Printf("marshaling package index failed (path '%s'): %v", packagePath, err)
 

--- a/util/package.go
+++ b/util/package.go
@@ -224,21 +224,21 @@ func NewPackage(basePath string) (*Package, error) {
 }
 
 func NewPackageWithResources(path string) (*Package, error) {
-	aPackage, err := NewPackage(path)
+	p, err := NewPackage(path)
 	if err != nil {
 		return nil, errors.Wrapf(err, "building package from path '%s' failed", path)
 	}
 
-	err = aPackage.LoadAssets()
+	err = p.LoadAssets()
 	if err != nil {
 		return nil, errors.Wrapf(err, "loading package assets failed (path '%s')", path)
 	}
 
-	err = aPackage.LoadDataSets()
+	err = p.LoadDataSets()
 	if err != nil {
 		return nil, errors.Wrapf(err, "loading package datasets failed (path '%s')", path)
 	}
-	return aPackage, nil
+	return p, nil
 }
 
 func (p *Package) HasCategory(category string) bool {

--- a/util/packages.go
+++ b/util/packages.go
@@ -13,13 +13,15 @@ import (
 	"github.com/pkg/errors"
 )
 
-var packageList []Package
+var packageList Packages
+
+type Packages []Package
 
 // GetPackages returns a slice with all existing packages.
 // The list is stored in memory and on the second request directly served from memory.
 // This assumes changes to packages only happen on restart (unless development mode is enabled).
 // Caching the packages request many file reads every time this method is called.
-func GetPackages(packagesBasePaths []string) ([]Package, error) {
+func GetPackages(packagesBasePaths []string) (Packages, error) {
 	if packageList != nil {
 		return packageList, nil
 	}
@@ -32,13 +34,13 @@ func GetPackages(packagesBasePaths []string) ([]Package, error) {
 	return packageList, nil
 }
 
-func getPackagesFromFilesystem(packagesBasePaths []string) ([]Package, error) {
+func getPackagesFromFilesystem(packagesBasePaths []string) (Packages, error) {
 	packagePaths, err := getPackagePaths(packagesBasePaths)
 	if err != nil {
 		return nil, err
 	}
 
-	var pList []Package
+	var pList Packages
 	for _, path := range packagePaths {
 		p, err := NewPackage(path)
 		if err != nil {


### PR DESCRIPTION
Just a few things I stumbled over browsing through the code:

* Instead of using `[]Package`, this introduces a `Packages` type. This will allow us to build more tooling like locks and similar on top of Packages.
* Rename `aPackage` to `p` as we use it in several other places.

No functional changes.