### PR TITLE
Add OpenAPI schemas for responses

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -54,6 +54,8 @@ paths:
                       count: 17
       operationId: get-categories
       description: List of the existing package categories and how many packages are in each category
+      parameters:
+        - $ref: '#/components/parameters/experimentalPackageParam'
   /search:
     get:
       summary: Search packages
@@ -85,11 +87,8 @@ paths:
           in: query
           name: package
           description: 'Filters by a specific package name, for example mysql. In contrast to the other endpoints, it will return by default all versions of this package.'
-        - schema:
-            type: string
-          in: query
-          name: internal
-          description: 'This can be set to true, to also list internal packages. This is set to false by default.'
+        - $ref: '#/components/parameters/internalPackageParam'
+        - $ref: '#/components/parameters/experimentalPackageParam'
   '/package/{package}/{version}':
     get:
       summary: GET package info
@@ -364,3 +363,20 @@ components:
       properties:
         github:
           type: string
+  parameters:
+    internalPackageParam:
+      name: internal
+      in: query
+      required: false
+      description: Set to true to also list internal packages
+      schema:
+        type: boolean
+        default: false
+    experimentalPackageParam:
+      name: experimental
+      in: query
+      required: false
+      description: Set to true to also list experimental packages
+      schema:
+        type: boolean
+        default: false

--- a/openapi.yml
+++ b/openapi.yml
@@ -27,7 +27,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
+                $ref: '#/components/schemas/IndexData'
       operationId: get
       description: Info about the registry
   /categories:
@@ -41,6 +41,8 @@ paths:
             application/json:
               schema:
                 type: array
+                items:
+                  $ref: '#/components/schemas/Category'
               examples:
                 example-1:
                   value:
@@ -63,6 +65,8 @@ paths:
             application/json:
               schema:
                 type: array
+                items:
+                  $ref: '#/components/schemas/BasePackage'
       operationId: get-search
       description: Search for packages. By default returns all the most recent packages available.
       parameters:
@@ -96,7 +100,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
+                $ref: '#/components/schemas/Package'
       operationId: get-package
       description: Info about a package
     parameters:
@@ -112,3 +116,251 @@ paths:
         in: path
         required: true
         description: Version of the package
+components:
+  schemas:
+    IndexData:
+      title: IndexData
+      type: object
+      properties:
+        version:
+          type: string
+        service.name:
+          type: string
+      required:
+        - version
+        - service.name
+    Category:
+      title: Category
+      type: object
+      properties:
+        id:
+          type: string
+        title:
+          type: string
+        count:
+          type: integer
+      required:
+        - id
+        - title
+        - count
+    Image:
+      title: Image
+      type: object
+      properties:
+        src:
+          type: string
+        title:
+          type: string
+        size:
+          type: string
+        type:
+          type: string
+      required:
+        - src
+    ProductRequirement:
+      title: Kibana
+      type: object
+      properties:
+        versions:
+          type: string
+    Requirement:
+      title: Requirement
+      type: object
+      properties:
+        Kibana:
+          $ref: '#/components/schemas/ProductRequirement'
+      required:
+        - Kibana
+    Dataset:
+      title: Dataset
+      type: object
+      properties:
+        title:
+          type: string
+        name:
+          type: string
+        release:
+          type: string
+        type:
+          type: string
+        ingest_pipeline:
+          type: string
+        package:
+          type: string
+        id:
+          type: string
+        path:
+          type: string
+        streams:
+          $ref: '#/components/schemas/Stream'
+      required:
+        - title
+        - name
+        - release
+        - type
+    Stream:
+      title: Stream
+      type: object
+      properties:
+        input:
+          type: string
+        vars:
+          $ref: '#/components/schemas/Variable'
+        dataset:
+          type: string
+        template_path:
+          type: string
+        template:
+          type: string
+        title:
+          type: string
+        description:
+          type: string
+        enabled:
+          type: boolean
+      required:
+        - input
+    Input:
+      title: Input
+      type: object
+      properties:
+        id:
+          type: string
+    Variable:
+      title: Variable
+      type: object
+      properties:
+        name:
+          type: string
+        type:
+          type: string
+        title:
+          type: string
+        description:
+          type: string
+        multi:
+          type: boolean
+        required:
+          type: boolean
+        show_user:
+          type: boolean
+        default:
+          type: object
+      required:
+        - name
+        - type
+        - multi
+        - required
+        - show_user
+    BasePackage:
+      title: BasePackage
+      type: object
+      properties:
+        name:
+          type: string
+        title:
+          type: string
+        version:
+          type: string
+        description:
+          type: string
+        type:
+          type: string
+        download:
+          type: string
+        downloads:
+          type: array
+          items:
+            $ref: '#/components/schemas/Download'
+        path:
+          type: string
+        icons:
+          type: array
+          items:
+            $ref: '#/components/schemas/Image'
+        internal:
+          type: string
+      required:
+        - name
+        - version
+        - description
+        - type
+    Download:
+      title: Download
+      type: object
+      properties:
+        path:
+          type: string
+        type:
+          type: string
+      required:
+        - path
+        - type
+    Package:
+      title: Package
+      allOf:
+        - $ref: '#/components/schemas/BasePackage'
+        - type: object
+          properties:
+            format_version:
+              type: string
+            readme:
+              type: string
+            license:
+              type: string
+            categories:
+              type: array
+              items:
+                type: string
+            release:
+              type: string
+            requirement:
+              $ref: '#/components/schemas/Requirement'
+            screenshots:
+              $ref: '#/components/schemas/Image'
+            assets:
+              type: array
+              items:
+                type: string
+            datasets:
+              type: array
+              items:
+                $ref: '#/components/schemas/Dataset'
+            datasources:
+              type: array
+              items:
+                $ref: '#/components/schemas/Datasource'
+            owner:
+              $ref: '#/components/schemas/Owner'
+          required:
+            - format_version
+            - categories
+            - requirement
+      description: ''
+    Datasource:
+      title: Datasource
+      type: object
+      properties:
+        name:
+          type: string
+        title:
+          type: string
+        description:
+          type: string
+        inputs:
+          type: array
+          items:
+            $ref: '#/components/schemas/Input'
+        multiple:
+          type: boolean
+      required:
+        - name
+        - title
+        - description
+        - inputs
+    Owner:
+      title: Owner
+      type: object
+      properties:
+        github:
+          type: string

--- a/openapi.yml
+++ b/openapi.yml
@@ -84,7 +84,6 @@ paths:
           description: Filters the package by the given category. Available categories can be seend when going to /categories endpoint.
         - schema:
             type: string
-            default: ''
           in: query
           name: package
           description: 'Filters by a specific package name, for example mysql. In contrast to the other endpoints, it will return by default all versions of this package.'

--- a/openapi.yml
+++ b/openapi.yml
@@ -84,6 +84,7 @@ paths:
           description: Filters the package by the given category. Available categories can be seend when going to /categories endpoint.
         - schema:
             type: string
+            default: ''
           in: query
           name: package
           description: 'Filters by a specific package name, for example mysql. In contrast to the other endpoints, it will return by default all versions of this package.'
@@ -174,27 +175,24 @@ components:
       title: Dataset
       type: object
       properties:
-        title:
+        type:
           type: string
         name:
           type: string
-        release:
+        title:
           type: string
-        type:
+        release:
           type: string
         ingest_pipeline:
           type: string
+        streams:
+          $ref: '#/components/schemas/Stream'
         package:
-          type: string
-        id:
           type: string
         path:
           type: string
-        streams:
-          $ref: '#/components/schemas/Stream'
       required:
         - title
-        - name
         - release
         - type
     Stream:
@@ -209,8 +207,6 @@ components:
           type: string
         template_path:
           type: string
-        template:
-          type: string
         title:
           type: string
         description:
@@ -223,8 +219,18 @@ components:
       title: Input
       type: object
       properties:
-        id:
+        type:
           type: string
+        vars:
+          $ref: '#/components/schemas/Variable'
+        title:
+          type: string
+        description:
+          type: string
+        streams:
+          $ref: '#/components/schemas/Stream'
+      required:
+        - type
     Variable:
       title: Variable
       type: object
@@ -321,14 +327,14 @@ components:
               type: array
               items:
                 type: string
+            config_templates:
+              type: array
+              items:
+                $ref: '#/components/schemas/ConfigTemplate'
             datasets:
               type: array
               items:
                 $ref: '#/components/schemas/Dataset'
-            datasources:
-              type: array
-              items:
-                $ref: '#/components/schemas/Datasource'
             owner:
               $ref: '#/components/schemas/Owner'
           required:
@@ -336,8 +342,8 @@ components:
             - categories
             - requirement
       description: ''
-    Datasource:
-      title: Datasource
+    ConfigTemplate:
+      title: ConfigTemplate
       type: object
       properties:
         name:


### PR DESCRIPTION
## Summary

- Created OpenAPI schemas for the response types by looking at the `*Handler` functions and  `util/*.go` `struct`s 
- Changed `internal` query param from a `string` to a `boolean` with a default value of `false`
- Added the same schema for the previously undocumented `experimental` param

It might be easiest to review by using an online viewer like https://editor.swagger.io/ and importing the URL to the raw file https://raw.githubusercontent.com/jfsiii/package-registry/cd276b32f7c82bc01dbbf380684c789ca3672eb7/openapi.yml or copying & pasting it in and reviewing the docs it generates from the spec file

<img width="2004" alt="Screen Shot 2020-06-29 at 4 49 05 PM" src="https://user-images.githubusercontent.com/57655/86054629-80c3df80-ba28-11ea-92e3-6877a65da986.png">
