### PR TITLE
Rename datasources to config_templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Remove support for Elasticsearch requirements [#516](https://github.com/elastic/package-registry/pull/516)
 * Rename `kibana` query param to `kibana.version`. [#518](https://github.com/elastic/package-registry/pull/518)
 * Remove `removable` flag from package manifest. [#532](https://github.com/elastic/package-registry/pull/532)
+* Rename `datasources` to `config_templates` in dataset manifest. [#570](https://github.com/elastic/package-registry/pull/570)
 
 ### Bugfixes
 

--- a/testdata/package/datasources/1.0.0/manifest.yml
+++ b/testdata/package/datasources/1.0.0/manifest.yml
@@ -9,7 +9,7 @@ type: integration
 license: basic
 release: beta
 
-datasources:
+config_templates:
   -
     # Do we need a name for the data source?
     name: nginx

--- a/testdata/package/default_pipeline/0.0.2/manifest.yml
+++ b/testdata/package/default_pipeline/0.0.2/manifest.yml
@@ -9,7 +9,7 @@ type: integration
 release: beta
 
 
-datasources:
+config_templates:
   - name: logs
     title: Logs datasource
     description: Datasource for your log files.

--- a/testdata/package/ecs_style_dataset/0.0.1/manifest.yml
+++ b/testdata/package/ecs_style_dataset/0.0.1/manifest.yml
@@ -8,7 +8,7 @@ categories: ["logs"]
 type: integration
 release: beta
 
-datasources:
+config_templates:
   - name: logs
     title: Logs datasource
     description: Datasource for your log files.

--- a/testdata/package/example/1.0.0/manifest.yml
+++ b/testdata/package/example/1.0.0/manifest.yml
@@ -23,7 +23,7 @@ screenshots:
     size: 1492x1464
     type: image/png
 
-datasources:
+config_templates:
   - name: logs
     title: Logs datasource
     description: Datasource for your log files.

--- a/testdata/package/multiple_false/0.0.1/manifest.yml
+++ b/testdata/package/multiple_false/0.0.1/manifest.yml
@@ -9,7 +9,7 @@ type: integration
 release: beta
 
 
-datasources:
+config_templates:
   - name: logs
     title: Logs datasource
     description: Datasource for your log files.

--- a/testdata/package/reference/1.0.0/manifest.yml
+++ b/testdata/package/reference/1.0.0/manifest.yml
@@ -82,7 +82,7 @@ icons:
 
 # Defining a datasource allows the UI to generate a form for each input and generate the agent
 # config out of it. For a visual guide on what fields is used how in the UI, check out https://github.com/elastic/package-registry/pull/242
-datasources:
+config_templates:
   -
     # Do we need a name for the data source?
     name: nginx

--- a/util/package.go
+++ b/util/package.go
@@ -63,7 +63,7 @@ type Package struct {
 	Requirement     Requirement      `config:"requirement" json:"requirement"`
 	Screenshots     []Image          `config:"screenshots,omitempty" json:"screenshots,omitempty" yaml:"screenshots,omitempty"`
 	Assets          []string         `config:"assets,omitempty" json:"assets,omitempty" yaml:"assets,omitempty"`
-	ConfigTemplates []ConfigTemplate `config:"config_templates,omitempty" json:"config_templates,omitempty" yaml:"datasources,omitempty"`
+	ConfigTemplates []ConfigTemplate `config:"config_templates,omitempty" json:"config_templates,omitempty" yaml:"config_templates,omitempty"`
 	Datasets        []*Dataset       `config:"datasets,omitempty" json:"datasets,omitempty" yaml:"datasets,omitempty"`
 	Owner           *Owner           `config:"owner,omitempty" json:"owner,omitempty" yaml:"owner,omitempty"`
 

--- a/util/package.go
+++ b/util/package.go
@@ -55,17 +55,17 @@ type Package struct {
 	BasePackage   `config:",inline" json:",inline" yaml:",inline"`
 	FormatVersion string `config:"format_version" json:"format_version" yaml:"format_version"`
 
-	Readme        *string `config:"readme,omitempty" json:"readme,omitempty" yaml:"readme,omitempty"`
-	License       string  `config:"license,omitempty" json:"license,omitempty" yaml:"license,omitempty"`
-	versionSemVer *semver.Version
-	Categories    []string     `config:"categories" json:"categories"`
-	Release       string       `config:"release,omitempty" json:"release,omitempty"`
-	Requirement   Requirement  `config:"requirement" json:"requirement"`
-	Screenshots   []Image      `config:"screenshots,omitempty" json:"screenshots,omitempty" yaml:"screenshots,omitempty"`
-	Assets        []string     `config:"assets,omitempty" json:"assets,omitempty" yaml:"assets,omitempty"`
-	Datasources   []Datasource `config:"datasources,omitempty" json:"config_templates,omitempty" yaml:"datasources,omitempty"`
-	Datasets      []*Dataset   `config:"datasets,omitempty" json:"datasets,omitempty" yaml:"datasets,omitempty"`
-	Owner         *Owner       `config:"owner,omitempty" json:"owner,omitempty" yaml:"owner,omitempty"`
+	Readme          *string `config:"readme,omitempty" json:"readme,omitempty" yaml:"readme,omitempty"`
+	License         string  `config:"license,omitempty" json:"license,omitempty" yaml:"license,omitempty"`
+	versionSemVer   *semver.Version
+	Categories      []string         `config:"categories" json:"categories"`
+	Release         string           `config:"release,omitempty" json:"release,omitempty"`
+	Requirement     Requirement      `config:"requirement" json:"requirement"`
+	Screenshots     []Image          `config:"screenshots,omitempty" json:"screenshots,omitempty" yaml:"screenshots,omitempty"`
+	Assets          []string         `config:"assets,omitempty" json:"assets,omitempty" yaml:"assets,omitempty"`
+	ConfigTemplates []ConfigTemplate `config:"config_templates,omitempty" json:"config_templates,omitempty" yaml:"datasources,omitempty"`
+	Datasets        []*Dataset       `config:"datasets,omitempty" json:"datasets,omitempty" yaml:"datasets,omitempty"`
+	Owner           *Owner           `config:"owner,omitempty" json:"owner,omitempty" yaml:"owner,omitempty"`
 
 	// Local path to the package dir
 	BasePath string `json:"-" yaml:"-"`
@@ -85,7 +85,7 @@ type BasePackage struct {
 	Internal    bool       `config:"internal,omitempty" json:"internal,omitempty" yaml:"internal,omitempty"`
 }
 
-type Datasource struct {
+type ConfigTemplate struct {
 	Name        string  `config:"name" json:"name" validate:"required"`
 	Title       string  `config:"title" json:"title" validate:"required"`
 	Description string  `config:"description" json:"description" validate:"required"`
@@ -157,9 +157,9 @@ func NewPackage(basePath string) (*Package, error) {
 
 	// Default for the multiple flags is true.
 	trueValue := true
-	for i, _ := range p.Datasources {
-		if p.Datasources[i].Multiple == nil {
-			p.Datasources[i].Multiple = &trueValue
+	for i, _ := range p.ConfigTemplates {
+		if p.ConfigTemplates[i].Multiple == nil {
+			p.ConfigTemplates[i].Multiple = &trueValue
 		}
 	}
 	if p.Type == "" {


### PR DESCRIPTION
A previous PR renamed it to config_templates in the json output and Kibana was adjusted. This now adjusts it also on the input side. The package-storage and integrations repository also need to be updated.