### PR TITLE
Remove support for dataset.type: event

### DIFF
--- a/util/dataset.go
+++ b/util/dataset.go
@@ -27,8 +27,6 @@ const (
 var validTypes = map[string]string{
 	"logs":    "Logs",
 	"metrics": "Metrics",
-	// TODO: Remove as soon as endpoint package does not use it anymore
-	"events": "Events",
 }
 
 type Dataset struct {


### PR DESCRIPTION
No package is using this anymore.

Closing https://github.com/elastic/package-registry/issues/530