### PR TITLE
Fix that first package wins

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -32,7 +32,7 @@ var (
 )
 
 func TestEndpoints(t *testing.T) {
-	packagesBasePaths := []string{"./testdata/package"}
+	packagesBasePaths := []string{"./testdata/second_package_path", "./testdata/package"}
 
 	faviconHandleFunc, err := faviconHandler(testCacheTime)
 	require.NoError(t, err)
@@ -124,8 +124,8 @@ func TestPackageIndex(t *testing.T) {
 // TestAllPackageIndex generates and compares all index.json files for the test packages
 func TestAllPackageIndex(t *testing.T) {
 	testPackagePath := filepath.Join("testdata", "package")
-
-	packagesBasePath := []string{testPackagePath}
+	secondPackagePath := filepath.Join("testdata", "second_package_path")
+	packagesBasePath := []string{secondPackagePath, testPackagePath}
 	packageIndexHandler := packageIndexHandler(packagesBasePath, testCacheTime)
 
 	// find all packages

--- a/search.go
+++ b/search.go
@@ -137,7 +137,9 @@ func searchHandler(packagesBasePaths []string, cacheTime time.Duration) func(w h
 			if _, ok := packagesList[p.Name]; !ok {
 				packagesList[p.Name] = map[string]util.Package{}
 			}
-			packagesList[p.Name][p.Version] = p
+			if _, ok := packagesList[p.Name][p.Version]; !ok {
+				packagesList[p.Name][p.Version] = p
+			}
 		}
 
 		data, err := getPackageOutput(packagesList)

--- a/testdata/generated/package/multiversion/1.1.0/index.json
+++ b/testdata/generated/package/multiversion/1.1.0/index.json
@@ -1,6 +1,6 @@
 {
   "name": "multiversion",
-  "title": "Multi Version",
+  "title": "Multi Version Second with the same version! This one should win, because it is first.",
   "version": "1.1.0",
   "description": "Multiple versions of this integration exist.\n",
   "type": "integration",

--- a/testdata/generated/search-all.json
+++ b/testdata/generated/search-all.json
@@ -190,7 +190,7 @@
   },
   {
     "name": "multiversion",
-    "title": "Multi Version",
+    "title": "Multi Version Second with the same version! This one should win, because it is first.",
     "version": "1.1.0",
     "description": "Multiple versions of this integration exist.\n",
     "type": "integration",

--- a/testdata/generated/search-category-custom.json
+++ b/testdata/generated/search-category-custom.json
@@ -88,7 +88,7 @@
   },
   {
     "name": "multiversion",
-    "title": "Multi Version",
+    "title": "Multi Version Second with the same version! This one should win, because it is first.",
     "version": "1.1.0",
     "description": "Multiple versions of this integration exist.\n",
     "type": "integration",

--- a/testdata/generated/search-category-web.json
+++ b/testdata/generated/search-category-web.json
@@ -37,7 +37,7 @@
   },
   {
     "name": "multiversion",
-    "title": "Multi Version",
+    "title": "Multi Version Second with the same version! This one should win, because it is first.",
     "version": "1.1.0",
     "description": "Multiple versions of this integration exist.\n",
     "type": "integration",

--- a/testdata/generated/search-kibana721.json
+++ b/testdata/generated/search-kibana721.json
@@ -133,7 +133,7 @@
   },
   {
     "name": "multiversion",
-    "title": "Multi Version",
+    "title": "Multi Version Second with the same version! This one should win, because it is first.",
     "version": "1.1.0",
     "description": "Multiple versions of this integration exist.\n",
     "type": "integration",

--- a/testdata/generated/search-package-experimental.json
+++ b/testdata/generated/search-package-experimental.json
@@ -148,7 +148,7 @@
   },
   {
     "name": "multiversion",
-    "title": "Multi Version",
+    "title": "Multi Version Second with the same version! This one should win, because it is first.",
     "version": "1.1.0",
     "description": "Multiple versions of this integration exist.\n",
     "type": "integration",

--- a/testdata/generated/search-package-internal.json
+++ b/testdata/generated/search-package-internal.json
@@ -165,7 +165,7 @@
   },
   {
     "name": "multiversion",
-    "title": "Multi Version",
+    "title": "Multi Version Second with the same version! This one should win, because it is first.",
     "version": "1.1.0",
     "description": "Multiple versions of this integration exist.\n",
     "type": "integration",

--- a/testdata/generated/search.json
+++ b/testdata/generated/search.json
@@ -133,7 +133,7 @@
   },
   {
     "name": "multiversion",
-    "title": "Multi Version",
+    "title": "Multi Version Second with the same version! This one should win, because it is first.",
     "version": "1.1.0",
     "description": "Multiple versions of this integration exist.\n",
     "type": "integration",

--- a/testdata/second_package_path/multiversion/1.1.0/changelog.yml
+++ b/testdata/second_package_path/multiversion/1.1.0/changelog.yml
@@ -1,0 +1,25 @@
+- version: 1.1.0
+  changes:
+    - description: Fix broken template
+      type: bugfix
+      link: https://github.com/elastic/beats/issues/13507
+    - description: Cleanup changelog descriptions
+      type: added
+      link: https://github.com/elastic/beats/issues/13506
+    - description: Deprecating old mutliversion dashboard
+      type: deprecated
+      link: https://github.com/elastic/beats/issues/13501
+- version: 1.0.4
+  changes:
+    - description: >
+        Unexpected breaking change had to be introduced. This should not happen in a minor.
+      type: breaking-change
+      link: https://github.com/elastic/beats/issues/13504
+- version: 1.0.3
+  changes:
+    - description: Fix broken template
+      type: bugfix
+      link: https://github.com/elastic/beats/issues/13507
+    - description: It is a known issue that the dashboard does not load properly
+      type: known-issue
+      link: https://github.com/elastic/beats/issues/13506

--- a/testdata/second_package_path/multiversion/1.1.0/docs/README.md
+++ b/testdata/second_package_path/multiversion/1.1.0/docs/README.md
@@ -1,0 +1,3 @@
+# Multi version
+
+There are multiple versions of this package.

--- a/testdata/second_package_path/multiversion/1.1.0/img/icon.svg
+++ b/testdata/second_package_path/multiversion/1.1.0/img/icon.svg
@@ -1,0 +1,1 @@
+<?xml version="1.0" ?><svg style="enable-background:new 0 0 50 50;" version="1.1" viewBox="0 0 50 50" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><g id="Layer_1"><path d="M21,5H10v4H1v32h9v4h11v4h28V1H21V5z M3,39V11h7v28H3z M12,43v-2V9V7h9v36H12z M23,3h24v44H23v-2V5V3z"/></g><g/></svg>

--- a/testdata/second_package_path/multiversion/1.1.0/manifest.yml
+++ b/testdata/second_package_path/multiversion/1.1.0/manifest.yml
@@ -1,0 +1,18 @@
+format_version: 1.0.0
+
+name: multiversion
+title: Multi Version Second with the same version! This one should win, because it is first.
+description: >
+  Multiple versions of this integration exist.
+version: 1.1.0
+categories: ["custom", "web"]
+release: ga
+license: basic
+
+conditions:
+  kibana:
+    version: ">6.7.0"
+
+icons:
+- src: "/img/icon.svg"
+  type: "image/svg+xml"


### PR DESCRIPTION
In the search endpoint, follow up packages with the same name and version did overwrite the existing package. But we defined in the past that the first package found should win. This does a fix in the search endpoint and adds tests for it.

Long term I think the fix should not be in search but getPackages should already return a unique list, but this one here was easier to fix.

Also tests with multiple package paths were added so we see in case we break it in the future.