### PR TITLE
Remove legacy requirements

### DIFF
--- a/testdata/generated/package.json
+++ b/testdata/generated/package.json
@@ -94,6 +94,5 @@
   ],
   "owner": {
     "github": "ruflin"
-  },
-  "requirement": {}
+  }
 }

--- a/testdata/generated/package/base/0.2.0/index.json
+++ b/testdata/generated/package/base/0.2.0/index.json
@@ -30,6 +30,5 @@
     "/package/base/0.2.0/elasticsearch/index_template/events.json",
     "/package/base/0.2.0/elasticsearch/index_template/logs.json",
     "/package/base/0.2.0/elasticsearch/index_template/metrics.json"
-  ],
-  "requirement": {}
+  ]
 }

--- a/testdata/generated/package/datasources/1.0.0/index.json
+++ b/testdata/generated/package/datasources/1.0.0/index.json
@@ -179,6 +179,5 @@
       "package": "datasources",
       "path": "examplemetric"
     }
-  ],
-  "requirement": {}
+  ]
 }

--- a/testdata/generated/package/default_pipeline/0.0.2/index.json
+++ b/testdata/generated/package/default_pipeline/0.0.2/index.json
@@ -62,6 +62,5 @@
       "package": "default_pipeline",
       "path": "foo"
     }
-  ],
-  "requirement": {}
+  ]
 }

--- a/testdata/generated/package/ecs_style_dataset/0.0.1/index.json
+++ b/testdata/generated/package/ecs_style_dataset/0.0.1/index.json
@@ -41,6 +41,5 @@
       "package": "ecs_style_dataset",
       "path": "foo"
     }
-  ],
-  "requirement": {}
+  ]
 }

--- a/testdata/generated/package/example/0.0.2/index.json
+++ b/testdata/generated/package/example/0.0.2/index.json
@@ -32,6 +32,5 @@
     "/package/example/0.0.2/kibana/visualization/7e4084e0-5c99-11e9-8477-077ec9664dbd.json",
     "/package/example/0.0.2/kibana/visualization/80844540-5c97-11e9-8477-077ec9664dbd.json",
     "/package/example/0.0.2/kibana/visualization/ab48c3f0-5ca6-11e9-8477-077ec9664dbd.json"
-  ],
-  "requirement": {}
+  ]
 }

--- a/testdata/generated/package/example/1.0.0/index.json
+++ b/testdata/generated/package/example/1.0.0/index.json
@@ -94,6 +94,5 @@
   ],
   "owner": {
     "github": "ruflin"
-  },
-  "requirement": {}
+  }
 }

--- a/testdata/generated/package/experimental/0.0.1/index.json
+++ b/testdata/generated/package/experimental/0.0.1/index.json
@@ -16,6 +16,5 @@
   "assets": [
     "/package/experimental/0.0.1/manifest.yml",
     "/package/experimental/0.0.1/docs/README.md"
-  ],
-  "requirement": {}
+  ]
 }

--- a/testdata/generated/package/foo/1.0.0/index.json
+++ b/testdata/generated/package/foo/1.0.0/index.json
@@ -19,6 +19,5 @@
   "assets": [
     "/package/foo/1.0.0/manifest.yml",
     "/package/foo/1.0.0/docs/README.md"
-  ],
-  "requirement": {}
+  ]
 }

--- a/testdata/generated/package/internal/1.2.0/index.json
+++ b/testdata/generated/package/internal/1.2.0/index.json
@@ -15,6 +15,5 @@
   "assets": [
     "/package/internal/1.2.0/manifest.yml",
     "/package/internal/1.2.0/docs/README.md"
-  ],
-  "requirement": {}
+  ]
 }

--- a/testdata/generated/package/longdocs/1.0.4/index.json
+++ b/testdata/generated/package/longdocs/1.0.4/index.json
@@ -28,6 +28,5 @@
     "/package/longdocs/1.0.4/docs/README.md",
     "/package/longdocs/1.0.4/docs/data.json",
     "/package/longdocs/1.0.4/img/icon.svg"
-  ],
-  "requirement": {}
+  ]
 }

--- a/testdata/generated/package/metricsonly/2.0.1/index.json
+++ b/testdata/generated/package/metricsonly/2.0.1/index.json
@@ -23,6 +23,5 @@
     "/package/metricsonly/2.0.1/manifest.yml",
     "/package/metricsonly/2.0.1/docs/README.md",
     "/package/metricsonly/2.0.1/img/icon.svg"
-  ],
-  "requirement": {}
+  ]
 }

--- a/testdata/generated/package/multiple_false/0.0.1/index.json
+++ b/testdata/generated/package/multiple_false/0.0.1/index.json
@@ -61,6 +61,5 @@
       "package": "multiple_false",
       "path": "foo"
     }
-  ],
-  "requirement": {}
+  ]
 }

--- a/testdata/generated/package/multiversion/1.0.3/index.json
+++ b/testdata/generated/package/multiversion/1.0.3/index.json
@@ -28,6 +28,5 @@
     "/package/multiversion/1.0.3/manifest.yml",
     "/package/multiversion/1.0.3/docs/README.md",
     "/package/multiversion/1.0.3/img/icon.svg"
-  ],
-  "requirement": {}
+  ]
 }

--- a/testdata/generated/package/multiversion/1.0.4/index.json
+++ b/testdata/generated/package/multiversion/1.0.4/index.json
@@ -28,6 +28,5 @@
     "/package/multiversion/1.0.4/manifest.yml",
     "/package/multiversion/1.0.4/docs/README.md",
     "/package/multiversion/1.0.4/img/icon.svg"
-  ],
-  "requirement": {}
+  ]
 }

--- a/testdata/generated/package/multiversion/1.1.0/index.json
+++ b/testdata/generated/package/multiversion/1.1.0/index.json
@@ -28,6 +28,5 @@
     "/package/multiversion/1.1.0/manifest.yml",
     "/package/multiversion/1.1.0/docs/README.md",
     "/package/multiversion/1.1.0/img/icon.svg"
-  ],
-  "requirement": {}
+  ]
 }

--- a/testdata/generated/package/no_stream_configs/1.0.0/index.json
+++ b/testdata/generated/package/no_stream_configs/1.0.0/index.json
@@ -29,6 +29,5 @@
       "package": "no_stream_configs",
       "path": "log"
     }
-  ],
-  "requirement": {}
+  ]
 }

--- a/testdata/generated/package/reference/1.0.0/index.json
+++ b/testdata/generated/package/reference/1.0.0/index.json
@@ -106,6 +106,5 @@
   ],
   "owner": {
     "github": "ruflin"
-  },
-  "requirement": {}
+  }
 }

--- a/testdata/generated/package/yamlpipeline/1.0.0/index.json
+++ b/testdata/generated/package/yamlpipeline/1.0.0/index.json
@@ -63,6 +63,5 @@
       },
       "path": "log"
     }
-  ],
-  "requirement": {}
+  ]
 }

--- a/util/package.go
+++ b/util/package.go
@@ -66,9 +66,6 @@ type Package struct {
 	Datasets        []*Dataset       `config:"datasets,omitempty" json:"datasets,omitempty" yaml:"datasets,omitempty"`
 	Owner           *Owner           `config:"owner,omitempty" json:"owner,omitempty" yaml:"owner,omitempty"`
 
-	// Introduce it temporary to fix outdated Kibana snapshot
-	Requirement map[string]interface{} `json:"requirement"`
-
 	// Local path to the package dir
 	BasePath string `json:"-" yaml:"-"`
 }
@@ -179,8 +176,6 @@ func NewPackage(basePath string) (*Package, error) {
 			p.Screenshots[k].Src = s.getPath(p)
 		}
 	}
-
-	p.Requirement = map[string]interface{}{}
 
 	if p.Conditions != nil && p.Conditions.KibanaVersion != "" {
 		p.Conditions.kibanaConstraint, err = semver.NewConstraint(p.Conditions.KibanaVersion)


### PR DESCRIPTION
These legacy requirements were still in for compatiblity with the Kibana snapshots which were not up-to-date. As soon as these are, requirements can be removed.