### PR TITLE
Switch to production branch from package-storage

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -55,7 +55,8 @@ func fetchPackageStorage() error {
 
 	// If storage directory does not exists, check it out
 	if _, err := os.Stat(storageRepoDir); os.IsNotExist(err) {
-		return sh.Run("git", "clone", "--depth=1", "https://github.com/elastic/package-storage.git", storageRepoDir)
+		return sh.Run("git", "clone", "--depth=1", "--single-branch", "--branch", "production", "https://github.com/elastic/package-storage.git", storageRepoDir)
+
 	} else if err != nil {
 		// catch other errors
 		return err


### PR DESCRIPTION
As the master branch will not contain any packages anymore in the future, the packages used to run the registry locally must be adjusted. See https://github.com/elastic/package-storage/pull/116 for more details.