### PR TITLE
Remove packages from registry Docker build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@ package-registry
 
 .idea
 build
-public/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # This image contains the package-registry binary.
-# It expects packages to be mounted under /packages or have a config file loaded into /package-registry/config.yml
+# It expects packages to be mounted under /packages/package-registry or have a config file loaded into /package-registry/config.yml
 
 # Build binary
 ARG GO_VERSION=1.14.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,44 +1,37 @@
-# This Dockerfile allows to build the package-registry and packages together.
-# It is decoupled from the packages and the registry even though for now both are in the same repository.
-ARG GO_VERSION=1.14.2
-FROM golang:${GO_VERSION}
-
-# Get dependencies
-RUN \
-    apt-get update \
-      && apt-get install -y --no-install-recommends zip rsync \
-      && rm -rf /var/lib/apt/lists/*
-
-# Copy the package registry
-COPY ./ /home/package-registry
-WORKDIR /home/package-registry
-
-ENV GO111MODULE=on
-RUN go get -u github.com/magefile/mage
-# Prepare all the packages to be built
-RUN mage build
+# This image contains the package-registry binary.
+# It expects packages to be mounted under /packages or have a config file loaded into /package-registry/config.yml
 
 # Build binary
+ARG GO_VERSION=1.14.2
+FROM golang:${GO_VERSION} AS builder
+
+ENV GO111MODULE=on
+COPY ./ /package-registry
+WORKDIR /package-registry
 RUN go build .
 
-# Move all files need to run to its own directory
-# This will become useful for staged builds later on
-RUN mkdir -p /registry/public # left for legacy purposes
-RUN mkdir -p /registry/packages/package-storage
-RUN mv package-registry /registry/
-RUN cp -r build/package-storage/packages/* /registry/packages/package-storage/
-RUN cp config.docker.yml /registry/config.yml
+
+# Run binary
+FROM centos:7
+
+# Get dependencies
+RUN yum install -y zip rsync && yum clean all
+
+# Move binary from the builder image
+COPY --from=builder /package-registry/package-registry /package-registry/package-registry
 
 # Change to new working directory
-WORKDIR /registry
+WORKDIR /package-registry
 
-# Clean up files not needed
-RUN rm -rf /home/package-registry
+# Get in config which expects packages in /packages
+COPY config.docker.yml /package-registry/config.yml
 
+# Start registry when container is run an expose it on port 8080
 EXPOSE 8080
-
 ENTRYPOINT ["./package-registry"]
+
 # Make sure it's accessible from outside the container
 CMD ["--address=0.0.0.0:8080"]
 
 HEALTHCHECK --interval=1s --retries=30 CMD curl --silent --fail localhost:8080/health || exit 1
+

--- a/config.docker.yml
+++ b/config.docker.yml
@@ -1,6 +1,9 @@
 public_dir: ./public
+
+# If users want to add their own packages, they should be put under
+# /packages/package-registry or the config must be adjusted.
 package_paths:
-  - /packages
+  - /packages/package-registry
 
 cache_time.search: 10m
 cache_time.categories: 10m

--- a/config.docker.yml
+++ b/config.docker.yml
@@ -1,6 +1,6 @@
 public_dir: ./public
 package_paths:
-  - ./packages/package-storage
+  - /packages
 
 cache_time.search: 10m
 cache_time.categories: 10m

--- a/magefile.go
+++ b/magefile.go
@@ -44,14 +44,14 @@ func Build() error {
 		return err
 	}
 
-	err = fetchPackageStorage()
+	err = FetchPackageStorage()
 	if err != nil {
 		return err
 	}
 	return sh.Run("go", "build", ".")
 }
 
-func fetchPackageStorage() error {
+func FetchPackageStorage() error {
 
 	// If storage directory does not exists, check it out
 	if _, err := os.Stat(storageRepoDir); os.IsNotExist(err) {

--- a/magefile.go
+++ b/magefile.go
@@ -63,7 +63,7 @@ func fetchPackageStorage() error {
 
 	packageStorageRevision := os.Getenv("PACKAGE_STORAGE_REVISION")
 	if packageStorageRevision == "" {
-		packageStorageRevision = "master"
+		packageStorageRevision = "production"
 	}
 
 	err := sh.Run("git",

--- a/main_integration_test.go
+++ b/main_integration_test.go
@@ -23,8 +23,8 @@ import (
 // and the setup command works as expected.
 func TestSetup(t *testing.T) {
 
-	// Mage build is needed to pull in the packages from package-storage
-	err := sh.Run("mage", "build")
+	// Mage fetchPackageStorage is needed to pull in the packages from package-storage
+	err := sh.Run("mage", "fetchPackageStorage")
 	if err != nil {
 		t.Error(err)
 	}

--- a/main_integration_test.go
+++ b/main_integration_test.go
@@ -23,6 +23,12 @@ import (
 // and the setup command works as expected.
 func TestSetup(t *testing.T) {
 
+	// Mage build is needed to pull in the packages from package-storage
+	err := sh.Run("mage", "build")
+	if err != nil {
+		t.Error(err)
+	}
+
 	currentDir, err := os.Getwd()
 	if err != nil {
 		t.Error(err)

--- a/testing/environments/local.yml
+++ b/testing/environments/local.yml
@@ -19,7 +19,7 @@ services:
     build: ../..
     #image: docker.elastic.co/package-registry/package-registry:master
     volumes:
-      - ../../build/package-storage/packages:/packages
+      - ../../build/package-storage/packages:/packages/package-registry
     ports:
       - "127.0.0.1:8080:8080"
 

--- a/testing/environments/local.yml
+++ b/testing/environments/local.yml
@@ -19,7 +19,8 @@ services:
     build: ../..
     #image: docker.elastic.co/package-registry/package-registry:master
     volumes:
-      - ../../build/package-storage/packages:/packages/package-registry
+      - ./package-registry.config.yml:/package-registry/config.yml
+      - ../../build/package-storage/packages:/packages/package-storage
     ports:
       - "127.0.0.1:8080:8080"
 

--- a/testing/environments/local.yml
+++ b/testing/environments/local.yml
@@ -17,7 +17,9 @@ services:
 
   package-registry:
     build: ../..
-    image: docker.elastic.co/package-registry/package-registry:master
+    #image: docker.elastic.co/package-registry/package-registry:master
+    volumes:
+      - ../../build/package-storage/packages:/packages
     ports:
       - "127.0.0.1:8080:8080"
 

--- a/testing/environments/package-registry.config.yml
+++ b/testing/environments/package-registry.config.yml
@@ -1,0 +1,6 @@
+package_paths:
+  - /packages/package-storage
+
+cache_time.search: 10s
+cache_time.categories: 10s
+cache_time.catch_all: 10s


### PR DESCRIPTION
The Dockerfile for the registry itself should not contain any packages. Instead it should be empty and there are other distributions with packages, see elastic/package-storage#86. This removes the packages from the default Docker build.

Few additional changes in the this PR:

* Split up the Dockerfile in two stages to reduce the size of the image. Thanks @jsoriano for the contribution
* Switch over to production packages instead of master
* Select /packages as default path