### PR TITLE
Remove build trigger from package-storage:master

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -25,7 +25,6 @@ pipeline {
   }
   triggers {
     issueCommentTrigger('(?i).*(?:jenkins\\W+)?run\\W+(?:the\\W+)?tests(?:\\W+please)?.*')
-    upstream 'Beats/package-storage/master'
   }
   stages {
     /**


### PR DESCRIPTION
package-storage master is replaced by the 3 release branches. These have a fixed version of the registry attached so no need to trigger builds anymore here.