### PR TITLE
fix: reorder withMageEnv and dir steps

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -44,8 +44,8 @@ pipeline {
     stage('Lint') {
       steps {
         cleanup()
-        dir("${BASE_DIR}"){
-          withMageEnv(){
+        withMageEnv(){
+          dir("${BASE_DIR}"){
             sh(label: 'Checks formatting / linting',script: 'mage -debug check')
           }
         }
@@ -57,8 +57,8 @@ pipeline {
     stage('Build') {
       steps {
         cleanup()
-        dir("${BASE_DIR}"){
-          withMageEnv(){
+        withMageEnv(){
+          dir("${BASE_DIR}"){
             sh(label: 'Checks formatting / linting',script: 'mage -debug build')
           }
         }
@@ -70,8 +70,8 @@ pipeline {
     stage('Test') {
       steps {
         cleanup()
-        dir("${BASE_DIR}"){
-          withMageEnv(){
+        withMageEnv(){
+          dir("${BASE_DIR}"){
             sh(label: 'Runs the (unit) tests',script: 'mage -debug test|tee tests-report.txt')
           }
         }


### PR DESCRIPTION
## What does this PR do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->
It changes the order of the step withMageEnv and dir to avoid install mage with a go.mod file present.

## Why is it important?

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->

`go get package` will modify the go.mod file if it exits, this breaks the `mage check` target because it expects no modification on the local files. 

## Related issues
Closes https://github.com/elastic/package-registry/issues/593