### PR TITLE
Template path was not filled in when stream disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bugfixes
 
+* Always populate template_path. [#600](https://github.com/elastic/package-registry/pull/600)
+
 ### Added
 
 ### Deprecated

--- a/testdata/generated/package/datasources/1.0.0/index.json
+++ b/testdata/generated/package/datasources/1.0.0/index.json
@@ -171,6 +171,7 @@
               "default": "localhost"
             }
           ],
+          "template_path": "stream.yml.hbs",
           "title": "Title of the stream",
           "description": "Not enabled data source.",
           "enabled": false

--- a/util/dataset.go
+++ b/util/dataset.go
@@ -136,10 +136,11 @@ func NewDataset(basePath string, p *Package) (*Dataset, error) {
 	for i, _ := range d.Streams {
 		if d.Streams[i].Enabled == nil {
 			d.Streams[i].Enabled = &trueValue
-			// TODO: validate that the template path actually exists
-			if d.Streams[i].TemplatePath == "" {
-				d.Streams[i].TemplatePath = "stream.yml.hbs"
-			}
+		}
+
+		// TODO: validate that the template path actually exists
+		if d.Streams[i].TemplatePath == "" {
+			d.Streams[i].TemplatePath = "stream.yml.hbs"
 		}
 	}
 


### PR DESCRIPTION
The template path was not filled in when a stream was disabled by default. The issue was that the template path addition was inside the if clause but it should not be. This PR fixes this.