### PR TITLE
Update master to be v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Known Issue
 
 
-## [v0.7.0](https://github.com/elastic/package-registry/compare/v0.7.0...v0.7.1)
+## [v0.7.1](https://github.com/elastic/package-registry/compare/v0.7.0...v0.7.1)
 
 ### Bugfixes
 

--- a/main.go
+++ b/main.go
@@ -29,7 +29,7 @@ const (
 	packageDir = "package"
 
 	serviceName = "package-registry"
-	version     = "0.7.1"
+	version     = "0.8.0"
 )
 
 var (

--- a/testdata/generated/index.json
+++ b/testdata/generated/index.json
@@ -1,4 +1,4 @@
 {
  "service.name": "package-registry",
- "version": "0.7.1"
+ "version": "0.8.0"
 }


### PR DESCRIPTION
The next release is likely going to be v0.8.0. Update the version for it.