### PR TITLE
Update testing to run against 7.9.0-SNAPSHOT

### DIFF
--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.0.0-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.9.0-SNAPSHOT
     healthcheck:
       test: ["CMD", "curl", "-f", "-u", "elastic:changeme", "http://127.0.0.1:9200/"]
       retries: 300
@@ -20,7 +20,7 @@ services:
     - "ELASTIC_PASSWORD=changeme"
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:8.0.0-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:7.9.0-SNAPSHOT
     healthcheck:
       test: "curl -f http://localhost:5601/login | grep kbn-injected-metadata 2>&1 >/dev/null"
       retries: 600


### PR DESCRIPTION
Based on https://github.com/elastic/integrations/pull/202 standard registry tests should run against 7.9. We should make sure in the future it is run against not only 7.9 but all the different versions.