### PR TITLE
Update api docs for /search

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The `/search` API endpoint has few additional query parameters. More might be ad
 * package: Filters by a specific package name, for example `mysql`. Returns the most recent version. 
 * internal: This can be set to true, to also list internal packages. This is set to `false` by default.
 * all: This can be set to true to list all package versions. This is set to `false` by default.
+* experimental: This can be set to true to list packages considered to be experimental. This is set to `false` by default.
 
 The different query parameters above can be combined, so `?package=mysql&kibana=7.3.0` will return all mysql package versions
 which are compatible with `7.3.0`.

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ The `/search` API endpoint has few additional query parameters. More might be ad
   a package requires 7.4, the package will not be returned or an older compatible package will be shown.
   By default this endpoint always returns only the newest compatible package.
 * category: Filters the package by the given category. Available categories can be seend when going to `/categories` endpoint.
-* package: Filters by a specific package name, for example `mysql`. In contrast to the other endpoints, it will return
-  by default all versions of this package.
+* package: Filters by a specific package name, for example `mysql`. Returns the most recent version. 
 * internal: This can be set to true, to also list internal packages. This is set to `false` by default.
+* all: This can be set to true to list all package versions. This is set to `false` by default.
 
 The different query parameters above can be combined, so `?package=mysql&kibana=7.3.0` will return all mysql package versions
 which are compatible with `7.3.0`.


### PR DESCRIPTION
- updates `package`  parameter to reflect a past change where only the most recent version is not returned and not all versions
- adds `all` parameter to reflect a past change where this is needed to show all the versions of a package
- adds `experimental` parameter to reflect a past change where this is needed to show all packages considered to be experimental