### PR TITLE
Rename image src to path and have src as the original value from the …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Rename version to service.version in index handler. [#633](https://github.com/elastic/package-registry/pull/633)
 * Remove config `public_dir` which is replaced by `package_paths`. [#632](https://github.com/elastic/package-registry/pull/632)
 * Ship packages as zip instead of tar.gz [#628](https://github.com/elastic/package-registry/pull/628)
+* Rename image src to path and have src as the original value from the manifest. [#](https://github.com/elastic/package-registry/pull/)
 
 ### Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Rename version to service.version in index handler. [#633](https://github.com/elastic/package-registry/pull/633)
 * Remove config `public_dir` which is replaced by `package_paths`. [#632](https://github.com/elastic/package-registry/pull/632)
 * Ship packages as zip instead of tar.gz [#628](https://github.com/elastic/package-registry/pull/628)
-* Rename image src to path and have src as the original value from the manifest. [#](https://github.com/elastic/package-registry/pull/)
 * Rename image src to path and have src as the original value from the manifest. [#629](https://github.com/elastic/package-registry/pull/629)
 
 ### Bugfixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Remove config `public_dir` which is replaced by `package_paths`. [#632](https://github.com/elastic/package-registry/pull/632)
 * Ship packages as zip instead of tar.gz [#628](https://github.com/elastic/package-registry/pull/628)
 * Rename image src to path and have src as the original value from the manifest. [#](https://github.com/elastic/package-registry/pull/)
+* Rename image src to path and have src as the original value from the manifest. [#629](https://github.com/elastic/package-registry/pull/629)
 
 ### Bugfixes
 

--- a/openapi.yml
+++ b/openapi.yml
@@ -6,9 +6,6 @@ info:
     name: Elastic-License
     url: 'https://github.com/elastic/package-registry/blob/master/LICENSE.txt'
   description: Elastic Package Registry
-  contact:
-    name: Nicolas Ruflin
-    email: spam@ruflin.com
 servers:
   - url: 'https://epr.elastic.co'
     description: public
@@ -146,6 +143,8 @@ components:
       title: Image
       type: object
       properties:
+        path:
+          type: string
         src:
           type: string
         title:

--- a/testdata/generated/package.json
+++ b/testdata/generated/package.json
@@ -19,12 +19,14 @@
   },
   "screenshots": [
     {
-      "src": "/package/example/1.0.0/img/kibana-iptables.png",
+      "src": "/img/kibana-iptables.png",
+      "path": "/package/example/1.0.0/img/kibana-iptables.png",
       "title": "IP Tables Overview dashboard",
       "size": "1492x1382"
     },
     {
-      "src": "/package/example/1.0.0/img/kibana-iptables-ubiquity.png",
+      "src": "/img/kibana-iptables-ubiquity.png",
+      "path": "/package/example/1.0.0/img/kibana-iptables-ubiquity.png",
       "title": "IP Tables Ubiquity Dashboard",
       "size": "1492x1464",
       "type": "image/png"

--- a/testdata/generated/package/example/1.0.0/index.json
+++ b/testdata/generated/package/example/1.0.0/index.json
@@ -19,12 +19,14 @@
   },
   "screenshots": [
     {
-      "src": "/package/example/1.0.0/img/kibana-iptables.png",
+      "src": "/img/kibana-iptables.png",
+      "path": "/package/example/1.0.0/img/kibana-iptables.png",
       "title": "IP Tables Overview dashboard",
       "size": "1492x1382"
     },
     {
-      "src": "/package/example/1.0.0/img/kibana-iptables-ubiquity.png",
+      "src": "/img/kibana-iptables-ubiquity.png",
+      "path": "/package/example/1.0.0/img/kibana-iptables-ubiquity.png",
       "title": "IP Tables Ubiquity Dashboard",
       "size": "1492x1464",
       "type": "image/png"

--- a/testdata/generated/package/longdocs/1.0.4/index.json
+++ b/testdata/generated/package/longdocs/1.0.4/index.json
@@ -9,7 +9,8 @@
   "path": "/package/longdocs/1.0.4",
   "icons": [
     {
-      "src": "/package/longdocs/1.0.4/img/icon.svg",
+      "src": "/img/icon.svg",
+      "path": "/package/longdocs/1.0.4/img/icon.svg",
       "type": "image/svg+xml"
     }
   ],

--- a/testdata/generated/package/metricsonly/2.0.1/index.json
+++ b/testdata/generated/package/metricsonly/2.0.1/index.json
@@ -9,7 +9,8 @@
   "path": "/package/metricsonly/2.0.1",
   "icons": [
     {
-      "src": "/package/metricsonly/2.0.1/img/icon.svg",
+      "src": "/img/icon.svg",
+      "path": "/package/metricsonly/2.0.1/img/icon.svg",
       "type": "image/svg+xml"
     }
   ],

--- a/testdata/generated/package/multiversion/1.0.3/index.json
+++ b/testdata/generated/package/multiversion/1.0.3/index.json
@@ -9,7 +9,8 @@
   "path": "/package/multiversion/1.0.3",
   "icons": [
     {
-      "src": "/package/multiversion/1.0.3/img/icon.svg",
+      "src": "/img/icon.svg",
+      "path": "/package/multiversion/1.0.3/img/icon.svg",
       "type": "image/svg+xml"
     }
   ],

--- a/testdata/generated/package/multiversion/1.0.4/index.json
+++ b/testdata/generated/package/multiversion/1.0.4/index.json
@@ -9,7 +9,8 @@
   "path": "/package/multiversion/1.0.4",
   "icons": [
     {
-      "src": "/package/multiversion/1.0.4/img/icon.svg",
+      "src": "/img/icon.svg",
+      "path": "/package/multiversion/1.0.4/img/icon.svg",
       "type": "image/svg+xml"
     }
   ],

--- a/testdata/generated/package/multiversion/1.1.0/index.json
+++ b/testdata/generated/package/multiversion/1.1.0/index.json
@@ -9,7 +9,8 @@
   "path": "/package/multiversion/1.1.0",
   "icons": [
     {
-      "src": "/package/multiversion/1.1.0/img/icon.svg",
+      "src": "/img/icon.svg",
+      "path": "/package/multiversion/1.1.0/img/icon.svg",
       "type": "image/svg+xml"
     }
   ],

--- a/testdata/generated/package/reference/1.0.0/index.json
+++ b/testdata/generated/package/reference/1.0.0/index.json
@@ -9,7 +9,8 @@
   "path": "/package/reference/1.0.0",
   "icons": [
     {
-      "src": "/package/reference/1.0.0/img/icon.svg",
+      "src": "/img/icon.svg",
+      "path": "/package/reference/1.0.0/img/icon.svg",
       "size": "32x32",
       "type": "image/svg+xml"
     }

--- a/testdata/generated/search-all.json
+++ b/testdata/generated/search-all.json
@@ -70,7 +70,8 @@
     "path": "/package/longdocs/1.0.4",
     "icons": [
       {
-        "src": "/package/longdocs/1.0.4/img/icon.svg",
+        "src": "/img/icon.svg",
+        "path": "/package/longdocs/1.0.4/img/icon.svg",
         "type": "image/svg+xml"
       }
     ]
@@ -86,7 +87,8 @@
     "path": "/package/metricsonly/2.0.1",
     "icons": [
       {
-        "src": "/package/metricsonly/2.0.1/img/icon.svg",
+        "src": "/img/icon.svg",
+        "path": "/package/metricsonly/2.0.1/img/icon.svg",
         "type": "image/svg+xml"
       }
     ]
@@ -112,7 +114,8 @@
     "path": "/package/multiversion/1.0.3",
     "icons": [
       {
-        "src": "/package/multiversion/1.0.3/img/icon.svg",
+        "src": "/img/icon.svg",
+        "path": "/package/multiversion/1.0.3/img/icon.svg",
         "type": "image/svg+xml"
       }
     ]
@@ -128,7 +131,8 @@
     "path": "/package/multiversion/1.0.4",
     "icons": [
       {
-        "src": "/package/multiversion/1.0.4/img/icon.svg",
+        "src": "/img/icon.svg",
+        "path": "/package/multiversion/1.0.4/img/icon.svg",
         "type": "image/svg+xml"
       }
     ]
@@ -144,7 +148,8 @@
     "path": "/package/multiversion/1.1.0",
     "icons": [
       {
-        "src": "/package/multiversion/1.1.0/img/icon.svg",
+        "src": "/img/icon.svg",
+        "path": "/package/multiversion/1.1.0/img/icon.svg",
         "type": "image/svg+xml"
       }
     ]
@@ -170,7 +175,8 @@
     "path": "/package/reference/1.0.0",
     "icons": [
       {
-        "src": "/package/reference/1.0.0/img/icon.svg",
+        "src": "/img/icon.svg",
+        "path": "/package/reference/1.0.0/img/icon.svg",
         "size": "32x32",
         "type": "image/svg+xml"
       }

--- a/testdata/generated/search-category-custom.json
+++ b/testdata/generated/search-category-custom.json
@@ -30,7 +30,8 @@
     "path": "/package/longdocs/1.0.4",
     "icons": [
       {
-        "src": "/package/longdocs/1.0.4/img/icon.svg",
+        "src": "/img/icon.svg",
+        "path": "/package/longdocs/1.0.4/img/icon.svg",
         "type": "image/svg+xml"
       }
     ]
@@ -46,7 +47,8 @@
     "path": "/package/metricsonly/2.0.1",
     "icons": [
       {
-        "src": "/package/metricsonly/2.0.1/img/icon.svg",
+        "src": "/img/icon.svg",
+        "path": "/package/metricsonly/2.0.1/img/icon.svg",
         "type": "image/svg+xml"
       }
     ]
@@ -72,7 +74,8 @@
     "path": "/package/multiversion/1.1.0",
     "icons": [
       {
-        "src": "/package/multiversion/1.1.0/img/icon.svg",
+        "src": "/img/icon.svg",
+        "path": "/package/multiversion/1.1.0/img/icon.svg",
         "type": "image/svg+xml"
       }
     ]
@@ -98,7 +101,8 @@
     "path": "/package/reference/1.0.0",
     "icons": [
       {
-        "src": "/package/reference/1.0.0/img/icon.svg",
+        "src": "/img/icon.svg",
+        "path": "/package/reference/1.0.0/img/icon.svg",
         "size": "32x32",
         "type": "image/svg+xml"
       }

--- a/testdata/generated/search-category-web.json
+++ b/testdata/generated/search-category-web.json
@@ -20,7 +20,8 @@
     "path": "/package/longdocs/1.0.4",
     "icons": [
       {
-        "src": "/package/longdocs/1.0.4/img/icon.svg",
+        "src": "/img/icon.svg",
+        "path": "/package/longdocs/1.0.4/img/icon.svg",
         "type": "image/svg+xml"
       }
     ]
@@ -36,7 +37,8 @@
     "path": "/package/multiversion/1.1.0",
     "icons": [
       {
-        "src": "/package/multiversion/1.1.0/img/icon.svg",
+        "src": "/img/icon.svg",
+        "path": "/package/multiversion/1.1.0/img/icon.svg",
         "type": "image/svg+xml"
       }
     ]
@@ -52,7 +54,8 @@
     "path": "/package/reference/1.0.0",
     "icons": [
       {
-        "src": "/package/reference/1.0.0/img/icon.svg",
+        "src": "/img/icon.svg",
+        "path": "/package/reference/1.0.0/img/icon.svg",
         "size": "32x32",
         "type": "image/svg+xml"
       }

--- a/testdata/generated/search-kibana652.json
+++ b/testdata/generated/search-kibana652.json
@@ -50,7 +50,8 @@
     "path": "/package/metricsonly/2.0.1",
     "icons": [
       {
-        "src": "/package/metricsonly/2.0.1/img/icon.svg",
+        "src": "/img/icon.svg",
+        "path": "/package/metricsonly/2.0.1/img/icon.svg",
         "type": "image/svg+xml"
       }
     ]

--- a/testdata/generated/search-kibana721.json
+++ b/testdata/generated/search-kibana721.json
@@ -60,7 +60,8 @@
     "path": "/package/longdocs/1.0.4",
     "icons": [
       {
-        "src": "/package/longdocs/1.0.4/img/icon.svg",
+        "src": "/img/icon.svg",
+        "path": "/package/longdocs/1.0.4/img/icon.svg",
         "type": "image/svg+xml"
       }
     ]
@@ -76,7 +77,8 @@
     "path": "/package/metricsonly/2.0.1",
     "icons": [
       {
-        "src": "/package/metricsonly/2.0.1/img/icon.svg",
+        "src": "/img/icon.svg",
+        "path": "/package/metricsonly/2.0.1/img/icon.svg",
         "type": "image/svg+xml"
       }
     ]
@@ -102,7 +104,8 @@
     "path": "/package/multiversion/1.1.0",
     "icons": [
       {
-        "src": "/package/multiversion/1.1.0/img/icon.svg",
+        "src": "/img/icon.svg",
+        "path": "/package/multiversion/1.1.0/img/icon.svg",
         "type": "image/svg+xml"
       }
     ]
@@ -128,7 +131,8 @@
     "path": "/package/reference/1.0.0",
     "icons": [
       {
-        "src": "/package/reference/1.0.0/img/icon.svg",
+        "src": "/img/icon.svg",
+        "path": "/package/reference/1.0.0/img/icon.svg",
         "size": "32x32",
         "type": "image/svg+xml"
       }

--- a/testdata/generated/search-package-experimental.json
+++ b/testdata/generated/search-package-experimental.json
@@ -70,7 +70,8 @@
     "path": "/package/longdocs/1.0.4",
     "icons": [
       {
-        "src": "/package/longdocs/1.0.4/img/icon.svg",
+        "src": "/img/icon.svg",
+        "path": "/package/longdocs/1.0.4/img/icon.svg",
         "type": "image/svg+xml"
       }
     ]
@@ -86,7 +87,8 @@
     "path": "/package/metricsonly/2.0.1",
     "icons": [
       {
-        "src": "/package/metricsonly/2.0.1/img/icon.svg",
+        "src": "/img/icon.svg",
+        "path": "/package/metricsonly/2.0.1/img/icon.svg",
         "type": "image/svg+xml"
       }
     ]
@@ -112,7 +114,8 @@
     "path": "/package/multiversion/1.1.0",
     "icons": [
       {
-        "src": "/package/multiversion/1.1.0/img/icon.svg",
+        "src": "/img/icon.svg",
+        "path": "/package/multiversion/1.1.0/img/icon.svg",
         "type": "image/svg+xml"
       }
     ]
@@ -138,7 +141,8 @@
     "path": "/package/reference/1.0.0",
     "icons": [
       {
-        "src": "/package/reference/1.0.0/img/icon.svg",
+        "src": "/img/icon.svg",
+        "path": "/package/reference/1.0.0/img/icon.svg",
         "size": "32x32",
         "type": "image/svg+xml"
       }

--- a/testdata/generated/search-package-internal.json
+++ b/testdata/generated/search-package-internal.json
@@ -71,7 +71,8 @@
     "path": "/package/longdocs/1.0.4",
     "icons": [
       {
-        "src": "/package/longdocs/1.0.4/img/icon.svg",
+        "src": "/img/icon.svg",
+        "path": "/package/longdocs/1.0.4/img/icon.svg",
         "type": "image/svg+xml"
       }
     ]
@@ -87,7 +88,8 @@
     "path": "/package/metricsonly/2.0.1",
     "icons": [
       {
-        "src": "/package/metricsonly/2.0.1/img/icon.svg",
+        "src": "/img/icon.svg",
+        "path": "/package/metricsonly/2.0.1/img/icon.svg",
         "type": "image/svg+xml"
       }
     ]
@@ -113,7 +115,8 @@
     "path": "/package/multiversion/1.1.0",
     "icons": [
       {
-        "src": "/package/multiversion/1.1.0/img/icon.svg",
+        "src": "/img/icon.svg",
+        "path": "/package/multiversion/1.1.0/img/icon.svg",
         "type": "image/svg+xml"
       }
     ]
@@ -139,7 +142,8 @@
     "path": "/package/reference/1.0.0",
     "icons": [
       {
-        "src": "/package/reference/1.0.0/img/icon.svg",
+        "src": "/img/icon.svg",
+        "path": "/package/reference/1.0.0/img/icon.svg",
         "size": "32x32",
         "type": "image/svg+xml"
       }

--- a/testdata/generated/search.json
+++ b/testdata/generated/search.json
@@ -60,7 +60,8 @@
     "path": "/package/longdocs/1.0.4",
     "icons": [
       {
-        "src": "/package/longdocs/1.0.4/img/icon.svg",
+        "src": "/img/icon.svg",
+        "path": "/package/longdocs/1.0.4/img/icon.svg",
         "type": "image/svg+xml"
       }
     ]
@@ -76,7 +77,8 @@
     "path": "/package/metricsonly/2.0.1",
     "icons": [
       {
-        "src": "/package/metricsonly/2.0.1/img/icon.svg",
+        "src": "/img/icon.svg",
+        "path": "/package/metricsonly/2.0.1/img/icon.svg",
         "type": "image/svg+xml"
       }
     ]
@@ -102,7 +104,8 @@
     "path": "/package/multiversion/1.1.0",
     "icons": [
       {
-        "src": "/package/multiversion/1.1.0/img/icon.svg",
+        "src": "/img/icon.svg",
+        "path": "/package/multiversion/1.1.0/img/icon.svg",
         "type": "image/svg+xml"
       }
     ]
@@ -128,7 +131,8 @@
     "path": "/package/reference/1.0.0",
     "icons": [
       {
-        "src": "/package/reference/1.0.0/img/icon.svg",
+        "src": "/img/icon.svg",
+        "path": "/package/reference/1.0.0/img/icon.svg",
         "size": "32x32",
         "type": "image/svg+xml"
       }

--- a/util/package.go
+++ b/util/package.go
@@ -107,6 +107,7 @@ type Owner struct {
 
 type Image struct {
 	Src   string `config:"src" json:"src" validate:"required"`
+	Path  string `config:"path" json:"path"`
 	Title string `config:"title" json:"title,omitempty"`
 	Size  string `config:"size" json:"size,omitempty"`
 	Type  string `config:"type" json:"type,omitempty"`
@@ -167,13 +168,13 @@ func NewPackage(basePath string) (*Package, error) {
 
 	if p.Icons != nil {
 		for k, i := range p.Icons {
-			p.Icons[k].Src = i.getPath(p)
+			p.Icons[k].Path = i.getPath(p)
 		}
 	}
 
 	if p.Screenshots != nil {
 		for k, s := range p.Screenshots {
-			p.Screenshots[k].Src = s.getPath(p)
+			p.Screenshots[k].Path = s.getPath(p)
 		}
 	}
 


### PR DESCRIPTION
…manifest

All the configs specified in the manifest file by the user should be exposed without changes in our JSON output. In the case of images, the src was overwritten by the path variable. This means what was in the manifest and outputted by JSON was not a 1:1 match.

It is ok to add additional fields in the JSON output but the original fields should never be touched.

This is a breaking change and need adjustements in Kibana.