### PR TITLE
Add cache time for / index request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Add `cache_time.index` as config option. [#631](https://github.com/elastic/package-registry/pull/631)
+
 ### Deprecated
 
 ### Known Issue

--- a/config.docker.yml
+++ b/config.docker.yml
@@ -5,6 +5,7 @@ public_dir: ./public
 package_paths:
   - /packages/package-registry
 
+cache_time.index: 10s
 cache_time.search: 10m
 cache_time.categories: 10m
 cache_time.catch_all: 10m

--- a/config.reference.yml
+++ b/config.reference.yml
@@ -1,6 +1,7 @@
 package_paths:
   - ./packages
 
+cache_time.index: 10s
 cache_time.search: 10m
 cache_time.categories: 10m
 cache_time.catch_all: 10m

--- a/main.go
+++ b/main.go
@@ -39,6 +39,7 @@ var (
 
 	defaultConfig = Config{
 		PublicDir:           "./public", // left for legacy purposes
+		CacheTimeIndex:      10 * time.Second,
 		CacheTimeSearch:     10 * time.Minute,
 		CacheTimeCategories: 10 * time.Minute,
 		CacheTimeCatchAll:   10 * time.Minute,
@@ -54,6 +55,7 @@ func init() {
 type Config struct {
 	PublicDir           string        `config:"public_dir"` // left for legacy purposes
 	PackagePaths        []string      `config:"package_paths"`
+	CacheTimeIndex      time.Duration `config:"cache_time.index"`
 	CacheTimeSearch     time.Duration `config:"cache_time.search"`
 	CacheTimeCategories time.Duration `config:"cache_time.categories"`
 	CacheTimeCatchAll   time.Duration `config:"cache_time.catch_all"`
@@ -164,7 +166,7 @@ func getRouter(config *Config, packagesBasePaths []string) (*mux.Router, error) 
 	if err != nil {
 		return nil, err
 	}
-	indexHandlerFunc, err := indexHandler(config.CacheTimeCatchAll)
+	indexHandlerFunc, err := indexHandler(config.CacheTimeIndex)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The current request to / was cached the the as all the static artifacts. But this info changes every time the registry is deployed with a new version. To have the new version available as soon as possible and not potentially cached for a long time, an additional configuration cache option for this endpoint was introduced.