### PR TITLE
Rename version to service.version in index handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking changes
 
+* Rename version to service.version in index handler. [#](https://github.com/elastic/package-registry/pull/)
+
 ### Bugfixes
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking changes
 
-* Rename version to service.version in index handler. [#](https://github.com/elastic/package-registry/pull/)
+* Rename version to service.version in index handler. [#633](https://github.com/elastic/package-registry/pull/633)
 
 ### Bugfixes
 

--- a/index.go
+++ b/index.go
@@ -12,7 +12,7 @@ import (
 
 type indexData struct {
 	ServiceName string `json:"service.name"`
-	Version     string `json:"version"`
+	Version     string `json:"service.version"`
 }
 
 func indexHandler(cacheTime time.Duration) (func(w http.ResponseWriter, r *http.Request), error) {

--- a/testdata/generated/index.json
+++ b/testdata/generated/index.json
@@ -1,4 +1,4 @@
 {
  "service.name": "package-registry",
- "version": "0.11.0"
+ "service.version": "0.11.0"
 }


### PR DESCRIPTION
To be in line with ECS, version has been renamed to service.version: https://www.elastic.co/guide/en/ecs/current/ecs-service.html Even though this is marked as a breaking change, I do not assume this will break any current usage of the registry.