### PR TITLE
Update testing environment to 7.10

### DIFF
--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.9.0-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.10.0-SNAPSHOT
     healthcheck:
       test: ["CMD", "curl", "-f", "-u", "elastic:changeme", "http://127.0.0.1:9200/"]
       retries: 300
@@ -20,7 +20,7 @@ services:
     - "ELASTIC_PASSWORD=changeme"
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:7.9.0-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:7.10.0-SNAPSHOT
     healthcheck:
       test: "curl -f http://localhost:5601/login | grep kbn-injected-metadata 2>&1 >/dev/null"
       retries: 600


### PR DESCRIPTION
Moving forward we will make some breaking changes in the registry. Some of these are only supported by Kibana >= 7.10. Because of this the testing environment needs to be updated.