### PR TITLE
Prepare v0.11.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/elastic/package-registry/compare/v0.10.0...master)
+## [Unreleased](https://github.com/elastic/package-registry/compare/v0.11.0...master)
+
+### Breaking changes
+
+### Bugfixes
+
+### Added
+
+### Deprecated
+
+### Known Issue
+
+## [v0.11.0](https://github.com/elastic/package-registry/compare/v0.10.0...v0.11.0)
 
 ### Breaking changes
 
@@ -13,15 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Ship packages as zip instead of tar.gz [#628](https://github.com/elastic/package-registry/pull/628)
 * Rename image src to path and have src as the original value from the manifest. [#629](https://github.com/elastic/package-registry/pull/629)
 
-### Bugfixes
-
 ### Added
 
 * Add `cache_time.index` as config option. [#631](https://github.com/elastic/package-registry/pull/631)
-
-### Deprecated
-
-### Known Issue
 
 ## [v0.10.0](https://github.com/elastic/package-registry/compare/v0.9.0...v0.10.0)
 


### PR DESCRIPTION
Quite a few changes went in recently including some breaking changes for Kibana. It is time to roll out a new version.