### PR TITLE
Increment service.version to 0.12.0

### DIFF
--- a/main.go
+++ b/main.go
@@ -28,7 +28,7 @@ const (
 	packageDir = "package"
 
 	serviceName = "package-registry"
-	version     = "0.11.0"
+	version     = "0.12.0"
 )
 
 var (

--- a/testdata/generated/index.json
+++ b/testdata/generated/index.json
@@ -1,4 +1,4 @@
 {
  "service.name": "package-registry",
- "service.version": "0.11.0"
+ "service.version": "0.12.0"
 }


### PR DESCRIPTION
With 0.11.0 out https://github.com/elastic/package-registry/releases/tag/v0.11.0, the service.version should be increased to the next potential release version which is 0.12.0.