### PR TITLE
Add query to filter on asset type

### DIFF
--- a/search.go
+++ b/search.go
@@ -27,6 +27,7 @@ func searchHandler(packagesBasePaths []string, cacheTime time.Duration) func(w h
 		var category string
 		// Leaving out `a` here to not use a reserved name
 		var packageQuery string
+		var assetQuery string
 		var all bool
 		var internal bool
 		var experimental bool
@@ -48,6 +49,10 @@ func searchHandler(packagesBasePaths []string, cacheTime time.Duration) func(w h
 
 			if v := query.Get("package"); v != "" {
 				packageQuery = v
+			}
+
+			if v := query.Get("asset"); v != "" {
+				assetQuery = v
 			}
 
 			if v := query.Get("all"); v != "" {
@@ -114,6 +119,20 @@ func searchHandler(packagesBasePaths []string, cacheTime time.Duration) func(w h
 			// If package Query is set, all versions of this package are returned
 			if packageQuery != "" && packageQuery != p.Name {
 				continue
+			}
+
+			if assetQuery != "" {
+				assetFound := false
+				for _, a := range p.Assets {
+					if strings.Contains(a, assetQuery) {
+						assetFound = true
+						break
+
+					}
+				}
+				if !assetFound {
+					continue
+				}
 			}
 
 			addPackage := true


### PR DESCRIPTION
This current implementation checks if any of the assets paths contains the asset.

As an example, `http://localhost:8080/search?experimental=true&asset=foo/` returns the package default_pipeline. It contains the following assets:

```
  "assets": [
    "/package/default_pipeline/0.0.2/manifest.yml",
    "/package/default_pipeline/0.0.2/docs/README.md",
    "/package/default_pipeline/0.0.2/dataset/foo/manifest.yml",
    "/package/default_pipeline/0.0.2/dataset/foo/fields/base-fields.yml",
    "/package/default_pipeline/0.0.2/dataset/foo/agent/stream/stream.yml.hbs",
    "/package/default_pipeline/0.0.2/dataset/foo/elasticsearch/ingest_pipeline/default.json"
  ],
```

This might not be expected as `foo` here is the dataset name. Probably some additional flattening of the assets is needed.