### PR TITLE
Bump release version to 0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Known Issue
 
-## [v0.11.0](https://github.com/elastic/package-registry/compare/v0.11.0...v0.12.0)
+## [v0.12.0](https://github.com/elastic/package-registry/compare/v0.11.0...v0.12.0)
 
 ### Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/elastic/package-registry/compare/v0.11.0...master)
+## [Unreleased](https://github.com/elastic/package-registry/compare/v0.12.0...master)
+
+### Breaking changes
+
+### Bugfixes
+
+### Added
+
+### Deprecated
+
+### Known Issue
+
+## [v0.11.0](https://github.com/elastic/package-registry/compare/v0.11.0...v0.12.0)
 
 ### Breaking changes
 
@@ -13,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bugfixes
 
 ### Added
+
 * Add validation for icons and screenshots. [#537](https://github.com/elastic/package-registry/pull/537)
 
 ### Deprecated

--- a/main.go
+++ b/main.go
@@ -25,8 +25,6 @@ import (
 )
 
 const (
-	packageDir = "package"
-
 	serviceName = "package-registry"
 	version     = "0.13.0"
 )

--- a/main.go
+++ b/main.go
@@ -28,7 +28,7 @@ const (
 	packageDir = "package"
 
 	serviceName = "package-registry"
-	version     = "0.12.0"
+	version     = "0.13.0"
 )
 
 var (

--- a/testdata/generated/index.json
+++ b/testdata/generated/index.json
@@ -1,4 +1,4 @@
 {
  "service.name": "package-registry",
- "service.version": "0.12.0"
+ "service.version": "0.13.0"
 }


### PR DESCRIPTION
This PR releases a new version of the package-registry: 0.12.0