### PR TITLE
Fix: expose proper EPR version

### DIFF
--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ import (
 
 const (
 	serviceName = "package-registry"
-	version     = "0.13.0"
+	version     = "0.12.1"
 )
 
 var (

--- a/testdata/generated/index.json
+++ b/testdata/generated/index.json
@@ -1,4 +1,4 @@
 {
  "service.name": "package-registry",
- "service.version": "0.13.0"
+ "service.version": "0.12.1"
 }


### PR DESCRIPTION
I noticed that EPR is exposed with unreleased version (0.13.1). This PR fixes it.