### PR TITLE
Set cache headers for 404 and 400 to 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Breaking changes
 
 ### Bugfixes
+* Set cache headers for 404 and 400 to 0. [#649](https://github.com/elastic/package-registry/pull/649)
 
 ### Added
 

--- a/handler.go
+++ b/handler.go
@@ -34,7 +34,7 @@ func cacheHeaders(w http.ResponseWriter, cacheTime time.Duration) {
 
 func noCacheHeaders(w http.ResponseWriter) {
 	w.Header().Add("Cache-Control", "max-age=0")
-	w.Header().Add("Cache-Control", "private, no store")
+	w.Header().Add("Cache-Control", "private, no-store")
 }
 
 func jsonHeader(w http.ResponseWriter) {

--- a/handler.go
+++ b/handler.go
@@ -17,10 +17,12 @@ import (
 var errResourceNotFound = errors.New("resource not found")
 
 func notFoundError(w http.ResponseWriter, err error) {
+	cacheHeaders(w, 0)
 	http.Error(w, err.Error(), http.StatusNotFound)
 }
 
 func badRequest(w http.ResponseWriter, errorMessage string) {
+	cacheHeaders(w, 0)
 	http.Error(w, errorMessage, http.StatusBadRequest)
 }
 

--- a/handler.go
+++ b/handler.go
@@ -17,12 +17,12 @@ import (
 var errResourceNotFound = errors.New("resource not found")
 
 func notFoundError(w http.ResponseWriter, err error) {
-	cacheHeaders(w, 0)
+	noCacheHeaders(w)
 	http.Error(w, err.Error(), http.StatusNotFound)
 }
 
 func badRequest(w http.ResponseWriter, errorMessage string) {
-	cacheHeaders(w, 0)
+	noCacheHeaders(w)
 	http.Error(w, errorMessage, http.StatusBadRequest)
 }
 
@@ -30,6 +30,11 @@ func cacheHeaders(w http.ResponseWriter, cacheTime time.Duration) {
 	maxAge := fmt.Sprintf("max-age=%.0f", cacheTime.Seconds())
 	w.Header().Add("Cache-Control", maxAge)
 	w.Header().Add("Cache-Control", "public")
+}
+
+func noCacheHeaders(w http.ResponseWriter) {
+	w.Header().Add("Cache-Control", "max-age=0")
+	w.Header().Add("Cache-Control", "private, no store")
 }
 
 func jsonHeader(w http.ResponseWriter) {

--- a/main_integration_test.go
+++ b/main_integration_test.go
@@ -79,7 +79,7 @@ func TestSetup(t *testing.T) {
 	}
 
 	// Run setup in ingest_manager against registry to see if no errors are returned
-	req, err := http.NewRequest("POST", "http://elastic:changeme@localhost:5601/api/ingest_manager/setup", nil)
+	req, err := http.NewRequest("POST", "http://elastic:changeme@localhost:5601/api/fleet/setup", nil)
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
Fastly caches 404 headers by default. This could cause issues when rolling out a new registry and a path was requested to early. This sets the cache time to 0.

Fastly docs: https://docs.fastly.com/en/guides/http-status-codes-cached-by-default