### PR TITLE
Add not found handler to router

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bugfixes
 
+* Set cache headers for 404 for all API endpoints to private, no-store.[#652](https://github.com/elastic/package-registry/pull/652)
+
 ### Added
 
 * Add "traces" as legal event type. [#656](https://github.com/elastic/package-registry/pull/656)
@@ -69,7 +71,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Breaking changes
 
 ### Bugfixes
-* Set cache headers for 404 and 400 to private, no-store. [#649](https://github.com/elastic/package-registry/pull/649)[#652](https://github.com/elastic/package-registry/pull/652)
+* Set cache headers for 404 and 400 to private, no-store. [#649](https://github.com/elastic/package-registry/pull/649)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,7 +71,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Breaking changes
 
 ### Bugfixes
-* Set cache headers for 404 and 400 to private, no-store. [#649](https://github.com/elastic/package-registry/pull/649)
+* Set cache headers for 404 and 400 to 0. [#649](https://github.com/elastic/package-registry/pull/649)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Breaking changes
 
 ### Bugfixes
-* Set cache headers for 404 and 400 to 0. [#649](https://github.com/elastic/package-registry/pull/649)
+* Set cache headers for 404 and 400 to private, no-store. [#649](https://github.com/elastic/package-registry/pull/649)[#652](https://github.com/elastic/package-registry/pull/652)
 
 ### Added
 

--- a/handler.go
+++ b/handler.go
@@ -16,6 +16,12 @@ import (
 
 var errResourceNotFound = errors.New("resource not found")
 
+func notFoundHandler(err error) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		notFoundError(w, err)
+	})
+}
+
 func notFoundError(w http.ResponseWriter, err error) {
 	noCacheHeaders(w)
 	http.Error(w, err.Error(), http.StatusNotFound)

--- a/main.go
+++ b/main.go
@@ -176,6 +176,7 @@ func getRouter(config *Config, packagesBasePaths []string) (*mux.Router, error) 
 	router.HandleFunc(packageIndexRouterPath, packageIndexHandler)
 	router.PathPrefix("/package").HandlerFunc(staticHandler(packagesBasePaths, "/package", config.CacheTimeCatchAll))
 	router.Use(loggingMiddleware)
+	router.NotFoundHandler = http.Handler(notFoundHandler(fmt.Errorf("404 page not found")))
 	return router, nil
 }
 


### PR DESCRIPTION
So far, the default not found handler was used from mux. To set specific headers, this must be overwritten.