### PR TITLE
Add ilm policy field to data stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add "traces" as legal event type. [#656](https://github.com/elastic/package-registry/pull/656)
 * Add input-level `template_path` field. [#655](https://github.com/elastic/package-registry/pull/655)
 * Add "hidden" field to data stream. [#660] (https://github.com/elastic/package-registry/pull/660)
+* Add "ilm_policy" field to data stream. [#657] (https://github.com/elastic/package-registry/pull/657)
+
 ### Deprecated
 
 ### Known Issue

--- a/config.yml
+++ b/config.yml
@@ -1,3 +1,4 @@
 package_paths:
   - ./testdata/package
   - ./build/package-storage/packages
+  - /Users/fejoh/Documents/WORK/SOURCE/endpoint-package/out/packages

--- a/config.yml
+++ b/config.yml
@@ -1,4 +1,3 @@
 package_paths:
   - ./testdata/package
   - ./build/package-storage/packages
-  - /Users/fejoh/Documents/WORK/SOURCE/endpoint-package/out/packages

--- a/testdata/generated/categories-experimental.json
+++ b/testdata/generated/categories-experimental.json
@@ -22,7 +22,7 @@
   {
     "id": "custom",
     "title": "Custom",
-    "count": 11
+    "count": 12
   },
   {
     "id": "message_queue",

--- a/testdata/generated/categories.json
+++ b/testdata/generated/categories.json
@@ -17,7 +17,7 @@
   {
     "id": "custom",
     "title": "Custom",
-    "count": 11
+    "count": 12
   },
   {
     "id": "message_queue",

--- a/testdata/generated/index.json
+++ b/testdata/generated/index.json
@@ -1,4 +1,4 @@
 {
  "service.name": "package-registry",
- "service.version": "0.14.0"
+ "service.version": "0.14.1"
 }

--- a/testdata/generated/package/ilm_policy/1.0.0/index.json
+++ b/testdata/generated/package/ilm_policy/1.0.0/index.json
@@ -1,0 +1,43 @@
+{
+  "name": "ilmpolicy",
+  "title": "ILM Policy",
+  "version": "1.0.0",
+  "release": "beta",
+  "description": "Test form ILM Policy in Package",
+  "type": "solution",
+  "download": "/epr/ilmpolicy/ilmpolicy-1.0.0.zip",
+  "path": "/package/ilmpolicy/1.0.0",
+  "format_version": "1.0.0",
+  "readme": "/package/ilmpolicy/1.0.0/docs/README.md",
+  "license": "basic",
+  "categories": [
+    "custom"
+  ],
+  "conditions": {
+    "kibana.version": "\u003e=7.0.0"
+  },
+  "assets": [
+    "/package/ilmpolicy/1.0.0/manifest.yml",
+    "/package/ilmpolicy/1.0.0/docs/README.md",
+    "/package/ilmpolicy/1.0.0/data_stream/ilm_policy/manifest.yml",
+    "/package/ilmpolicy/1.0.0/data_stream/ilm_policy/fields/base-fields.yml",
+    "/package/ilmpolicy/1.0.0/data_stream/ilm_policy/fields/some_fields.yml",
+    "/package/ilmpolicy/1.0.0/data_stream/ilm_policy/elasticsearch/ilm/diagnostics.json"
+  ],
+  "data_streams": [
+    {
+      "type": "metrics",
+      "dataset": "ilmpolicy.ilm_policy",
+      "ilm_policy": "diagnostics",
+      "title": "ILM policy overrride data stream",
+      "release": "experimental",
+      "package": "ilmpolicy",
+      "elasticsearch": {
+        "index_template.mappings": {
+          "dynamic": false
+        }
+      },
+      "path": "ilm_policy"
+    }
+  ]
+}

--- a/testdata/generated/search-all.json
+++ b/testdata/generated/search-all.json
@@ -70,6 +70,16 @@
     "path": "/package/hidden/1.0.0"
   },
   {
+    "name": "ilmpolicy",
+    "title": "ILM Policy",
+    "version": "1.0.0",
+    "release": "beta",
+    "description": "Test form ILM Policy in Package",
+    "type": "solution",
+    "download": "/epr/ilmpolicy/ilmpolicy-1.0.0.zip",
+    "path": "/package/ilmpolicy/1.0.0"
+  },
+  {
     "name": "input_level_templates",
     "title": "Input level templates",
     "version": "1.0.0",

--- a/testdata/generated/search-category-custom.json
+++ b/testdata/generated/search-category-custom.json
@@ -30,6 +30,16 @@
     "path": "/package/hidden/1.0.0"
   },
   {
+    "name": "ilmpolicy",
+    "title": "ILM Policy",
+    "version": "1.0.0",
+    "release": "beta",
+    "description": "Test form ILM Policy in Package",
+    "type": "solution",
+    "download": "/epr/ilmpolicy/ilmpolicy-1.0.0.zip",
+    "path": "/package/ilmpolicy/1.0.0"
+  },
+  {
     "name": "input_level_templates",
     "title": "Input level templates",
     "version": "1.0.0",

--- a/testdata/generated/search-kibana721.json
+++ b/testdata/generated/search-kibana721.json
@@ -60,6 +60,16 @@
     "path": "/package/hidden/1.0.0"
   },
   {
+    "name": "ilmpolicy",
+    "title": "ILM Policy",
+    "version": "1.0.0",
+    "release": "beta",
+    "description": "Test form ILM Policy in Package",
+    "type": "solution",
+    "download": "/epr/ilmpolicy/ilmpolicy-1.0.0.zip",
+    "path": "/package/ilmpolicy/1.0.0"
+  },
+  {
     "name": "longdocs",
     "title": "Long Docs",
     "version": "1.0.4",

--- a/testdata/generated/search-package-experimental.json
+++ b/testdata/generated/search-package-experimental.json
@@ -80,6 +80,16 @@
     "path": "/package/hidden/1.0.0"
   },
   {
+    "name": "ilmpolicy",
+    "title": "ILM Policy",
+    "version": "1.0.0",
+    "release": "beta",
+    "description": "Test form ILM Policy in Package",
+    "type": "solution",
+    "download": "/epr/ilmpolicy/ilmpolicy-1.0.0.zip",
+    "path": "/package/ilmpolicy/1.0.0"
+  },
+  {
     "name": "input_level_templates",
     "title": "Input level templates",
     "version": "1.0.0",

--- a/testdata/generated/search-package-internal.json
+++ b/testdata/generated/search-package-internal.json
@@ -60,6 +60,16 @@
     "path": "/package/hidden/1.0.0"
   },
   {
+    "name": "ilmpolicy",
+    "title": "ILM Policy",
+    "version": "1.0.0",
+    "release": "beta",
+    "description": "Test form ILM Policy in Package",
+    "type": "solution",
+    "download": "/epr/ilmpolicy/ilmpolicy-1.0.0.zip",
+    "path": "/package/ilmpolicy/1.0.0"
+  },
+  {
     "name": "input_level_templates",
     "title": "Input level templates",
     "version": "1.0.0",

--- a/testdata/generated/search.json
+++ b/testdata/generated/search.json
@@ -60,6 +60,16 @@
     "path": "/package/hidden/1.0.0"
   },
   {
+    "name": "ilmpolicy",
+    "title": "ILM Policy",
+    "version": "1.0.0",
+    "release": "beta",
+    "description": "Test form ILM Policy in Package",
+    "type": "solution",
+    "download": "/epr/ilmpolicy/ilmpolicy-1.0.0.zip",
+    "path": "/package/ilmpolicy/1.0.0"
+  },
+  {
     "name": "input_level_templates",
     "title": "Input level templates",
     "version": "1.0.0",

--- a/testdata/package/ilm_policy/1.0.0/data_stream/ilm_policy/elasticsearch/ilm/diagnostics.json
+++ b/testdata/package/ilm_policy/1.0.0/data_stream/ilm_policy/elasticsearch/ilm/diagnostics.json
@@ -1,0 +1,15 @@
+{
+    "policy": {
+        "phases": {
+            "hot": {
+                "min_age": "0ms",
+                "actions": {
+                    "rollover": {
+                        "max_size": "10gb",
+                        "max_age": "1d"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/testdata/package/ilm_policy/1.0.0/data_stream/ilm_policy/fields/base-fields.yml
+++ b/testdata/package/ilm_policy/1.0.0/data_stream/ilm_policy/fields/base-fields.yml
@@ -1,0 +1,16 @@
+- name: data_stream.type
+  type: constant_keyword
+  description: >
+    Data stream type.
+- name: data_stream.dataset
+  type: constant_keyword
+  description: >
+    Data stream dataset.
+- name: data_stream.namespace
+  type: constant_keyword
+  description: >
+    Data stream namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/testdata/package/ilm_policy/1.0.0/data_stream/ilm_policy/fields/some_fields.yml
+++ b/testdata/package/ilm_policy/1.0.0/data_stream/ilm_policy/fields/some_fields.yml
@@ -1,0 +1,14 @@
+- name: source
+  title: Source
+  group: 2
+  type: group
+  fields:
+    - name: geo.city_name
+      level: core
+      type: keyword
+      description: City name.
+      ignore_above: 1024
+- name: foobar
+  type: text
+  description: A field with a pattern defined
+  pattern: '^[a-zA-Z]$'

--- a/testdata/package/ilm_policy/1.0.0/data_stream/ilm_policy/manifest.yml
+++ b/testdata/package/ilm_policy/1.0.0/data_stream/ilm_policy/manifest.yml
@@ -1,0 +1,6 @@
+title: ILM policy overrride data stream
+type: metrics
+ilm_policy: diagnostics
+elasticsearch:
+  index_template.mappings:
+    dynamic: false

--- a/testdata/package/ilm_policy/1.0.0/manifest.yml
+++ b/testdata/package/ilm_policy/1.0.0/manifest.yml
@@ -1,0 +1,14 @@
+format_version: 1.0.0
+
+name: ilmpolicy
+description: Test form ILM Policy in Package
+version: 1.0.0
+title: ILM Policy
+categories: ["custom"]
+type: solution
+release: beta
+
+conditions:
+  kibana:
+    version: ">=7.0.0"
+

--- a/util/data_stream.go
+++ b/util/data_stream.go
@@ -38,6 +38,7 @@ type DataStream struct {
 	// Name and type of the data stream. This is linked to data_stream.dataset and data_stream.type fields.
 	Type      string `config:"type" json:"type" validate:"required"`
 	Dataset   string `config:"dataset" json:"dataset,omitempty" yaml:"dataset,omitempty"`
+	Hidden    bool   `config:"hidden" json:"hidden,omitempty" yaml:"hidden,omitempty"`
 	IlmPolicy string `config:"ilm_policy" json:"ilm_policy,omitempty" yaml:"ilm_policy,omitempty"`
 
 	Title   string `config:"title" json:"title" validate:"required"`

--- a/util/data_stream.go
+++ b/util/data_stream.go
@@ -39,7 +39,6 @@ type DataStream struct {
 	Type      string `config:"type" json:"type" validate:"required"`
 	Dataset   string `config:"dataset" json:"dataset,omitempty" yaml:"dataset,omitempty"`
 	IlmPolicy string `config:"ilm_policy" json:"ilm_policy,omitempty" yaml:"ilm_policy,omitempty"`
-	Hidden    bool   `config:"hidden" json:"hidden,omitempty" yaml:"hidden,omitempty"`
 
 	Title   string `config:"title" json:"title" validate:"required"`
 	Release string `config:"release" json:"release"`

--- a/util/data_stream.go
+++ b/util/data_stream.go
@@ -36,9 +36,10 @@ var validTypes = map[string]string{
 
 type DataStream struct {
 	// Name and type of the data stream. This is linked to data_stream.dataset and data_stream.type fields.
-	Type    string `config:"type" json:"type" validate:"required"`
-	Dataset string `config:"dataset" json:"dataset,omitempty" yaml:"dataset,omitempty"`
-	Hidden  bool   `config:"hidden" json:"hidden,omitempty" yaml:"hidden,omitempty"`
+	Type      string `config:"type" json:"type" validate:"required"`
+	Dataset   string `config:"dataset" json:"dataset,omitempty" yaml:"dataset,omitempty"`
+	IlmPolicy string `config:"ilm_policy" json:"ilm_policy,omitempty" yaml:"ilm_policy,omitempty"`
+	Hidden    bool   `config:"hidden" json:"hidden,omitempty" yaml:"hidden,omitempty"`
 
 	Title   string `config:"title" json:"title" validate:"required"`
 	Release string `config:"release" json:"release"`


### PR DESCRIPTION
Issue: elastic/security-team#548

This PR adds the ilm_policy field to data stream manifest file. The ilm_policy is required to specify an alternate ilm policy to override the policy specified by the type field e.g. logs, metrics.

### `ilm_policy` field

This feature is needed so that we can get more flexibility when defining data streams within our packages, specifically when it comes to ilm_policy. Currently, the ilm_policy is tied to the type of the data stream. We want to add a field where we can specify an ilm_policy to override this behavior. There will be a subsequent PR to the Fleet code that will install the components according to this new ilm_policy field.

Our specific use case that is driving this is to define a data stream that is meant to collect documents that are used for diagnostics/telemetry. There will be a separate telemetry server that will query this particular data stream and collect the documents. As a result, we want the ilm_policy to be fairly aggressive as we do not need the documents to stay in storage for very long.