### PR TITLE
Switch for disabling validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Package validation is disabled by default. [#] (https://github.com/elastic/package-registry/pull/)
+
 ### Deprecated
 
 ### Known Issues

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* Package validation is disabled by default. [#] (https://github.com/elastic/package-registry/pull/)
+* Package validation is disabled by default. [#667] (https://github.com/elastic/package-registry/pull/667)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* Package validation is disabled by default. [#667] (https://github.com/elastic/package-registry/pull/667)
+* Package validation can be disabled via command line option. [#667] (https://github.com/elastic/package-registry/pull/667)
 
 ### Deprecated
 

--- a/main.go
+++ b/main.go
@@ -46,6 +46,7 @@ func init() {
 	flag.StringVar(&address, "address", "localhost:8080", "Address of the package-registry service.")
 	// This flag is experimental and might be removed in the future or renamed
 	flag.BoolVar(&dryRun, "dry-run", false, "Runs a dry-run of the registry without starting the web service (experimental)")
+	flag.BoolVar(&util.EnablePackageValidation, "validate", false, "Validate package content")
 }
 
 type Config struct {
@@ -60,6 +61,10 @@ func main() {
 	flag.Parse()
 	log.Println("Package registry started.")
 	defer log.Println("Package registry stopped.")
+
+	if dryRun {
+		util.EnablePackageValidation = true // dry-run enables the package validation
+	}
 
 	config := mustLoadConfig()
 	packagesBasePaths := getPackagesBasePaths(config)

--- a/main.go
+++ b/main.go
@@ -46,7 +46,7 @@ func init() {
 	flag.StringVar(&address, "address", "localhost:8080", "Address of the package-registry service.")
 	// This flag is experimental and might be removed in the future or renamed
 	flag.BoolVar(&dryRun, "dry-run", false, "Runs a dry-run of the registry without starting the web service (experimental)")
-	flag.BoolVar(&util.EnablePackageValidation, "validate", false, "Validate package content")
+	flag.BoolVar(&util.PackageValidationDisabled, "disable-package-validation", false, "Disable package content validation")
 }
 
 type Config struct {
@@ -61,10 +61,6 @@ func main() {
 	flag.Parse()
 	log.Println("Package registry started.")
 	defer log.Println("Package registry stopped.")
-
-	if dryRun {
-		util.EnablePackageValidation = true // dry-run enables the package validation
-	}
 
 	config := mustLoadConfig()
 	packagesBasePaths := getPackagesBasePaths(config)

--- a/util/data_stream.go
+++ b/util/data_stream.go
@@ -155,6 +155,10 @@ func NewDataStream(basePath string, p *Package) (*DataStream, error) {
 }
 
 func (d *DataStream) Validate() error {
+	if !EnablePackageValidation {
+		return nil
+	}
+
 	pipelineDir := filepath.Join(d.BasePath, "elasticsearch", DirIngestPipeline)
 	paths, err := filepath.Glob(filepath.Join(pipelineDir, "*"))
 	if err != nil {

--- a/util/data_stream.go
+++ b/util/data_stream.go
@@ -185,7 +185,7 @@ func NewDataStream(basePath string, p *Package) (*DataStream, error) {
 }
 
 func (d *DataStream) Validate() error {
-	if !EnablePackageValidation {
+	if PackageValidationDisabled {
 		return nil
 	}
 

--- a/util/package.go
+++ b/util/package.go
@@ -168,6 +168,11 @@ func NewPackage(basePath string) (*Package, error) {
 		p.License = DefaultLicense
 	}
 
+	p.versionSemVer, err = semver.StrictNewVersion(p.Version)
+	if err != nil {
+		return nil, errors.Wrap(err, "invalid package version")
+	}
+
 	if p.Icons != nil {
 		for k, i := range p.Icons {
 			p.Icons[k].Path = i.getPath(p)
@@ -308,6 +313,10 @@ func collectAssets(pattern string) ([]string, error) {
 // Validate is called during Unpack of the manifest.
 // The validation here is only related to the fields directly specified in the manifest itself.
 func (p *Package) Validate() error {
+	if !EnablePackageValidation {
+		return nil
+	}
+
 	if p.FormatVersion == "" {
 		return fmt.Errorf("no format_version set: %v", p)
 	}
@@ -334,11 +343,6 @@ func (p *Package) Validate() error {
 		if _, ok := CategoryTitles[c]; !ok {
 			return fmt.Errorf("invalid category: %s", c)
 		}
-	}
-
-	p.versionSemVer, err = semver.StrictNewVersion(p.Version)
-	if err != nil {
-		return errors.Wrap(err, "invalid package version")
 	}
 
 	for _, i := range p.Icons {

--- a/util/package.go
+++ b/util/package.go
@@ -313,7 +313,7 @@ func collectAssets(pattern string) ([]string, error) {
 // Validate is called during Unpack of the manifest.
 // The validation here is only related to the fields directly specified in the manifest itself.
 func (p *Package) Validate() error {
-	if !EnablePackageValidation {
+	if PackageValidationDisabled {
 		return nil
 	}
 

--- a/util/package_test.go
+++ b/util/package_test.go
@@ -112,6 +112,7 @@ var packageTests = []struct {
 }
 
 func TestValidate(t *testing.T) {
+	EnablePackageValidation = true
 	for _, tt := range packageTests {
 		t.Run(tt.description, func(t *testing.T) {
 			err := tt.p.Validate()

--- a/util/package_test.go
+++ b/util/package_test.go
@@ -112,7 +112,6 @@ var packageTests = []struct {
 }
 
 func TestValidate(t *testing.T) {
-	EnablePackageValidation = true
 	for _, tt := range packageTests {
 		t.Run(tt.description, func(t *testing.T) {
 			err := tt.p.Validate()

--- a/util/packages.go
+++ b/util/packages.go
@@ -13,8 +13,8 @@ import (
 	"github.com/pkg/errors"
 )
 
-// EnablePackageValidation is a flag which can enable package content validation (package, data streams, assets, etc.).
-var EnablePackageValidation = true
+// PackageValidationDisabled is a flag which can disable package content validation (package, data streams, assets, etc.).
+var PackageValidationDisabled bool
 
 var packageList Packages
 

--- a/util/packages.go
+++ b/util/packages.go
@@ -14,8 +14,7 @@ import (
 )
 
 // EnablePackageValidation is a flag which can enable package content validation (package, data streams, assets, etc.).
-// As the validation is relatively heavy process, it's disabled in runtime by default.
-var EnablePackageValidation bool
+var EnablePackageValidation = true
 
 var packageList Packages
 

--- a/util/packages.go
+++ b/util/packages.go
@@ -13,6 +13,10 @@ import (
 	"github.com/pkg/errors"
 )
 
+// EnablePackageValidation is a flag which can enable package content validation (package, data streams, assets, etc.).
+// As the validation is relatively heavy process, it's disabled in runtime by default.
+var EnablePackageValidation bool
+
 var packageList Packages
 
 type Packages []Package


### PR DESCRIPTION
Issue: https://github.com/elastic/package-registry/issues/653

This PR introduces a switch for disabling package validation. In public image builds of package-storage the validation will be shifted from runtime to build time.

Changes:
- added switch to disable package validation
- refactored `Validate()` methods to become idempotent

Unit tests are passing.