### PR TITLE
Release 0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/elastic/package-registry/compare/v0.15.0...master)
+## [0.16.0](https://github.com/elastic/package-registry/compare/v0.15.0...v0.16.0)
 
 ### Breaking changes
 

--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ import (
 
 const (
 	serviceName = "package-registry"
-	version     = "0.15.1"
+	version     = "0.16.0"
 )
 
 var (

--- a/testdata/generated/index.json
+++ b/testdata/generated/index.json
@@ -1,4 +1,4 @@
 {
  "service.name": "package-registry",
- "service.version": "0.15.1"
+ "service.version": "0.16.0"
 }


### PR DESCRIPTION
This PR prepares release of package-registry v0.16.0.

Issue: https://github.com/elastic/package-registry/issues/653