### PR TITLE
Add streaming category

### DIFF
--- a/util/package.go
+++ b/util/package.go
@@ -44,6 +44,7 @@ var CategoryTitles = map[string]string{
 	"os_system":         "OS & System",
 	"productivity":      "Productivity",
 	"security":          "Security",
+	"streaming":         "Data Streaming"
 	"support":           "Support",
 	"ticketing":         "Ticketing",
 	"version_control":   "Version Control",

--- a/util/package.go
+++ b/util/package.go
@@ -44,7 +44,7 @@ var CategoryTitles = map[string]string{
 	"os_system":         "OS & System",
 	"productivity":      "Productivity",
 	"security":          "Security",
-	"streaming":         "Data Streaming"
+	"streaming":         "Data Streaming",
 	"support":           "Support",
 	"ticketing":         "Ticketing",
 	"version_control":   "Version Control",


### PR DESCRIPTION
This PR adds `streaming` category useful to tag `stan` package, or `NATS Streaming`.
stan PR: https://github.com/elastic/integrations/pull/532
stan docs: https://github.com/nats-io/stan.go