### PR TITLE
Fix the package not loading if it has an accidental file left in the package root directory.

### DIFF
--- a/util/packages.go
+++ b/util/packages.go
@@ -74,14 +74,13 @@ func getPackagePaths(allPaths []string) ([]string, error) {
 			if info.IsDir() {
 				log.Printf("%-20s\t%10s\t%s", dirs[0], dirs[1], path)
 				foundPaths = append(foundPaths, path)
-			} else {
-				// Not expected file, return nil in order to continue processing sibling directories
-				// Fixes an annoying problem when the .DS_Store file is left behind and the package
-				// is not loading without any error information
-				log.Printf("error: unexpected file: %s", path)
-				return nil
+				return filepath.SkipDir
 			}
-			return filepath.SkipDir // don't need to go deeper
+			// Not expected file, return nil in order to continue processing sibling directories
+			// Fixes an annoying problem when the .DS_Store file is left behind and the package
+			// is not loading without any error information
+			log.Printf("error: unexpected file: %s", path)
+			return nil
 		})
 		if err != nil {
 			return nil, errors.Wrapf(err, "listing packages failed (path: %s)", packagesPath)

--- a/util/packages.go
+++ b/util/packages.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/pkg/errors"
 )
 
@@ -72,14 +73,20 @@ func getPackagePaths(allPaths []string) ([]string, error) {
 			}
 
 			if info.IsDir() {
-				log.Printf("%-20s\t%10s\t%s", dirs[0], dirs[1], path)
-				foundPaths = append(foundPaths, path)
+				versionDir := dirs[1]
+				_, err := semver.StrictNewVersion(versionDir)
+				if err != nil {
+					log.Printf("warning: unexpected directory: %s, ignoring", path)
+				} else {
+					log.Printf("%-20s\t%10s\t%s", dirs[0], versionDir, path)
+					foundPaths = append(foundPaths, path)
+				}
 				return filepath.SkipDir
 			}
-			// Not expected file, return nil in order to continue processing sibling directories
+			// Unexpected file, return nil in order to continue processing sibling directories
 			// Fixes an annoying problem when the .DS_Store file is left behind and the package
 			// is not loading without any error information
-			log.Printf("error: unexpected file: %s", path)
+			log.Printf("warning: unexpected file: %s, ignoring", path)
 			return nil
 		})
 		if err != nil {

--- a/util/packages.go
+++ b/util/packages.go
@@ -74,6 +74,12 @@ func getPackagePaths(allPaths []string) ([]string, error) {
 			if info.IsDir() {
 				log.Printf("%-20s\t%10s\t%s", dirs[0], dirs[1], path)
 				foundPaths = append(foundPaths, path)
+			} else {
+				// Not expected file, return nil in order to continue processing sibling directories
+				// Fixes an annoying problem when the .DS_Store file is left behind and the package
+				// is not loading without any error information
+				log.Printf("error: unexpected file: %s", path)
+				return nil
 			}
 			return filepath.SkipDir // don't need to go deeper
 		})


### PR DESCRIPTION
Fix the package not loading if it has an accidental file in the package root directory.
Log the error and load the remaining sibling directories.

Addresses https://github.com/elastic/package-registry/issues/672

<img width="896" alt="Screen Shot 2021-01-20 at 9 11 18 PM" src="https://user-images.githubusercontent.com/872351/105271095-e8787e00-5b64-11eb-91f2-5dd22f3c74b9.png">
