### PR TITLE
Add "dataset_is_prefix" field to data_stream, if present.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Add "dataset_is_prefix" field to data stream. [#674] (https://github.com/elastic/package-registry/pull/674)
+
 ### Deprecated
 
 ### Known Issues

--- a/util/data_stream.go
+++ b/util/data_stream.go
@@ -36,11 +36,11 @@ var validTypes = map[string]string{
 
 type DataStream struct {
 	// Name and type of the data stream. This is linked to data_stream.dataset and data_stream.type fields.
-	Type      string `config:"type" json:"type" validate:"required"`
-	Dataset   string `config:"dataset" json:"dataset,omitempty" yaml:"dataset,omitempty"`
-	Hidden    bool   `config:"hidden" json:"hidden,omitempty" yaml:"hidden,omitempty"`
-	IlmPolicy string `config:"ilm_policy" json:"ilm_policy,omitempty" yaml:"ilm_policy,omitempty"`
-	DatasetIsPrefix    bool   `config:"dataset_is_prefix" json:"dataset_is_prefix,omitempty" yaml:"dataset_is_prefix,omitempty"`
+	Type            string `config:"type" json:"type" validate:"required"`
+	Dataset         string `config:"dataset" json:"dataset,omitempty" yaml:"dataset,omitempty"`
+	Hidden          bool   `config:"hidden" json:"hidden,omitempty" yaml:"hidden,omitempty"`
+	IlmPolicy       string `config:"ilm_policy" json:"ilm_policy,omitempty" yaml:"ilm_policy,omitempty"`
+	DatasetIsPrefix bool   `config:"dataset_is_prefix" json:"dataset_is_prefix,omitempty" yaml:"dataset_is_prefix,omitempty"`
 
 	Title   string `config:"title" json:"title" validate:"required"`
 	Release string `config:"release" json:"release"`

--- a/util/data_stream.go
+++ b/util/data_stream.go
@@ -40,6 +40,7 @@ type DataStream struct {
 	Dataset   string `config:"dataset" json:"dataset,omitempty" yaml:"dataset,omitempty"`
 	Hidden    bool   `config:"hidden" json:"hidden,omitempty" yaml:"hidden,omitempty"`
 	IlmPolicy string `config:"ilm_policy" json:"ilm_policy,omitempty" yaml:"ilm_policy,omitempty"`
+	DatasetIsPrefix    bool   `config:"dataset_is_prefix" json:"dataset_is_prefix,omitempty" yaml:"dataset_is_prefix,omitempty"`
 
 	Title   string `config:"title" json:"title" validate:"required"`
 	Release string `config:"release" json:"release"`


### PR DESCRIPTION
This change exposes the new field `dataset_is_prefix` so that it can be used by Kibana/EPM.

The field was added to package-spec in https://github.com/elastic/package-spec/pull/102