### PR TITLE
Bumping up version in main.go

### DIFF
--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ import (
 
 const (
 	serviceName = "package-registry"
-	version     = "0.17.0"
+	version     = "0.17.1"
 )
 
 var (

--- a/testdata/generated/index.json
+++ b/testdata/generated/index.json
@@ -1,4 +1,4 @@
 {
  "service.name": "package-registry",
- "service.version": "0.17.0"
+ "service.version": "0.17.1"
 }


### PR DESCRIPTION
Follow up to https://github.com/elastic/package-registry/pull/678 according to step 6. of https://github.com/elastic/package-registry#release:

> 6. Update the main.go to increase the version number to the version of the potential next release version.
