### PR TITLE
Add base data stream into package

### DIFF
--- a/util/package.go
+++ b/util/package.go
@@ -67,20 +67,23 @@ type Package struct {
 
 	// Local path to the package dir
 	BasePath string `json:"-" yaml:"-"`
+
+	ExpandDataStream bool `config:"expand_data_stream,omitempty" json:"expand_data_stream,omitempty" yaml:"expand_data_stream,omitempty"`
 }
 
 // BasePackage is used for the output of the package info in the /search endpoint
 type BasePackage struct {
-	Name        string  `config:"name" json:"name"`
-	Title       *string `config:"title,omitempty" json:"title,omitempty" yaml:"title,omitempty"`
-	Version     string  `config:"version" json:"version"`
-	Release     string  `config:"release,omitempty" json:"release,omitempty"`
-	Description string  `config:"description" json:"description"`
-	Type        string  `config:"type" json:"type"`
-	Download    string  `json:"download" yaml:"download,omitempty"`
-	Path        string  `json:"path" yaml:"path,omitempty"`
-	Icons       []Image `config:"icons,omitempty" json:"icons,omitempty" yaml:"icons,omitempty"`
-	Internal    bool    `config:"internal,omitempty" json:"internal,omitempty" yaml:"internal,omitempty"`
+	Name            string            `config:"name" json:"name"`
+	Title           *string           `config:"title,omitempty" json:"title,omitempty" yaml:"title,omitempty"`
+	Version         string            `config:"version" json:"version"`
+	Release         string            `config:"release,omitempty" json:"release,omitempty"`
+	Description     string            `config:"description" json:"description"`
+	Type            string            `config:"type" json:"type"`
+	Download        string            `json:"download" yaml:"download,omitempty"`
+	Path            string            `json:"path" yaml:"path,omitempty"`
+	Icons           []Image           `config:"icons,omitempty" json:"icons,omitempty" yaml:"icons,omitempty"`
+	Internal        bool              `config:"internal,omitempty" json:"internal,omitempty" yaml:"internal,omitempty"`
+	BaseDataStreams []*BaseDataStream `config:"base_data_streams,omitempty" json:"base_data_streams,omitempty" yaml:"base_data_streams,omitempty"`
 }
 
 type PolicyTemplate struct {
@@ -423,7 +426,7 @@ func (p *Package) LoadDataSets() error {
 
 		dataStreamBasePath := filepath.Join(dataStreamsBasePath, dataStreamPath)
 
-		d, err := NewDataStream(dataStreamBasePath, p)
+		d, bd, err := NewDataStream(dataStreamBasePath, p)
 		if err != nil {
 			return err
 		}
@@ -431,6 +434,9 @@ func (p *Package) LoadDataSets() error {
 		// TODO: Validate that each input specified in a stream also is defined in the package
 
 		p.DataStreams = append(p.DataStreams, d)
+		if bd != nil {
+			p.BaseDataStreams = append(p.BaseDataStreams, bd)
+		}
 	}
 
 	return nil
@@ -447,7 +453,7 @@ func (p *Package) ValidateDataStreams() error {
 	for _, dataStreamPath := range dataStreamPaths {
 		dataStreamBasePath := filepath.Join(dataStreamsBasePath, dataStreamPath)
 
-		d, err := NewDataStream(dataStreamBasePath, p)
+		d, _, err := NewDataStream(dataStreamBasePath, p)
 		if err != nil {
 			return errors.Wrapf(err, "building data stream failed (path: %s)", dataStreamBasePath)
 		}


### PR DESCRIPTION
(just a draft PR for my small poc)
This PR is to adjust the code to read the new config option `expand_data_stream` at the package level. When `expand_data_stream` is set to true, abstract data stream info and store them into the `/search` API endpoint result.

For example with `expand_data_stream: true` in AWS package, `/search` API response will look like this:
```
[
  {
    "name": "aws",
    "title": "AWS",
    "version": "0.3.18",
    "release": "beta",
    "description": "AWS Integration",
    "type": "integration",
    "download": "/epr/aws/aws-0.3.18.zip",
    "path": "/package/aws/0.3.18",
    "icons": [
      {
        "src": "/img/logo_aws.svg",
        "path": "/package/aws/0.3.18/img/logo_aws.svg",
        "title": "logo aws",
        "size": "32x32",
        "type": "image/svg+xml"
      }
    ],
    "base_data_streams": [
      ...
      {
        "type": "metrics",
        "dataset": "aws.ec2_metrics",
        "title": "AWS EC2 metrics",
        "release": "beta",
        "description": "AWS EC2 Integration",
        "icons": [
          {
            "src": "../img/logo_aws_ec2.svg",
            "path": "",
            "title": "logo aws ec2",
            "size": "32x32",
            "type": "image/svg+xml"
          }
        ]
      },
      ...
    ]
  }
]
```