### PR TITLE
Don't use SNAPSHOT artifacts

### DIFF
--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.10.0-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.10.0
     healthcheck:
       test: ["CMD", "curl", "-f", "-u", "elastic:changeme", "http://127.0.0.1:9200/"]
       retries: 300
@@ -20,7 +20,7 @@ services:
     - "ELASTIC_PASSWORD=changeme"
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:7.10.0-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:7.10.0
     healthcheck:
       test: "curl -f http://localhost:5601/login | grep kbn-injected-metadata 2>&1 >/dev/null"
       retries: 600


### PR DESCRIPTION
Related: https://github.com/elastic/package-registry/issues/615#issuecomment-772567446

Since snapshot release artifacts of past releases eventually go away and we [agreed](https://github.com/elastic/package-registry/issues/615#issuecomment-772547176) to test against `7.10.0` of the stack until #615 is properly resolved, this PR updates the Docker images to use the `7.10.0` tags instead of the `7.10.0-SNAPSHOT` tags.