### PR TITLE
[jjbb] remove periodic-folder-trigger

### DIFF
--- a/.ci/jobs/defaults.yml
+++ b/.ci/jobs/defaults.yml
@@ -16,5 +16,8 @@
     publishers:
       - email:
           recipients: infra-root+build@elastic.co
-    periodic-folder-trigger: 1w
+    # Webhook based rather than polling otherwise the GitHub API quota
+    # will be overkilled. For such, periodic-folder-trigger is not needed
+    # anymore, so we keep the comment below for clarity.
+    # periodic-folder-trigger: 1w
     prune-dead-branches: true


### PR DESCRIPTION
## What does this PR do?

Use the default value for periodic-folder-trigger = `none`

> periodic-folder-trigger (str): How often to scan for new branches or pull/change requests. Valid values: 1m, 2m, 5m, 10m, 15m, 20m, 25m, 30m, 1h, 2h, 4h, 8h, 12h, 1d, 2d, 1w, 2w, 4w. (default none)

[docs](https://docs.openstack.org/infra/jenkins-job-builder/project_workflow_multibranch.html)

## Why

Reduce the build load in the `beats-ci` for this particular scan, we don't build PRs when there is change in their target branch to reduce the number of resources in the cloud.

For instance, last night the trigger happened and triggered the build for all the PRs for another multibranch project, as a consequence there were a big long queue.

<img src="https://user-images.githubusercontent.com/2871786/110764011-6e05d980-824a-11eb-959f-e95a71865a29.png" width="40%">.

<img src="https://user-images.githubusercontent.com/2871786/110764273-bf15cd80-824a-11eb-91c3-47c2d16914fb.png">

