### PR TITLE
Don't serialize empty path as YAML

### DIFF
--- a/util/package.go
+++ b/util/package.go
@@ -109,6 +109,7 @@ type Image struct {
 	// Src is relative inside the package
 	Src string `config:"src" json:"src" validate:"required"`
 	// Path is the absolute path in the url
+	// TODO: remove yaml struct tag once mage ImportBeats is removed from elastic/integrations repo.
 	Path  string `config:"path" json:"path" yaml:"path,omitempty"`
 	Title string `config:"title" json:"title,omitempty"`
 	Size  string `config:"size" json:"size,omitempty"`

--- a/util/package.go
+++ b/util/package.go
@@ -109,7 +109,7 @@ type Image struct {
 	// Src is relative inside the package
 	Src string `config:"src" json:"src" validate:"required"`
 	// Path is the absolute path in the url
-	Path  string `config:"path" json:"path"`
+	Path  string `config:"path" json:"path" yaml:"path,omitempty"`
 	Title string `config:"title" json:"title,omitempty"`
 	Size  string `config:"size" json:"size,omitempty"`
 	Type  string `config:"type" json:"type,omitempty"`


### PR DESCRIPTION
Resolves the following `path` errors in https://github.com/elastic/integrations/issues/765:

```
   1. file "/Users/shaunak/development/github/integrations/packages/traefik/manifest.yml" is invalid: field screenshots.0: Additional property path is not allowed
   ...
   3. file "/Users/shaunak/development/github/integrations/packages/traefik/manifest.yml" is invalid: field icons.0: Additional property path is not allowed
```

