### PR TITLE
Honor PACKAGE_STORAGE_REVISION env var

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -8,10 +8,11 @@ package main
 
 import (
 	"fmt"
-	"github.com/pkg/errors"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/pkg/errors"
 
 	"github.com/magefile/mage/mg"
 	"github.com/magefile/mage/sh"

--- a/magefile.go
+++ b/magefile.go
@@ -8,6 +8,7 @@ package main
 
 import (
 	"fmt"
+	"github.com/pkg/errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -41,14 +42,9 @@ func Build() error {
 }
 
 func FetchPackageStorage() error {
-
-	// If storage directory does not exists, check it out
-	if _, err := os.Stat(storageRepoDir); os.IsNotExist(err) {
-		return sh.Run("git", "clone", "--depth=1", "--single-branch", "--branch", "production", "https://github.com/elastic/package-storage.git", storageRepoDir)
-
-	} else if err != nil {
-		// catch other errors
-		return err
+	// Remove old storage directory
+	if err := os.RemoveAll(storageRepoDir); err != nil {
+		return errors.Wrapf(err, "failed to remove existing storage directory: %s", storageRepoDir)
 	}
 
 	packageStorageRevision := os.Getenv("PACKAGE_STORAGE_REVISION")
@@ -56,36 +52,9 @@ func FetchPackageStorage() error {
 		packageStorageRevision = "production"
 	}
 
-	err := sh.Run("git",
-		"--git-dir", filepath.Join(storageRepoDir, ".git"), "--work-tree", storageRepoDir,
-		"reset", "--hard")
-	if err != nil {
-		return err
-	}
-
-	err = sh.Run("git",
-		"--git-dir", filepath.Join(storageRepoDir, ".git"), "--work-tree", storageRepoDir,
-		"clean", "-df")
-	if err != nil {
-		return err
-	}
-
-	err = sh.Run("git",
-		"--git-dir", filepath.Join(storageRepoDir, ".git"), "--work-tree", storageRepoDir,
-		"fetch")
-	if err != nil {
-		return err
-	}
-
-	err = sh.Run("git",
-		"--git-dir", filepath.Join(storageRepoDir, ".git"), "--work-tree", storageRepoDir,
-		"checkout",
-		packageStorageRevision)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	// Check out fresh storage directory
+	return sh.Run("git", "clone", "--depth=1", "--single-branch",
+		"--branch", packageStorageRevision, "https://github.com/elastic/package-storage.git", storageRepoDir)
 }
 
 func Check() error {


### PR DESCRIPTION
This PR fixes a bug with the `mage build` command. The command takes an optional `PACKAGE_STORAGE_REVISION` environment variable, which defaults to `production`.  However, if this variable is set to something other than `production`, the command does not work as expected; it still checks out the `production` branch of the `package-storage` repo into `build/package-storage`.

This PR fixes this bug by always removing the `build/package-storage` folder and then checking out the specified branch via the `PACKAGE_STORAGE_REVISION` environment variables, defaulting to `production`. I realize removing  the `build/package-storage` folder each time slows things down but this only affects developers of `package-registry`, not consumers of it. 