### PR TITLE
Fix: define synthetics type

### DIFF
--- a/util/data_stream.go
+++ b/util/data_stream.go
@@ -29,9 +29,10 @@ const (
 )
 
 var validTypes = map[string]string{
-	"logs":    "Logs",
-	"metrics": "Metrics",
-	"traces":  "Traces",
+	"logs":       "Logs",
+	"metrics":    "Metrics",
+	"synthetics": "Synthetics",
+	"traces":     "Traces",
 }
 
 type DataStream struct {


### PR DESCRIPTION
This PR defines the missing "synthetics" type.

Spotted in: https://github.com/elastic/package-storage/pull/1140