### PR TITLE
Bump up version to 0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/elastic/package-registry/compare/v0.17.0...master)
+## [Unreleased](https://github.com/elastic/package-registry/compare/v0.18.0...master)
 
 ### Breaking changes
 
 ### Bugfixes
 
 ### Added
+
+### Deprecated
+
+### Known Issues
+
+## [Unreleased](https://github.com/elastic/package-registry/compare/v0.17.0...v0.18.0)
+
+### Breaking changes
+
+### Bugfixes
+
+### Added
+
+* Support "synthetics" type. [#688] (https://github.com/elastic/package-registry/pull/688)
 
 ### Deprecated
 

--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ import (
 
 const (
 	serviceName = "package-registry"
-	version     = "0.17.1"
+	version     = "0.18.0"
 )
 
 var (

--- a/testdata/generated/index.json
+++ b/testdata/generated/index.json
@@ -1,4 +1,4 @@
 {
  "service.name": "package-registry",
- "service.version": "0.17.1"
+ "service.version": "0.18.0"
 }


### PR DESCRIPTION
This PR bumps up the release version to 0.18.0 (as 0.17.0 is released).