### PR TITLE
Bump elastic stack version automation

### DIFF
--- a/.ci/bump-stack-version.sh
+++ b/.ci/bump-stack-version.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# Given the stack version this script will bump the version.
+#
+# This script is executed by the automation we are putting in place
+# and it requires the git add/commit commands.
+#
+# Parameters:
+#	$1 -> the version to be bumped. Mandatory.
+#	$2 -> whether to create a branch where to commit the changes to.
+#		  this is required when reusing an existing Pull Request.
+#		  Optional. Default true.
+#
+set -euo pipefail
+MSG="parameter missing."
+VERSION=${1:?$MSG}
+CREATE_BRANCH=${2:-true}
+
+OS=$(uname -s| tr '[:upper:]' '[:lower:]')
+
+if [ "${OS}" == "darwin" ] ; then
+	SED="sed -i .bck"
+else
+	SED="sed -i"
+fi
+
+echo "Update stack with version ${VERSION}"
+${SED} -E -e "s#(image: docker\.elastic\.co/.*):[0-9]+\.[0-9]+\.[0-9]+(-[a-f0-9]{8})?#\1:${VERSION}#g" testing/environments/snapshot.yml
+
+echo "Commit changes"
+if [ "$CREATE_BRANCH" = "true" ]; then
+	git checkout -b "update-stack-version-$(date "+%Y%m%d%H%M%S")"
+else
+	echo "Branch creation disabled."
+fi
+git add testing/environments/snapshot.yml
+git diff --staged --quiet || git commit -m "bump stack version ${VERSION}"
+git --no-pager log -1
+
+echo "You can now push and create a Pull Request"

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ package-registry
 
 .idea
 build
+
+## Exclude generated backup files when running the bump automation
+*.bck

--- a/testing/environments/README.md
+++ b/testing/environments/README.md
@@ -1,3 +1,5 @@
+# Usage
+
 Firstly, refresh docker images:
 
 ```bash
@@ -9,3 +11,14 @@ Run docker containers:
 ```bash
 $ docker-compose -f snapshot.yml -f local.yml up --force-recreate
 ```
+
+# Bump versions
+
+There is an automation in place to bump the Elastic stack versions to a pinned version.
+
+In case you need to manually bump the existing version in `testing/environments/snapshot.yml` then please run the script
+`.ci/bump-stack-version.sh <VERSION> "true"`.
+
+Where `<VERSION>` is the docker image tag without the `-SNAPSHOT`, and `"true"` means to create a git branch.
+
+**NOTE**: If you change the versioning format be sure it's also updated accordingly in `.ci/bump-stack-version.sh`.

--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.10.0
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.0.0-SNAPSHOT
     healthcheck:
       test: ["CMD", "curl", "-f", "-u", "elastic:changeme", "http://127.0.0.1:9200/"]
       retries: 300
@@ -20,7 +20,7 @@ services:
     - "ELASTIC_PASSWORD=changeme"
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:7.10.0
+    image: docker.elastic.co/kibana/kibana:8.0.0-SNAPSHOT
     healthcheck:
       test: "curl -f http://localhost:5601/login | grep kbn-injected-metadata 2>&1 >/dev/null"
       retries: 600


### PR DESCRIPTION
## What does this PR do?

Script to bump the versions:

```diff
## I changed the sh script to exist after the sed
$ ./.ci/bump-stack-version.sh 8.0.0-3beeb19e
Update stack with version 8.0.0-3beeb19e
diff --git a/testing/environments/snapshot.yml b/testing/environments/snapshot.yml
index dbbade2f..f79c5e95 100644
--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.0.0-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.0.0-3beeb19e-SNAPSHOT
     healthcheck:
       test: ["CMD", "curl", "-f", "-u", "elastic:changeme", "http://127.0.0.1:9200/"]
       retries: 300
@@ -20,7 +20,7 @@ services:
     - "ELASTIC_PASSWORD=changeme"
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:8.0.0-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:8.0.0-3beeb19e-SNAPSHOT
     healthcheck:
       test: "curl -f http://localhost:5601/login | grep kbn-injected-metadata 2>&1 >/dev/null"
       retries: 600
~
```

This PR is one part of the required changes to enable the automation. 

## Why is it important?

Handle the stack versions on a PR basis to ensure breaking changes are handled correctly. Unfortunately we cannot use `dependabot` since those versions are handled differently.

## Issues

Similar to https://github.com/elastic/beats/pull/25148

## Follow ups

- Enable automerge with `mergify`?