### PR TITLE
Release v0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bugfixes
 
+### Added
+
+### Deprecated
+
+### Known Issues
+
+## [0.19.0](https://github.com/elastic/package-registry/compare/v0.18.0...v0.19.0)
+
+### Breaking changes
+
+### Bugfixes
+
 * Disable Handlebars parsing. [#692] (https://github.com/elastic/package-registry/pull/692)
 
 ### Added

--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ import (
 
 const (
 	serviceName = "package-registry"
-	version     = "0.18.1"
+	version     = "0.19.0"
 )
 
 var (

--- a/testdata/generated/index.json
+++ b/testdata/generated/index.json
@@ -1,4 +1,4 @@
 {
  "service.name": "package-registry",
- "service.version": "0.18.1"
+ "service.version": "0.19.0"
 }


### PR DESCRIPTION
This PR bumps up the release version to v0.19.0, so we can release the fix for ingest pipelines.