### PR TITLE
Bump up next minor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/elastic/package-registry/compare/v0.18.0...master)
+## [Unreleased](https://github.com/elastic/package-registry/compare/v0.19.0...master)
 
 ### Breaking changes
 

--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ import (
 
 const (
 	serviceName = "package-registry"
-	version     = "0.19.0"
+	version     = "0.19.1"
 )
 
 var (

--- a/testdata/generated/index.json
+++ b/testdata/generated/index.json
@@ -1,4 +1,4 @@
 {
  "service.name": "package-registry",
- "service.version": "0.19.0"
+ "service.version": "0.19.1"
 }


### PR DESCRIPTION
This PR bumps up minor (to v0.19.1) after creating new release tag (v0.19.0).