### PR TITLE
Update Go version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # It expects packages to be mounted under /packages/package-registry or have a config file loaded into /package-registry/config.yml
 
 # Build binary
-ARG GO_VERSION=1.14.2
+ARG GO_VERSION=1.16.7
 FROM golang:${GO_VERSION} AS builder
 
 ENV GO111MODULE=on


### PR DESCRIPTION
This version is not used by CI as it is overridden in the Jenkinsfile, but it can be used locally by developers running `docker build`.