### PR TITLE
Disable the http profiler by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* Enable HTTP profiling with pprof, add -httpprof flag to configure the address or disable it. [#709](https://github.com/elastic/package-registry/pull/709)
+* Add -httpprof flag to enable HTTP profiling with pprof. [#709](https://github.com/elastic/package-registry/pull/709)
 
 ### Deprecated
 

--- a/README.md
+++ b/README.md
@@ -244,9 +244,9 @@ Agent [configuration guide](https://www.elastic.co/guide/en/apm/agent/go/current
 ## Performance profiling
 
 You can enable the HTTP profiler in Package Registry starting it with the `-httpprof <address>` flag.
-It will be available in the given address.
+It will be listening in the given address.
 
-You can read more about this profiler in the [pprof documentation](https://pkg.go.dev/net/http/pprof).
+You can read more about this profiler and the available endpoints in the [pprof documentation](https://pkg.go.dev/net/http/pprof).
 
 ## Release
 

--- a/README.md
+++ b/README.md
@@ -243,9 +243,8 @@ Agent [configuration guide](https://www.elastic.co/guide/en/apm/agent/go/current
 
 ## Performance profiling
 
-Package registry starts the HTTP profiler in the local port 6060 by default.
-The listening address can be configured using the `-httpprof` flag. An empty
-value disables it.
+You can enable the HTTP profiler in Package Registry starting it with the `-httpprof <address>` flag.
+It will be available in the given address.
 
 You can read more about this profiler in the [pprof documentation](https://pkg.go.dev/net/http/pprof).
 

--- a/main.go
+++ b/main.go
@@ -50,7 +50,7 @@ var (
 
 func init() {
 	flag.StringVar(&address, "address", "localhost:8080", "Address of the package-registry service.")
-	flag.StringVar(&httpProfAddress, "httpprof", "localhost:6060", "Address of the HTTP profiler, use empty value to disable it.")
+	flag.StringVar(&httpProfAddress, "httpprof", "", "Enable HTTP profiler listening on the given address.")
 	// This flag is experimental and might be removed in the future or renamed
 	flag.BoolVar(&dryRun, "dry-run", false, "Runs a dry-run of the registry without starting the web service (experimental)")
 	flag.BoolVar(&util.PackageValidationDisabled, "disable-package-validation", false, "Disable package content validation")


### PR DESCRIPTION
Follow up of https://github.com/elastic/package-registry/pull/709.