### PR TITLE
chore(ci): filter branches to monitor

### DIFF
--- a/.ci/jobs/package-registry.yml
+++ b/.ci/jobs/package-registry.yml
@@ -13,6 +13,7 @@
           discover-pr-forks-trust: permission
           discover-pr-origin: merge-current
           discover-tags: true
+          head-filter-regex: '(^master|^experimental|PR-.*|v\d+\.\d+\.\d+)'
           notification-context: 'package-registry'
           repo: package-registry
           repo-owner: elastic


### PR DESCRIPTION
## What does this PR do?
It filters the branches and tags to be monitored by the CI, in this case master, experimental and any git tag (vX.Y.Z)

## Why is it important?
Reduce CI overhead