### PR TITLE
Adjust counting logic for categories/policy templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * Add -httpprof flag to enable HTTP profiling with pprof. [#709](https://github.com/elastic/package-registry/pull/709)
+* Adjust counting logic for categories/policy templates. [#716](https://github.com/elastic/package-registry/pull/716)
 
 ### Deprecated
 

--- a/categories.go
+++ b/categories.go
@@ -147,11 +147,15 @@ func (filter categoriesFilter) FilterCategories(ctx context.Context, packageList
 					Count: 0,
 				}
 			}
-
 			categories[c].Count = categories[c].Count + 1
 		}
 
 		if filter.IncludePolicyTemplates {
+			// /categories counts policies and packages separately, but packages are counted too
+			// if they don't match but any of their policies does (for the AWS case this would mean that
+			// the count for "datastore" would be 3: the Package and the RDS and DynamoDB policies).
+			var extraPackageCategories []string
+
 			for _, t := range p.PolicyTemplates {
 				// Skip when policy template level `categories` is empty and there is only one policy template
 				if t.Categories == nil && len(p.PolicyTemplates) == 1 {
@@ -172,6 +176,10 @@ func (filter categoriesFilter) FilterCategories(ctx context.Context, packageList
 						}
 					}
 
+					if !contains(p.Categories, c) && !contains(extraPackageCategories, c) {
+						extraPackageCategories = append(extraPackageCategories, c)
+						categories[c].Count = categories[c].Count + 1
+					}
 					categories[c].Count = categories[c].Count + 1
 				}
 			}
@@ -201,4 +209,13 @@ func getCategoriesOutput(ctx context.Context, categories map[string]*Category) (
 	}
 
 	return json.MarshalIndent(outputCategories, "", "  ")
+}
+
+func contains(categories []string, cat string) bool {
+	for _, c := range categories {
+		if c == cat {
+			return true
+		}
+	}
+	return false
 }

--- a/categories.go
+++ b/categories.go
@@ -176,7 +176,7 @@ func (filter categoriesFilter) FilterCategories(ctx context.Context, packageList
 						}
 					}
 
-					if !p.HasCategory(c) && !contains(extraPackageCategories, c) {
+					if !p.HasCategory(c) && !util.StringsContains(extraPackageCategories, c) {
 						extraPackageCategories = append(extraPackageCategories, c)
 						categories[c].Count = categories[c].Count + 1
 					}
@@ -209,13 +209,4 @@ func getCategoriesOutput(ctx context.Context, categories map[string]*Category) (
 	}
 
 	return json.MarshalIndent(outputCategories, "", "  ")
-}
-
-func contains(categories []string, cat string) bool {
-	for _, c := range categories {
-		if c == cat {
-			return true
-		}
-	}
-	return false
 }

--- a/categories.go
+++ b/categories.go
@@ -176,7 +176,7 @@ func (filter categoriesFilter) FilterCategories(ctx context.Context, packageList
 						}
 					}
 
-					if !contains(p.Categories, c) && !contains(extraPackageCategories, c) {
+					if !p.HasCategory(c) && !contains(extraPackageCategories, c) {
 						extraPackageCategories = append(extraPackageCategories, c)
 						categories[c].Count = categories[c].Count + 1
 					}

--- a/main_test.go
+++ b/main_test.go
@@ -64,6 +64,7 @@ func TestEndpoints(t *testing.T) {
 		{"/search?internal=bar", "/search", "search-package-internal-error.json", searchHandler(packagesBasePaths, testCacheTime)},
 		{"/search?experimental=true", "/search", "search-package-experimental.json", searchHandler(packagesBasePaths, testCacheTime)},
 		{"/search?experimental=foo", "/search", "search-package-experimental-error.json", searchHandler(packagesBasePaths, testCacheTime)},
+		{"/search?category=datastore&experimental=true", "/search", "search-category-datastore.json", searchHandler(packagesBasePaths, testCacheTime)},
 		{"/favicon.ico", "", "favicon.ico", faviconHandleFunc},
 	}
 

--- a/search.go
+++ b/search.go
@@ -171,7 +171,7 @@ func (filter searchFilter) Filter(ctx context.Context, packages util.Packages) m
 				packagesList[p.Name] = map[string]util.Package{}
 			}
 
-			// TODO filter unrelevant policy templates
+			// TODO filter not relevant policy templates
 
 			if _, ok := packagesList[p.Name][p.Version]; !ok {
 				packagesList[p.Name][p.Version] = p

--- a/search.go
+++ b/search.go
@@ -171,7 +171,7 @@ func (filter searchFilter) Filter(ctx context.Context, packages util.Packages) m
 				packagesList[p.Name] = map[string]util.Package{}
 			}
 
-			if !p.HasCategory(filter.Category) {
+			if filter.Category != "" && !p.HasCategory(filter.Category) {
 				// It means that package's policy template has the category
 				p = filterPolicyTemplates(p, filter.Category)
 			}

--- a/search.go
+++ b/search.go
@@ -130,7 +130,7 @@ func (filter searchFilter) Filter(ctx context.Context, packages util.Packages) m
 		// Filter by category first as this could heavily reduce the number of packages
 		// It must happen before the version filtering as there only the newest version
 		// is exposed and there could be an older package with more versions.
-		if filter.Category != "" && !p.HasCategory(filter.Category) {
+		if filter.Category != "" && !p.HasCategory(filter.Category) { // TODO or p.HasPolicyTemplateWithCategory()
 			continue
 		}
 
@@ -170,6 +170,9 @@ func (filter searchFilter) Filter(ctx context.Context, packages util.Packages) m
 			if _, ok := packagesList[p.Name]; !ok {
 				packagesList[p.Name] = map[string]util.Package{}
 			}
+
+			// TODO filter unrelevant policy templates
+
 			if _, ok := packagesList[p.Name][p.Version]; !ok {
 				packagesList[p.Name][p.Version] = p
 			}

--- a/testdata/generated/categories-include-policy-templates.json
+++ b/testdata/generated/categories-include-policy-templates.json
@@ -17,7 +17,7 @@
   {
     "id": "compute",
     "title": "compute",
-    "count": 1
+    "count": 2
   },
   {
     "id": "containers",

--- a/testdata/generated/categories-include-policy-templates.json
+++ b/testdata/generated/categories-include-policy-templates.json
@@ -7,7 +7,7 @@
   {
     "id": "azure",
     "title": "Azure",
-    "count": 1
+    "count": 2
   },
   {
     "id": "cloud",
@@ -27,12 +27,17 @@
   {
     "id": "crm",
     "title": "CRM",
-    "count": 1
+    "count": 2
   },
   {
     "id": "custom",
     "title": "Custom",
     "count": 13
+  },
+  {
+    "id": "datastore",
+    "title": "Datastore",
+    "count": 2
   },
   {
     "id": "message_queue",

--- a/testdata/generated/package.json
+++ b/testdata/generated/package.json
@@ -57,7 +57,10 @@
           "type": "foo"
         }
       ],
-      "multiple": true
+      "multiple": true,
+      "categories": [
+        "datastore"
+      ]
     }
   ],
   "data_streams": [

--- a/testdata/generated/package/example/1.0.0/index.json
+++ b/testdata/generated/package/example/1.0.0/index.json
@@ -57,7 +57,10 @@
           "type": "foo"
         }
       ],
-      "multiple": true
+      "multiple": true,
+      "categories": [
+        "datastore"
+      ]
     }
   ],
   "data_streams": [

--- a/testdata/generated/search-category-datastore.json
+++ b/testdata/generated/search-category-datastore.json
@@ -1,0 +1,19 @@
+[
+  {
+    "name": "example",
+    "title": "Example Integration",
+    "version": "1.0.0",
+    "release": "ga",
+    "description": "This is the example integration",
+    "type": "integration",
+    "download": "/epr/example/example-1.0.0.zip",
+    "path": "/package/example/1.0.0",
+    "policy_templates": [
+      {
+        "name": "logs",
+        "title": "Logs datasource",
+        "description": "Datasource for your log files."
+      }
+    ]
+  }
+]

--- a/testdata/package/example/1.0.0/manifest.yml
+++ b/testdata/package/example/1.0.0/manifest.yml
@@ -23,5 +23,7 @@ policy_templates:
   - name: logs
     title: Logs datasource
     description: Datasource for your log files.
+    categories:
+      - datastore
     inputs:
       - type: foo

--- a/util/package.go
+++ b/util/package.go
@@ -286,12 +286,15 @@ func NewPackage(basePath string) (*Package, error) {
 }
 
 func (p *Package) HasCategory(category string) bool {
-	for _, c := range p.Categories {
-		if c == category {
+	return StringsContains(p.Categories, category)
+}
+
+func (p *Package) HasPolicyTemplateWithCategory(category string) bool {
+	for _, pt := range p.PolicyTemplates {
+		if StringsContains(pt.Categories, category) {
 			return true
 		}
 	}
-
 	return false
 }
 

--- a/util/strings.go
+++ b/util/strings.go
@@ -1,0 +1,15 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package util
+
+// StringsContains function checks if needle is present in the stack.
+func StringsContains(haystack []string, needle string) bool {
+	for _, h := range haystack {
+		if h == needle {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Issue: https://github.com/elastic/package-registry/issues/714

This PR corrects following issues:

- [x] `/categories` counts policies and packages separatedly as now, but packages are counted too if they don't match but any of their policies does (for the AWS case this would mean that the count for datastore would be 3: the package and the rds and dynamodb policies, it is 2 now).
- [x] `/search` returns packages with their policies filtered out (for AWS it would return a package with just 2 policies, what would match the count of 3).
