### PR TITLE
Fix: don't list old packages with categories incompatible with latest revisions 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bugfixes
 
+* Fix: don't list old packages with categories incompatible with latest revisions. [#719](https://github.com/elastic/package-registry/pull/719)
+
 ### Added
 
 * Support `elasticsearch.privileges.indices` in data stream manifests. [#713](https://github.com/elastic/package-registry/pull/713)

--- a/categories.go
+++ b/categories.go
@@ -40,7 +40,7 @@ func categoriesHandler(packagesBasePaths []string, cacheTime time.Duration) func
 			return
 		}
 
-		packageList := filter.Filter(r.Context(), packages)
+		packageList := filter.FilterPackages(r.Context(), packages)
 		categories := filter.FilterCategories(r.Context(), packageList)
 
 		data, err := getCategoriesOutput(r.Context(), categories)
@@ -94,7 +94,7 @@ func newCategoriesFilterFromParams(r *http.Request) (categoriesFilter, error) {
 	return filter, nil
 }
 
-func (filter categoriesFilter) Filter(ctx context.Context, packages util.Packages) map[string]util.Package {
+func (filter categoriesFilter) FilterPackages(ctx context.Context, packages util.Packages) map[string]util.Package {
 	span, ctx := apm.StartSpan(ctx, "FilterPackages", "app")
 	defer span.End()
 

--- a/main_test.go
+++ b/main_test.go
@@ -57,6 +57,7 @@ func TestEndpoints(t *testing.T) {
 		{"/search?kibana.version=6.5.2", "/search", "search-kibana652.json", searchHandler(packagesBasePaths, testCacheTime)},
 		{"/search?kibana.version=7.2.1", "/search", "search-kibana721.json", searchHandler(packagesBasePaths, testCacheTime)},
 		{"/search?category=web", "/search", "search-category-web.json", searchHandler(packagesBasePaths, testCacheTime)},
+		{"/search?category=web&all=true", "/search", "search-category-web-all.json", searchHandler(packagesBasePaths, testCacheTime)},
 		{"/search?category=custom", "/search", "search-category-custom.json", searchHandler(packagesBasePaths, testCacheTime)},
 		{"/search?package=example", "/search", "search-package-example.json", searchHandler(packagesBasePaths, testCacheTime)},
 		{"/search?package=example&all=true", "/search", "search-package-example-all.json", searchHandler(packagesBasePaths, testCacheTime)},

--- a/testdata/generated/search-category-web-all.json
+++ b/testdata/generated/search-category-web-all.json
@@ -1,0 +1,105 @@
+[
+  {
+    "name": "example",
+    "title": "Example",
+    "version": "0.0.2",
+    "release": "beta",
+    "description": "This is the example integration.",
+    "type": "integration",
+    "download": "/epr/example/example-0.0.2.zip",
+    "path": "/package/example/0.0.2"
+  },
+  {
+    "name": "longdocs",
+    "title": "Long Docs",
+    "version": "1.0.4",
+    "release": "ga",
+    "description": "This integration contains pretty long documentation.\nIt is used to show the different visualisations inside a documentation to test how we handle it.\nThe integration does not contain any assets except the documentation page.\n",
+    "type": "integration",
+    "download": "/epr/longdocs/longdocs-1.0.4.zip",
+    "path": "/package/longdocs/1.0.4",
+    "icons": [
+      {
+        "src": "/img/icon.svg",
+        "path": "/package/longdocs/1.0.4/img/icon.svg",
+        "type": "image/svg+xml"
+      }
+    ]
+  },
+  {
+    "name": "multiversion",
+    "title": "Multi Version",
+    "version": "1.0.3",
+    "release": "ga",
+    "description": "Multiple versions of this integration exist.\n",
+    "type": "integration",
+    "download": "/epr/multiversion/multiversion-1.0.3.zip",
+    "path": "/package/multiversion/1.0.3",
+    "icons": [
+      {
+        "src": "/img/icon.svg",
+        "path": "/package/multiversion/1.0.3/img/icon.svg",
+        "type": "image/svg+xml"
+      }
+    ]
+  },
+  {
+    "name": "multiversion",
+    "title": "Multi Version",
+    "version": "1.0.4",
+    "release": "ga",
+    "description": "Multiple versions of this integration exist.\n",
+    "type": "integration",
+    "download": "/epr/multiversion/multiversion-1.0.4.zip",
+    "path": "/package/multiversion/1.0.4",
+    "icons": [
+      {
+        "src": "/img/icon.svg",
+        "path": "/package/multiversion/1.0.4/img/icon.svg",
+        "type": "image/svg+xml"
+      }
+    ]
+  },
+  {
+    "name": "multiversion",
+    "title": "Multi Version Second with the same version! This one should win, because it is first.",
+    "version": "1.1.0",
+    "release": "ga",
+    "description": "Multiple versions of this integration exist.\n",
+    "type": "integration",
+    "download": "/epr/multiversion/multiversion-1.1.0.zip",
+    "path": "/package/multiversion/1.1.0",
+    "icons": [
+      {
+        "src": "/img/icon.svg",
+        "path": "/package/multiversion/1.1.0/img/icon.svg",
+        "type": "image/svg+xml"
+      }
+    ]
+  },
+  {
+    "name": "reference",
+    "title": "Reference package",
+    "version": "1.0.0",
+    "release": "ga",
+    "description": "This package is used for defining all the properties of a package, the possible assets etc. It serves as a reference on all the config options which are possible.\n",
+    "type": "integration",
+    "download": "/epr/reference/reference-1.0.0.zip",
+    "path": "/package/reference/1.0.0",
+    "icons": [
+      {
+        "src": "/img/icon.svg",
+        "path": "/package/reference/1.0.0/img/icon.svg",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "nginx",
+        "title": "Nginx logs and metrics.",
+        "description": "Collecting logs and metrics from nginx."
+      }
+    ]
+  }
+]

--- a/testdata/generated/search-category-web.json
+++ b/testdata/generated/search-category-web.json
@@ -1,15 +1,5 @@
 [
   {
-    "name": "example",
-    "title": "Example",
-    "version": "0.0.2",
-    "release": "beta",
-    "description": "This is the example integration.",
-    "type": "integration",
-    "download": "/epr/example/example-0.0.2.zip",
-    "path": "/package/example/0.0.2"
-  },
-  {
     "name": "longdocs",
     "title": "Long Docs",
     "version": "1.0.4",

--- a/testdata/package/example/1.0.0/manifest.yml
+++ b/testdata/package/example/1.0.0/manifest.yml
@@ -11,7 +11,8 @@ release: ga
 owner.github: "ruflin"
 
 conditions:
-  kibana.version: "~7.x.x"
+  kibana:
+    version: "~7.x.x"
 
 screenshots:
   - src: /img/kibana-envoyproxy.jpg


### PR DESCRIPTION
Issue: https://github.com/elastic/package-registry/issues/714

This PR addresses [this](https://github.com/elastic/package-registry/issues/714#issuecomment-914340280) and [this](https://github.com/elastic/package-registry/issues/714#issuecomment-904519559) issue, so that old packages are hidden from search results.

In tests:

`example-0.0.2` has `web` category, but it's hidden from `/search?category=web`, because `example-1.0.0` doesn't have this category. The implementation without `all=true` will focus only on latest packages. This is inline with numbers returned by category endpoint.

Personal comment:

I think that this search/category logic must be refactored as it's too much tangled at the moment.