### PR TITLE
Fix the documentation for kibana.version query param

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,22 +14,22 @@ Examples for each API endpoint can be found here: https://github.com/elastic/pac
 
 The `/search` API endpoint has few additional query parameters. More might be added in the future, but for now these are:
 
-* kibana: Filters out all the packages which are not compatible with the given Kibana version. If it is set to `7.3.1` and
+* `kibana.version`: Filters out all the packages which are not compatible with the given Kibana version. If it is set to `7.3.1` and
   a package requires 7.4, the package will not be returned or an older compatible package will be shown.
   By default this endpoint always returns only the newest compatible package.
-* category: Filters the package by the given category. Available categories can be seend when going to `/categories` endpoint.
-* package: Filters by a specific package name, for example `mysql`. Returns the most recent version.
-* internal: This can be set to true, to also list internal packages. This is set to `false` by default.
-* all: This can be set to true to list all package versions. This is set to `false` by default.
-* experimental: This can be set to true to list packages considered to be experimental. This is set to `false` by default.
+* `category`: Filters the package by the given category. Available categories can be seend when going to `/categories` endpoint.
+* `package`: Filters by a specific package name, for example `mysql`. Returns the most recent version.
+* `internal`: This can be set to true, to also list internal packages. This is set to `false` by default.
+* `all`: This can be set to true to list all package versions. This is set to `false` by default.
+* `experimental`: This can be set to true to list packages considered to be experimental. This is set to `false` by default.
 
 The different query parameters above can be combined, so `?package=mysql&kibana=7.3.0` will return all mysql package versions
 which are compatible with `7.3.0`.
 
 The `/categories` API endpoint has two additional query parameters.
 
-* experimental: This can be set to true to list categories from experimental packages. This is set to `false` by default.
-* include_policy_templates: This can be set to true to include categories from policy templates. This is set to `false` by default.
+* `experimental`: This can be set to true to list categories from experimental packages. This is set to `false` by default.
+* `include_policy_templates`: This can be set to true to include categories from policy templates. This is set to `false` by default.
 
 ## Package structure
 

--- a/openapi.yml
+++ b/openapi.yml
@@ -72,7 +72,7 @@ paths:
         - schema:
             type: string
           in: query
-          name: kibana
+          name: kibana.version
           description: 'Filters out all the packages which are not compatible with the given Kibana version. If it is set to 7.3.1 and a package requires 7.4, the package will not be returned or an older compatible package will be shown. By default this endpoint always returns only the newest compatible package.'
         - schema:
             type: string


### PR DESCRIPTION
The docs said the name of the parameter was `kibana`, but the code uses `kibana.version`.
So this fixes the docs.

https://github.com/elastic/package-registry/blob/95673bb86e422c64ef2db16675b90660c28a0f27/search.go#L71