### PR TITLE
De-dot 'kibana.version' in /package JSON responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking changes
 
+* Change format of responses to `/package` to make `{"constraint": {"kibana.version": "7.16.0"}}` be `{"constraint": {"kibana": {"version": "7.16.0"}}}`. [#733](https://github.com/elastic/package-registry/pull/733)
+
 ### Bugfixes
 
 ### Added

--- a/testdata/generated/package.json
+++ b/testdata/generated/package.json
@@ -15,7 +15,9 @@
     "azure"
   ],
   "conditions": {
-    "kibana.version": "~7.x.x"
+    "kibana": {
+      "version": "~7.x.x"
+    }
   },
   "screenshots": [
     {

--- a/testdata/generated/package/elasticsearch_privileges/1.0.0/index.json
+++ b/testdata/generated/package/elasticsearch_privileges/1.0.0/index.json
@@ -14,7 +14,9 @@
     "custom"
   ],
   "conditions": {
-    "kibana.version": "\u003e=7.16.0"
+    "kibana": {
+      "version": "\u003e=7.16.0"
+    }
   },
   "assets": [
     "/package/elasticsearch_privileges/1.0.0/manifest.yml",

--- a/testdata/generated/package/example/0.0.2/index.json
+++ b/testdata/generated/package/example/0.0.2/index.json
@@ -14,7 +14,9 @@
     "web"
   ],
   "conditions": {
-    "kibana.version": "\u003e=6.0.0"
+    "kibana": {
+      "version": "\u003e=6.0.0"
+    }
   },
   "assets": [
     "/package/example/0.0.2/manifest.yml",

--- a/testdata/generated/package/example/1.0.0/index.json
+++ b/testdata/generated/package/example/1.0.0/index.json
@@ -15,7 +15,9 @@
     "azure"
   ],
   "conditions": {
-    "kibana.version": "~7.x.x"
+    "kibana": {
+      "version": "~7.x.x"
+    }
   },
   "screenshots": [
     {

--- a/testdata/generated/package/foo/1.0.0/index.json
+++ b/testdata/generated/package/foo/1.0.0/index.json
@@ -14,7 +14,9 @@
     "custom"
   ],
   "conditions": {
-    "kibana.version": "\u003e=7.0.0"
+    "kibana": {
+      "version": "\u003e=7.0.0"
+    }
   },
   "assets": [
     "/package/foo/1.0.0/manifest.yml",

--- a/testdata/generated/package/hidden/1.0.0/index.json
+++ b/testdata/generated/package/hidden/1.0.0/index.json
@@ -14,7 +14,9 @@
     "custom"
   ],
   "conditions": {
-    "kibana.version": "\u003e=7.0.0"
+    "kibana": {
+      "version": "\u003e=7.0.0"
+    }
   },
   "assets": [
     "/package/hidden/1.0.0/manifest.yml",

--- a/testdata/generated/package/ilm_policy/1.0.0/index.json
+++ b/testdata/generated/package/ilm_policy/1.0.0/index.json
@@ -14,7 +14,9 @@
     "custom"
   ],
   "conditions": {
-    "kibana.version": "\u003e=7.0.0"
+    "kibana": {
+      "version": "\u003e=7.0.0"
+    }
   },
   "assets": [
     "/package/ilmpolicy/1.0.0/manifest.yml",

--- a/testdata/generated/package/input_groups/0.0.1/index.json
+++ b/testdata/generated/package/input_groups/0.0.1/index.json
@@ -24,7 +24,9 @@
     "cloud"
   ],
   "conditions": {
-    "kibana.version": "~7.x.x"
+    "kibana": {
+      "version": "~7.x.x"
+    }
   },
   "screenshots": [
     {

--- a/testdata/generated/package/input_level_templates/1.0.0/index.json
+++ b/testdata/generated/package/input_level_templates/1.0.0/index.json
@@ -14,7 +14,9 @@
     "custom"
   ],
   "conditions": {
-    "kibana.version": "\u003e=7.11.0"
+    "kibana": {
+      "version": "\u003e=7.11.0"
+    }
   },
   "assets": [
     "/package/input_level_templates/1.0.0/manifest.yml",

--- a/testdata/generated/package/longdocs/1.0.4/index.json
+++ b/testdata/generated/package/longdocs/1.0.4/index.json
@@ -22,7 +22,9 @@
     "web"
   ],
   "conditions": {
-    "kibana.version": "\u003e6.7.0"
+    "kibana": {
+      "version": "\u003e6.7.0"
+    }
   },
   "assets": [
     "/package/longdocs/1.0.4/manifest.yml",

--- a/testdata/generated/package/multiversion/1.0.3/index.json
+++ b/testdata/generated/package/multiversion/1.0.3/index.json
@@ -22,7 +22,9 @@
     "web"
   ],
   "conditions": {
-    "kibana.version": "\u003e6.7.0"
+    "kibana": {
+      "version": "\u003e6.7.0"
+    }
   },
   "assets": [
     "/package/multiversion/1.0.3/changelog.yml",

--- a/testdata/generated/package/multiversion/1.0.4/index.json
+++ b/testdata/generated/package/multiversion/1.0.4/index.json
@@ -22,7 +22,9 @@
     "web"
   ],
   "conditions": {
-    "kibana.version": "\u003e6.7.0"
+    "kibana": {
+      "version": "\u003e6.7.0"
+    }
   },
   "assets": [
     "/package/multiversion/1.0.4/changelog.yml",

--- a/testdata/generated/package/multiversion/1.1.0/index.json
+++ b/testdata/generated/package/multiversion/1.1.0/index.json
@@ -22,7 +22,9 @@
     "web"
   ],
   "conditions": {
-    "kibana.version": "\u003e6.7.0"
+    "kibana": {
+      "version": "\u003e6.7.0"
+    }
   },
   "assets": [
     "/package/multiversion/1.1.0/changelog.yml",

--- a/testdata/generated/package/reference/1.0.0/index.json
+++ b/testdata/generated/package/reference/1.0.0/index.json
@@ -23,7 +23,9 @@
     "web"
   ],
   "conditions": {
-    "kibana.version": "\u003e6.7.0  \u003c7.6.0"
+    "kibana": {
+      "version": "\u003e6.7.0  \u003c7.6.0"
+    }
   },
   "assets": [
     "/package/reference/1.0.0/changelog.yml",

--- a/testdata/generated/package/traces/1.0.0/index.json
+++ b/testdata/generated/package/traces/1.0.0/index.json
@@ -14,7 +14,9 @@
     "monitoring"
   ],
   "conditions": {
-    "kibana.version": "~7.x.x"
+    "kibana": {
+      "version": "~7.x.x"
+    }
   },
   "assets": [
     "/package/fakeapm/1.0.0/manifest.yml",

--- a/util/package.go
+++ b/util/package.go
@@ -107,8 +107,13 @@ type PolicyTemplate struct {
 }
 
 type Conditions struct {
-	KibanaVersion    string `config:"kibana.version,omitempty" json:"kibana.version,omitempty" yaml:"kibana.version,omitempty"`
-	kibanaConstraint *semver.Constraints
+	Kibana *KibanaConditions `config:"kibana,omitempty" json:"kibana,omitempty" yaml:"kibana,omitempty"`
+}
+
+// KibanaConditions defines conditions for Kibana (e.g. required version).
+type KibanaConditions struct {
+	Version    string `config:"version" json:"version" yaml:"version"`
+	constraint *semver.Constraints
 }
 
 type Version struct {
@@ -239,10 +244,10 @@ func NewPackage(basePath string) (*Package, error) {
 		}
 	}
 
-	if p.Conditions != nil && p.Conditions.KibanaVersion != "" {
-		p.Conditions.kibanaConstraint, err = semver.NewConstraint(p.Conditions.KibanaVersion)
+	if p.Conditions != nil && p.Conditions.Kibana != nil {
+		p.Conditions.Kibana.constraint, err = semver.NewConstraint(p.Conditions.Kibana.Version)
 		if err != nil {
-			return nil, errors.Wrapf(err, "invalid Kibana versions range: %s", p.Conditions.KibanaVersion)
+			return nil, errors.Wrapf(err, "invalid Kibana versions range: %s", p.Conditions.Kibana.Version)
 		}
 	}
 
@@ -299,13 +304,12 @@ func (p *Package) HasPolicyTemplateWithCategory(category string) bool {
 }
 
 func (p *Package) HasKibanaVersion(version *semver.Version) bool {
-
 	// If the version is not specified, it is for all versions
-	if p.Conditions == nil || version == nil || p.Conditions.kibanaConstraint == nil {
+	if p.Conditions == nil || p.Conditions.Kibana == nil || p.Conditions.Kibana.constraint == nil || version == nil {
 		return true
 	}
 
-	return p.Conditions.kibanaConstraint.Check(version)
+	return p.Conditions.Kibana.constraint.Check(version)
 }
 
 func (p *Package) IsNewerOrEqual(pp Package) bool {

--- a/util/package_test.go
+++ b/util/package_test.go
@@ -40,7 +40,7 @@ var packageTests = []struct {
 				Title: &title,
 			},
 			Conditions: &Conditions{
-				KibanaVersion: "bar",
+				Kibana: &KibanaConditions{Version: "bar"},
 			},
 		},
 		false,
@@ -53,7 +53,7 @@ var packageTests = []struct {
 				Description: "my description",
 			},
 			Conditions: &Conditions{
-				KibanaVersion: ">=1.2.3 <=4.5.6",
+				Kibana: &KibanaConditions{Version: ">=1.2.3 <=4.5.6"},
 			},
 			Categories: []string{"custom", "foo"},
 		},
@@ -190,7 +190,9 @@ func TestHasKibanaVersion(t *testing.T) {
 
 			p := Package{
 				Conditions: &Conditions{
-					kibanaConstraint: constraint,
+					Kibana: &KibanaConditions{
+						constraint: constraint,
+					},
 				},
 			}
 


### PR DESCRIPTION
This changes the response JSON from

```
  "conditions": {
    "kibana.version": "^7.15.0"
  },
```

to

```
  "conditions": {
    "kibana": {
      "version": "^7.15.0"
    }
  },
```

Closes #730