### PR TITLE
[Fleet] Add categories to search response output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 package-registry
 
 .idea
+*.iml
 build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Add categories to /search output. Categories are added to the package and policy-templates. [#722](https://github.com/elastic/package-registry/issues/722)
+
 ### Deprecated
 
 ### Known Issues

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* Add categories to /search output. Categories are added to the package and policy-templates. [#722](https://github.com/elastic/package-registry/issues/722)
+* Add categories to /search output. Categories are added to the package and policy-templates. [#735](https://github.com/elastic/package-registry/pull/735)
 
 ### Deprecated
 

--- a/testdata/generated/search-all.json
+++ b/testdata/generated/search-all.json
@@ -7,7 +7,10 @@
     "description": "This package contains a datastream with the dataset_is_prefix flag set to true.\n",
     "type": "integration",
     "download": "/epr/dataset_is_prefix/dataset_is_prefix-0.0.1.zip",
-    "path": "/package/dataset_is_prefix/0.0.1"
+    "path": "/package/dataset_is_prefix/0.0.1",
+    "categories": [
+      "custom"
+    ]
   },
   {
     "name": "datasources",
@@ -24,6 +27,9 @@
         "title": "Datasource title",
         "description": "Details about the data source."
       }
+    ],
+    "categories": [
+      "custom"
     ]
   },
   {
@@ -41,6 +47,10 @@
         "title": "Logs datasource",
         "description": "Datasource for your log files."
       }
+    ],
+    "categories": [
+      "containers",
+      "message_queue"
     ]
   },
   {
@@ -58,6 +68,9 @@
         "title": "Logs datasource",
         "description": "Datasource for your log files."
       }
+    ],
+    "categories": [
+      "monitoring"
     ]
   },
   {
@@ -68,7 +81,10 @@
     "description": "Test package-specified Elasticsearch index privileges",
     "type": "solution",
     "download": "/epr/elasticsearch_privileges/elasticsearch_privileges-1.0.0.zip",
-    "path": "/package/elasticsearch_privileges/1.0.0"
+    "path": "/package/elasticsearch_privileges/1.0.0",
+    "categories": [
+      "custom"
+    ]
   },
   {
     "name": "example",
@@ -78,7 +94,10 @@
     "description": "This is the example integration.",
     "type": "integration",
     "download": "/epr/example/example-0.0.2.zip",
-    "path": "/package/example/0.0.2"
+    "path": "/package/example/0.0.2",
+    "categories": [
+      "web"
+    ]
   },
   {
     "name": "example",
@@ -93,8 +112,15 @@
       {
         "name": "logs",
         "title": "Logs datasource",
-        "description": "Datasource for your log files."
+        "description": "Datasource for your log files.",
+        "categories": [
+          "datastore"
+        ]
       }
+    ],
+    "categories": [
+      "crm",
+      "azure"
     ]
   },
   {
@@ -105,7 +131,10 @@
     "description": "This is the foo integration",
     "type": "solution",
     "download": "/epr/foo/foo-1.0.0.zip",
-    "path": "/package/foo/1.0.0"
+    "path": "/package/foo/1.0.0",
+    "categories": [
+      "custom"
+    ]
   },
   {
     "name": "hidden",
@@ -115,7 +144,10 @@
     "description": "This is the hidden integration",
     "type": "solution",
     "download": "/epr/hidden/hidden-1.0.0.zip",
-    "path": "/package/hidden/1.0.0"
+    "path": "/package/hidden/1.0.0",
+    "categories": [
+      "custom"
+    ]
   },
   {
     "name": "ilmpolicy",
@@ -125,7 +157,10 @@
     "description": "Test form ILM Policy in Package",
     "type": "solution",
     "download": "/epr/ilmpolicy/ilmpolicy-1.0.0.zip",
-    "path": "/package/ilmpolicy/1.0.0"
+    "path": "/package/ilmpolicy/1.0.0",
+    "categories": [
+      "custom"
+    ]
   },
   {
     "name": "input_groups",
@@ -158,8 +193,15 @@
             "size": "32x32",
             "type": "image/svg+xml"
           }
+        ],
+        "categories": [
+          "compute"
         ]
       }
+    ],
+    "categories": [
+      "aws",
+      "cloud"
     ]
   },
   {
@@ -177,6 +219,9 @@
         "title": "Input level templates",
         "description": "Input with input-level template to use input-level vars with"
       }
+    ],
+    "categories": [
+      "custom"
     ]
   },
   {
@@ -194,6 +239,10 @@
         "path": "/package/longdocs/1.0.4/img/icon.svg",
         "type": "image/svg+xml"
       }
+    ],
+    "categories": [
+      "custom",
+      "web"
     ]
   },
   {
@@ -211,6 +260,9 @@
         "path": "/package/metricsonly/2.0.1/img/icon.svg",
         "type": "image/svg+xml"
       }
+    ],
+    "categories": [
+      "custom"
     ]
   },
   {
@@ -228,6 +280,9 @@
         "title": "Logs datasource",
         "description": "Datasource for your log files."
       }
+    ],
+    "categories": [
+      "custom"
     ]
   },
   {
@@ -245,6 +300,10 @@
         "path": "/package/multiversion/1.0.3/img/icon.svg",
         "type": "image/svg+xml"
       }
+    ],
+    "categories": [
+      "custom",
+      "web"
     ]
   },
   {
@@ -262,6 +321,10 @@
         "path": "/package/multiversion/1.0.4/img/icon.svg",
         "type": "image/svg+xml"
       }
+    ],
+    "categories": [
+      "custom",
+      "web"
     ]
   },
   {
@@ -279,6 +342,10 @@
         "path": "/package/multiversion/1.1.0/img/icon.svg",
         "type": "image/svg+xml"
       }
+    ],
+    "categories": [
+      "custom",
+      "web"
     ]
   },
   {
@@ -289,7 +356,10 @@
     "description": "This package does contain a dataset but not stream configs.\n",
     "type": "integration",
     "download": "/epr/no_stream_configs/no_stream_configs-1.0.0.zip",
-    "path": "/package/no_stream_configs/1.0.0"
+    "path": "/package/no_stream_configs/1.0.0",
+    "categories": [
+      "custom"
+    ]
   },
   {
     "name": "reference",
@@ -314,6 +384,10 @@
         "title": "Nginx logs and metrics.",
         "description": "Collecting logs and metrics from nginx."
       }
+    ],
+    "categories": [
+      "custom",
+      "web"
     ]
   },
   {
@@ -324,6 +398,9 @@
     "description": "This package contains a yaml pipeline.\n",
     "type": "integration",
     "download": "/epr/yamlpipeline/yamlpipeline-1.0.0.zip",
-    "path": "/package/yamlpipeline/1.0.0"
+    "path": "/package/yamlpipeline/1.0.0",
+    "categories": [
+      "custom"
+    ]
   }
 ]

--- a/testdata/generated/search-category-custom.json
+++ b/testdata/generated/search-category-custom.json
@@ -7,7 +7,10 @@
     "description": "This package contains a datastream with the dataset_is_prefix flag set to true.\n",
     "type": "integration",
     "download": "/epr/dataset_is_prefix/dataset_is_prefix-0.0.1.zip",
-    "path": "/package/dataset_is_prefix/0.0.1"
+    "path": "/package/dataset_is_prefix/0.0.1",
+    "categories": [
+      "custom"
+    ]
   },
   {
     "name": "datasources",
@@ -24,6 +27,9 @@
         "title": "Datasource title",
         "description": "Details about the data source."
       }
+    ],
+    "categories": [
+      "custom"
     ]
   },
   {
@@ -34,7 +40,10 @@
     "description": "Test package-specified Elasticsearch index privileges",
     "type": "solution",
     "download": "/epr/elasticsearch_privileges/elasticsearch_privileges-1.0.0.zip",
-    "path": "/package/elasticsearch_privileges/1.0.0"
+    "path": "/package/elasticsearch_privileges/1.0.0",
+    "categories": [
+      "custom"
+    ]
   },
   {
     "name": "foo",
@@ -44,7 +53,10 @@
     "description": "This is the foo integration",
     "type": "solution",
     "download": "/epr/foo/foo-1.0.0.zip",
-    "path": "/package/foo/1.0.0"
+    "path": "/package/foo/1.0.0",
+    "categories": [
+      "custom"
+    ]
   },
   {
     "name": "hidden",
@@ -54,7 +66,10 @@
     "description": "This is the hidden integration",
     "type": "solution",
     "download": "/epr/hidden/hidden-1.0.0.zip",
-    "path": "/package/hidden/1.0.0"
+    "path": "/package/hidden/1.0.0",
+    "categories": [
+      "custom"
+    ]
   },
   {
     "name": "ilmpolicy",
@@ -64,7 +79,10 @@
     "description": "Test form ILM Policy in Package",
     "type": "solution",
     "download": "/epr/ilmpolicy/ilmpolicy-1.0.0.zip",
-    "path": "/package/ilmpolicy/1.0.0"
+    "path": "/package/ilmpolicy/1.0.0",
+    "categories": [
+      "custom"
+    ]
   },
   {
     "name": "input_level_templates",
@@ -81,6 +99,9 @@
         "title": "Input level templates",
         "description": "Input with input-level template to use input-level vars with"
       }
+    ],
+    "categories": [
+      "custom"
     ]
   },
   {
@@ -98,6 +119,10 @@
         "path": "/package/longdocs/1.0.4/img/icon.svg",
         "type": "image/svg+xml"
       }
+    ],
+    "categories": [
+      "custom",
+      "web"
     ]
   },
   {
@@ -115,6 +140,9 @@
         "path": "/package/metricsonly/2.0.1/img/icon.svg",
         "type": "image/svg+xml"
       }
+    ],
+    "categories": [
+      "custom"
     ]
   },
   {
@@ -132,6 +160,9 @@
         "title": "Logs datasource",
         "description": "Datasource for your log files."
       }
+    ],
+    "categories": [
+      "custom"
     ]
   },
   {
@@ -149,6 +180,10 @@
         "path": "/package/multiversion/1.1.0/img/icon.svg",
         "type": "image/svg+xml"
       }
+    ],
+    "categories": [
+      "custom",
+      "web"
     ]
   },
   {
@@ -159,7 +194,10 @@
     "description": "This package does contain a dataset but not stream configs.\n",
     "type": "integration",
     "download": "/epr/no_stream_configs/no_stream_configs-1.0.0.zip",
-    "path": "/package/no_stream_configs/1.0.0"
+    "path": "/package/no_stream_configs/1.0.0",
+    "categories": [
+      "custom"
+    ]
   },
   {
     "name": "reference",
@@ -184,6 +222,10 @@
         "title": "Nginx logs and metrics.",
         "description": "Collecting logs and metrics from nginx."
       }
+    ],
+    "categories": [
+      "custom",
+      "web"
     ]
   },
   {
@@ -194,6 +236,9 @@
     "description": "This package contains a yaml pipeline.\n",
     "type": "integration",
     "download": "/epr/yamlpipeline/yamlpipeline-1.0.0.zip",
-    "path": "/package/yamlpipeline/1.0.0"
+    "path": "/package/yamlpipeline/1.0.0",
+    "categories": [
+      "custom"
+    ]
   }
 ]

--- a/testdata/generated/search-category-datastore.json
+++ b/testdata/generated/search-category-datastore.json
@@ -12,8 +12,15 @@
       {
         "name": "logs",
         "title": "Logs datasource",
-        "description": "Datasource for your log files."
+        "description": "Datasource for your log files.",
+        "categories": [
+          "datastore"
+        ]
       }
+    ],
+    "categories": [
+      "crm",
+      "azure"
     ]
   }
 ]

--- a/testdata/generated/search-category-web-all.json
+++ b/testdata/generated/search-category-web-all.json
@@ -7,7 +7,10 @@
     "description": "This is the example integration.",
     "type": "integration",
     "download": "/epr/example/example-0.0.2.zip",
-    "path": "/package/example/0.0.2"
+    "path": "/package/example/0.0.2",
+    "categories": [
+      "web"
+    ]
   },
   {
     "name": "longdocs",
@@ -24,6 +27,10 @@
         "path": "/package/longdocs/1.0.4/img/icon.svg",
         "type": "image/svg+xml"
       }
+    ],
+    "categories": [
+      "custom",
+      "web"
     ]
   },
   {
@@ -41,6 +48,10 @@
         "path": "/package/multiversion/1.0.3/img/icon.svg",
         "type": "image/svg+xml"
       }
+    ],
+    "categories": [
+      "custom",
+      "web"
     ]
   },
   {
@@ -58,6 +69,10 @@
         "path": "/package/multiversion/1.0.4/img/icon.svg",
         "type": "image/svg+xml"
       }
+    ],
+    "categories": [
+      "custom",
+      "web"
     ]
   },
   {
@@ -75,6 +90,10 @@
         "path": "/package/multiversion/1.1.0/img/icon.svg",
         "type": "image/svg+xml"
       }
+    ],
+    "categories": [
+      "custom",
+      "web"
     ]
   },
   {
@@ -100,6 +119,10 @@
         "title": "Nginx logs and metrics.",
         "description": "Collecting logs and metrics from nginx."
       }
+    ],
+    "categories": [
+      "custom",
+      "web"
     ]
   }
 ]

--- a/testdata/generated/search-category-web.json
+++ b/testdata/generated/search-category-web.json
@@ -14,6 +14,10 @@
         "path": "/package/longdocs/1.0.4/img/icon.svg",
         "type": "image/svg+xml"
       }
+    ],
+    "categories": [
+      "custom",
+      "web"
     ]
   },
   {
@@ -31,6 +35,10 @@
         "path": "/package/multiversion/1.1.0/img/icon.svg",
         "type": "image/svg+xml"
       }
+    ],
+    "categories": [
+      "custom",
+      "web"
     ]
   },
   {
@@ -56,6 +64,10 @@
         "title": "Nginx logs and metrics.",
         "description": "Collecting logs and metrics from nginx."
       }
+    ],
+    "categories": [
+      "custom",
+      "web"
     ]
   }
 ]

--- a/testdata/generated/search-kibana652.json
+++ b/testdata/generated/search-kibana652.json
@@ -7,7 +7,10 @@
     "description": "This package contains a datastream with the dataset_is_prefix flag set to true.\n",
     "type": "integration",
     "download": "/epr/dataset_is_prefix/dataset_is_prefix-0.0.1.zip",
-    "path": "/package/dataset_is_prefix/0.0.1"
+    "path": "/package/dataset_is_prefix/0.0.1",
+    "categories": [
+      "custom"
+    ]
   },
   {
     "name": "datasources",
@@ -24,6 +27,9 @@
         "title": "Datasource title",
         "description": "Details about the data source."
       }
+    ],
+    "categories": [
+      "custom"
     ]
   },
   {
@@ -41,6 +47,10 @@
         "title": "Logs datasource",
         "description": "Datasource for your log files."
       }
+    ],
+    "categories": [
+      "containers",
+      "message_queue"
     ]
   },
   {
@@ -58,6 +68,9 @@
         "title": "Logs datasource",
         "description": "Datasource for your log files."
       }
+    ],
+    "categories": [
+      "monitoring"
     ]
   },
   {
@@ -68,7 +81,10 @@
     "description": "This is the example integration.",
     "type": "integration",
     "download": "/epr/example/example-0.0.2.zip",
-    "path": "/package/example/0.0.2"
+    "path": "/package/example/0.0.2",
+    "categories": [
+      "web"
+    ]
   },
   {
     "name": "metricsonly",
@@ -85,6 +101,9 @@
         "path": "/package/metricsonly/2.0.1/img/icon.svg",
         "type": "image/svg+xml"
       }
+    ],
+    "categories": [
+      "custom"
     ]
   },
   {
@@ -102,6 +121,9 @@
         "title": "Logs datasource",
         "description": "Datasource for your log files."
       }
+    ],
+    "categories": [
+      "custom"
     ]
   },
   {
@@ -112,7 +134,10 @@
     "description": "This package does contain a dataset but not stream configs.\n",
     "type": "integration",
     "download": "/epr/no_stream_configs/no_stream_configs-1.0.0.zip",
-    "path": "/package/no_stream_configs/1.0.0"
+    "path": "/package/no_stream_configs/1.0.0",
+    "categories": [
+      "custom"
+    ]
   },
   {
     "name": "yamlpipeline",
@@ -122,6 +147,9 @@
     "description": "This package contains a yaml pipeline.\n",
     "type": "integration",
     "download": "/epr/yamlpipeline/yamlpipeline-1.0.0.zip",
-    "path": "/package/yamlpipeline/1.0.0"
+    "path": "/package/yamlpipeline/1.0.0",
+    "categories": [
+      "custom"
+    ]
   }
 ]

--- a/testdata/generated/search-kibana721.json
+++ b/testdata/generated/search-kibana721.json
@@ -7,7 +7,10 @@
     "description": "This package contains a datastream with the dataset_is_prefix flag set to true.\n",
     "type": "integration",
     "download": "/epr/dataset_is_prefix/dataset_is_prefix-0.0.1.zip",
-    "path": "/package/dataset_is_prefix/0.0.1"
+    "path": "/package/dataset_is_prefix/0.0.1",
+    "categories": [
+      "custom"
+    ]
   },
   {
     "name": "datasources",
@@ -24,6 +27,9 @@
         "title": "Datasource title",
         "description": "Details about the data source."
       }
+    ],
+    "categories": [
+      "custom"
     ]
   },
   {
@@ -41,6 +47,10 @@
         "title": "Logs datasource",
         "description": "Datasource for your log files."
       }
+    ],
+    "categories": [
+      "containers",
+      "message_queue"
     ]
   },
   {
@@ -58,6 +68,9 @@
         "title": "Logs datasource",
         "description": "Datasource for your log files."
       }
+    ],
+    "categories": [
+      "monitoring"
     ]
   },
   {
@@ -73,8 +86,15 @@
       {
         "name": "logs",
         "title": "Logs datasource",
-        "description": "Datasource for your log files."
+        "description": "Datasource for your log files.",
+        "categories": [
+          "datastore"
+        ]
       }
+    ],
+    "categories": [
+      "crm",
+      "azure"
     ]
   },
   {
@@ -85,7 +105,10 @@
     "description": "This is the foo integration",
     "type": "solution",
     "download": "/epr/foo/foo-1.0.0.zip",
-    "path": "/package/foo/1.0.0"
+    "path": "/package/foo/1.0.0",
+    "categories": [
+      "custom"
+    ]
   },
   {
     "name": "hidden",
@@ -95,7 +118,10 @@
     "description": "This is the hidden integration",
     "type": "solution",
     "download": "/epr/hidden/hidden-1.0.0.zip",
-    "path": "/package/hidden/1.0.0"
+    "path": "/package/hidden/1.0.0",
+    "categories": [
+      "custom"
+    ]
   },
   {
     "name": "ilmpolicy",
@@ -105,7 +131,10 @@
     "description": "Test form ILM Policy in Package",
     "type": "solution",
     "download": "/epr/ilmpolicy/ilmpolicy-1.0.0.zip",
-    "path": "/package/ilmpolicy/1.0.0"
+    "path": "/package/ilmpolicy/1.0.0",
+    "categories": [
+      "custom"
+    ]
   },
   {
     "name": "input_groups",
@@ -138,8 +167,15 @@
             "size": "32x32",
             "type": "image/svg+xml"
           }
+        ],
+        "categories": [
+          "compute"
         ]
       }
+    ],
+    "categories": [
+      "aws",
+      "cloud"
     ]
   },
   {
@@ -157,6 +193,10 @@
         "path": "/package/longdocs/1.0.4/img/icon.svg",
         "type": "image/svg+xml"
       }
+    ],
+    "categories": [
+      "custom",
+      "web"
     ]
   },
   {
@@ -174,6 +214,9 @@
         "path": "/package/metricsonly/2.0.1/img/icon.svg",
         "type": "image/svg+xml"
       }
+    ],
+    "categories": [
+      "custom"
     ]
   },
   {
@@ -191,6 +234,9 @@
         "title": "Logs datasource",
         "description": "Datasource for your log files."
       }
+    ],
+    "categories": [
+      "custom"
     ]
   },
   {
@@ -208,6 +254,10 @@
         "path": "/package/multiversion/1.1.0/img/icon.svg",
         "type": "image/svg+xml"
       }
+    ],
+    "categories": [
+      "custom",
+      "web"
     ]
   },
   {
@@ -218,7 +268,10 @@
     "description": "This package does contain a dataset but not stream configs.\n",
     "type": "integration",
     "download": "/epr/no_stream_configs/no_stream_configs-1.0.0.zip",
-    "path": "/package/no_stream_configs/1.0.0"
+    "path": "/package/no_stream_configs/1.0.0",
+    "categories": [
+      "custom"
+    ]
   },
   {
     "name": "reference",
@@ -243,6 +296,10 @@
         "title": "Nginx logs and metrics.",
         "description": "Collecting logs and metrics from nginx."
       }
+    ],
+    "categories": [
+      "custom",
+      "web"
     ]
   },
   {
@@ -253,6 +310,9 @@
     "description": "This package contains a yaml pipeline.\n",
     "type": "integration",
     "download": "/epr/yamlpipeline/yamlpipeline-1.0.0.zip",
-    "path": "/package/yamlpipeline/1.0.0"
+    "path": "/package/yamlpipeline/1.0.0",
+    "categories": [
+      "custom"
+    ]
   }
 ]

--- a/testdata/generated/search-package-example-all.json
+++ b/testdata/generated/search-package-example-all.json
@@ -7,7 +7,10 @@
     "description": "This is the example integration.",
     "type": "integration",
     "download": "/epr/example/example-0.0.2.zip",
-    "path": "/package/example/0.0.2"
+    "path": "/package/example/0.0.2",
+    "categories": [
+      "web"
+    ]
   },
   {
     "name": "example",
@@ -22,8 +25,15 @@
       {
         "name": "logs",
         "title": "Logs datasource",
-        "description": "Datasource for your log files."
+        "description": "Datasource for your log files.",
+        "categories": [
+          "datastore"
+        ]
       }
+    ],
+    "categories": [
+      "crm",
+      "azure"
     ]
   }
 ]

--- a/testdata/generated/search-package-example.json
+++ b/testdata/generated/search-package-example.json
@@ -12,8 +12,15 @@
       {
         "name": "logs",
         "title": "Logs datasource",
-        "description": "Datasource for your log files."
+        "description": "Datasource for your log files.",
+        "categories": [
+          "datastore"
+        ]
       }
+    ],
+    "categories": [
+      "crm",
+      "azure"
     ]
   }
 ]

--- a/testdata/generated/search-package-experimental.json
+++ b/testdata/generated/search-package-experimental.json
@@ -7,7 +7,10 @@
     "description": "This package contains a datastream with the dataset_is_prefix flag set to true.\n",
     "type": "integration",
     "download": "/epr/dataset_is_prefix/dataset_is_prefix-0.0.1.zip",
-    "path": "/package/dataset_is_prefix/0.0.1"
+    "path": "/package/dataset_is_prefix/0.0.1",
+    "categories": [
+      "custom"
+    ]
   },
   {
     "name": "datasources",
@@ -24,6 +27,9 @@
         "title": "Datasource title",
         "description": "Details about the data source."
       }
+    ],
+    "categories": [
+      "custom"
     ]
   },
   {
@@ -41,6 +47,10 @@
         "title": "Logs datasource",
         "description": "Datasource for your log files."
       }
+    ],
+    "categories": [
+      "containers",
+      "message_queue"
     ]
   },
   {
@@ -58,6 +68,9 @@
         "title": "Logs datasource",
         "description": "Datasource for your log files."
       }
+    ],
+    "categories": [
+      "monitoring"
     ]
   },
   {
@@ -68,7 +81,10 @@
     "description": "Test package-specified Elasticsearch index privileges",
     "type": "solution",
     "download": "/epr/elasticsearch_privileges/elasticsearch_privileges-1.0.0.zip",
-    "path": "/package/elasticsearch_privileges/1.0.0"
+    "path": "/package/elasticsearch_privileges/1.0.0",
+    "categories": [
+      "custom"
+    ]
   },
   {
     "name": "example",
@@ -83,8 +99,15 @@
       {
         "name": "logs",
         "title": "Logs datasource",
-        "description": "Datasource for your log files."
+        "description": "Datasource for your log files.",
+        "categories": [
+          "datastore"
+        ]
       }
+    ],
+    "categories": [
+      "crm",
+      "azure"
     ]
   },
   {
@@ -95,7 +118,10 @@
     "description": "Experimental package, should be set by default",
     "type": "solution",
     "download": "/epr/experimental/experimental-0.0.1.zip",
-    "path": "/package/experimental/0.0.1"
+    "path": "/package/experimental/0.0.1",
+    "categories": [
+      "aws"
+    ]
   },
   {
     "name": "fakeapm",
@@ -105,7 +131,10 @@
     "description": "Not actually APM",
     "type": "integration",
     "download": "/epr/fakeapm/fakeapm-1.0.0.zip",
-    "path": "/package/fakeapm/1.0.0"
+    "path": "/package/fakeapm/1.0.0",
+    "categories": [
+      "monitoring"
+    ]
   },
   {
     "name": "foo",
@@ -115,7 +144,10 @@
     "description": "This is the foo integration",
     "type": "solution",
     "download": "/epr/foo/foo-1.0.0.zip",
-    "path": "/package/foo/1.0.0"
+    "path": "/package/foo/1.0.0",
+    "categories": [
+      "custom"
+    ]
   },
   {
     "name": "hidden",
@@ -125,7 +157,10 @@
     "description": "This is the hidden integration",
     "type": "solution",
     "download": "/epr/hidden/hidden-1.0.0.zip",
-    "path": "/package/hidden/1.0.0"
+    "path": "/package/hidden/1.0.0",
+    "categories": [
+      "custom"
+    ]
   },
   {
     "name": "ilmpolicy",
@@ -135,7 +170,10 @@
     "description": "Test form ILM Policy in Package",
     "type": "solution",
     "download": "/epr/ilmpolicy/ilmpolicy-1.0.0.zip",
-    "path": "/package/ilmpolicy/1.0.0"
+    "path": "/package/ilmpolicy/1.0.0",
+    "categories": [
+      "custom"
+    ]
   },
   {
     "name": "input_groups",
@@ -168,8 +206,15 @@
             "size": "32x32",
             "type": "image/svg+xml"
           }
+        ],
+        "categories": [
+          "compute"
         ]
       }
+    ],
+    "categories": [
+      "aws",
+      "cloud"
     ]
   },
   {
@@ -187,6 +232,9 @@
         "title": "Input level templates",
         "description": "Input with input-level template to use input-level vars with"
       }
+    ],
+    "categories": [
+      "custom"
     ]
   },
   {
@@ -204,6 +252,10 @@
         "path": "/package/longdocs/1.0.4/img/icon.svg",
         "type": "image/svg+xml"
       }
+    ],
+    "categories": [
+      "custom",
+      "web"
     ]
   },
   {
@@ -221,6 +273,9 @@
         "path": "/package/metricsonly/2.0.1/img/icon.svg",
         "type": "image/svg+xml"
       }
+    ],
+    "categories": [
+      "custom"
     ]
   },
   {
@@ -238,6 +293,9 @@
         "title": "Logs datasource",
         "description": "Datasource for your log files."
       }
+    ],
+    "categories": [
+      "custom"
     ]
   },
   {
@@ -255,6 +313,10 @@
         "path": "/package/multiversion/1.1.0/img/icon.svg",
         "type": "image/svg+xml"
       }
+    ],
+    "categories": [
+      "custom",
+      "web"
     ]
   },
   {
@@ -265,7 +327,10 @@
     "description": "This package does contain a dataset but not stream configs.\n",
     "type": "integration",
     "download": "/epr/no_stream_configs/no_stream_configs-1.0.0.zip",
-    "path": "/package/no_stream_configs/1.0.0"
+    "path": "/package/no_stream_configs/1.0.0",
+    "categories": [
+      "custom"
+    ]
   },
   {
     "name": "reference",
@@ -290,6 +355,10 @@
         "title": "Nginx logs and metrics.",
         "description": "Collecting logs and metrics from nginx."
       }
+    ],
+    "categories": [
+      "custom",
+      "web"
     ]
   },
   {
@@ -300,6 +369,9 @@
     "description": "This package contains a yaml pipeline.\n",
     "type": "integration",
     "download": "/epr/yamlpipeline/yamlpipeline-1.0.0.zip",
-    "path": "/package/yamlpipeline/1.0.0"
+    "path": "/package/yamlpipeline/1.0.0",
+    "categories": [
+      "custom"
+    ]
   }
 ]

--- a/testdata/generated/search-package-internal.json
+++ b/testdata/generated/search-package-internal.json
@@ -7,7 +7,10 @@
     "description": "This package contains a datastream with the dataset_is_prefix flag set to true.\n",
     "type": "integration",
     "download": "/epr/dataset_is_prefix/dataset_is_prefix-0.0.1.zip",
-    "path": "/package/dataset_is_prefix/0.0.1"
+    "path": "/package/dataset_is_prefix/0.0.1",
+    "categories": [
+      "custom"
+    ]
   },
   {
     "name": "datasources",
@@ -24,6 +27,9 @@
         "title": "Datasource title",
         "description": "Details about the data source."
       }
+    ],
+    "categories": [
+      "custom"
     ]
   },
   {
@@ -41,6 +47,10 @@
         "title": "Logs datasource",
         "description": "Datasource for your log files."
       }
+    ],
+    "categories": [
+      "containers",
+      "message_queue"
     ]
   },
   {
@@ -58,6 +68,9 @@
         "title": "Logs datasource",
         "description": "Datasource for your log files."
       }
+    ],
+    "categories": [
+      "monitoring"
     ]
   },
   {
@@ -68,7 +81,10 @@
     "description": "Test package-specified Elasticsearch index privileges",
     "type": "solution",
     "download": "/epr/elasticsearch_privileges/elasticsearch_privileges-1.0.0.zip",
-    "path": "/package/elasticsearch_privileges/1.0.0"
+    "path": "/package/elasticsearch_privileges/1.0.0",
+    "categories": [
+      "custom"
+    ]
   },
   {
     "name": "example",
@@ -83,8 +99,15 @@
       {
         "name": "logs",
         "title": "Logs datasource",
-        "description": "Datasource for your log files."
+        "description": "Datasource for your log files.",
+        "categories": [
+          "datastore"
+        ]
       }
+    ],
+    "categories": [
+      "crm",
+      "azure"
     ]
   },
   {
@@ -95,7 +118,10 @@
     "description": "This is the foo integration",
     "type": "solution",
     "download": "/epr/foo/foo-1.0.0.zip",
-    "path": "/package/foo/1.0.0"
+    "path": "/package/foo/1.0.0",
+    "categories": [
+      "custom"
+    ]
   },
   {
     "name": "hidden",
@@ -105,7 +131,10 @@
     "description": "This is the hidden integration",
     "type": "solution",
     "download": "/epr/hidden/hidden-1.0.0.zip",
-    "path": "/package/hidden/1.0.0"
+    "path": "/package/hidden/1.0.0",
+    "categories": [
+      "custom"
+    ]
   },
   {
     "name": "ilmpolicy",
@@ -115,7 +144,10 @@
     "description": "Test form ILM Policy in Package",
     "type": "solution",
     "download": "/epr/ilmpolicy/ilmpolicy-1.0.0.zip",
-    "path": "/package/ilmpolicy/1.0.0"
+    "path": "/package/ilmpolicy/1.0.0",
+    "categories": [
+      "custom"
+    ]
   },
   {
     "name": "input_groups",
@@ -148,8 +180,15 @@
             "size": "32x32",
             "type": "image/svg+xml"
           }
+        ],
+        "categories": [
+          "compute"
         ]
       }
+    ],
+    "categories": [
+      "aws",
+      "cloud"
     ]
   },
   {
@@ -167,6 +206,9 @@
         "title": "Input level templates",
         "description": "Input with input-level template to use input-level vars with"
       }
+    ],
+    "categories": [
+      "custom"
     ]
   },
   {
@@ -178,7 +220,8 @@
     "type": "integration",
     "download": "/epr/internal/internal-1.2.0.zip",
     "path": "/package/internal/1.2.0",
-    "internal": true
+    "internal": true,
+    "categories": []
   },
   {
     "name": "longdocs",
@@ -195,6 +238,10 @@
         "path": "/package/longdocs/1.0.4/img/icon.svg",
         "type": "image/svg+xml"
       }
+    ],
+    "categories": [
+      "custom",
+      "web"
     ]
   },
   {
@@ -212,6 +259,9 @@
         "path": "/package/metricsonly/2.0.1/img/icon.svg",
         "type": "image/svg+xml"
       }
+    ],
+    "categories": [
+      "custom"
     ]
   },
   {
@@ -229,6 +279,9 @@
         "title": "Logs datasource",
         "description": "Datasource for your log files."
       }
+    ],
+    "categories": [
+      "custom"
     ]
   },
   {
@@ -246,6 +299,10 @@
         "path": "/package/multiversion/1.1.0/img/icon.svg",
         "type": "image/svg+xml"
       }
+    ],
+    "categories": [
+      "custom",
+      "web"
     ]
   },
   {
@@ -256,7 +313,10 @@
     "description": "This package does contain a dataset but not stream configs.\n",
     "type": "integration",
     "download": "/epr/no_stream_configs/no_stream_configs-1.0.0.zip",
-    "path": "/package/no_stream_configs/1.0.0"
+    "path": "/package/no_stream_configs/1.0.0",
+    "categories": [
+      "custom"
+    ]
   },
   {
     "name": "reference",
@@ -281,6 +341,10 @@
         "title": "Nginx logs and metrics.",
         "description": "Collecting logs and metrics from nginx."
       }
+    ],
+    "categories": [
+      "custom",
+      "web"
     ]
   },
   {
@@ -291,6 +355,9 @@
     "description": "This package contains a yaml pipeline.\n",
     "type": "integration",
     "download": "/epr/yamlpipeline/yamlpipeline-1.0.0.zip",
-    "path": "/package/yamlpipeline/1.0.0"
+    "path": "/package/yamlpipeline/1.0.0",
+    "categories": [
+      "custom"
+    ]
   }
 ]

--- a/testdata/generated/search-package-internal.json
+++ b/testdata/generated/search-package-internal.json
@@ -220,8 +220,7 @@
     "type": "integration",
     "download": "/epr/internal/internal-1.2.0.zip",
     "path": "/package/internal/1.2.0",
-    "internal": true,
-    "categories": []
+    "internal": true
   },
   {
     "name": "longdocs",

--- a/testdata/generated/search.json
+++ b/testdata/generated/search.json
@@ -7,7 +7,10 @@
     "description": "This package contains a datastream with the dataset_is_prefix flag set to true.\n",
     "type": "integration",
     "download": "/epr/dataset_is_prefix/dataset_is_prefix-0.0.1.zip",
-    "path": "/package/dataset_is_prefix/0.0.1"
+    "path": "/package/dataset_is_prefix/0.0.1",
+    "categories": [
+      "custom"
+    ]
   },
   {
     "name": "datasources",
@@ -24,6 +27,9 @@
         "title": "Datasource title",
         "description": "Details about the data source."
       }
+    ],
+    "categories": [
+      "custom"
     ]
   },
   {
@@ -41,6 +47,10 @@
         "title": "Logs datasource",
         "description": "Datasource for your log files."
       }
+    ],
+    "categories": [
+      "containers",
+      "message_queue"
     ]
   },
   {
@@ -58,6 +68,9 @@
         "title": "Logs datasource",
         "description": "Datasource for your log files."
       }
+    ],
+    "categories": [
+      "monitoring"
     ]
   },
   {
@@ -68,7 +81,10 @@
     "description": "Test package-specified Elasticsearch index privileges",
     "type": "solution",
     "download": "/epr/elasticsearch_privileges/elasticsearch_privileges-1.0.0.zip",
-    "path": "/package/elasticsearch_privileges/1.0.0"
+    "path": "/package/elasticsearch_privileges/1.0.0",
+    "categories": [
+      "custom"
+    ]
   },
   {
     "name": "example",
@@ -83,8 +99,15 @@
       {
         "name": "logs",
         "title": "Logs datasource",
-        "description": "Datasource for your log files."
+        "description": "Datasource for your log files.",
+        "categories": [
+          "datastore"
+        ]
       }
+    ],
+    "categories": [
+      "crm",
+      "azure"
     ]
   },
   {
@@ -95,7 +118,10 @@
     "description": "This is the foo integration",
     "type": "solution",
     "download": "/epr/foo/foo-1.0.0.zip",
-    "path": "/package/foo/1.0.0"
+    "path": "/package/foo/1.0.0",
+    "categories": [
+      "custom"
+    ]
   },
   {
     "name": "hidden",
@@ -105,7 +131,10 @@
     "description": "This is the hidden integration",
     "type": "solution",
     "download": "/epr/hidden/hidden-1.0.0.zip",
-    "path": "/package/hidden/1.0.0"
+    "path": "/package/hidden/1.0.0",
+    "categories": [
+      "custom"
+    ]
   },
   {
     "name": "ilmpolicy",
@@ -115,7 +144,10 @@
     "description": "Test form ILM Policy in Package",
     "type": "solution",
     "download": "/epr/ilmpolicy/ilmpolicy-1.0.0.zip",
-    "path": "/package/ilmpolicy/1.0.0"
+    "path": "/package/ilmpolicy/1.0.0",
+    "categories": [
+      "custom"
+    ]
   },
   {
     "name": "input_groups",
@@ -148,8 +180,15 @@
             "size": "32x32",
             "type": "image/svg+xml"
           }
+        ],
+        "categories": [
+          "compute"
         ]
       }
+    ],
+    "categories": [
+      "aws",
+      "cloud"
     ]
   },
   {
@@ -167,6 +206,9 @@
         "title": "Input level templates",
         "description": "Input with input-level template to use input-level vars with"
       }
+    ],
+    "categories": [
+      "custom"
     ]
   },
   {
@@ -184,6 +226,10 @@
         "path": "/package/longdocs/1.0.4/img/icon.svg",
         "type": "image/svg+xml"
       }
+    ],
+    "categories": [
+      "custom",
+      "web"
     ]
   },
   {
@@ -201,6 +247,9 @@
         "path": "/package/metricsonly/2.0.1/img/icon.svg",
         "type": "image/svg+xml"
       }
+    ],
+    "categories": [
+      "custom"
     ]
   },
   {
@@ -218,6 +267,9 @@
         "title": "Logs datasource",
         "description": "Datasource for your log files."
       }
+    ],
+    "categories": [
+      "custom"
     ]
   },
   {
@@ -235,6 +287,10 @@
         "path": "/package/multiversion/1.1.0/img/icon.svg",
         "type": "image/svg+xml"
       }
+    ],
+    "categories": [
+      "custom",
+      "web"
     ]
   },
   {
@@ -245,7 +301,10 @@
     "description": "This package does contain a dataset but not stream configs.\n",
     "type": "integration",
     "download": "/epr/no_stream_configs/no_stream_configs-1.0.0.zip",
-    "path": "/package/no_stream_configs/1.0.0"
+    "path": "/package/no_stream_configs/1.0.0",
+    "categories": [
+      "custom"
+    ]
   },
   {
     "name": "reference",
@@ -270,6 +329,10 @@
         "title": "Nginx logs and metrics.",
         "description": "Collecting logs and metrics from nginx."
       }
+    ],
+    "categories": [
+      "custom",
+      "web"
     ]
   },
   {
@@ -280,6 +343,9 @@
     "description": "This package contains a yaml pipeline.\n",
     "type": "integration",
     "download": "/epr/yamlpipeline/yamlpipeline-1.0.0.zip",
-    "path": "/package/yamlpipeline/1.0.0"
+    "path": "/package/yamlpipeline/1.0.0",
+    "categories": [
+      "custom"
+    ]
   }
 ]

--- a/util/package.go
+++ b/util/package.go
@@ -88,11 +88,11 @@ type BasePackage struct {
 
 // BasePolicyTemplate is used for the package policy templates in the /search endpoint
 type BasePolicyTemplate struct {
-	Name        string  `config:"name" json:"name" validate:"required"`
-	Title       string  `config:"title" json:"title" validate:"required"`
-	Description string  `config:"description" json:"description" validate:"required"`
-	Icons       []Image `config:"icons,omitempty" json:"icons,omitempty" yaml:"icons,omitempty"`
-	Categories  []string `config:"categories,omitempty" json:"categories,omitempty" yaml:"categories,omitempty"`
+	Name        string  	`config:"name" json:"name" validate:"required"`
+	Title       string  	`config:"title" json:"title" validate:"required"`
+	Description string  	`config:"description" json:"description" validate:"required"`
+	Icons       []Image 	`config:"icons,omitempty" json:"icons,omitempty" yaml:"icons,omitempty"`
+	Categories  []string 	`config:"categories,omitempty" json:"categories,omitempty" yaml:"categories,omitempty"`
 }
 
 type PolicyTemplate struct {

--- a/util/package.go
+++ b/util/package.go
@@ -83,6 +83,7 @@ type BasePackage struct {
 	Icons               []Image              `config:"icons,omitempty" json:"icons,omitempty" yaml:"icons,omitempty"`
 	Internal            bool                 `config:"internal,omitempty" json:"internal,omitempty" yaml:"internal,omitempty"`
 	BasePolicyTemplates []BasePolicyTemplate `json:"policy_templates,omitempty"`
+	Categories          []string             `config:"categories" json:"categories"`
 }
 
 // BasePolicyTemplate is used for the package policy templates in the /search endpoint

--- a/util/package.go
+++ b/util/package.go
@@ -91,6 +91,7 @@ type BasePolicyTemplate struct {
 	Title       string  `config:"title" json:"title" validate:"required"`
 	Description string  `config:"description" json:"description" validate:"required"`
 	Icons       []Image `config:"icons,omitempty" json:"icons,omitempty" yaml:"icons,omitempty"`
+	Categories  []string `config:"categories,omitempty" json:"categories,omitempty" yaml:"categories,omitempty"`
 }
 
 type PolicyTemplate struct {
@@ -181,6 +182,7 @@ func NewPackage(basePath string) (*Package, error) {
 			Name:        t.Name,
 			Title:       t.Title,
 			Description: t.Description,
+			Categories:  t.Categories,
 		}
 
 		for k, i := range p.PolicyTemplates[i].Icons {

--- a/util/package.go
+++ b/util/package.go
@@ -83,16 +83,16 @@ type BasePackage struct {
 	Icons               []Image              `config:"icons,omitempty" json:"icons,omitempty" yaml:"icons,omitempty"`
 	Internal            bool                 `config:"internal,omitempty" json:"internal,omitempty" yaml:"internal,omitempty"`
 	BasePolicyTemplates []BasePolicyTemplate `json:"policy_templates,omitempty"`
-	Categories          []string             `config:"categories" json:"categories"`
+	Categories          []string             `config:"categories,omitempty" json:"categories,omitempty" yaml:"categories,omitempty"`
 }
 
 // BasePolicyTemplate is used for the package policy templates in the /search endpoint
 type BasePolicyTemplate struct {
-	Name        string  	`config:"name" json:"name" validate:"required"`
-	Title       string  	`config:"title" json:"title" validate:"required"`
-	Description string  	`config:"description" json:"description" validate:"required"`
-	Icons       []Image 	`config:"icons,omitempty" json:"icons,omitempty" yaml:"icons,omitempty"`
-	Categories  []string 	`config:"categories,omitempty" json:"categories,omitempty" yaml:"categories,omitempty"`
+	Name        string   `config:"name" json:"name" validate:"required"`
+	Title       string   `config:"title" json:"title" validate:"required"`
+	Description string   `config:"description" json:"description" validate:"required"`
+	Icons       []Image  `config:"icons,omitempty" json:"icons,omitempty" yaml:"icons,omitempty"`
+	Categories  []string `config:"categories,omitempty" json:"categories,omitempty" yaml:"categories,omitempty"`
 }
 
 type PolicyTemplate struct {


### PR DESCRIPTION
Closes https://github.com/elastic/package-registry/issues/722

This adds the categories to the search-response output.
-  Inclusion of categories is required so clients can build a facetted browser, merging multiple sources into overlapping category taxonomy. (this is the goal of https://github.com/elastic/kibana/issues/93084)
-  Adding this will also avoid having to run repeated requests to EPR. Now Kibana needs to issue a search each time a category is selected. It also needs to run a single-search up-front for all packages just so it can provide a total count. This PR will remove the need for this redundant network traffic.


cc @joshdover 