### PR TITLE
Add config from environment and config path flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Configuration file path can be selected with the `-config` flag.
+* Configuration flags can be provided using environment variables.
+
 ### Deprecated
 
 ### Known Issues

--- a/README.md
+++ b/README.md
@@ -175,6 +175,21 @@ elastic-package stack up -v -d
 
 For Docker / Kubernetes the `/health` endpoint can be queried. As soon as `/health` returns a 200, the service is ready.
 
+## Configuration
+
+Package Registry needs to be configured with the source of packages. This
+configuration is loaded by default from the `config.yml` file. An example file
+is provided with the distribution.
+
+Cache headers can also be configured in the configuration file. They are used
+to inform clients about the amount of time a resource is considered fresh. Check
+the reference configuration file for the available settings.
+
+Additional runtime settings can be provided using flags, for more information
+about the available flags, use `package-registry -help`. Flags can be provided
+also as environment variables, in their uppercased form, for example
+`EPR_DRY_RUN=true` is equivalent to adding the `-dry-run` flag.
+
 ## Performance monitoring
 
 Package Registry is instrumented with the [Elastic APM Go Agent](https://www.elastic.co/guide/en/apm/agent/go/current/index.html). You can configure the agent to send the data to any APM Server using the following environment variables:

--- a/flags.go
+++ b/flags.go
@@ -1,0 +1,33 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package main
+
+import (
+	"flag"
+	"os"
+	"strings"
+)
+
+func parseFlags() {
+	flagsFromEnv()
+	flag.Parse()
+}
+
+func flagsFromEnv() {
+	flag.VisitAll(func(f *flag.Flag) {
+		envName := flagEnvName(f.Name)
+		if value, found := os.LookupEnv(envName); found {
+			f.Value.Set(value)
+		}
+	})
+}
+
+const flagEnvPrefix = "EPR_"
+
+func flagEnvName(name string) string {
+	name = strings.ToUpper(name)
+	name = strings.ReplaceAll(name, "-", "_")
+	return flagEnvPrefix + name
+}

--- a/flags_test.go
+++ b/flags_test.go
@@ -1,0 +1,53 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package main
+
+import (
+	"flag"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFlagsFromEnv(t *testing.T) {
+	expected := "my value"
+	os.Setenv("EPR_TEST_DUMMY", expected)
+
+	var dummyFlag string
+	flag.StringVar(&dummyFlag, "test-dummy", "default", "Dummy flag used for testing.")
+	require.Equal(t, "default", dummyFlag)
+
+	flagsFromEnv()
+	require.Equal(t, expected, dummyFlag)
+}
+
+func TestFlagsPrecedence(t *testing.T) {
+	expected := "flag value"
+	os.Setenv("EPR_TEST_PRECEDENCE_DUMMY", "other value")
+	os.Args = append(os.Args, "-test-precedence-dummy="+expected)
+
+	var dummyFlag string
+	flag.StringVar(&dummyFlag, "test-precedence-dummy", "default", "Dummy flag used for testing.")
+	require.Equal(t, "default", dummyFlag)
+
+	parseFlags()
+	require.Equal(t, expected, dummyFlag)
+}
+
+func TestFlagEnvName(t *testing.T) {
+	cases := []struct {
+		flagName string
+		expected string
+	}{
+		{"dry-run", "EPR_DRY_RUN"},
+		{"test-dummy", "EPR_TEST_DUMMY"},
+	}
+
+	for _, c := range cases {
+		assert.Equal(t, c.expected, flagEnvName(c.flagName))
+	}
+}

--- a/main.go
+++ b/main.go
@@ -38,7 +38,7 @@ var (
 	httpProfAddress string
 
 	dryRun     bool
-	configPath = "config.yml"
+	configPath string
 
 	defaultConfig = Config{
 		CacheTimeIndex:      10 * time.Second,
@@ -50,6 +50,7 @@ var (
 
 func init() {
 	flag.StringVar(&address, "address", "localhost:8080", "Address of the package-registry service.")
+	flag.StringVar(&configPath, "config", "config.yml", "Path to the configuration file.")
 	flag.StringVar(&httpProfAddress, "httpprof", "", "Enable HTTP profiler listening on the given address.")
 	// This flag is experimental and might be removed in the future or renamed
 	flag.BoolVar(&dryRun, "dry-run", false, "Runs a dry-run of the registry without starting the web service (experimental)")
@@ -65,7 +66,7 @@ type Config struct {
 }
 
 func main() {
-	flag.Parse()
+	parseFlags()
 	log.Println("Package registry started.")
 	defer log.Println("Package registry stopped.")
 


### PR DESCRIPTION
Thinking about adding the TLS flags for #711, I found that it could be handy, specially for the containerized registry, to allow to include these settings using environment variables.

So for example to add certificates to a containerized registry, one needs to mount the certificates as volumes, and add the environment variables, what is a common practice. Using flags only, the command line needs to be modified, what can override other defaults as the default address or `-disable-package-validation`, [included in current distribution images](https://github.com/elastic/package-storage/blob/989ded50e8455777e2556dfd3d72735b284d5751/Dockerfile#L16).

This change includes:
* Some documentation notes about how the registry can be configured.
* A new flag `-config` to select the configuration file.
* Flags can be provided using environment variables. Flags have precedence over environment variables.