### PR TITLE
Fixes duplicate key error in YAML marshalling

### DIFF
--- a/packages/package.go
+++ b/packages/package.go
@@ -59,7 +59,7 @@ type Package struct {
 	Readme          *string `config:"readme,omitempty" json:"readme,omitempty" yaml:"readme,omitempty"`
 	License         string  `config:"license,omitempty" json:"license,omitempty" yaml:"license,omitempty"`
 	versionSemVer   *semver.Version
-	Categories      []string         `config:"categories" json:"categories"`
+	Categories      []string         `config:"categories" json:"categories" yaml:"-"`
 	Screenshots     []Image          `config:"screenshots,omitempty" json:"screenshots,omitempty" yaml:"screenshots,omitempty"`
 	Assets          []string         `config:"assets,omitempty" json:"assets,omitempty" yaml:"assets,omitempty"`
 	PolicyTemplates []PolicyTemplate `config:"policy_templates,omitempty" json:"policy_templates,omitempty" yaml:"policy_templates,omitempty"`


### PR DESCRIPTION
Found when using import-beats script from elastic/integrations. https://github.com/elastic/integrations/issues/1876

```
panic: Duplicated key 'categories' in struct util.Package [recovered]
        panic: Duplicated key 'categories' in struct util.Package

goroutine 1 [running]:
gopkg.in/yaml%2ev2.handleErr(0xc001748c98)
        C:/Users/Administrator/go/pkg/mod/gopkg.in/yaml.v2@v2.4.0/yaml.go:249 +0x6d
panic({0x159bc60, 0xc0000360f0})
        C:/Program Files/Go/src/runtime/panic.go:1038 +0x215
gopkg.in/yaml%2ev2.(*encoder).structv(0xc0009b0b00, {0x0, 0x0}, {0x15f88a0, 0xc00004e000, 0x0})
        C:/Users/Administrator/go/pkg/mod/gopkg.in/yaml.v2@v2.4.0/encode.go:211 +0xe9
gopkg.in/yaml%2ev2.(*encoder).marshal(0xc0009b0b00, {0x0, 0x0}, {0x15f88a0, 0xc00004e000, 0x34})
        C:/Users/Administrator/go/pkg/mod/gopkg.in/yaml.v2@v2.4.0/encode.go:160 +0x9a5
gopkg.in/yaml%2ev2.(*encoder).marshalDoc(0xc0009b0b00, {0x0, 0x0}, {0x15f88a0, 0xc00004e000, 0xc001748cb8})
        C:/Users/Administrator/go/pkg/mod/gopkg.in/yaml.v2@v2.4.0/encode.go:93 +0x125
gopkg.in/yaml%2ev2.Marshal({0x15f88a0, 0xc00004e000})
        C:/Users/Administrator/go/pkg/mod/gopkg.in/yaml.v2@v2.4.0/yaml.go:203 +0x37e
main.(*packageRepository).save(0xc001749d98, {0x160f982, 0x8})
        C:/git/integrations/dev/import-beats/packages.go:269 +0x235
main.build({{0x160f52a, 0x8}, {0x1616cd9, 0x15}, {0x160f292, 0x7}, {0x160f84a, 0x8}, {0x160fc20, 0x9}, ...})
        C:/git/integrations/dev/import-beats/main.go:139 +0x2df
main.main()
        C:/git/integrations/dev/import-beats/main.go:102 +0x4b8
exit status 2
```

This PR resolves this error.