### PR TITLE
Use Ubuntu LTS as base image instead of CentOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Update Gorilla to 1.8.0. [#759](https://github.com/elastic/package-registry/pull/759)
 * Support package signatures. [#760](https://github.com/elastic/package-registry/pull/760)
 * Update Go runtime to 1.17.3. [#764](https://github.com/elastic/package-registry/pull/764)
-* Use Ubuntu LTS as base image instead of CentOS []()
+* Use Ubuntu LTS as base image instead of CentOS [#787](https://github.com/elastic/package-registry/pull/787)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Update Gorilla to 1.8.0. [#759](https://github.com/elastic/package-registry/pull/759)
 * Support package signatures. [#760](https://github.com/elastic/package-registry/pull/760)
 * Update Go runtime to 1.17.3. [#764](https://github.com/elastic/package-registry/pull/764)
+* Use Ubuntu LTS as base image instead of CentOS []()
 
 ### Deprecated
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,11 +12,12 @@ RUN go build .
 
 
 # Run binary
-FROM centos:7
+FROM ubuntu:20.04
 
 # Get dependencies
-# mailcap - installs "/etc/mime.types" used by the package-registry binary
-RUN yum install -y zip rsync mailcap && yum clean all
+RUN apt-get update && \
+    apt-get install -y mime-support zip rsync curl && \
+    apt-get clean all
 
 # Move binary from the builder image
 COPY --from=builder /package-registry/package-registry /package-registry/package-registry


### PR DESCRIPTION
Move to Ubuntu LTS as other Elastic projects have done after the discontinuation of CentOS fixed releases in favour of CentOS Stream.

Image size goes after this change from 242MB to 143MB.