### PR TITLE
Prepare release 1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/elastic/package-registry/compare/v1.6.0...main)
+## [v1.7.0](https://github.com/elastic/package-registry/compare/v1.6.0...v1.7.0)
 
 ### Breaking changes
 

--- a/main.go
+++ b/main.go
@@ -30,7 +30,7 @@ import (
 
 const (
 	serviceName = "package-registry"
-	version     = "1.6.1"
+	version     = "1.7.0"
 )
 
 var (

--- a/testdata/generated/index.json
+++ b/testdata/generated/index.json
@@ -1,4 +1,4 @@
 {
   "service.name": "package-registry",
-  "service.version": "1.6.1"
+  "service.version": "1.7.0"
 }


### PR DESCRIPTION
Prepare release with the changes to deprecate the release tag, and adding the `prerelease` parameter for search requests (https://github.com/elastic/package-registry/pull/785).

Part of https://github.com/elastic/package-spec/issues/225.