### PR TITLE
Update README and OpenAPI to include prerelease parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,16 +19,18 @@ The `/search` API endpoint has few additional query parameters. More might be ad
   By default this endpoint always returns only the newest compatible package.
 * `category`: Filters the package by the given category. Available categories can be seend when going to `/categories` endpoint.
 * `package`: Filters by a specific package name, for example `mysql`. Returns the most recent version.
-* `all`: This can be set to true to list all package versions. This is set to `false` by default.
-* `experimental`: This can be set to true to list packages considered to be experimental. This is set to `false` by default.
+* `all`: This can be set to `true` to list all package versions. This is set to `false` by default.
+* `prerelease`: This can be set to `true` to list prerelease versions of packages. This is set to `false` by default.
+* `experimental` (deprecated): This can be set to `true` to list packages considered to be experimental. This is set to `false` by default.
 
 The different query parameters above can be combined, so `?package=mysql&kibana.version=7.3.0` will return all mysql package versions
 which are compatible with `7.3.0`.
 
 The `/categories` API endpoint has two additional query parameters.
 
-* `experimental`: This can be set to true to list categories from experimental packages. This is set to `false` by default.
-* `include_policy_templates`: This can be set to true to include categories from policy templates. This is set to `false` by default.
+* `prerelease`: This can be set to `true` to list prerelease versions of packages. This is set to `false` by default.
+* `experimental` (deprecated): This can be set to `true` to list categories from experimental packages. This is set to `false` by default.
+* `include_policy_templates`: This can be set to `true` to include categories from policy templates. This is set to `false` by default.
 
 ## Package structure
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The `/search` API endpoint has few additional query parameters. More might be ad
 * `category`: Filters the package by the given category. Available categories can be seend when going to `/categories` endpoint.
 * `package`: Filters by a specific package name, for example `mysql`. Returns the most recent version.
 * `all`: This can be set to `true` to list all package versions. This is set to `false` by default.
-* `prerelease`: This can be set to `true` to list prerelease versions of packages. This is set to `false` by default.
+* `prerelease`: This can be set to `true` to list prerelease versions of packages. Versions are considered prereleases if they are not stable according to sematic versioning, that is, if they are 0.x versions, or if they contain a prerelease tag. This is set to `false` by default.
 * `experimental` (deprecated): This can be set to `true` to list packages considered to be experimental. This is set to `false` by default.
 
 The different query parameters above can be combined, so `?package=mysql&kibana.version=7.3.0` will return all mysql package versions
@@ -28,7 +28,7 @@ which are compatible with `7.3.0`.
 
 The `/categories` API endpoint has two additional query parameters.
 
-* `prerelease`: This can be set to `true` to list prerelease versions of packages. This is set to `false` by default.
+* `prerelease`: This can be set to `true` to list prerelease versions of packages. Versions are considered prereleases if they are not stable according to sematic versioning, that is, if they are 0.x versions, or if they contain a prerelease tag. This is set to `false` by default.
 * `experimental` (deprecated): This can be set to `true` to list categories from experimental packages. This is set to `false` by default.
 * `include_policy_templates`: This can be set to `true` to include categories from policy templates. This is set to `false` by default.
 

--- a/openapi.yml
+++ b/openapi.yml
@@ -380,7 +380,7 @@ components:
       name: prerelease
       in: query
       required: false
-      description: Set to true to also list experimental packages
+      description: Set to true to also list prerelease versions of packages
       schema:
         type: boolean
         default: false

--- a/openapi.yml
+++ b/openapi.yml
@@ -53,6 +53,7 @@ paths:
       description: List of the existing package categories and how many packages are in each category
       parameters:
         - $ref: '#/components/parameters/experimentalPackageParam'
+        - $ref: '#/components/parameters/prereleasePackageParam'
   /search:
     get:
       summary: Search packages
@@ -85,6 +86,7 @@ paths:
           name: package
           description: 'Filters by a specific package name, for example mysql. In contrast to the other endpoints, it will return by default all versions of this package.'
         - $ref: '#/components/parameters/experimentalPackageParam'
+        - $ref: '#/components/parameters/prereleasePackageParam'
   '/package/{package}/{version}':
     get:
       summary: GET package info
@@ -367,6 +369,15 @@ components:
   parameters:
     experimentalPackageParam:
       name: experimental
+      in: query
+      required: false
+      deprecated: true
+      description: Set to true to also list experimental packages
+      schema:
+        type: boolean
+        default: false
+    prereleasePackageParam:
+      name: prerelease
       in: query
       required: false
       description: Set to true to also list experimental packages


### PR DESCRIPTION
Update README and OpenAPI definition accordingly to the changes in #785.

OpenAPI definition is still most likely outdated in any case, there is another open issue about this (https://github.com/elastic/package-registry/issues/761).