### PR TITLE
Prepare stub for Storage Indexer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Prepare stub for Storage Indexer. Disable fetching packages from Package Storage v1. [#811](https://github.com/elastic/package-registry/pull/811)
+
 ### Deprecated
 
 ### Known Issues

--- a/magefile.go
+++ b/magefile.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/magefile/mage/mg"
 	"github.com/magefile/mage/sh"
-	"github.com/pkg/errors"
 )
 
 var (
@@ -34,27 +33,7 @@ var (
 )
 
 func Build() error {
-	err := FetchPackageStorage()
-	if err != nil {
-		return err
-	}
 	return sh.Run("go", "build", ".")
-}
-
-func FetchPackageStorage() error {
-	// Remove old storage directory
-	if err := os.RemoveAll(storageRepoDir); err != nil {
-		return errors.Wrapf(err, "failed to remove existing storage directory: %s", storageRepoDir)
-	}
-
-	packageStorageRevision := os.Getenv("PACKAGE_STORAGE_REVISION")
-	if packageStorageRevision == "" {
-		packageStorageRevision = "production"
-	}
-
-	// Check out fresh storage directory
-	return sh.Run("git", "clone", "--depth=1", "--single-branch",
-		"--branch", packageStorageRevision, "https://github.com/elastic/package-storage.git", storageRepoDir)
 }
 
 func Check() error {

--- a/main.go
+++ b/main.go
@@ -64,8 +64,8 @@ func init() {
 	// This flag is experimental and might be removed in the future or renamed
 	flag.BoolVar(&dryRun, "dry-run", false, "Runs a dry-run of the registry without starting the web service (experimental).")
 	flag.BoolVar(&packages.ValidationDisabled, "disable-package-validation", false, "Disable package content validation.")
-	// This flag is experimental and might be removed in the future or renamed
-	flag.BoolVar(&featureStorageIndexer, "feature-storage-indexer", false, "Enable storage indexer to include packages from Package Storage v2 (experimental).")
+	// This flag is a technical preview and might be removed in the future or renamed
+	flag.BoolVar(&featureStorageIndexer, "feature-storage-indexer", false, "Enable storage indexer to include packages from Package Storage v2 (technical preview).")
 }
 
 type Config struct {

--- a/main.go
+++ b/main.go
@@ -26,6 +26,7 @@ import (
 	ucfgYAML "github.com/elastic/go-ucfg/yaml"
 
 	"github.com/elastic/package-registry/packages"
+	"github.com/elastic/package-registry/storage"
 	"github.com/elastic/package-registry/util"
 )
 
@@ -44,6 +45,8 @@ var (
 	dryRun     bool
 	configPath string
 
+	featureStorageIndexer bool
+
 	defaultConfig = Config{
 		CacheTimeIndex:      10 * time.Second,
 		CacheTimeSearch:     10 * time.Minute,
@@ -61,6 +64,8 @@ func init() {
 	// This flag is experimental and might be removed in the future or renamed
 	flag.BoolVar(&dryRun, "dry-run", false, "Runs a dry-run of the registry without starting the web service (experimental).")
 	flag.BoolVar(&packages.ValidationDisabled, "disable-package-validation", false, "Disable package content validation.")
+	// This flag is experimental and might be removed in the future or renamed
+	flag.BoolVar(&featureStorageIndexer, "feature-storage-indexer", false, "Enable storage indexer to include packages from Package Storage v2 (experimental).")
 }
 
 type Config struct {
@@ -123,18 +128,22 @@ func initServer(logger *zap.Logger) *http.Server {
 
 	config := mustLoadConfig(logger)
 	packagesBasePaths := getPackagesBasePaths(config)
-	indexer := NewCombinedIndexer(
-		packages.NewFileSystemIndexer(packagesBasePaths...),
-		packages.NewZipFileSystemIndexer(packagesBasePaths...),
-	)
-	ensurePackagesAvailable(ctx, logger, indexer)
+
+	var indexers []Indexer
+	indexers = append(indexers, packages.NewFileSystemIndexer(packagesBasePaths...))
+	indexers = append(indexers, packages.NewZipFileSystemIndexer(packagesBasePaths...))
+	if featureStorageIndexer {
+		indexers = append(indexers, storage.NewIndexer())
+	}
+	combinedIndexer := NewCombinedIndexer(indexers...)
+	ensurePackagesAvailable(ctx, logger, combinedIndexer)
 
 	// If -dry-run=true is set, service stops here after validation
 	if dryRun {
 		os.Exit(0)
 	}
 
-	router := mustLoadRouter(logger, config, indexer)
+	router := mustLoadRouter(logger, config, combinedIndexer)
 	apmgorilla.Instrument(router, apmgorilla.WithTracer(apmTracer))
 
 	return &http.Server{Addr: address, Handler: router}

--- a/main.go
+++ b/main.go
@@ -130,10 +130,11 @@ func initServer(logger *zap.Logger) *http.Server {
 	packagesBasePaths := getPackagesBasePaths(config)
 
 	var indexers []Indexer
-	indexers = append(indexers, packages.NewFileSystemIndexer(packagesBasePaths...))
-	indexers = append(indexers, packages.NewZipFileSystemIndexer(packagesBasePaths...))
 	if featureStorageIndexer {
 		indexers = append(indexers, storage.NewIndexer())
+	} else {
+		indexers = append(indexers, packages.NewFileSystemIndexer(packagesBasePaths...))
+		indexers = append(indexers, packages.NewZipFileSystemIndexer(packagesBasePaths...))
 	}
 	combinedIndexer := NewCombinedIndexer(indexers...)
 	ensurePackagesAvailable(ctx, logger, combinedIndexer)

--- a/storage/indexer.go
+++ b/storage/indexer.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
 package storage
 
 import (

--- a/storage/indexer.go
+++ b/storage/indexer.go
@@ -1,0 +1,21 @@
+package storage
+
+import (
+	"context"
+
+	"github.com/elastic/package-registry/packages"
+)
+
+type Indexer struct{}
+
+func NewIndexer() *Indexer {
+	return new(Indexer)
+}
+
+func (i *Indexer) Init(context.Context) error {
+	return nil
+}
+
+func (i *Indexer) Get(context.Context, *packages.GetOptions) (packages.Packages, error) {
+	panic("not implemented yet")
+}


### PR DESCRIPTION
Issue: https://github.com/elastic/package-registry/issues/767

This PR introduces a stub for the future v2 Storage Indexer. It removes the logic responsible for pulling packages from Package Storage v1.

Comment:

I'd rather publish a set of smaller PRs instead of a huge one with the entire implementation.