### PR TITLE
ci: publish docker images

### DIFF
--- a/.ci/deploy-package-registry.groovy
+++ b/.ci/deploy-package-registry.groovy
@@ -1,0 +1,49 @@
+#!/usr/bin/env groovy
+
+@Library('apm@current') _
+
+pipeline {
+  agent { label 'ubuntu-20' }
+  environment {
+    BASE_DIR = "src/github.com/elastic/package-registry"
+    PIPELINE_LOG_LEVEL = 'INFO'
+    DOCKER_REGISTRY = 'docker.elastic.co'
+    DOCKER_REGISTRY_SECRET = 'secret/observability-team/ci/docker-registry/prod'
+    DOCKER_TAG = "${params.DOCKER_TAG}"
+    DOCKER_IMG_SOURCE = "${env.DOCKER_REGISTRY}/package-registry/distribution:production"
+    DOCKER_IMG_TARGET = "${env.DOCKER_REGISTRY}/package-registry/distribution:${env.DOCKER_TAG}"
+  }
+  options {
+    timeout(time: 1, unit: 'HOURS')
+    buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '20', daysToKeepStr: '30'))
+    timestamps()
+    ansiColor('xterm')
+    disableResume()
+    durabilityHint('PERFORMANCE_OPTIMIZED')
+    rateLimitBuilds(throttle: [count: 60, durationName: 'hour', userBoost: true])
+    quietPeriod(10)
+  }
+  parameters {
+    string(name: 'DOCKER_TAG', defaultValue: 'latest', description: 'The docker tag to be published.')
+  }
+  stages {
+    stage('Publish Docker image'){
+      options { skipDefaultCheckout() }
+      steps {
+        dockerLogin(secret: "${env.DOCKER_REGISTRY_SECRET}", registry: "${env.DOCKER_REGISTRY}")
+        retryWithSleep(retries: 3, seconds: 5, backoff: true) {
+          sh(label: 'Docker pull', script: 'docker pull ${DOCKER_IMG_SOURCE}')
+        }
+        sh(label: 'Docker retag',  script: 'docker tag ${DOCKER_IMG_SOURCE} ${DOCKER_IMG_TARGET}')
+        retryWithSleep(retries: 3, seconds: 5, backoff: true) {
+          sh(label: 'Docker push', script: 'docker push ${DOCKER_IMG_TARGET}')
+        }
+      }
+    }
+  }
+  post {
+    cleanup {
+      notifyBuildResult(prComment: false)
+    }
+  }
+}

--- a/.ci/jobs/deploy-package-registry-pipeline.yml
+++ b/.ci/jobs/deploy-package-registry-pipeline.yml
@@ -1,0 +1,24 @@
+---
+- job:
+    name: deploy-package-registry
+    display-name: deploy package registry
+    description: deploy package registry
+    project-type: pipeline
+    parameters:
+      - string:
+          name: DOCKER_TAG
+          default: latest
+          description: The docker tag to be published.
+    pipeline-scm:
+      script-path: .ci/deploy-package-registry.groovy
+      scm:
+        - git:
+            url: git@github.com:elastic/package-registry.git
+            refspec: +refs/heads/*:refs/remotes/origin/* +refs/pull/*/head:refs/remotes/origin/pr/*
+            wipe-workspace: 'True'
+            name: origin
+            shallow-clone: true
+            credentials-id: f6c7695a-671e-4f4f-a331-acdce44ff9ba
+            reference-repo: /var/lib/jenkins/.git-references/package-registry.git
+            branches:
+              - main


### PR DESCRIPTION
### What

Tag the production docker image with the Unified Release version.

### Why

The docker images will be available as soon as the tag release is created in https://github.com/elastic/fleet-server

https://github.com/elastic/fleet-server/tags

Therefore, versions will be aligned with the releases.

### Issues

Notifies https://github.com/elastic/fleet-server/pull/1471