### PR TITLE
Prepare release v1.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [unreleased](https://github.com/elastic/package-registry/compare/v1.8.0...main)
+## [v1.9.0](https://github.com/elastic/package-registry/compare/v1.8.0...v1.9.0)
 
 ### Breaking changes
 

--- a/main.go
+++ b/main.go
@@ -32,7 +32,7 @@ import (
 
 const (
 	serviceName = "package-registry"
-	version     = "1.8.1"
+	version     = "1.9.0"
 )
 
 var (

--- a/testdata/generated/index.json
+++ b/testdata/generated/index.json
@@ -1,4 +1,4 @@
 {
   "service.name": "package-registry",
-  "service.version": "1.8.1"
+  "service.version": "1.9.0"
 }


### PR DESCRIPTION
This PR prepares Package Registry for the next release. We need to support input type packages ([meta-issue](https://github.com/elastic/package-spec/issues/319)).