### PR TITLE
Fix: unmarshal policy_templates into BasePolicyTemplates

### DIFF
--- a/packages/marshaler.go
+++ b/packages/marshaler.go
@@ -33,5 +33,6 @@ func (p *Package) UnmarshalJSON(data []byte) error {
 	if err != nil {
 		return err
 	}
+	((*Package)(aux.Alias)).setBasePolicyTemplates()
 	return ((*Package)(aux.Alias)).setRuntimeFields()
 }

--- a/packages/marshaler_test.go
+++ b/packages/marshaler_test.go
@@ -52,13 +52,14 @@ func TestUnmarshalJSON(t *testing.T) {
 	require.NoError(t, err, "packages should be loaded")
 	for i := range indexer.packageList {
 		require.Equal(t, packages[i].Name, indexer.packageList[i].Name)
-		require.Equal(t, packages[i].Version, indexer.packageList[i].Version)
-		require.Equal(t, packages[i].Title, indexer.packageList[i].Title)
-		require.Equal(t, packages[i].versionSemVer, indexer.packageList[i].versionSemVer)
+		assert.Equal(t, packages[i].Version, indexer.packageList[i].Version)
+		assert.Equal(t, packages[i].Title, indexer.packageList[i].Title)
+		assert.Equal(t, packages[i].versionSemVer, indexer.packageList[i].versionSemVer)
+		assert.Len(t, packages[i].BasePolicyTemplates, len(packages[i].PolicyTemplates))
 		if indexer.packageList[i].Conditions != nil && indexer.packageList[i].Conditions.Kibana != nil {
-			require.Equal(t, packages[i].Conditions.Kibana.constraint, indexer.packageList[i].Conditions.Kibana.constraint)
+			assert.Equal(t, packages[i].Conditions.Kibana.constraint, indexer.packageList[i].Conditions.Kibana.constraint)
 		}
-		require.Nil(t, packages[i].fsBuilder)
+		assert.Nil(t, packages[i].fsBuilder)
 	}
 }
 

--- a/packages/package.go
+++ b/packages/package.go
@@ -213,19 +213,10 @@ func NewPackage(basePath string, fsBuilder FileSystemBuilder) (*Package, error) 
 
 		// Collect basic information from policy templates and store into the /search endpoint
 		t := p.PolicyTemplates[i]
-		baseT := BasePolicyTemplate{
-			Name:        t.Name,
-			Title:       t.Title,
-			Description: t.Description,
-			Categories:  t.Categories,
-		}
 
 		for k, i := range p.PolicyTemplates[i].Icons {
 			t.Icons[k].Path = i.getPath(p)
 		}
-
-		baseT.Icons = t.Icons
-		p.BasePolicyTemplates = append(p.BasePolicyTemplates, baseT)
 
 		// Store paths for all screenshots under each policy template
 		if p.PolicyTemplates[i].Screenshots != nil {
@@ -249,6 +240,8 @@ func NewPackage(basePath string, fsBuilder FileSystemBuilder) (*Package, error) 
 			p.PolicyTemplates[i].Readme = &readmePathShort
 		}
 	}
+
+	p.setBasePolicyTemplates()
 
 	if p.Type == "" {
 		p.Type = defaultType
@@ -336,6 +329,23 @@ func (p *Package) setRuntimeFields() error {
 		}
 	}
 	return nil
+}
+
+// setBasePolicyTemplates method mirrors policy_templates from Package to a corresponding property in BasePackage.
+// It's required to perform that sync, because PolicyTemplates and BasePolicyTemplates have same JSON annotation
+// (policy_template).
+func (p *Package) setBasePolicyTemplates() {
+	for _, t := range p.PolicyTemplates {
+		baseT := BasePolicyTemplate{
+			Name:        t.Name,
+			Title:       t.Title,
+			Description: t.Description,
+			Categories:  t.Categories,
+			Icons:       t.Icons,
+		}
+
+		p.BasePolicyTemplates = append(p.BasePolicyTemplates, baseT)
+	}
 }
 
 func (p *Package) HasCategory(category string) bool {


### PR DESCRIPTION
This PR fixes the issue around unmarshaling `BasePolicyTemplates`. `PolicyTemplates` and `BasePolicyTemplates` are unmarshalled from `policy_templates` and only one field is populated.