### PR TITLE
Use independent flag sets in tests

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -11,12 +11,18 @@ import (
 )
 
 func parseFlags() {
-	flagsFromEnv()
-	flag.Parse()
+	parseFlagSetWithArgs(flag.CommandLine, os.Args)
 }
 
-func flagsFromEnv() {
-	flag.VisitAll(func(f *flag.Flag) {
+func parseFlagSetWithArgs(flagSet *flag.FlagSet, args []string) {
+	flagsFromEnv(flagSet)
+
+	// Skip args[0] as flag.Parse() does.
+	flagSet.Parse(args[1:])
+}
+
+func flagsFromEnv(flagSet *flag.FlagSet) {
+	flagSet.VisitAll(func(f *flag.Flag) {
 		envName := flagEnvName(f.Name)
 		if value, found := os.LookupEnv(envName); found {
 			f.Value.Set(value)

--- a/flags_test.go
+++ b/flags_test.go
@@ -18,23 +18,25 @@ func TestFlagsFromEnv(t *testing.T) {
 	os.Setenv("EPR_TEST_DUMMY", expected)
 
 	var dummyFlag string
-	flag.StringVar(&dummyFlag, "test-dummy", "default", "Dummy flag used for testing.")
+	flagSet := flag.NewFlagSet("", flag.PanicOnError)
+	flagSet.StringVar(&dummyFlag, "test-dummy", "default", "Dummy flag used for testing.")
 	require.Equal(t, "default", dummyFlag)
 
-	flagsFromEnv()
+	flagsFromEnv(flagSet)
 	require.Equal(t, expected, dummyFlag)
 }
 
 func TestFlagsPrecedence(t *testing.T) {
 	expected := "flag value"
 	os.Setenv("EPR_TEST_PRECEDENCE_DUMMY", "other value")
-	os.Args = append(os.Args, "-test-precedence-dummy="+expected)
 
 	var dummyFlag string
-	flag.StringVar(&dummyFlag, "test-precedence-dummy", "default", "Dummy flag used for testing.")
+	flagSet := flag.NewFlagSet("", flag.PanicOnError)
+	flagSet.StringVar(&dummyFlag, "test-precedence-dummy", "default", "Dummy flag used for testing.")
 	require.Equal(t, "default", dummyFlag)
 
-	parseFlags()
+	args := []string{"test", "-test-precedence-dummy=" + expected}
+	parseFlagSetWithArgs(flagSet, args)
 	require.Equal(t, expected, dummyFlag)
 }
 


### PR DESCRIPTION
Tests were registering a flag in the default flagset, producing panics
if the same test is run multiple times with `-count`.

Using the default flag set may also have conflicts with the flags passed
to the actual test runner.

Use new flagsets in tests to avoid these problems.