### PR TITLE
Prepare release 1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [unreleased](https://github.com/elastic/package-registry/compare/v1.9.0...main)
+## [v1.10.0](https://github.com/elastic/package-registry/compare/v1.9.0...v1.10.0)
 
 ### Breaking changes
 

--- a/main.go
+++ b/main.go
@@ -35,7 +35,7 @@ import (
 
 const (
 	serviceName         = "package-registry"
-	version             = "1.9.1"
+	version             = "1.10.0"
 	defaultInstanceName = "localhost"
 )
 

--- a/testdata/generated/index.json
+++ b/testdata/generated/index.json
@@ -1,4 +1,4 @@
 {
   "service.name": "package-registry",
-  "service.version": "1.9.1"
+  "service.version": "1.10.0"
 }


### PR DESCRIPTION
Prepare release with changes to add support for "threat_intel" category and the required instrumentation to expose Prometheus metrics.

Part of https://github.com/elastic/package-registry/issues/797
