### PR TITLE
dockerfile: remove GO111MODULE env variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@
 ARG GO_VERSION=1.18.3
 FROM golang:${GO_VERSION} AS builder
 
-ENV GO111MODULE=on
 COPY ./ /package-registry
 WORKDIR /package-registry
 RUN go build .


### PR DESCRIPTION
As of Go 1.16 module-aware mode is enabled by default so
GO111MODULE=on is no longer needed.

See https://go.dev/doc/go1.16#go-command

This should also help with forward compatibility as
GOPATH and GO111MODULE will be removed in the future,

See https://github.com/golang/go/wiki/GOPATH#deprecating-and-removing-gopath-development-mode