### PR TITLE
dockerfile: replace mime-support with media-types

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ FROM ubuntu:22.04
 
 # Get dependencies
 RUN apt-get update && \
-    apt-get install -y mime-support zip rsync curl && \
+    apt-get install -y media-types zip rsync curl && \
     apt-get clean all
 
 # Move binary from the builder image


### PR DESCRIPTION
mailcap was added back when the image was using centOS to add
/etc/mime.types.

See https://github.com/elastic/package-registry/pull/599

Later, the package registry moved to Ubuntu LTS and mailcap was
replaced by mime-support which also installs mailcap.

Now mime-support is a transitional package and we can replace it with
media-types, to only install the file (/etc/mime.types) that we need.

The issue with mailcap is the large dependency tree and the dependency
on perl, by replacing mime-support with media-types we can reduce the
image size.

Before: 202MB
After: 148MB