### PR TITLE
dockerfile: remove apt cache folder after update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,8 @@ FROM ubuntu:22.04
 
 # Get dependencies
 RUN apt-get update && \
-    apt-get install -y mime-support zip rsync curl && \
-    apt-get clean all
+    apt-get install -y mime-support zip rsync curl \
+    && rm -rf /var/lib/apt/lists/*
 
 # Move binary from the builder image
 COPY --from=builder /package-registry/package-registry /package-registry/package-registry


### PR DESCRIPTION
From https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#apt-get

In addition, when you clean up the apt cache by removing /var/lib/apt/lists it
reduces the image size, since the apt cache is not stored in a layer.

We can also remove the apt-get clean command because official images
automatically run apt-get clean, so explicit invocation is not required.

Before: 202MB
After: 167MB