### PR TITLE
Collect storage indexer metrics from its implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bugfixes
 
+* Collect storage indexer metrics in the storage indexer itself. [#851](https://github.com/elastic/package-registry/pull/851)
+
 ### Added
 
 * Add `elastic.subscription` condition to package index metadata, use this value for backwards compatibility with previous `license` field. [#826](https://github.com/elastic/package-registry/pull/826)

--- a/indexer.go
+++ b/indexer.go
@@ -6,9 +6,7 @@ package main
 
 import (
 	"context"
-	"time"
 
-	"github.com/elastic/package-registry/metrics"
 	"github.com/elastic/package-registry/packages"
 )
 
@@ -34,8 +32,6 @@ func (c CombinedIndexer) Init(ctx context.Context) error {
 }
 
 func (c CombinedIndexer) Get(ctx context.Context, opts *packages.GetOptions) (packages.Packages, error) {
-	start := time.Now()
-	defer metrics.StorageIndexerGetDurationSeconds.Observe(time.Since(start).Seconds())
 	var packages packages.Packages
 	for _, indexer := range c {
 		p, err := indexer.Get(ctx, opts)

--- a/storage/indexer.go
+++ b/storage/indexer.go
@@ -173,6 +173,9 @@ func (i *Indexer) updateIndex(ctx context.Context) error {
 }
 
 func (i *Indexer) Get(ctx context.Context, opts *packages.GetOptions) (packages.Packages, error) {
+	start := time.Now()
+	defer metrics.StorageIndexerGetDurationSeconds.Observe(time.Since(start).Seconds())
+
 	i.m.RLock()
 	defer i.m.RUnlock()
 


### PR DESCRIPTION
Move collection of storage indexer metrics to its implementation, so these metrics are collected also when the combined indexer is not used, and only if the storage indexer is.