### PR TITLE
Expose source.license through the API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * Add `elastic.subscription` condition to package index metadata, use this value for backwards compatibility with previous `license` field. [#826](https://github.com/elastic/package-registry/pull/826)
+* Add `source.license` to relevant API responses when available. [#854](https://github.com/elastic/package-registry/pull/854)
 
 ### Deprecated
 

--- a/packages/package.go
+++ b/packages/package.go
@@ -82,7 +82,7 @@ type BasePackage struct {
 	Title               *string              `config:"title,omitempty" json:"title,omitempty" yaml:"title,omitempty"`
 	Version             string               `config:"version" json:"version"`
 	Release             string               `config:"release,omitempty" json:"release,omitempty"`
-	Source              *Source              `config:"source,omitempty" json:"source,omitempty"`
+	Source              *Source              `config:"source,omitempty" json:"source,omitempty" yaml:"source,omitempty"`
 	Description         string               `config:"description" json:"description"`
 	Type                string               `config:"type" json:"type"`
 	Download            string               `json:"download" yaml:"download,omitempty"`

--- a/packages/package.go
+++ b/packages/package.go
@@ -124,7 +124,7 @@ type PolicyTemplate struct {
 
 // Source contains metadata about the source of the package and its distribution.
 type Source struct {
-	License string `config:"license" json:"license"`
+	License string `config:"license,omitempty" json:"license,omitempty" yaml:"license,omitempty"`
 }
 
 type Conditions struct {

--- a/packages/package.go
+++ b/packages/package.go
@@ -82,6 +82,7 @@ type BasePackage struct {
 	Title               *string              `config:"title,omitempty" json:"title,omitempty" yaml:"title,omitempty"`
 	Version             string               `config:"version" json:"version"`
 	Release             string               `config:"release,omitempty" json:"release,omitempty"`
+	Source              *Source              `config:"source,omitempty" json:"source,omitempty"`
 	Description         string               `config:"description" json:"description"`
 	Type                string               `config:"type" json:"type"`
 	Download            string               `json:"download" yaml:"download,omitempty"`
@@ -119,6 +120,11 @@ type PolicyTemplate struct {
 	Type         string `config:"type,omitempty" json:"type,omitempty" yaml:"type,omitempty"`
 	Input        string `config:"input,omitempty" json:"input,omitempty" yaml:"input,omitempty"`
 	TemplatePath string `config:"template_path,omitempty" json:"template_path,omitempty" yaml:"template_path,omitempty"`
+}
+
+// Source contains metadata about the source of the package and its distribution.
+type Source struct {
+	License string `config:"license" json:"license"`
 }
 
 type Conditions struct {

--- a/packages/testdata/marshaler/packages.json
+++ b/packages/testdata/marshaler/packages.json
@@ -700,6 +700,9 @@
    "title": "Example Integration",
    "version": "1.1.0",
    "release": "ga",
+   "source": {
+    "license": "Elastic-2.0"
+   },
    "description": "This is the example integration",
    "type": "integration",
    "download": "/epr/example/example-1.1.0.zip",
@@ -799,6 +802,9 @@
    "title": "Example Integration",
    "version": "1.2.0-rc1",
    "release": "ga",
+   "source": {
+    "license": "Elastic-2.0"
+   },
    "description": "This is the example integration",
    "type": "integration",
    "download": "/epr/example/example-1.2.0-rc1.zip",

--- a/testdata/generated/package/example/1.1.0/index.json
+++ b/testdata/generated/package/example/1.1.0/index.json
@@ -3,6 +3,9 @@
   "title": "Example Integration",
   "version": "1.1.0",
   "release": "ga",
+  "source": {
+    "license": "Elastic-2.0"
+  },
   "description": "This is the example integration",
   "type": "integration",
   "download": "/epr/example/example-1.1.0.zip",

--- a/testdata/generated/package/example/1.2.0-rc1/index.json
+++ b/testdata/generated/package/example/1.2.0-rc1/index.json
@@ -3,6 +3,9 @@
   "title": "Example Integration",
   "version": "1.2.0-rc1",
   "release": "ga",
+  "source": {
+    "license": "Elastic-2.0"
+  },
   "description": "This is the example integration",
   "type": "integration",
   "download": "/epr/example/example-1.2.0-rc1.zip",

--- a/testdata/generated/search-all.json
+++ b/testdata/generated/search-all.json
@@ -74,6 +74,9 @@
     "title": "Example Integration",
     "version": "1.1.0",
     "release": "ga",
+    "source": {
+      "license": "Elastic-2.0"
+    },
     "description": "This is the example integration",
     "type": "integration",
     "download": "/epr/example/example-1.1.0.zip",

--- a/testdata/generated/search-category-datastore-prerelease.json
+++ b/testdata/generated/search-category-datastore-prerelease.json
@@ -42,6 +42,9 @@
     "title": "Example Integration",
     "version": "1.2.0-rc1",
     "release": "ga",
+    "source": {
+      "license": "Elastic-2.0"
+    },
     "description": "This is the example integration",
     "type": "integration",
     "download": "/epr/example/example-1.2.0-rc1.zip",

--- a/testdata/generated/search-category-datastore.json
+++ b/testdata/generated/search-category-datastore.json
@@ -42,6 +42,9 @@
     "title": "Example Integration",
     "version": "1.2.0-rc1",
     "release": "ga",
+    "source": {
+      "license": "Elastic-2.0"
+    },
     "description": "This is the example integration",
     "type": "integration",
     "download": "/epr/example/example-1.2.0-rc1.zip",

--- a/testdata/generated/search-kibana800.json
+++ b/testdata/generated/search-kibana800.json
@@ -42,6 +42,9 @@
     "title": "Example Integration",
     "version": "1.1.0",
     "release": "ga",
+    "source": {
+      "license": "Elastic-2.0"
+    },
     "description": "This is the example integration",
     "type": "integration",
     "download": "/epr/example/example-1.1.0.zip",

--- a/testdata/generated/search-package-example-all.json
+++ b/testdata/generated/search-package-example-all.json
@@ -36,6 +36,9 @@
     "title": "Example Integration",
     "version": "1.1.0",
     "release": "ga",
+    "source": {
+      "license": "Elastic-2.0"
+    },
     "description": "This is the example integration",
     "type": "integration",
     "download": "/epr/example/example-1.1.0.zip",

--- a/testdata/generated/search-package-example.json
+++ b/testdata/generated/search-package-example.json
@@ -4,6 +4,9 @@
     "title": "Example Integration",
     "version": "1.1.0",
     "release": "ga",
+    "source": {
+      "license": "Elastic-2.0"
+    },
     "description": "This is the example integration",
     "type": "integration",
     "download": "/epr/example/example-1.1.0.zip",

--- a/testdata/generated/search-package-experimental.json
+++ b/testdata/generated/search-package-experimental.json
@@ -147,6 +147,9 @@
     "title": "Example Integration",
     "version": "1.2.0-rc1",
     "release": "ga",
+    "source": {
+      "license": "Elastic-2.0"
+    },
     "description": "This is the example integration",
     "type": "integration",
     "download": "/epr/example/example-1.2.0-rc1.zip",

--- a/testdata/generated/search-package-internal.json
+++ b/testdata/generated/search-package-internal.json
@@ -42,6 +42,9 @@
     "title": "Example Integration",
     "version": "1.1.0",
     "release": "ga",
+    "source": {
+      "license": "Elastic-2.0"
+    },
     "description": "This is the example integration",
     "type": "integration",
     "download": "/epr/example/example-1.1.0.zip",

--- a/testdata/generated/search-package-prerelease.json
+++ b/testdata/generated/search-package-prerelease.json
@@ -147,6 +147,9 @@
     "title": "Example Integration",
     "version": "1.2.0-rc1",
     "release": "ga",
+    "source": {
+      "license": "Elastic-2.0"
+    },
     "description": "This is the example integration",
     "type": "integration",
     "download": "/epr/example/example-1.2.0-rc1.zip",

--- a/testdata/generated/search.json
+++ b/testdata/generated/search.json
@@ -42,6 +42,9 @@
     "title": "Example Integration",
     "version": "1.1.0",
     "release": "ga",
+    "source": {
+      "license": "Elastic-2.0"
+    },
     "description": "This is the example integration",
     "type": "integration",
     "download": "/epr/example/example-1.1.0.zip",

--- a/testdata/package/example/1.1.0/manifest.yml
+++ b/testdata/package/example/1.1.0/manifest.yml
@@ -7,6 +7,8 @@ title: Example Integration
 categories: ["crm", "azure"]
 type: integration
 release: ga
+source:
+  license: Elastic-2.0
 
 owner.github: "ruflin"
 

--- a/testdata/package/example/1.2.0-rc1/manifest.yml
+++ b/testdata/package/example/1.2.0-rc1/manifest.yml
@@ -7,6 +7,8 @@ title: Example Integration
 categories: ["crm", "azure", "cloud"]
 type: integration
 release: ga
+source:
+  license: Elastic-2.0
 
 owner.github: "ruflin"
 


### PR DESCRIPTION
Add label indicating the distribution license of the package, as defined in https://github.com/elastic/package-spec/pull/355.

Required by Fleet for https://github.com/elastic/package-spec/issues/298 (https://github.com/elastic/package-spec/issues/298#issuecomment-1196023007).