### PR TITLE
Fix: proxy mode doesn't need local packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * Update favicon to be the Elastic Package Registry logo. [#858](https://github.com/elastic/package-registry/pull/858)
-* Implement proxy mode. [#860](https://github.com/elastic/package-registry/pull/860)
-* Proxy mode doesn't need local packages. [#871](https://github.com/elastic/package-registry/pull/871)
+* Implement proxy mode. [#860](https://github.com/elastic/package-registry/pull/860) [#871](https://github.com/elastic/package-registry/pull/871)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bugfixes
 
-* Proxy mode doesn't need local packages. [#871](https://github.com/elastic/package-registry/pull/871)
-
 ### Added
 
 * Update favicon to be the Elastic Package Registry logo. [#858](https://github.com/elastic/package-registry/pull/858)
 * Implement proxy mode. [#860](https://github.com/elastic/package-registry/pull/860)
+* Proxy mode doesn't need local packages. [#871](https://github.com/elastic/package-registry/pull/871)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bugfixes
 
+* Proxy mode doesn't need local packages. [#871](https://github.com/elastic/package-registry/pull/871)
+
 ### Added
 
 * Update favicon to be the Elastic Package Registry logo. [#858](https://github.com/elastic/package-registry/pull/858)


### PR DESCRIPTION
Issue: https://github.com/elastic/package-registry/issues/770

I missed the use case when there are no local packages available at all. It's pretty common in the elastic-package stack.