### PR TITLE
Return just latest versions in proxy mode /search

### DIFF
--- a/search.go
+++ b/search.go
@@ -53,6 +53,7 @@ func searchHandlerWithProxyMode(indexer Indexer, proxyMode *proxymode.ProxyMode,
 				return
 			}
 			packages = packages.Join(proxiedPackages)
+			packages = latestPackagesVersion(packages)
 		}
 
 		data, err := getPackageOutput(r.Context(), packages)


### PR DESCRIPTION
This PR adds the needed changes to return just the latest versions of each package in queries against `/search`.

Scenario:
- In development:
    - elastic_package_registry version 0.0.4
    - elastic_package_registry version 0.0.5
    - elastic_package_registry version 0.0.6
- In EPR proxy:
    - Up to 0.0.5 version published

Tested using `elastic-package stack up`
- Before:
```
 $ curl -k -s "https://localhost:8080/search?experimental=true&package=elastic_package_registry" | jq -r .[].version
0.0.5
0.0.6
```
- After:
```
 $ curl -k -s "https://localhost:8080/search?experimental=true&package=elastic_package_registry" | jq -r .[].version
0.0.6
```
