### PR TITLE
Use JSON decoder tokenizer to parse packages from storage indexer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bugfixes
 
+* Reduce peak memory footprint of recycling indices from storage. [#881](https://github.com/elastic/package-registry/pull/881)
+
 ### Added
 
 ### Deprecated

--- a/storage/fakestorage.go
+++ b/storage/fakestorage.go
@@ -21,12 +21,12 @@ var FakeIndexerOptions = IndexerOptions{
 	WatchInterval:                0,
 }
 
-func PrepareFakeServer(t *testing.T, indexPath string) *fakestorage.Server {
+func PrepareFakeServer(tb testing.TB, indexPath string) *fakestorage.Server {
 	indexContent, err := ioutil.ReadFile(indexPath)
-	require.NoError(t, err, "index file must be populated")
+	require.NoError(tb, err, "index file must be populated")
 
 	const firstRevision = "1"
-	serverObjects := prepareServerObjects(t, firstRevision, indexContent)
+	serverObjects := prepareServerObjects(tb, firstRevision, indexContent)
 	return fakestorage.NewServer(serverObjects)
 }
 
@@ -41,11 +41,11 @@ func updateFakeServer(t *testing.T, server *fakestorage.Server, revision, indexP
 	}
 }
 
-func prepareServerObjects(t *testing.T, revision string, indexContent []byte) []fakestorage.Object {
+func prepareServerObjects(tb testing.TB, revision string, indexContent []byte) []fakestorage.Object {
 	var index searchIndexAll
 	err := json.Unmarshal(indexContent, &index)
-	require.NoError(t, err, "index file must be valid")
-	require.NotEmpty(t, index.Packages, "index file must contain some package entries")
+	require.NoError(tb, err, "index file must be valid")
+	require.NotEmpty(tb, index.Packages, "index file must contain some package entries")
 
 	var serverObjects []fakestorage.Object
 	// Add cursor and index file
@@ -61,6 +61,6 @@ func prepareServerObjects(t *testing.T, revision string, indexContent []byte) []
 		},
 		Content: indexContent,
 	})
-	t.Logf("Prepared %d packages with total %d server objects.", len(index.Packages), len(serverObjects))
+	tb.Logf("Prepared %d packages with total %d server objects.", len(index.Packages), len(serverObjects))
 	return serverObjects
 }

--- a/storage/index.go
+++ b/storage/index.go
@@ -43,6 +43,8 @@ func loadSearchIndexAll(ctx context.Context, storageClient *storage.Client, buck
 	// Using `Unmarshal(doc, &sia)` would require to read the whole document.
 	// Using `dec.Decode(&sia)` would also make the decoder to keep the whole document
 	// in memory.
+	// `jsoniter` seemed to be slightly faster, but to use more memory for our use case,
+	// and we are looking to optimize for memory use.
 	var sia searchIndexAll
 	dec := json.NewDecoder(objectReader)
 	for dec.More() {
@@ -71,7 +73,6 @@ func loadSearchIndexAll(ctx context.Context, storageClient *storage.Client, buck
 			if err != nil {
 				return nil, errors.Wrapf(err, "unexpected error parsing package from index file (token: %v)", token)
 			}
-			// TODO: Apply transforms for package here and directly build the `packages.Packages` array.
 			sia.Packages = append(sia.Packages, p)
 		}
 

--- a/storage/index.go
+++ b/storage/index.go
@@ -66,6 +66,7 @@ func loadSearchIndexAll(ctx context.Context, storageClient *storage.Client, buck
 			if err != nil {
 				return nil, errors.Wrapf(err, "unexpected error parsing package from index file (token: %v)", token)
 			}
+			// TODO: Apply transforms for package here and directly build the `packages.Packages` array?
 			sia.Packages = append(sia.Packages, p)
 		}
 
@@ -74,7 +75,6 @@ func loadSearchIndexAll(ctx context.Context, storageClient *storage.Client, buck
 		if err != nil {
 			return nil, errors.Wrapf(err, "unexpected error while reading index file")
 		}
-		// We only want an array now.
 		if delim, ok := token.(json.Delim); !ok || delim != ']' {
 			return nil, errors.Errorf("expected closing array, found %v", token)
 		}

--- a/storage/indexer_test.go
+++ b/storage/indexer_test.go
@@ -27,6 +27,19 @@ func TestInit(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func BenchmarkInit(b *testing.B) {
+	// given
+	fs := PrepareFakeServer(b, "testdata/search-index-all-full.json")
+	defer fs.Stop()
+	storageClient := fs.Client()
+
+	for i := 0; i < b.N; i++ {
+		indexer := NewIndexer(storageClient, FakeIndexerOptions)
+		err := indexer.Init(context.Background())
+		require.NoError(b, err)
+	}
+}
+
 func TestGet_ListAllPackages(t *testing.T) {
 	// given
 	fs := PrepareFakeServer(t, "testdata/search-index-all-full.json")


### PR DESCRIPTION
Use JSON decoder tokenizer to parse packages from storage indexer, and add a benchmark for the "Init" process.

The benchmark allows to compare results: slightly more allocations are needed now, but about 30% less memory is used, and it is slightly faster.

This can probably be further improved by directly applying the transformations on the parsed packages. It could be also nice to benchmark just this function and not the whole Init process, though this is the heaviest part of this process.

Before:
```
goos: linux
goarch: amd64
pkg: github.com/elastic/package-registry/storage
cpu: 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz
BenchmarkInit-8                3         398302468 ns/op        235217858 B/op    648922 allocs/op
```

After:
```
goos: linux
goarch: amd64
pkg: github.com/elastic/package-registry/storage
cpu: 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz
BenchmarkInit-8                3         379386685 ns/op        168450578 B/op    650022 allocs/op
```