### PR TITLE
Use retriable HTTP client in proxy mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Use retriable HTTP client in proxy mode. [#883](https://github.com/elastic/package-registry/pull/883)
+
 ### Deprecated
 
 ### Known Issues

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/felixge/httpsnoop v1.0.3
 	github.com/fsouza/fake-gcs-server v1.40.2
 	github.com/gorilla/mux v1.8.0
+	github.com/hashicorp/go-retryablehttp v0.7.1
 	github.com/joeshaw/multierror v0.0.0-20140124173710-69b34d4ec901
 	github.com/magefile/mage v1.14.0
 	github.com/pkg/errors v0.9.1
@@ -42,6 +43,7 @@ require (
 	github.com/googleapis/enterprise-certificate-proxy v0.1.0 // indirect
 	github.com/googleapis/gax-go/v2 v2.4.0 // indirect
 	github.com/gorilla/handlers v1.5.1 // indirect
+	github.com/hashicorp/go-cleanhttp v0.5.1 // indirect
 	github.com/jcchavezs/porto v0.3.0 // indirect
 	github.com/kr/pretty v0.3.0 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -242,6 +242,12 @@ github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2z
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
+github.com/hashicorp/go-cleanhttp v0.5.1 h1:dH3aiDG9Jvb5r5+bYHsikaOUIpcM0xvgMXVoDkXMzJM=
+github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
+github.com/hashicorp/go-hclog v0.9.2 h1:CG6TE5H9/JXsFWJCfoIVpKFIkFe6ysEuHirp4DxCsHI=
+github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
+github.com/hashicorp/go-retryablehttp v0.7.1 h1:sUiuQAnLlbvmExtFQs72iFW/HXeUn8Z1aJLQ4LJJbTQ=
+github.com/hashicorp/go-retryablehttp v0.7.1/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=

--- a/proxymode/logger.go
+++ b/proxymode/logger.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
 package proxymode
 
 import (

--- a/proxymode/logger.go
+++ b/proxymode/logger.go
@@ -1,0 +1,49 @@
+package proxymode
+
+import (
+	"github.com/hashicorp/go-retryablehttp"
+	"go.uber.org/zap"
+)
+
+type zapLoggerAdapter struct {
+	target *zap.Logger
+}
+
+var _ retryablehttp.LeveledLogger = new(zapLoggerAdapter)
+
+func withZapLoggerAdapter(target *zap.Logger) retryablehttp.LeveledLogger {
+	return &zapLoggerAdapter{
+		target: target,
+	}
+}
+
+func (a zapLoggerAdapter) Error(msg string, keysAndValues ...interface{}) {
+	a.target.Error(msg, keysAndValuesAsZapFields(keysAndValues...)...)
+}
+
+func (a zapLoggerAdapter) Info(msg string, keysAndValues ...interface{}) {
+	a.target.Info(msg, keysAndValuesAsZapFields(keysAndValues...)...)
+}
+
+func (a zapLoggerAdapter) Debug(msg string, keysAndValues ...interface{}) {
+	a.target.Debug(msg, keysAndValuesAsZapFields(keysAndValues...)...)
+}
+
+func (a zapLoggerAdapter) Warn(msg string, keysAndValues ...interface{}) {
+	a.target.Warn(msg, keysAndValuesAsZapFields(keysAndValues...)...)
+}
+
+// keysAndValuesAsZapFields function transforms the LeveledLogger arguments to the zap.Logger interface.
+func keysAndValuesAsZapFields(keysAndValues ...interface{}) []zap.Field {
+	fields := make([]zap.Field, len(keysAndValues)/2)
+	var j int
+	for i := 0; i < len(keysAndValues); i += 2 {
+		key, ok := keysAndValues[i].(string)
+		if !ok {
+			continue // something is wrong with the key, string expected
+		}
+		fields[j] = zap.Any(key, keysAndValues[i+1])
+		j++
+	}
+	return fields
+}


### PR DESCRIPTION
Fixes: https://github.com/elastic/package-registry/issues/882

This PR replaces the original HTTP client with [go-retryablehttp](https://github.com/hooqtv/go-retryablehttp) client. It uses a custom retry policy to additionally check the content type header.

Testing:

```
EPR_LOG_LEVEL=debug go run . -feature-proxy-mode -proxy-to https://elastic.co # not EPR endpoint
```

Logs:

```
{"log.level":"debug","@timestamp":"2022-09-21T15:12:59.342+0200","log.origin":{"file.name":"proxymode/proxymode.go","file.line":116},"message":"Proxy /search request","request.uri":"https://elastic.co/search?prerelease=true","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2022-09-21T15:12:59.342+0200","log.origin":{"file.name":"proxymode/logger.go","file.line":29},"message":"performing request","method":"GET","url":"https://elastic.co/search?prerelease=true","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2022-09-21T15:13:00.285+0200","log.origin":{"file.name":"proxymode/logger.go","file.line":29},"message":"retrying request","request":"GET https://elastic.co/search?prerelease=true (status: 200)","timeout":1000000000,"remaining":4,"ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2022-09-21T15:13:01.484+0200","log.origin":{"file.name":"proxymode/logger.go","file.line":29},"message":"retrying request","request":"GET https://elastic.co/search?prerelease=true (status: 200)","timeout":2000000000,"remaining":3,"ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2022-09-21T15:13:03.697+0200","log.origin":{"file.name":"proxymode/logger.go","file.line":29},"message":"retrying request","request":"GET https://elastic.co/search?prerelease=true (status: 200)","timeout":4000000000,"remaining":2,"ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2022-09-21T15:13:07.899+0200","log.origin":{"file.name":"proxymode/logger.go","file.line":29},"message":"retrying request","request":"GET https://elastic.co/search?prerelease=true (status: 200)","timeout":8000000000,"remaining":1,"ecs.version":"1.6.0"}
{"log.level":"error","@timestamp":"2022-09-21T15:13:16.102+0200","log.origin":{"file.name":"package-registry/search.go","file.line":51},"message":"proxy mode: search failed","error":{"message":"can't proxy search request: GET https://elastic.co/search?prerelease=true giving up after 5 attempt(s): unexpected content type: text/html; charset=utf-8","stack_trace":"\ngithub.com/elastic/package-registry/proxymode.(*ProxyMode).Search\n\t/Users/marcin.tojek/go/src/github.com/elastic/package-registry/proxymode/proxymode.go:119\nmain.searchHandlerWithProxyMode.func1\n\t/Users/marcin.tojek/go/src/github.com/elastic/package-registry/search.go:49\nnet/http.HandlerFunc.ServeHTTP\n\t/usr/local/Cellar/go/1.19.1/libexec/src/net/http/server.go:2109\ngo.elastic.co/apm/module/apmhttp.(*handler).ServeHTTP\n\t/Users/marcin.tojek/go/pkg/mod/go.elastic.co/apm/module/apmhttp@v1.15.0/handler.go:74\ngithub.com/felixge/httpsnoop.CaptureMetrics.func1\n\t/Users/marcin.tojek/go/pkg/mod/github.com/felixge/httpsnoop@v1.0.3/capture_metrics.go:29\ngithub.com/felixge/httpsnoop.(*Metrics).CaptureMetrics\n\t/Users/marcin.tojek/go/pkg/mod/github.com/felixge/httpsnoop@v1.0.3/capture_metrics.go:84\ngithub.com/felixge/httpsnoop.CaptureMetricsFn\n\t/Users/marcin.tojek/go/pkg/mod/github.com/felixge/httpsnoop@v1.0.3/capture_metrics.go:39\ngithub.com/felixge/httpsnoop.CaptureMetrics\n\t/Users/marcin.tojek/go/pkg/mod/github.com/felixge/httpsnoop@v1.0.3/capture_metrics.go:28\ngithub.com/elastic/package-registry/util.captureZapFieldsForRequest\n\t/Users/marcin.tojek/go/src/github.com/elastic/package-registry/util/logging.go:120\ngithub.com/elastic/package-registry/util.logRequest\n\t/Users/marcin.tojek/go/src/github.com/elastic/package-registry/util/logging.go:114\ngithub.com/elastic/package-registry/util.LoggingMiddleware.func1.1\n\t/Users/marcin.tojek/go/src/github.com/elastic/package-registry/util/logging.go:105\nnet/http.HandlerFunc.ServeHTTP\n\t/usr/local/Cellar/go/1.19.1/libexec/src/net/http/server.go:2109\ngithub.com/gorilla/mux.(*Router).ServeHTTP\n\t/Users/marcin.tojek/go/pkg/mod/github.com/gorilla/mux@v1.8.0/mux.go:210\nnet/http.serverHandler.ServeHTTP\n\t/usr/local/Cellar/go/1.19.1/libexec/src/net/http/server.go:2947\nnet/http.(*conn).serve\n\t/usr/local/Cellar/go/1.19.1/libexec/src/net/http/server.go:1991\nruntime.goexit\n\t/usr/local/Cellar/go/1.19.1/libexec/src/runtime/asm_amd64.s:1594"},"ecs.version":"1.6.0"}
```