### PR TITLE
Remove prerelease packages when experimental=true is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking changes
 
+* Search results for requests including `experimental=true` don't return
+  prerelease versions of packages that have been released at least once as GA. [#893](https://github.com/elastic/package-registry/pull/893)
+
 ### Bugfixes
 
 ### Added

--- a/packages/packages_test.go
+++ b/packages/packages_test.go
@@ -192,19 +192,26 @@ func TestPackagesFilter(t *testing.T) {
 				AllVersions:  true,
 				Experimental: true,
 			},
-			Expected: filterTestPackages,
+			Expected: removeFilterTestPackages(filterTestPackages,
+				filterTestPackage{Name: "apache", Version: "1.0.0-rc1"},
+				filterTestPackage{Name: "apache", Version: "2.0.0-rc2"},
+			),
 		},
 		{
+			// Prerelease versions must be skipped if there are GA versions.
+			// See: https://github.com/elastic/ingest-dev/issues/1285
 			Title: "apache package experimental search - legacy kibana",
 			Filter: Filter{
 				PackageName:  "apache",
 				Experimental: true,
 			},
 			Expected: []filterTestPackage{
-				{Name: "apache", Version: "2.0.0-rc2"},
+				{Name: "apache", Version: "1.0.0"},
 			},
 		},
 		{
+			// Prerelease versions must be skipped if there are GA versions.
+			// See: https://github.com/elastic/ingest-dev/issues/1285
 			Title: "apache package experimental search all versions - legacy kibana",
 			Filter: Filter{
 				PackageName:  "apache",
@@ -212,9 +219,7 @@ func TestPackagesFilter(t *testing.T) {
 				AllVersions:  true,
 			},
 			Expected: []filterTestPackage{
-				{Name: "apache", Version: "1.0.0-rc1"},
 				{Name: "apache", Version: "1.0.0"},
-				{Name: "apache", Version: "2.0.0-rc2"},
 			},
 		},
 		{

--- a/packages/packages_test.go
+++ b/packages/packages_test.go
@@ -199,7 +199,7 @@ func TestPackagesFilter(t *testing.T) {
 		},
 		{
 			// Prerelease versions must be skipped if there are GA versions.
-			// See: https://github.com/elastic/ingest-dev/issues/1285
+			// See: https://github.com/elastic/package-registry/pull/893
 			Title: "apache package experimental search - legacy kibana",
 			Filter: Filter{
 				PackageName:  "apache",
@@ -211,7 +211,7 @@ func TestPackagesFilter(t *testing.T) {
 		},
 		{
 			// Prerelease versions must be skipped if there are GA versions.
-			// See: https://github.com/elastic/ingest-dev/issues/1285
+			// See: https://github.com/elastic/package-registry/pull/893
 			Title: "apache package experimental search all versions - legacy kibana",
 			Filter: Filter{
 				PackageName:  "apache",

--- a/packages/packages_test.go
+++ b/packages/packages_test.go
@@ -71,6 +71,19 @@ func TestPackagesFilter(t *testing.T) {
 			Type:          "integration",
 			KibanaVersion: "^8.0.0",
 		},
+		{
+			Name:          "redisenterprise",
+			Version:       "0.1.1",
+			Release:       "beta",
+			Type:          "integration",
+			KibanaVersion: "^7.14.0 || ^8.0.0",
+		},
+		{
+			Name:          "redisenterprise",
+			Version:       "1.0.0",
+			Type:          "integration",
+			KibanaVersion: "^8.0.0",
+		},
 	}
 	packages := buildFilterTestPackages(filterTestPackages)
 
@@ -149,6 +162,7 @@ func TestPackagesFilter(t *testing.T) {
 			Expected: []filterTestPackage{
 				{Name: "apache", Version: "1.0.0"},
 				{Name: "nginx", Version: "2.0.0"},
+				{Name: "redisenterprise", Version: "1.0.0"},
 				// FIXME: This package should be returned.
 				// {Name: "logstash", Version: "1.1.0"},
 			},
@@ -184,6 +198,30 @@ func TestPackagesFilter(t *testing.T) {
 				{Name: "apache", Version: "2.0.0-rc2"},
 			},
 		},
+		{
+			Title: "redisenterprise experimental search - future kibana",
+			Filter: Filter{
+				PackageName:   "redisenterprise",
+				Prerelease:    true,
+				KibanaVersion: semver.MustParse("8.7.0"),
+			},
+			Expected: []filterTestPackage{
+				{Name: "redisenterprise", Version: "1.0.0"},
+			},
+		},
+		{
+			Title: "redisenterprise experimental search all versions - future kibana",
+			Filter: Filter{
+				PackageName:   "redisenterprise",
+				Prerelease:    true,
+				KibanaVersion: semver.MustParse("8.7.0"),
+				AllVersions:   true,
+			},
+			Expected: []filterTestPackage{
+				{Name: "redisenterprise", Version: "0.1.1"},
+				{Name: "redisenterprise", Version: "1.0.0"},
+			},
+		},
 
 		// Legacy Kibana, experimental is always true.
 		{
@@ -193,8 +231,11 @@ func TestPackagesFilter(t *testing.T) {
 				Experimental: true,
 			},
 			Expected: removeFilterTestPackages(filterTestPackages,
+				// Prerelease versions must be skipped if there are GA versions.
+				// See: https://github.com/elastic/package-registry/pull/893
 				filterTestPackage{Name: "apache", Version: "1.0.0-rc1"},
 				filterTestPackage{Name: "apache", Version: "2.0.0-rc2"},
+				filterTestPackage{Name: "redisenterprise", Version: "0.1.1"},
 			),
 		},
 		{
@@ -220,6 +261,34 @@ func TestPackagesFilter(t *testing.T) {
 			},
 			Expected: []filterTestPackage{
 				{Name: "apache", Version: "1.0.0"},
+			},
+		},
+		{
+			Title: "redisenterprise experimental search all versions - legacy kibana 7.14.0",
+			Filter: Filter{
+				PackageName:   "redisenterprise",
+				Experimental:  true,
+				KibanaVersion: semver.MustParse("7.14.0"),
+				AllVersions:   true,
+			},
+			Expected: []filterTestPackage{
+				// Only version available for 7.14 is 0.1.1, that is a prerelease.
+				{Name: "redisenterprise", Version: "0.1.1"},
+			},
+		},
+		{
+			Title: "redisenterprise experimental search all versions - legacy kibana 8.5.0",
+			Filter: Filter{
+				PackageName:   "redisenterprise",
+				Experimental:  true,
+				KibanaVersion: semver.MustParse("8.5.0"),
+				AllVersions:   true,
+			},
+			Expected: []filterTestPackage{
+				// There are two versions available for 8.5, but we return only
+				// the GA one to avoid exposing prereleases to legacy kibanas.
+				// See: https://github.com/elastic/package-registry/pull/893
+				{Name: "redisenterprise", Version: "1.0.0"},
 			},
 		},
 		{

--- a/testdata/generated/categories-experimental.json
+++ b/testdata/generated/categories-experimental.json
@@ -12,7 +12,7 @@
   {
     "id": "cloud",
     "title": "Cloud",
-    "count": 2
+    "count": 1
   },
   {
     "id": "containers",

--- a/testdata/generated/search-category-datastore.json
+++ b/testdata/generated/search-category-datastore.json
@@ -40,15 +40,15 @@
   {
     "name": "example",
     "title": "Example Integration",
-    "version": "1.2.0-rc1",
+    "version": "1.1.0",
     "release": "ga",
     "source": {
       "license": "Elastic-2.0"
     },
     "description": "This is the example integration",
     "type": "integration",
-    "download": "/epr/example/example-1.2.0-rc1.zip",
-    "path": "/package/example/1.2.0-rc1",
+    "download": "/epr/example/example-1.1.0.zip",
+    "path": "/package/example/1.1.0",
     "policy_templates": [
       {
         "name": "logs",
@@ -62,9 +62,6 @@
     "conditions": {
       "kibana": {
         "version": "^7.16.0 || ^8.0.0"
-      },
-      "elastic": {
-        "subscription": "gold"
       }
     },
     "owner": {
@@ -72,8 +69,7 @@
     },
     "categories": [
       "crm",
-      "azure",
-      "cloud"
+      "azure"
     ]
   },
   {

--- a/testdata/generated/search-package-experimental.json
+++ b/testdata/generated/search-package-experimental.json
@@ -174,15 +174,15 @@
   {
     "name": "example",
     "title": "Example Integration",
-    "version": "1.2.0-rc1",
+    "version": "1.1.0",
     "release": "ga",
     "source": {
       "license": "Elastic-2.0"
     },
     "description": "This is the example integration",
     "type": "integration",
-    "download": "/epr/example/example-1.2.0-rc1.zip",
-    "path": "/package/example/1.2.0-rc1",
+    "download": "/epr/example/example-1.1.0.zip",
+    "path": "/package/example/1.1.0",
     "policy_templates": [
       {
         "name": "logs",
@@ -196,9 +196,6 @@
     "conditions": {
       "kibana": {
         "version": "^7.16.0 || ^8.0.0"
-      },
-      "elastic": {
-        "subscription": "gold"
       }
     },
     "owner": {
@@ -206,8 +203,7 @@
     },
     "categories": [
       "crm",
-      "azure",
-      "cloud"
+      "azure"
     ]
   },
   {


### PR DESCRIPTION
Remove prerelease packages from search responses when `experimental=true` is used, for packages that have non-prerelease versions available.

That is for example:
* If only `1.0.0-beta1` and `1.0.0-beta2` versions exist for a package, both are returned.
* If `1.0.0-beta1`, `1.0.0-beta2` and `1.0.0` versions exist for a package, only `1.0.0` version is returned.

This way packages published as prerelease according to semver won't be available for versions of kibana that don't implement https://github.com/elastic/kibana/issues/122973.
This is done to avoid unexpectedly publishing prerelease packages to versions of Kibana that use `experimental=true` when the single registry v2 is used.

A side effect of this change is that prereleases of new packages for older versions of Kibana will "disappear" once a GA version is published.

This implements the suggestion from https://github.com/elastic/ingest-dev/issues/1285#issuecomment-1259271623.

There is some code duplication, I am intentionally keeping it to clearly separate the code path for old and new versions of Kibana.