### PR TITLE
Update default proxy URL

### DIFF
--- a/main.go
+++ b/main.go
@@ -88,7 +88,7 @@ func init() {
 
 	// The following proxy-indexer related flags are technical preview and might be removed in the future or renamed
 	flag.BoolVar(&featureProxyMode, "feature-proxy-mode", false, "Enable proxy mode to include packages from other endpoint (technical preview).")
-	flag.StringVar(&proxyTo, "proxy-to", "https://epr-snapshot.elastic.co/", "Proxy-to endpoint")
+	flag.StringVar(&proxyTo, "proxy-to", "https://epr.elastic.co/", "Proxy-to endpoint")
 }
 
 type Config struct {


### PR DESCRIPTION
This PR updates the default value for the parameter `proxy-to` to use the Elastic Package Registry production DNS as a proxy.

