### PR TITLE
Update dependabot reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,5 +8,5 @@ updates:
     labels:
       - automation
     reviewers:
-      - "elastic/integrations-developer-experience"
+      - "elastic/ecosystem"
     open-pull-requests-limit: 10


### PR DESCRIPTION
This PR updates the dependabot configuration to assign as reviewer elastic/ecosystem team.

Latest PRs created by dependabot have no reviewer (e.g. https://github.com/elastic/package-registry/pull/902)