### PR TITLE
Trigger remote Elastic Package Registry job

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -178,7 +178,7 @@ def triggerRemoteUpdateEPR() {
       token: TOKEN,
       parameters: [
         dry_run: true,
-        draft_pr: true,
+        draft: true,
         version: "99.99.99"
       ],
       useCrumbCache: true,

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -120,7 +120,6 @@ pipeline {
         pushDockerImage()
       }
     }
-
     stage('Trigger bump Elastic Package Registry') {
       environment {
         EPR_VERSION = "v99.99.99"
@@ -170,7 +169,7 @@ def pushDockerImage(){
 }
 
 def triggerRemoteUpdateEPR() {
-  echo("Triggering update-package-registry-job-remote")
+  echo("Triggering update-package-registry-job-remote with version ${env.EPR_VERSION}")
   withCredentials([string(credentialsId: env.UPDATE_PACKAGE_REGISTRY_CREDENTIALS, variable: 'TOKEN')]) {
     triggerRemoteJob(auth: CredentialsAuth(credentials: 'local-readonly-api-token'),
       job: 'https://internal-ci.elastic.co/job/package_storage/job/update-package-registry-job-remote',

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -121,8 +121,11 @@ pipeline {
       }
     }
     stage('Trigger bump Elastic Package Registry') {
+      when {
+        buildingTag()
+      }
       environment {
-        EPR_VERSION = "v99.99.99"
+        EPR_VERSION = env.TAG_NAME
       }
       steps {
         cleanup()

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -12,6 +12,9 @@ pipeline {
     DOCKER_REGISTRY_SECRET = 'secret/observability-team/ci/docker-registry/prod'
     DOCKER_IMG = "${env.DOCKER_REGISTRY}/package-registry/package-registry"
     DOCKER_IMG_PR = "${env.DOCKER_REGISTRY}/observability-ci/package-registry"
+
+    // Update EPR
+    UPDATE_PACKAGE_REGISTRY_CREDENTIALS = 'update-package-registry-version'
   }
   options {
     timeout(time: 1, unit: 'HOURS')
@@ -117,6 +120,17 @@ pipeline {
         pushDockerImage()
       }
     }
+
+    stage('Trigger bump Elastic Package Registry') {
+      environment {
+        DOCKER_IMG_TAG = "${env.DOCKER_IMG}:${env.GIT_BASE_COMMIT}"
+        DOCKER_IMG_TAG_BRANCH = "${env.DOCKER_IMG}:${env.BRANCH_NAME}"
+      }
+      steps {
+        cleanup()
+        triggerRemoteUpdateEPR()
+      }
+    }
   }
   post {
     cleanup {
@@ -153,5 +167,21 @@ def pushDockerImage(){
       sh(label: 'Push Docker image name',
         script: "docker push ${env.DOCKER_IMG_TAG_BRANCH}")
     }
+  }
+}
+
+def triggerRemoteUpdateEPR() {
+  echo("Triggering update-package-registry-job-remote")
+  withCredentials([string(credentialsId: env.UPDATE_PACKAGE_REGISTRY_CREDENTIALS, variable: 'TOKEN')]) {
+    triggerRemoteJob(auth: CredentialsAuth(credentials: 'local-readonly-api-token'),
+      job: 'https://internal-ci.elastic.co/job/package_storage/job/update-package-registry-job-remote',
+      token: TOKEN,
+      parameters: [
+        dry_run: true,
+        draft_pr: true,
+        version: "99.99.99"
+      ],
+      useCrumbCache: true,
+      useJobInfoCache: true)
   }
 }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -125,7 +125,7 @@ pipeline {
         buildingTag()
       }
       environment {
-        EPR_VERSION = env.TAG_NAME
+        EPR_VERSION = "${env.TAG_NAME}"
       }
       steps {
         cleanup()

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -178,8 +178,8 @@ def triggerRemoteUpdateEPR() {
       job: 'https://internal-ci.elastic.co/job/package_storage/job/update-package-registry-job-remote',
       token: TOKEN,
       parameters: [
-        dry_run: true,
-        draft: true,
+        dry_run: false,
+        draft: false,
         version: env.EPR_VERSION
       ],
       useCrumbCache: true,

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -123,8 +123,7 @@ pipeline {
 
     stage('Trigger bump Elastic Package Registry') {
       environment {
-        DOCKER_IMG_TAG = "${env.DOCKER_IMG}:${env.GIT_BASE_COMMIT}"
-        DOCKER_IMG_TAG_BRANCH = "${env.DOCKER_IMG}:${env.BRANCH_NAME}"
+        EPR_VERSION = "v99.99.99"
       }
       steps {
         cleanup()
@@ -179,7 +178,7 @@ def triggerRemoteUpdateEPR() {
       parameters: [
         dry_run: true,
         draft: true,
-        version: "99.99.99"
+        version: env.EPR_VERSION
       ],
       useCrumbCache: true,
       useJobInfoCache: true)


### PR DESCRIPTION
This PR adds a new stage in the CI job to trigger a Jenkins job that will bump Elastic Package Registry where it is needed.