### PR TITLE
Add subcategories definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* New categories. []()
 * Update default value for `proxy-url` parameter to be Elastic Package Registry production. [#899](https://github.com/elastic/package-registry/pull/899)
 
 ### Deprecated

--- a/categories/categories.go
+++ b/categories/categories.go
@@ -1,0 +1,72 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package categories
+
+import (
+	_ "embed"
+	"fmt"
+	"io"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Category is a common structure for all kinds of categories.
+type Category struct {
+	Title string `yaml:"title"`
+}
+
+// MainCategory is a main category, that can have subcategories.
+type MainCategory struct {
+	Category `yaml:",inline"`
+
+	SubCategories map[string]SubCategory `yaml:"subcategories"`
+}
+
+// SubCategory is a sub-category, should be contained in a Category.
+type SubCategory struct {
+	Category `yaml:",inline"`
+}
+
+// Categories is a list of categories.
+type Categories map[string]MainCategory
+
+func (categories Categories) TitlesMap() map[string]string {
+	if len(categories) == 0 {
+		return nil
+	}
+	titles := make(map[string]string)
+	for name, category := range categories {
+		titles[name] = category.Title
+
+		for name, category := range category.SubCategories {
+			titles[name] = category.Title
+		}
+	}
+	return titles
+}
+
+// ReadCategories reads the categories from a reader.
+func ReadCategories(r io.Reader) (Categories, error) {
+	var categoriesFile struct {
+		Categories Categories `yaml:"categories"`
+	}
+	dec := yaml.NewDecoder(r)
+	err := dec.Decode(&categoriesFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode categories: %w", err)
+	}
+	// TODO: Check for duplicated categories.
+	return categoriesFile.Categories, nil
+}
+
+// MustReadCategories reads the categories from a reader and panics if there is any error.
+func MustReadCategories(r io.Reader) Categories {
+	categories, err := ReadCategories(r)
+	if err != nil {
+		panic(err)
+	}
+
+	return categories
+}

--- a/categories/categories.yml
+++ b/categories/categories.yml
@@ -1,0 +1,143 @@
+categories:
+  aws:
+    title: "AWS"
+  azure:
+    title: "Azure"
+  cloud:
+    title: "Cloud"
+  config_management:
+    title: "Config management"
+  containers:
+    title: "Containers"
+  crm:
+    title: "CRM"
+  custom:
+    title: "Custom"
+  datastore:
+    title: "Datastore"
+  elastic_stack:
+    title: "Elastic Stack"
+  enterprise_serch:
+    title: "Enterprise Search"
+    subcategories:
+      app_search:
+        title: "Application Search"
+      connector: # TODO: Do we want three different connector categories?
+        title: "Connector"
+      connector_client:
+        title: "Connector Client"
+      connector_package:
+        title: "Connector Package"
+      crawler:
+        title: "Crawler"
+      language_client:
+        title: "Language Client"
+      native_search:
+        title: "Native Search"
+      workplace_search:
+        title: "Workplace Search"
+      content_source:
+        title: "Content Source"
+      sdk_search:
+        title: "SDK"
+  google_cloud:
+    title: "Google Cloud"
+  infrastructure:
+    title: "Infrastructure"
+    subcategories:
+      analytics_engine:
+        title: "Analytics Engine"
+      big_data: # TODO: Unify "big_data" and "analytics_engine"?
+        title: "Big Data"
+      kubernetes: # TODO: Duplicate of "kubernetes"?
+        title: "Kubernetes"
+      load_balancer:
+        title: "Load Balancer"
+      message_broker: # TODO: Duplicate of "message_queue"?
+        title: "Message Broker"
+      monitoring: # TODO: Duplicate of "monitoring".
+        title: "Monitoring"
+      notification: # TODO: Duplicate of "notification".
+        title: "Notification"
+      process_manager:
+        title: "Process Manager"
+      stream_processing:
+        title: "Stream Processing"
+      virtualization:
+        title: "Virtualization Platform"
+      webserver: # TODO: Duplicate of "web"?
+        title: "Web Server"
+      websphere: # TODO: Too specific.
+        title: "WebSphere Application Server"
+  kubernetes:
+    title: "Kubernetes"
+  languages:
+    title: "Languages"
+  message_queue:
+    title: "Message Queue"
+  monitoring:
+    title: "Monitoring"
+  network:
+    title: "Network"
+  notification:
+    title: "Notification"
+  observability:
+    title: "Observability"
+    subcategories:
+      application_observability:
+        title: "Application"
+      java_observability:
+        title: "Java"
+      monitoring: # TODO: Duplicate of "monitoring" and "infrastructure/monitoring"?
+        title: "Monitoring"
+  os_system:
+    title: "OS & System"
+  productivity:
+    title: "Productivity"
+  security:
+    title: "Security"
+    subcategories:
+      auditd:
+        title: "AuditD"
+      authentication:
+        title: "Authentication"
+      cdn_security:
+        title: "Content Delivery Network"
+      database_security:
+        title: "Database"
+      dns_security:
+        title: "DNS"
+      edr_xdr:
+        title: "EDR/XDR"
+      email_security:
+        title: "e-mail"
+      credential_management:
+        title: "Credential Management"
+      firewall:
+        title: "Firewall"
+      iam:
+        title: "Identity and Access Management"
+      ids_ips:
+        title: "IDS/IPS"
+      network_security:
+        title: "Network"
+      productivity_security:
+        title: "Productivity"
+      proxy_security:
+        title: "Proxy"
+      threat_intel: # TODO: Duplicate of threat_intel"
+        title: "Threat Intelligence"
+      vpn_security:
+        title: "VPN"
+      web_application_firewall:
+        title: "Web Application Firewall"
+  support:
+    title: "Support"
+  ticketing:
+    title: "Ticketing"
+  threat_intel:
+    title: "Threat Intelligence"
+  version_control:
+    title: "Version Control"
+  web:
+    title: "Web"

--- a/categories/categories_test.go
+++ b/categories/categories_test.go
@@ -1,0 +1,30 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package categories
+
+import (
+	"bytes"
+	_ "embed"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+//go:embed testdata/sample.yml
+var sampleCategoriesYaml []byte
+
+func TestLoadCategories(t *testing.T) {
+	categories, err := ReadCategories(bytes.NewReader(sampleCategoriesYaml))
+	require.NoError(t, err)
+
+	if assert.Len(t, categories, 3) {
+		assert.Len(t, categories["security"].SubCategories, 2)
+	}
+
+	titles := categories.TitlesMap()
+	assert.Equal(t, "Security", titles["security"])
+	assert.Equal(t, "Web Server", titles["webserver"])
+}

--- a/categories/default.go
+++ b/categories/default.go
@@ -1,0 +1,33 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package categories
+
+import (
+	"bytes"
+	_ "embed"
+)
+
+//go:embed categories.yml
+var defaultCategoriesYml []byte
+
+var defaultCategories Categories
+
+var defaultCategoriesTitlesMap map[string]string
+
+func init() {
+	r := bytes.NewReader(defaultCategoriesYml)
+	defaultCategories = MustReadCategories(r)
+	defaultCategoriesTitlesMap = defaultCategories.TitlesMap()
+}
+
+// DefaultCategories returns the default categories.
+func DefaultCategories() Categories {
+	return defaultCategories
+}
+
+// TitlesMap is a convenience method that returns the titles of the default categories.
+func TitlesMap() map[string]string {
+	return defaultCategoriesTitlesMap
+}

--- a/categories/testdata/sample.yml
+++ b/categories/testdata/sample.yml
@@ -1,0 +1,17 @@
+categories:
+  datastore:
+    title: "Datastore"
+  infrastructure:
+    title: "Infrastructure"
+    subcategories:
+      load_balancer:
+        title: "Load Balancer"
+      webserver:
+        title: "Web Server"
+  security:
+    title: "Security"
+    subcategories:
+      edr_xdr:
+        title: "EDR/XDR"
+      network_security:
+        title: "Network"

--- a/packages/package.go
+++ b/packages/package.go
@@ -17,6 +17,7 @@ import (
 	"github.com/elastic/go-ucfg"
 	"github.com/elastic/go-ucfg/yaml"
 
+	"github.com/elastic/package-registry/categories"
 	"github.com/elastic/package-registry/util"
 )
 
@@ -26,33 +27,7 @@ const (
 	packagePathPrefix = "/package"
 )
 
-var CategoryTitles = map[string]string{
-	"aws":               "AWS",
-	"azure":             "Azure",
-	"cloud":             "Cloud",
-	"config_management": "Config management",
-	"containers":        "Containers",
-	"crm":               "CRM",
-	"custom":            "Custom",
-	"datastore":         "Datastore",
-	"elastic_stack":     "Elastic Stack",
-	"google_cloud":      "Google Cloud",
-	"infrastructure":    "Infrastructure",
-	"kubernetes":        "Kubernetes",
-	"languages":         "Languages",
-	"message_queue":     "Message Queue",
-	"monitoring":        "Monitoring",
-	"network":           "Network",
-	"notification":      "Notification",
-	"os_system":         "OS & System",
-	"productivity":      "Productivity",
-	"security":          "Security",
-	"support":           "Support",
-	"ticketing":         "Ticketing",
-	"threat_intel":      "Threat Intelligence",
-	"version_control":   "Version Control",
-	"web":               "Web",
-}
+var CategoryTitles = categories.TitlesMap()
 
 type Package struct {
 	BasePackage   `config:",inline" json:",inline" yaml:",inline"`


### PR DESCRIPTION
First stab to subcategories support.

By now it only models the categories with the subcategories, loading them from a yaml file. We can consider moving this yaml file to the spec so it can be also consumed from other places.

This PR doesn't include the changes in the API, this will come in a follow-up.