### PR TITLE
Fix handling of 404 responses in proxy mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bugfixes
 
 * Update Go runtime to 1.19.4. [#924](https://github.com/elastic/package-registry/pull/924)
+* Fix internal server error when proxy mode is used and a package that doesn't exist is requested. [#925](https://github.com/elastic/package-registry/pull/925)
 
 ### Added
 

--- a/artifacts.go
+++ b/artifacts.go
@@ -65,7 +65,9 @@ func artifactsHandlerWithProxyMode(indexer Indexer, proxyMode *proxymode.ProxyMo
 				http.Error(w, "internal server error", http.StatusInternalServerError)
 				return
 			}
-			pkgs = pkgs.Join(packages.Packages{proxiedPackage})
+			if proxiedPackage != nil {
+				pkgs = pkgs.Join(packages.Packages{proxiedPackage})
+			}
 		}
 		if len(pkgs) == 0 {
 			notFoundError(w, errArtifactNotFound)

--- a/package_index.go
+++ b/package_index.go
@@ -65,7 +65,9 @@ func packageIndexHandlerWithProxyMode(indexer Indexer, proxyMode *proxymode.Prox
 				http.Error(w, "internal server error", http.StatusInternalServerError)
 				return
 			}
-			pkgs = pkgs.Join(packages.Packages{proxiedPackage})
+			if proxiedPackage != nil {
+				pkgs = pkgs.Join(packages.Packages{proxiedPackage})
+			}
 		}
 		if len(pkgs) == 0 {
 			notFoundError(w, errPackageRevisionNotFound)

--- a/signatures.go
+++ b/signatures.go
@@ -65,7 +65,9 @@ func signaturesHandlerWithProxyMode(indexer Indexer, proxyMode *proxymode.ProxyM
 				http.Error(w, "internal server error", http.StatusInternalServerError)
 				return
 			}
-			pkgs = pkgs.Join(packages.Packages{proxiedPackage})
+			if proxiedPackage != nil {
+				pkgs = pkgs.Join(packages.Packages{proxiedPackage})
+			}
 		}
 		if len(pkgs) == 0 {
 			notFoundError(w, errSignatureFileNotFound)

--- a/static.go
+++ b/static.go
@@ -56,7 +56,9 @@ func staticHandlerWithProxyMode(indexer Indexer, proxyMode *proxymode.ProxyMode,
 				http.Error(w, "internal server error", http.StatusInternalServerError)
 				return
 			}
-			pkgs = pkgs.Join(packages.Packages{proxiedPackage})
+			if proxiedPackage != nil {
+				pkgs = pkgs.Join(packages.Packages{proxiedPackage})
+			}
 		}
 		if len(pkgs) == 0 {
 			notFoundError(w, errPackageRevisionNotFound)


### PR DESCRIPTION
When proxy mode is used, 404 errors received from the proxified server were retried forever, and reported as internal server errors after timeout. Handle them assuming that the package does not exist.