### PR TITLE
Don't forward headers when making requests to package storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bugfixes
 
 * Fix internal server error when proxy mode is used and a package that doesn't exist is requested. [#925](https://github.com/elastic/package-registry/pull/925)
+* Don't forward headers when requesting files from the package storage, just download them. [#935](https://github.com/elastic/package-registry/issues/935)
 
 ### Added
 

--- a/storage/resolver.go
+++ b/storage/resolver.go
@@ -29,7 +29,6 @@ func (resolver storageResolver) pipeRequestProxy(w http.ResponseWriter, r *http.
 	client := &http.Client{}
 
 	forwardRequest, err := http.NewRequestWithContext(r.Context(), r.Method, remoteURL, nil)
-	addRequestHeadersToRequest(r, forwardRequest)
 
 	resp, err := client.Do(forwardRequest)
 	if err != nil {
@@ -50,14 +49,6 @@ func (resolver storageResolver) pipeRequestProxy(w http.ResponseWriter, r *http.
 	}
 
 	return
-}
-
-func addRequestHeadersToRequest(orig, forward *http.Request) {
-	for header, values := range orig.Header {
-		for _, value := range values {
-			forward.Header.Add(header, value)
-		}
-	}
 }
 
 func addRequestHeadersToResponse(w http.ResponseWriter, resp *http.Response) {


### PR DESCRIPTION
Ensure that whenever we request the content to the package storage, we request the whole file, independently of conditional or range headers.