### PR TITLE
Add APM trace context to logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * Add some APM instrumentation to storage indexer. [#939](https://github.com/elastic/package-registry/pull/939)
-* Errors are logged through APM. [#941](https://github.com/elastic/package-registry/pull/941)
+* Errors are logged through APM. [#941](https://github.com/elastic/package-registry/pull/941) [#942](https://github.com/elastic/package-registry/pull/941)
 
 ### Deprecated
 

--- a/artifacts.go
+++ b/artifacts.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
+	"go.elastic.co/apm/module/apmzap/v2"
 	"go.uber.org/zap"
 
 	"github.com/elastic/package-registry/packages"
@@ -27,6 +28,8 @@ func artifactsHandler(logger *zap.Logger, indexer Indexer, cacheTime time.Durati
 
 func artifactsHandlerWithProxyMode(logger *zap.Logger, indexer Indexer, proxyMode *proxymode.ProxyMode, cacheTime time.Duration) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
+		logger := logger.With(apmzap.TraceContext(r.Context())...)
+
 		vars := mux.Vars(r)
 		packageName, ok := vars["packageName"]
 		if !ok {

--- a/categories.go
+++ b/categories.go
@@ -16,6 +16,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/Masterminds/semver/v3"
+	"go.elastic.co/apm/module/apmzap/v2"
 	"go.elastic.co/apm/v2"
 
 	"github.com/elastic/package-registry/internal/util"
@@ -31,6 +32,8 @@ func categoriesHandler(logger *zap.Logger, indexer Indexer, cacheTime time.Durat
 // categoriesHandler is a dynamic handler as it will also allow filtering in the future.
 func categoriesHandlerWithProxyMode(logger *zap.Logger, indexer Indexer, proxyMode *proxymode.ProxyMode, cacheTime time.Duration) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
+		logger := logger.With(apmzap.TraceContext(r.Context())...)
+
 		query := r.URL.Query()
 
 		filter, err := newCategoriesFilterFromQuery(query)

--- a/package_index.go
+++ b/package_index.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"go.elastic.co/apm/module/apmzap/v2"
 	"go.uber.org/zap"
 
 	"github.com/Masterminds/semver/v3"
@@ -31,6 +32,8 @@ func packageIndexHandler(logger *zap.Logger, indexer Indexer, cacheTime time.Dur
 
 func packageIndexHandlerWithProxyMode(logger *zap.Logger, indexer Indexer, proxyMode *proxymode.ProxyMode, cacheTime time.Duration) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
+		logger := logger.With(apmzap.TraceContext(r.Context())...)
+
 		vars := mux.Vars(r)
 		packageName, ok := vars["packageName"]
 		if !ok {

--- a/search.go
+++ b/search.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/pkg/errors"
+	"go.elastic.co/apm/module/apmzap/v2"
 	"go.elastic.co/apm/v2"
 	"go.uber.org/zap"
 
@@ -29,6 +30,8 @@ func searchHandler(logger *zap.Logger, indexer Indexer, cacheTime time.Duration)
 
 func searchHandlerWithProxyMode(logger *zap.Logger, indexer Indexer, proxyMode *proxymode.ProxyMode, cacheTime time.Duration) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
+		logger := logger.With(apmzap.TraceContext(r.Context())...)
+
 		filter, err := newSearchFilterFromQuery(r.URL.Query())
 		if err != nil {
 			badRequest(w, err.Error())

--- a/signatures.go
+++ b/signatures.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
+	"go.elastic.co/apm/module/apmzap/v2"
 	"go.uber.org/zap"
 
 	"github.com/elastic/package-registry/packages"
@@ -27,6 +28,8 @@ func signaturesHandler(logger *zap.Logger, indexer Indexer, cacheTime time.Durat
 
 func signaturesHandlerWithProxyMode(logger *zap.Logger, indexer Indexer, proxyMode *proxymode.ProxyMode, cacheTime time.Duration) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
+		logger := logger.With(apmzap.TraceContext(r.Context())...)
+
 		vars := mux.Vars(r)
 		packageName, ok := vars["packageName"]
 		if !ok {

--- a/static.go
+++ b/static.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/gorilla/mux"
+	"go.elastic.co/apm/module/apmzap/v2"
 	"go.uber.org/zap"
 
 	"github.com/elastic/package-registry/packages"
@@ -31,6 +32,8 @@ func staticHandler(logger *zap.Logger, indexer Indexer, cacheTime time.Duration)
 
 func staticHandlerWithProxyMode(logger *zap.Logger, indexer Indexer, proxyMode *proxymode.ProxyMode, cacheTime time.Duration) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		logger := logger.With(apmzap.TraceContext(r.Context())...)
+
 		params, err := staticParamsFromRequest(r)
 		if err != nil {
 			badRequest(w, err.Error())


### PR DESCRIPTION
This allows to correlate APM traces to logs in the UIs, so it is easier to find during what request an error happened.

This allows the UI to show these links from spans to the related errors:
![Captura desde 2022-12-15 18-22-57](https://user-images.githubusercontent.com/15763/207926960-7e896b31-dbda-42e2-a9b4-4f24d7f15fee.png)

And from errors, to the requests where they happened:
![Captura desde 2022-12-15 18-23-22](https://user-images.githubusercontent.com/15763/207927173-95066908-2083-4ac8-96a4-eec61a7867c7.png)

