### PR TITLE
Add support for Windows

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -71,20 +71,42 @@ pipeline {
      Execute unit tests.
      */
     stage('Test') {
-      steps {
-        cleanup()
-        withMageEnv(){
-          dir("${BASE_DIR}"){
-            sh(label: 'Runs the (unit) tests',script: 'mage -debug test|tee tests-report.txt')
+      parallel {
+        stage('Test on Linux') {
+          options { skipDefaultCheckout() }
+          steps {
+            cleanup()
+            withMageEnv(){
+              dir("${BASE_DIR}"){
+                sh(label: 'Runs the (unit) tests',script: 'mage -debug test|tee tests-report.txt')
+              }
+            }
           }
-        }
+          post {
+            always {
+              convertGoTestResults(
+                input: "${BASE_DIR}/tests-report.txt",
+                output: "${BASE_DIR}/junit-report.xml"
+              )
+            }
       }
-      post {
-        always {
-          convertGoTestResults(
-            input: "${BASE_DIR}/tests-report.txt",
-            output: "${BASE_DIR}/junit-report.xml"
-          )
+        }
+        stage('Test on Windows') {
+          agent { label 'windows-2022' }
+          options { skipDefaultCheckout() }
+          steps {
+            cleanup()
+            dir("${BASE_DIR}"){
+              withGoEnv() {
+                goTestJUnit(options: '-v ./...', output: 'junit-report.xml')
+              }
+            }
+          }
+          post {
+            always {
+              junit(allowEmptyResults: true, keepLongStdio: true, testResults: "${BASE_DIR}/junit-report.xml")
+            }
+          }
         }
       }
     }

--- a/main_test.go
+++ b/main_test.go
@@ -574,6 +574,9 @@ func listArchivedFiles(t *testing.T, body []byte) []byte {
 	var listing bytes.Buffer
 
 	for _, f := range zipReader.File {
+		// f.Name is populated from the zip file directly and is not validated for correctness.
+		// Using filepath.ToSlash(f.Name) ensures that the file name has the expected format
+		// regardless of the OS.
 		listing.WriteString(fmt.Sprintf("%d %s\n", f.UncompressedSize64, filepath.ToSlash(f.Name)))
 
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -382,7 +382,7 @@ func TestAllPackageIndex(t *testing.T) {
 	// find all manifests
 	var manifests []string
 	for _, path := range packagesBasePaths {
-		m, err := filepath.Glob(path + "/*/*/manifest.yml")
+		m, err := filepath.Glob(filepath.Join(path, "*", "*", "manifest.yml"))
 		require.NoError(t, err)
 		manifests = append(manifests, m...)
 	}
@@ -574,7 +574,7 @@ func listArchivedFiles(t *testing.T, body []byte) []byte {
 	var listing bytes.Buffer
 
 	for _, f := range zipReader.File {
-		listing.WriteString(fmt.Sprintf("%d %s\n", f.UncompressedSize64, f.Name))
+		listing.WriteString(fmt.Sprintf("%d %s\n", f.UncompressedSize64, filepath.ToSlash(f.Name)))
 
 	}
 	return listing.Bytes()

--- a/storage/paths.go
+++ b/storage/paths.go
@@ -6,7 +6,7 @@ package storage
 
 import (
 	"net/url"
-	"path/filepath"
+	"path"
 
 	"github.com/pkg/errors"
 )
@@ -37,7 +37,7 @@ func extractBucketNameFromURL(anURL string) (string, string, error) {
 }
 
 func joinObjectPaths(paths ...string) string {
-	p := filepath.Join(paths...)
+	p := path.Join(paths...)
 	return normalizeObjectPath(p)
 }
 


### PR DESCRIPTION
## Issue description

EPR currently fails to run on Windows due to the use of `filepath` library in an abstracted file system.

## What does this PR do?

* Add a Jenkins testing stage on Windows
* Fix Windows compatiblity

## Why is it important?

EPR currently cannot run on Windows.

## Related issues

* Closes https://github.com/elastic/package-registry/issues/955