### PR TITLE
Enable build pull request in buildkite

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -24,7 +24,7 @@ spec:
       pipeline_file: ".buildkite/pipeline.yml"
       provider_settings:
         build_pull_request_forks: false
-        build_pull_requests: false # PR builds are managed by buildkite-pr-bot
+        build_pull_requests: true
       teams:
         ecosystem: {}
         ingest-fp:


### PR DESCRIPTION
Enable the pull request trigger until we sort out the buildkite-pr-bot triggering issue.

Similar to what we saw with the elastic-package we need to set this property to true in order to trigger builds in buildkite.