### PR TITLE
Set commit status in buildkite bot

### DIFF
--- a/.buildkite/pull-requests.json
+++ b/.buildkite/pull-requests.json
@@ -5,6 +5,7 @@
         "allow_org_users": true,
         "allowed_repo_permissions": ["admin", "write"],
         "allowed_list": ["dependabot[bot]", "mergify[bot]"],
+        "set_commit_status": true,
         "build_on_commit": true,
         "build_on_comment": true,
         "trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:build|test)\\W+(?:this|it))",


### PR DESCRIPTION
Sets variable `set_commit_status: true` for the buildkite_pr_bot