### PR TITLE
Update provider settings

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -25,6 +25,10 @@ spec:
       provider_settings:
         build_pull_request_forks: false
         build_pull_requests: true
+        build_tags: true
+        filter_enabled: true
+        filter_condition: |
+          build.pull_request.id == null || (build.creator.name == 'elasticmachine' && build.pull_request.id != null)
       teams:
         ecosystem: {}
         ingest-fp:

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -22,6 +22,7 @@ spec:
     spec:
       repository: elastic/package-registry
       pipeline_file: ".buildkite/pipeline.yml"
+      branch_configuration: "main v1.* v2.*"
       provider_settings:
         build_pull_request_forks: false
         build_pull_requests: true


### PR DESCRIPTION
This PR adds new settings into the provider settings (Github) for the main Buildkite pipeline:
- `build_tags`: enable to run builds when tags are pushed
- `filter_enable` and `filter_condition`:  Add a new condition on the branches that Buildkite should run ([doc](https://buildkite.com/docs/pipelines/conditionals#conditionals-in-pipelines)) 
    - Allow builds that are not coming from pull requests
    - Allow builds from Pull Requests created just by the `elasticmachine` user
- `branch_configuration`: filter the branches or tags that trigger new builds in Buildkite ([doc](https://buildkite.com/docs/pipelines/branch-configuration))
    - Just allow `main` and tags (or branches) starting with `v1.*`  or `v2.*`. So it allows builds when tags like v1.20.0 or v2.0.1 are pushed to the repository



Related docs: https://registry.terraform.io/providers/buildkite/buildkite/latest/docs/resources/pipeline