### PR TITLE
Prepare changelog for v1.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [unreleased](https://github.com/elastic/package-registry/compare/v1.19.0...main)
+## [v1.20.0](https://github.com/elastic/package-registry/compare/v1.19.0...v1.20.0)
 
 ### Breaking changes
 

--- a/main.go
+++ b/main.go
@@ -38,7 +38,7 @@ import (
 
 const (
 	serviceName         = "package-registry"
-	version             = "1.19.1"
+	version             = "1.20.0"
 	defaultInstanceName = "localhost"
 )
 

--- a/testdata/generated/categories-proxy-kibana-filter.json
+++ b/testdata/generated/categories-proxy-kibana-filter.json
@@ -12,4 +12,3 @@
     "parent_title": "Custom"
   }
 ]
-

--- a/testdata/generated/categories-proxy.json
+++ b/testdata/generated/categories-proxy.json
@@ -19,4 +19,3 @@
     "parent_title": "Observability"
   }
 ]
-

--- a/testdata/generated/index.json
+++ b/testdata/generated/index.json
@@ -1,4 +1,4 @@
 {
   "service.name": "package-registry",
-  "service.version": "1.19.1"
+  "service.version": "1.20.0"
 }


### PR DESCRIPTION
This PR prepares the changelog for release v1.20.0. Main changes:
- Add new subcategory "Advanced Analytics (UEBA)"..
- Update Go environment to 1.20.4 ([Release Notes](https://go.dev/doc/devel/release#go1.20)).
- Fix categories response in proxy mode.