### PR TITLE
Buildkite: version from .go-version

### DIFF
--- a/.buildkite/hooks/post-checkout
+++ b/.buildkite/hooks/post-checkout
@@ -2,6 +2,11 @@
 
 set -euo pipefail
 
+echo "Golang version:"
+version=$(cat .go-version)
+export SETUP_GOLANG_VERSION="${version}"
+echo "${SETUP_GOLANG_VERSION}"
+
 checkout_merge() {
     local target_branch=$1
     local pr_commit=$2
@@ -48,11 +53,6 @@ checkout_merge "${TARGET_BRANCH}" "${PR_COMMIT}" "${MERGE_BRANCH}"
 
 echo "Commit information"
 git log --format=%B -n 1
-
-echo "Golang version:"
-version=$(cat .go-version)
-export SETUP_GOLANG_VERSION="${version}"
-echo "${SETUP_GOLANG_VERSION}"
 
 # Ensure buildkite groups are rendered
 echo ""

--- a/.buildkite/hooks/post-checkout
+++ b/.buildkite/hooks/post-checkout
@@ -2,11 +2,6 @@
 
 set -euo pipefail
 
-echo "Golang version:"
-version=$(cat .go-version)
-export SETUP_GOLANG_VERSION="${version}"
-echo "${SETUP_GOLANG_VERSION}"
-
 checkout_merge() {
     local target_branch=$1
     local pr_commit=$2

--- a/.buildkite/hooks/post-checkout
+++ b/.buildkite/hooks/post-checkout
@@ -49,5 +49,10 @@ checkout_merge "${TARGET_BRANCH}" "${PR_COMMIT}" "${MERGE_BRANCH}"
 echo "Commit information"
 git log --format=%B -n 1
 
+echo "Golang version:"
+version=$(cat .go-version)
+export SETUP_GOLANG_VERSION="${version}"
+echo "${SETUP_GOLANG_VERSION}"
+
 # Ensure buildkite groups are rendered
 echo ""

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -4,6 +4,11 @@ set -euo pipefail
 
 source .buildkite/scripts/tooling.sh
 
+echo "Golang version:"
+version=$(cat .go-version)
+export SETUP_GOLANG_VERSION="${version}"
+echo "${SETUP_GOLANG_VERSION}"
+
 DOCKER_REGISTRY_SECRET_PATH="kv/ci-shared/platform-ingest/docker_registry_prod"
 if [[ "$BUILDKITE_PIPELINE_SLUG" == "package-registry" && "$BUILDKITE_STEP_KEY" == "publish" ]] || \
     [[ "$BUILDKITE_PIPELINE_SLUG" == "package-registry-release-package-registry-distribution" && "$BUILDKITE_STEP_KEY" == "release-distribution" ]]; then

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,8 +1,8 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
 
 env:
+    # SETUP_GOLANG_VERSION from .go-version on post-checkout hook
   SETUP_MAGE_VERSION: '1.14.0'
-  SETUP_GOLANG_VERSION: '1.20.4'
   DOCKER_REGISTRY: 'docker.elastic.co'
   # TODO change namespace to `package-registry` for DOCKER_IMG
   DOCKER_IMG: "${DOCKER_REGISTRY}/observability-ci/temp-package-registry" # TODO needs to rename after tests: remove prefix temp
@@ -52,6 +52,7 @@ steps:
     plugins:
       - junit-annotate#v2.4.1:
           artifacts: "tests-report-*.xml"
+          fail-build-on-error: true
     agents:
       provider: "gcp" #junit plugin requires docker
     depends_on:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,6 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
 
 env:
-  # SETUP_GOLANG_VERSION from .go-version on post-checkout hook
   SETUP_MAGE_VERSION: '1.14.0'
   DOCKER_REGISTRY: 'docker.elastic.co'
   # TODO change namespace to `package-registry` for DOCKER_IMG

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
 
 env:
-    # SETUP_GOLANG_VERSION from .go-version on post-checkout hook
+  # SETUP_GOLANG_VERSION from .go-version on post-checkout hook
   SETUP_MAGE_VERSION: '1.14.0'
   DOCKER_REGISTRY: 'docker.elastic.co'
   # TODO change namespace to `package-registry` for DOCKER_IMG

--- a/.buildkite/scripts/run-tests.ps1
+++ b/.buildkite/scripts/run-tests.ps1
@@ -39,6 +39,8 @@ mage -debug test > test-report.txt
 $EXITCODE=$LASTEXITCODE
 $ErrorActionPreference = "Stop"
 
+Get-Content test-report.txt
+
 Get-Content test-report.txt | go-junit-report > "unicode-tests-report-win.xml"
 Get-Content unicode-tests-report-win.xml -Encoding Unicode | Set-Content -Encoding UTF8 tests-report-win.xml
 Remove-Item unicode-tests-report-win.xml, test-report.txt


### PR DESCRIPTION
A little update for SETUP_GOLANG_VERSION variable > it will be setup on pre-command
Add `fail-build-on-error: true` for plugin annotate, for failing if there are fails in tests (like on go-concert repo)
Test output for win step

