### PR TITLE
[Buildkite] Add echo messages to show the docker images pushed

### DIFF
--- a/.buildkite/scripts/publish.sh
+++ b/.buildkite/scripts/publish.sh
@@ -12,8 +12,10 @@ pushDockerImage() {
         --label TIMESTAMP="$(date +%Y-%m-%d_%H:%M)" \
         .
     retry 3 docker push "${DOCKER_IMG_TAG}"
+    echo "Pushed  docker image: ${DOCKER_IMG_TAG}"
     docker tag "${DOCKER_IMG_TAG}" "${DOCKER_IMG_TAG_BRANCH}"
     retry 3 docker push "${DOCKER_IMG_TAG_BRANCH}"
+    echo "Pushed docker image ${DOCKER_IMG_TAG_BRANCH}"
 }
 
 if [[ -n "${BUILDKITE_PULL_REQUEST:-}" ]]; then

--- a/.buildkite/scripts/publish.sh
+++ b/.buildkite/scripts/publish.sh
@@ -12,10 +12,10 @@ pushDockerImage() {
         --label TIMESTAMP="$(date +%Y-%m-%d_%H:%M)" \
         .
     retry 3 docker push "${DOCKER_IMG_TAG}"
-    echo "Pushed  docker image: ${DOCKER_IMG_TAG}"
+    echo "Docker image pushed: ${DOCKER_IMG_TAG}"
     docker tag "${DOCKER_IMG_TAG}" "${DOCKER_IMG_TAG_BRANCH}"
     retry 3 docker push "${DOCKER_IMG_TAG_BRANCH}"
-    echo "Pushed docker image ${DOCKER_IMG_TAG_BRANCH}"
+    echo "Docker image pushed: ${DOCKER_IMG_TAG_BRANCH}"
 }
 
 if [[ -n "${BUILDKITE_PULL_REQUEST:-}" ]]; then


### PR DESCRIPTION
This PR includes echo commands to show the docker images that have been pushed.

Previously in Jenkins, those images could be checked in the output. For instance
https://fleet-ci.elastic.co/blue/organizations/jenkins/Ingest-manager%2Fpackage-registry/detail/PR-1047/1/pipeline/360