### PR TITLE
Buildkite: avoid buildkite collapsing

### DIFF
--- a/.buildkite/scripts/run-tests.ps1
+++ b/.buildkite/scripts/run-tests.ps1
@@ -39,7 +39,13 @@ mage -debug test > test-report.txt
 $EXITCODE=$LASTEXITCODE
 $ErrorActionPreference = "Stop"
 
-Get-Content test-report.txt
+# Buildkite collapse logs under --- symbols
+# need to change --- to anything else or switch off collapsing (note: not available at the moment of this commit)
+$contest = Get-Content test-report.txt
+foreach ($line in $contest) {
+    $changed = $line -replace '---', '----'
+    Write-Host $changed
+}
 
 Get-Content test-report.txt | go-junit-report > "unicode-tests-report-win.xml"
 Get-Content unicode-tests-report-win.xml -Encoding Unicode | Set-Content -Encoding UTF8 tests-report-win.xml

--- a/.buildkite/scripts/run-tests.sh
+++ b/.buildkite/scripts/run-tests.sh
@@ -8,10 +8,13 @@ with_mage
 with_go_junit_report
 
 set +e
-mage -debug test | tee tests-report-linux.txt
+mage -debug test > tests-report-linux.txt
 exit_code=$?
-
 set -e
+
+# Buildkite collapse logs under --- symbols
+# need to change --- to anything else or switch off collapsing (note: not available at the moment of this commit)
+awk '{gsub("---", "----"); print }' tests-report-linux.txt
 
 # Create Junit report for junit annotation plugin
 go-junit-report > tests-report-linux.xml < tests-report-linux.txt

--- a/flags_test.go
+++ b/flags_test.go
@@ -45,7 +45,7 @@ func TestFlagEnvName(t *testing.T) {
 		flagName string
 		expected string
 	}{
-		{"dry-run44", "EPR_DRY_RUN"},
+		{"dry-run", "EPR_DRY_RUN"},
 		{"test-dummy", "EPR_TEST_DUMMY"},
 	}
 

--- a/flags_test.go
+++ b/flags_test.go
@@ -45,7 +45,7 @@ func TestFlagEnvName(t *testing.T) {
 		flagName string
 		expected string
 	}{
-		{"dry-run", "EPR_DRY_RUN"},
+		{"dry-run44", "EPR_DRY_RUN"},
 		{"test-dummy", "EPR_TEST_DUMMY"},
 	}
 


### PR DESCRIPTION
Right now buildkite collapsing groups by '---', this could be confusing reading test output. here I'm changing '---' to '----', only for the output (the file is the same)