### PR TITLE
[Fleet] Use capabilities filter on categories endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * Add new query parameter "capabilities" in search endpoint [#1054](https://github.com/elastic/package-registry/pull/1054)
+* Add new query parameter "capabilities" in categories endpoint [#1061](https://github.com/elastic/package-registry/pull/1061))
 
 ### Deprecated
 
@@ -34,7 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * New Security subcategory "Advanced Analytics (UEBA)" [#997](https://github.com/elastic/package-registry/pull/997)
-
+m
 ### Deprecated
 
 ### Known Issues

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * New Security subcategory "Advanced Analytics (UEBA)" [#997](https://github.com/elastic/package-registry/pull/997)
-m
 ### Deprecated
 
 ### Known Issues

--- a/categories.go
+++ b/categories.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	"go.uber.org/zap"
@@ -125,6 +126,10 @@ func newCategoriesFilterFromQuery(query url.Values) (*packages.Filter, error) {
 		if err != nil {
 			return nil, fmt.Errorf("invalid 'prerelease' query param: '%s'", v)
 		}
+	}
+
+	if v := query.Get("capabilities"); v != "" {
+		filter.Capabilities = strings.Split(v, ",")
 	}
 
 	return &filter, nil


### PR DESCRIPTION
## Description 

In order to get the correct count in Fleet UI we should probably filter on capabilities for `/categories` endpoint too.

That PR does that 

Test, the capabilities filter is already unit tested