### PR TITLE
Update docker tag for production scenario

### DIFF
--- a/.buildkite/scripts/publish-distribution.sh
+++ b/.buildkite/scripts/publish-distribution.sh
@@ -25,4 +25,5 @@ if [[ ${DRY_RUN:-true} == "true" ]]; then
 else
     echo "Docker push:"
     retry 3 docker push "${DOCKER_IMG_TARGET}"
+    echo "Docker image pushed: ${DOCKER_IMG_TARGET}"
 fi

--- a/.buildkite/scripts/publish-distribution.sh
+++ b/.buildkite/scripts/publish-distribution.sh
@@ -7,7 +7,12 @@ source .buildkite/scripts/tooling.sh
 DOCKER_TAG=$(buildkite-agent meta-data get DOCKER_TAG)
 echo "version for tagging: ${DOCKER_TAG}"
 DOCKER_IMG_SOURCE="${DOCKER_REGISTRY}/package-registry/distribution:${TAG_NAME}"
-DOCKER_IMG_TARGET="${DOCKER_REGISTRY}/package-registry/distribution:${TAG_NAME}-${DOCKER_TAG}"
+
+if [[ "${TAG_NAME}" == "production" ]]; then
+    DOCKER_IMG_TARGET="${DOCKER_REGISTRY}/package-registry/distribution:${DOCKER_TAG}"
+else
+    DOCKER_IMG_TARGET="${DOCKER_REGISTRY}/package-registry/distribution:${TAG_NAME}-${DOCKER_TAG}"
+fi
 
 echo "Docker pull"
 retry 3 docker pull "${DOCKER_IMG_SOURCE}"


### PR DESCRIPTION
This PR updates the docker image generated for the production image when a tag is pushed.

In case of lite the image should be:
- docker.elastic.co/package-registry/distribution:lite-8.9.0 (correct)

In case of production, the image should be (directly the tag):
- docker.elastic.co/package-registry/distribution:8.9.0 (currently the tag pushed is `production-8.9.0)

Build: https://buildkite.com/elastic/package-registry-release-package-registry-distribution/builds/26#01899cd0-4992-4230-ae68-9cce266f0796