### PR TITLE
[Buildkite] Update mergify settings to use Buildkite builds

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,7 +1,7 @@
 queue_rules:
   - name: default
     conditions:
-      - check-success=package-registry/pr-merge
+      - check-success=buildkite/package-registry
 
 pull_request_rules:
   - name: automatic approval for Dependabot pull requests


### PR DESCRIPTION
Update queue_rules condition to use Buildkite builds instead of Jenkins ones.