### PR TITLE
Update pull request condition for publish step

### DIFF
--- a/.buildkite/scripts/publish.sh
+++ b/.buildkite/scripts/publish.sh
@@ -18,7 +18,7 @@ pushDockerImage() {
     echo "Docker image pushed: ${DOCKER_IMG_TAG_BRANCH}"
 }
 
-if [[ -n "${BUILDKITE_PULL_REQUEST:-}" ]]; then
+if [[ "${BUILDKITE_PULL_REQUEST}" != "false" ]]; then
     DOCKER_NAMESPACE="${DOCKER_IMG_PR}"
     TAG_NAME="PR-${BUILDKITE_PULL_REQUEST}"
 else


### PR DESCRIPTION
Update docker publish script to ensure that it is used `docker.elastic.co/package-registry/package-registry` as docker image when pushing a new tag or pushing to a branch.

This build triggered after pushing tag `v1.21.0` did not retag correctly the docker image:

https://buildkite.com/elastic/package-registry/builds/345#018a17c9-682a-4de4-a631-bf8efbd8fbd1

In that build BUILDKITE_PULL_REQUEST value is `false` instead of empty string.