### PR TITLE
Add tls-min-version parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Add new parameter to specify minimum TLS version [#1103](https://github.com/elastic/package-registry/pull/1103)
+
 ### Deprecated
 
 ### Known Issues

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bugfixes
 
 * Update Go runtime to 1.21.3. [#1102](https://github.com/elastic/package-registry/pull/1102)
+* Raise an error if the value of environment variables used to set parameters are not valid [#1103](https://github.com/elastic/package-registry/pull/1103)
 
 ### Added
 

--- a/flags.go
+++ b/flags.go
@@ -21,14 +21,11 @@ var supportedTLSVersions map[string]uint16 = map[string]uint16{
 }
 
 type tlsVersionValue struct {
-	version *uint16
+	version uint16
 }
 
 func (t tlsVersionValue) String() string {
-	if t.version == nil {
-		return ""
-	}
-	switch *t.version {
+	switch t.version {
 	case tls.VersionTLS10:
 		return "1.0"
 	case tls.VersionTLS11:
@@ -43,14 +40,14 @@ func (t tlsVersionValue) String() string {
 }
 
 func (t tlsVersionValue) Value() uint16 {
-	return *t.version
+	return t.version
 }
 
-func (t tlsVersionValue) Set(s string) error {
+func (t *tlsVersionValue) Set(s string) error {
 	if _, ok := supportedTLSVersions[s]; !ok {
 		return fmt.Errorf("unsupported TLS version: %s", s)
 	}
-	*t.version = supportedTLSVersions[s]
+	t.version = supportedTLSVersions[s]
 	return nil
 }
 

--- a/flags.go
+++ b/flags.go
@@ -5,29 +5,68 @@
 package main
 
 import (
+	"crypto/tls"
+	"errors"
 	"flag"
+	"fmt"
 	"os"
 	"strings"
 )
 
-func parseFlags() {
-	parseFlagSetWithArgs(flag.CommandLine, os.Args)
+var supportedTLSVersions map[string]uint16 = map[string]uint16{
+	"1.0": tls.VersionTLS10,
+	"1.1": tls.VersionTLS11,
+	"1.2": tls.VersionTLS12,
+	"1.3": tls.VersionTLS13,
 }
 
-func parseFlagSetWithArgs(flagSet *flag.FlagSet, args []string) {
-	flagsFromEnv(flagSet)
+type tlsMinVersionValue struct {
+	version     *string
+	versionCode *uint16
+}
+
+func (t tlsMinVersionValue) String() string {
+	if t.version != nil {
+		return *t.version
+	}
+	return ""
+}
+
+func (t tlsMinVersionValue) Set(s string) error {
+	if _, ok := supportedTLSVersions[s]; !ok {
+		return fmt.Errorf("unsupported TLS version: %s", s)
+	}
+	*t.version = s
+	*t.versionCode = supportedTLSVersions[s]
+	return nil
+}
+
+func parseFlags() error {
+	return parseFlagSetWithArgs(flag.CommandLine, os.Args)
+}
+
+func parseFlagSetWithArgs(flagSet *flag.FlagSet, args []string) error {
+	err := flagsFromEnv(flagSet)
+	if err != nil {
+		return err
+	}
 
 	// Skip args[0] as flag.Parse() does.
 	flagSet.Parse(args[1:])
+	return nil
 }
 
-func flagsFromEnv(flagSet *flag.FlagSet) {
+func flagsFromEnv(flagSet *flag.FlagSet) error {
+	var flagErrors error
 	flagSet.VisitAll(func(f *flag.Flag) {
 		envName := flagEnvName(f.Name)
 		if value, found := os.LookupEnv(envName); found {
-			f.Value.Set(value)
+			if err := f.Value.Set(value); err != nil {
+				flagErrors = errors.Join(flagErrors, fmt.Errorf("failed to set -%s: %v", f.Name, err))
+			}
 		}
 	})
+	return flagErrors
 }
 
 const flagEnvPrefix = "EPR_"

--- a/flags.go
+++ b/flags.go
@@ -20,24 +20,37 @@ var supportedTLSVersions map[string]uint16 = map[string]uint16{
 	"1.3": tls.VersionTLS13,
 }
 
-type tlsMinVersionValue struct {
-	version     *string
-	versionCode *uint16
+type tlsVersionValue struct {
+	version *uint16
 }
 
-func (t tlsMinVersionValue) String() string {
-	if t.version != nil {
-		return *t.version
+func (t tlsVersionValue) String() string {
+	if t.version == nil {
+		return ""
 	}
-	return ""
+	switch *t.version {
+	case tls.VersionTLS10:
+		return "1.0"
+	case tls.VersionTLS11:
+		return "1.1"
+	case tls.VersionTLS12:
+		return "1.2"
+	case tls.VersionTLS13:
+		return "1.3"
+	default:
+		return ""
+	}
 }
 
-func (t tlsMinVersionValue) Set(s string) error {
+func (t tlsVersionValue) Value() uint16 {
+	return *t.version
+}
+
+func (t tlsVersionValue) Set(s string) error {
 	if _, ok := supportedTLSVersions[s]; !ok {
 		return fmt.Errorf("unsupported TLS version: %s", s)
 	}
-	*t.version = s
-	*t.versionCode = supportedTLSVersions[s]
+	*t.version = supportedTLSVersions[s]
 	return nil
 }
 

--- a/flags.go
+++ b/flags.go
@@ -20,12 +20,10 @@ var supportedTLSVersions map[string]uint16 = map[string]uint16{
 	"1.3": tls.VersionTLS13,
 }
 
-type tlsVersionValue struct {
-	version uint16
-}
+type tlsVersionValue uint16
 
 func (t tlsVersionValue) String() string {
-	switch t.version {
+	switch t {
 	case tls.VersionTLS10:
 		return "1.0"
 	case tls.VersionTLS11:
@@ -39,15 +37,11 @@ func (t tlsVersionValue) String() string {
 	}
 }
 
-func (t tlsVersionValue) Value() uint16 {
-	return t.version
-}
-
 func (t *tlsVersionValue) Set(s string) error {
 	if _, ok := supportedTLSVersions[s]; !ok {
 		return fmt.Errorf("unsupported TLS version: %s", s)
 	}
-	t.version = supportedTLSVersions[s]
+	*t = tlsVersionValue(supportedTLSVersions[s])
 	return nil
 }
 

--- a/flags_test.go
+++ b/flags_test.go
@@ -36,7 +36,8 @@ func TestFlagsPrecedence(t *testing.T) {
 	require.Equal(t, "default", dummyFlag)
 
 	args := []string{"test", "-test-precedence-dummy=" + expected}
-	parseFlagSetWithArgs(flagSet, args)
+	err := parseFlagSetWithArgs(flagSet, args)
+	require.NoError(t, err)
 	require.Equal(t, expected, dummyFlag)
 }
 

--- a/main.go
+++ b/main.go
@@ -54,7 +54,6 @@ var (
 	tlsCertFile string
 	tlsKeyFile  string
 
-	tlsMinVersionCode  uint16
 	tlsMinVersionValue tlsVersionValue
 
 	dryRun     bool
@@ -79,8 +78,6 @@ var (
 )
 
 func init() {
-	tlsMinVersionValue = tlsVersionValue{version: &tlsMinVersionCode}
-
 	flag.BoolVar(&printVersionInfo, "version", false, "Print Elastic Package Registry version")
 	flag.StringVar(&address, "address", "localhost:8080", "Address of the package-registry service.")
 	flag.StringVar(&metricsAddress, "metrics-address", "", "Address to expose the Prometheus metrics (experimental). ")

--- a/main.go
+++ b/main.go
@@ -117,7 +117,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	if tlsMinVersionValue.String() != "" {
+	if tlsMinVersionValue > 0 {
 		if tlsCertFile == "" || tlsKeyFile == "" {
 			log.Fatalf("-tls-min-version set but missing TLS cert and key files (-tls-cert and -tls-key)")
 		}

--- a/main.go
+++ b/main.go
@@ -255,8 +255,8 @@ func initServer(logger *zap.Logger, apmTracer *apm.Tracer, config *Config) *http
 	apmgorilla.Instrument(router, apmgorilla.WithTracer(apmTracer))
 
 	var tlsConfig tls.Config
-	if tlsMinVersionValue.String() != "" {
-		tlsConfig.MinVersion = tlsMinVersionValue.Value()
+	if tlsMinVersionValue > 0 {
+		tlsConfig.MinVersion = uint16(tlsMinVersionValue)
 	}
 	return &http.Server{Addr: address, Handler: router, TLSConfig: &tlsConfig}
 }


### PR DESCRIPTION
Fixes https://github.com/elastic/package-registry/issues/965

This PR adds a new parameter (and a new environment variable) to define the minimum TLS version supported.


If `-tls-min-version` is set, but `-tls-cert` and `-tls-key` are not specified , requests fail to package-registry service like this:
```shell
 $ curl -k -v -I --tls-max 1.3 https://localhost:8080
*   Trying 127.0.0.1:8080...
* Connected to localhost (127.0.0.1) port 8080 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* TLSv1.0 (OUT), TLS header, Certificate Status (22):
* TLSv1.3 (OUT), TLS handshake, Client hello (1):
* (5454) (IN), , Unknown (72):
* error:0A00010B:SSL routines::wrong version number
* Closing connection 0
curl: (35) error:0A00010B:SSL routines::wrong version number
```

## How to test this
1. create server certificate and key (accept all the default values)
   ```shell
   mkdir -p certs
   cd certs

   # create CA
   openssl genrsa -out servercakey.pem
   openssl req -new -x509 -key servercakey.pem -out serverca.crt

   # create Server certificates
   openssl genrsa -out server.key
   openssl req -new -key server.key -out server_reqout.txt
   openssl x509 -req -in server_reqout.txt -days 3650 -sha256 -CAcreateserial -CA serverca.crt -CAkey servercakey.pem -out server.crt
   ```
3. Create docker image
   ```shell
   docker rmi docker.elastic.co/package-registr/package-registry:tls-test || true
   docker build --no-cache -t docker.elastic.co/package-registry/package-registry:tls-test -f Dockerfile .
   ```
5. Run docker image with the required parameters
   ```shell
   # All parameters
   docker run --rm -p 8080:8080 -v $(pwd)/certs:/root/certs/ -e EPR_LOG_LEVEL=debug -e EPR_FEATURE_PROXY_MODE=true -e EPR_PROXY_TO=https://epr.elastic.co -e EPR_TLS_MIN_VERSION=1.2 -v /home/mariorodriguez/Coding/work/integrations/build/packages/:/packages/package-registry -it docker.elastic.co/package-registry/package-registry:tls-test

   # Just TLS_MIN_VERSION (it must fail)
   docker run --rm -p 8080:8080 -v $(pwd)/certs:/root/certs/ -e EPR_LOG_LEVEL=debug -e EPR_FEATURE_PROXY_MODE=true -e EPR_PROXY_TO=https://epr.elastic.co -e EPR_TLS_MIN_VERSION=1.2 -v /home/mariorodriguez/Coding/work/integrations/build/packages/:/packages/package-registry -it docker.elastic.co/package-registry/package-registry:tls-test
   ```
7. Test with curl
   ```shell
   curl -k -v -I --tls-max 1.3 https://localhost:8080
   curl -k -v -I --tls-max 1.2 https://localhost:8080
   curl -k -v -I --tls-max 1.1 https://localhost:8080
   curl -k -v -I --tls-max 1.0 https://localhost:8080
   ```

For instance, if package-registry is configured with EPR_TLS_MIN_VERSION=1.2 (or -tls-min-version 1.2):
```shell
 $ curl -k -I --tls-max 1.2 https://localhost:8080
HTTP/2 200 
cache-control: max-age=10
cache-control: public
content-type: application/json
content-length: 72
date: Wed, 25 Oct 2023 14:27:08 GMT

 $ curl -k -I --tls-max 1.3 https://localhost:8080
HTTP/2 200 
cache-control: max-age=10
cache-control: public
content-type: application/json
content-length: 72
date: Wed, 25 Oct 2023 14:27:22 GMT

 $ curl -k -I --tls-max 1.1 https://localhost:8080
curl: (35) error:0A0000BF:SSL routines::no protocols available
```