### PR TITLE
[Fleet] Add owner type to search response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add package and datastream agent privileges in the package endpoint [#1109](https://github.com/elastic/package-registry/pull/1109)
+- Add owner.type to the package endpoint [#1109](https://github.com/elastic/package-registry/pull/1115)
 
 ### Deprecated
 

--- a/packages/package.go
+++ b/packages/package.go
@@ -133,6 +133,7 @@ type Version struct {
 }
 
 type Owner struct {
+	Type   string `config:"type,omitempty" json:"type,omitempty"`
 	Github string `config:"github,omitempty" json:"github,omitempty"`
 }
 
@@ -152,7 +153,7 @@ type PackageAgent struct {
 }
 
 type PackageAgentPrivileges struct {
-	Root bool `config:"root,omitempty" json:"root,omitempty" yaml:"root,omitempty"`
+	root bool `config:"root,omitempty" json:"root,omitempty" yaml:"root,omitempty"`
 }
 
 type PackageElasticsearch struct {

--- a/packages/package.go
+++ b/packages/package.go
@@ -153,7 +153,7 @@ type PackageAgent struct {
 }
 
 type PackageAgentPrivileges struct {
-	root bool `config:"root,omitempty" json:"root,omitempty" yaml:"root,omitempty"`
+	Root bool `config:"root,omitempty" json:"root,omitempty" yaml:"root,omitempty"`
 }
 
 type PackageElasticsearch struct {

--- a/packages/testdata/marshaler/packages.json
+++ b/packages/testdata/marshaler/packages.json
@@ -1945,6 +1945,7 @@
     }
    },
    "owner": {
+    "type": "elastic",
     "github": "ruflin"
    },
    "categories": [

--- a/testdata/generated/package/reference/1.0.0/index.json
+++ b/testdata/generated/package/reference/1.0.0/index.json
@@ -21,6 +21,7 @@
     }
   },
   "owner": {
+    "type": "elastic",
     "github": "ruflin"
   },
   "categories": [

--- a/testdata/generated/search-all-proxy.json
+++ b/testdata/generated/search-all-proxy.json
@@ -544,6 +544,7 @@
       }
     },
     "owner": {
+      "type": "elastic",
       "github": "ruflin"
     },
     "categories": [

--- a/testdata/generated/search-all.json
+++ b/testdata/generated/search-all.json
@@ -505,6 +505,7 @@
       }
     },
     "owner": {
+      "type": "elastic",
       "github": "ruflin"
     },
     "categories": [

--- a/testdata/generated/search-category-custom.json
+++ b/testdata/generated/search-category-custom.json
@@ -295,6 +295,7 @@
       }
     },
     "owner": {
+      "type": "elastic",
       "github": "ruflin"
     },
     "categories": [

--- a/testdata/generated/search-category-observability-subcategories.json
+++ b/testdata/generated/search-category-observability-subcategories.json
@@ -84,6 +84,7 @@
       }
     },
     "owner": {
+      "type": "elastic",
       "github": "ruflin"
     },
     "categories": [

--- a/testdata/generated/search-category-web-all.json
+++ b/testdata/generated/search-category-web-all.json
@@ -136,6 +136,7 @@
       }
     },
     "owner": {
+      "type": "elastic",
       "github": "ruflin"
     },
     "categories": [

--- a/testdata/generated/search-category-web.json
+++ b/testdata/generated/search-category-web.json
@@ -84,6 +84,7 @@
       }
     },
     "owner": {
+      "type": "elastic",
       "github": "ruflin"
     },
     "categories": [

--- a/testdata/generated/search-just-latest-proxy.json
+++ b/testdata/generated/search-just-latest-proxy.json
@@ -398,6 +398,7 @@
       }
     },
     "owner": {
+      "type": "elastic",
       "github": "ruflin"
     },
     "categories": [

--- a/testdata/generated/search-kibana721.json
+++ b/testdata/generated/search-kibana721.json
@@ -257,6 +257,7 @@
       }
     },
     "owner": {
+      "type": "elastic",
       "github": "ruflin"
     },
     "categories": [

--- a/testdata/generated/search-package-experimental.json
+++ b/testdata/generated/search-package-experimental.json
@@ -552,6 +552,7 @@
       }
     },
     "owner": {
+      "type": "elastic",
       "github": "ruflin"
     },
     "categories": [

--- a/testdata/generated/search-package-internal.json
+++ b/testdata/generated/search-package-internal.json
@@ -359,6 +359,7 @@
       }
     },
     "owner": {
+      "type": "elastic",
       "github": "ruflin"
     },
     "categories": [

--- a/testdata/generated/search-package-prerelease.json
+++ b/testdata/generated/search-package-prerelease.json
@@ -560,6 +560,7 @@
       }
     },
     "owner": {
+      "type": "elastic",
       "github": "ruflin"
     },
     "categories": [

--- a/testdata/generated/search-prerelease-capabilities-none.json
+++ b/testdata/generated/search-prerelease-capabilities-none.json
@@ -527,6 +527,7 @@
       }
     },
     "owner": {
+      "type": "elastic",
       "github": "ruflin"
     },
     "categories": [

--- a/testdata/generated/search-prerelease-capabilities-observability-security.json
+++ b/testdata/generated/search-prerelease-capabilities-observability-security.json
@@ -535,6 +535,7 @@
       }
     },
     "owner": {
+      "type": "elastic",
       "github": "ruflin"
     },
     "categories": [

--- a/testdata/generated/search-spec-max-2.10.0.json
+++ b/testdata/generated/search-spec-max-2.10.0.json
@@ -552,6 +552,7 @@
       }
     },
     "owner": {
+      "type": "elastic",
       "github": "ruflin"
     },
     "categories": [

--- a/testdata/generated/search.json
+++ b/testdata/generated/search.json
@@ -359,6 +359,7 @@
       }
     },
     "owner": {
+      "type": "elastic",
       "github": "ruflin"
     },
     "categories": [

--- a/testdata/package/reference/1.0.0/manifest.yml
+++ b/testdata/package/reference/1.0.0/manifest.yml
@@ -31,6 +31,7 @@ type: integration
 # Details about the owner of the package. Current only github link is supported.
 # A package can only have a single owner, the owner can be a user or a team.
 owner:
+  type: elastic
   github: "ruflin"
 
 conditions:
@@ -68,8 +69,7 @@ screenshots:
 # Icons options are commented out as currently not icons added
 # It is expected that icons are in svg, but other formats are supported.
 icons:
-  -
-    # src is a required field
+  - # src is a required field
     src: "/img/icon.svg"
     # This helps to send the right header
     type: "image/svg+xml"
@@ -79,16 +79,14 @@ icons:
 # Defining a datasource allows the UI to generate a form for each input and generate the agent
 # config out of it. For a visual guide on what fields is used how in the UI, check out https://github.com/elastic/package-registry/pull/242
 policy_templates:
-  -
-    # Do we need a name for the data source?
+  - # Do we need a name for the data source?
     name: nginx
     title: Nginx logs and metrics.
     description: Collecting logs and metrics from nginx.
 
     # List of inputs this datasource supports
     inputs:
-      -
-        # An id can be given, in case the type used here is not unique
+      - # An id can be given, in case the type used here is not unique
         # This is for selection in the stream
         # id: nginx
 
@@ -109,8 +107,7 @@ policy_templates:
             title: Hosts
 
             description: List of nginx hosts to collect data from.
-            default:
-              ["http://127.0.0.1"]
+            default: ["http://127.0.0.1"]
             # All the config options that are required should be shown in the UI
             required: true
             multi: true


### PR DESCRIPTION
## Description 

Add owner type to search response so it can be display in kibana  https://github.com/elastic/kibana/issues/167981

For example for 1password:
<img width="646" alt="Screenshot 2023-11-14 at 10 58 47 AM" src="https://github.com/elastic/package-registry/assets/1336873/e9165a62-27bf-4d00-9315-9c110a6f2212">



## Todo 

- [x] changelog
- [x] Tests