### PR TITLE
Re-wrap errors using standard libraries

### DIFF
--- a/artifacts.go
+++ b/artifacts.go
@@ -5,12 +5,13 @@
 package main
 
 import (
+	"errors"
 	"net/http"
 	"time"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/gorilla/mux"
-	"github.com/pkg/errors"
+
 	"go.elastic.co/apm/module/apmzap/v2"
 	"go.uber.org/zap"
 

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.7.5
 	github.com/joeshaw/multierror v0.0.0-20140124173710-69b34d4ec901
 	github.com/magefile/mage v1.15.0
-	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.18.0
 	github.com/stretchr/testify v1.8.4
 	go.elastic.co/apm/module/apmgorilla/v2 v2.4.8
@@ -51,6 +50,7 @@ require (
 	github.com/gorilla/handlers v1.5.2 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pkg/xattr v0.4.9 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.5.0 // indirect

--- a/internal/util/mapstr.go
+++ b/internal/util/mapstr.go
@@ -10,10 +10,9 @@ package util
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 var (
@@ -215,7 +214,7 @@ func flatten(prefix string, in, out MapStr) MapStr {
 func toMapStr(v interface{}) (MapStr, error) {
 	m, ok := tryToMapStr(v)
 	if !ok {
-		return nil, errors.Errorf("expected map but type is %T", v)
+		return nil, fmt.Errorf("expected map but type is %T", v)
 	}
 	return m, nil
 }

--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@ import (
 
 	gstorage "cloud.google.com/go/storage"
 	"github.com/gorilla/mux"
-	"github.com/pkg/errors"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"go.elastic.co/apm/module/apmgorilla/v2"
@@ -300,13 +300,13 @@ func getConfig(logger *zap.Logger) (*Config, error) {
 		logger.Fatal("Configuration file is not available: " + configPath)
 	}
 	if err != nil {
-		return nil, errors.Wrapf(err, "reading config failed (path: %s)", configPath)
+		return nil, fmt.Errorf("reading config failed (path: %s): %w", configPath, err)
 	}
 
 	config := defaultConfig
 	err = cfg.Unpack(&config)
 	if err != nil {
-		return nil, errors.Wrapf(err, "unpacking config failed (path: %s)", configPath)
+		return nil, fmt.Errorf("unpacking config failed (path: %s): %w", configPath, err)
 	}
 	return &config, nil
 }
@@ -364,7 +364,7 @@ func getRouter(logger *zap.Logger, config *Config, indexer Indexer) (*mux.Router
 		ProxyTo: proxyTo,
 	})
 	if err != nil {
-		return nil, errors.Wrapf(err, "can't create proxy mode")
+		return nil, fmt.Errorf("can't create proxy mode: %w", err)
 	}
 	artifactsHandler := artifactsHandlerWithProxyMode(logger, indexer, proxyMode, config.CacheTimeCatchAll)
 	signaturesHandler := signaturesHandlerWithProxyMode(logger, indexer, proxyMode, config.CacheTimeCatchAll)

--- a/package_index.go
+++ b/package_index.go
@@ -5,10 +5,10 @@
 package main
 
 import (
+	"errors"
 	"net/http"
 	"time"
 
-	"github.com/pkg/errors"
 	"go.elastic.co/apm/module/apmzap/v2"
 	"go.uber.org/zap"
 

--- a/packages/package.go
+++ b/packages/package.go
@@ -5,6 +5,7 @@
 package packages
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -12,7 +13,6 @@ import (
 	"strings"
 
 	"github.com/Masterminds/semver/v3"
-	"github.com/pkg/errors"
 
 	"github.com/elastic/go-ucfg"
 	"github.com/elastic/go-ucfg/yaml"
@@ -310,18 +310,18 @@ func NewPackage(basePath string, fsBuilder FileSystemBuilder) (*Package, error) 
 
 	err = p.LoadAssets()
 	if err != nil {
-		return nil, errors.Wrapf(err, "loading package assets failed (path '%s')", p.BasePath)
+		return nil, fmt.Errorf("loading package assets failed (path '%s'): %w", p.BasePath, err)
 	}
 
 	err = p.LoadDataSets()
 	if err != nil {
-		return nil, errors.Wrapf(err, "loading package data streams failed (path '%s')", p.BasePath)
+		return nil, fmt.Errorf("loading package data streams failed (path '%s'): %w", p.BasePath, err)
 	}
 
 	// Read path for package signature
 	p.SignaturePath, err = p.getSignaturePath()
 	if err != nil {
-		return nil, errors.Wrapf(err, "can't process the package signature")
+		return nil, fmt.Errorf("can't process the package signature: %w", err)
 	}
 	return p, nil
 }
@@ -595,7 +595,7 @@ func (p *Package) Validate() error {
 
 	err = p.validateVersionConsistency()
 	if err != nil {
-		return errors.Wrap(err, "version in manifest file is not consistent with path")
+		return fmt.Errorf("version in manifest file is not consistent with path: %w", err)
 	}
 
 	return p.ValidateDataStreams()
@@ -604,7 +604,7 @@ func (p *Package) Validate() error {
 func (p *Package) validateVersionConsistency() error {
 	versionPackage, err := semver.NewVersion(p.Version)
 	if err != nil {
-		return errors.Wrap(err, "invalid version defined in manifest")
+		return fmt.Errorf("invalid version defined in manifest: %w", err)
 	}
 
 	baseDir := path.Base(p.BasePath)
@@ -683,12 +683,12 @@ func (p *Package) ValidateDataStreams() error {
 
 		d, err := NewDataStream(dataStreamBasePath, p)
 		if err != nil {
-			return errors.Wrapf(err, "building data stream failed (path: %s)", dataStreamBasePath)
+			return fmt.Errorf("building data stream failed (path: %s): %w", dataStreamBasePath, err)
 		}
 
 		err = d.Validate()
 		if err != nil {
-			return errors.Wrapf(err, "validating data stream failed (path: %s)", dataStreamBasePath)
+			return fmt.Errorf("validating data stream failed (path: %s): %w", dataStreamBasePath, err)
 		}
 	}
 	return nil
@@ -712,7 +712,7 @@ func (p *Package) getSignaturePath() (string, error) {
 		return "", nil
 	}
 	if err != nil {
-		return "", errors.Wrap(err, "can't stat signature file")
+		return "", fmt.Errorf("can't stat signature file: %w", err)
 	}
 	return p.GetDownloadPath() + ".sig", nil
 }

--- a/packages/packages.go
+++ b/packages/packages.go
@@ -15,7 +15,7 @@ import (
 	"time"
 
 	"github.com/Masterminds/semver/v3"
-	"github.com/pkg/errors"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"go.elastic.co/apm/v2"
 	"go.uber.org/zap"
@@ -182,7 +182,7 @@ var ZipFileSystemBuilder = func(p *Package) (PackageFileSystem, error) {
 func (i *FileSystemIndexer) Init(ctx context.Context) (err error) {
 	i.packageList, err = i.getPackagesFromFileSystem(ctx)
 	if err != nil {
-		return errors.Wrapf(err, "reading packages from filesystem failed")
+		return fmt.Errorf("reading packages from filesystem failed: %w", err)
 	}
 	return nil
 }
@@ -229,7 +229,7 @@ func (i *FileSystemIndexer) getPackagesFromFileSystem(ctx context.Context) (Pack
 		for _, path := range packagePaths {
 			p, err := NewPackage(path, i.fsBuilder)
 			if err != nil {
-				return nil, errors.Wrapf(err, "loading package failed (path: %s)", path)
+				return nil, fmt.Errorf("loading package failed (path: %s): %w", path, err)
 			}
 
 			key := packageKey{name: p.Name, version: p.Version}
@@ -280,7 +280,7 @@ func (i *FileSystemIndexer) getPackagePaths(packagesPath string) ([]string, erro
 		return nil
 	})
 	if err != nil {
-		return nil, errors.Wrapf(err, "listing packages failed (path: %s)", packagesPath)
+		return nil, fmt.Errorf("listing packages failed (path: %s): %w", packagesPath, err)
 	}
 	return foundPaths, nil
 }

--- a/packages/resolver.go
+++ b/packages/resolver.go
@@ -4,7 +4,9 @@
 
 package packages
 
-import "net/http"
+import (
+	"net/http"
+)
 
 type RemoteResolver interface {
 	ArtifactsHandler(w http.ResponseWriter, r *http.Request, p *Package)

--- a/search.go
+++ b/search.go
@@ -15,7 +15,7 @@ import (
 	"time"
 
 	"github.com/Masterminds/semver/v3"
-	"github.com/pkg/errors"
+
 	"go.elastic.co/apm/module/apmzap/v2"
 	"go.elastic.co/apm/v2"
 	"go.uber.org/zap"
@@ -44,7 +44,7 @@ func searchHandlerWithProxyMode(logger *zap.Logger, indexer Indexer, proxyMode *
 
 		packages, err := indexer.Get(r.Context(), &opts)
 		if err != nil {
-			notFoundError(w, errors.Wrapf(err, "fetching package failed"))
+			notFoundError(w, fmt.Errorf("fetching package failed: %w", err))
 			return
 		}
 

--- a/signatures.go
+++ b/signatures.go
@@ -5,12 +5,13 @@
 package main
 
 import (
+	"errors"
 	"net/http"
 	"time"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/gorilla/mux"
-	"github.com/pkg/errors"
+
 	"go.elastic.co/apm/module/apmzap/v2"
 	"go.uber.org/zap"
 

--- a/storage/index.go
+++ b/storage/index.go
@@ -7,9 +7,10 @@ package storage
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	"cloud.google.com/go/storage"
-	"github.com/pkg/errors"
+
 	"go.elastic.co/apm/v2"
 	"go.uber.org/zap"
 
@@ -35,7 +36,7 @@ func loadSearchIndexAll(ctx context.Context, logger *zap.Logger, storageClient *
 	rootedIndexStoragePath := buildIndexStoragePath(rootStoragePath, aCursor, indexFile)
 	objectReader, err := storageClient.Bucket(bucketName).Object(rootedIndexStoragePath).NewReader(ctx)
 	if err != nil {
-		return nil, errors.Wrapf(err, "can't read the index file (path: %s)", rootedIndexStoragePath)
+		return nil, fmt.Errorf("can't read the index file (path: %s): %w", rootedIndexStoragePath, err)
 	}
 	defer objectReader.Close()
 
@@ -53,7 +54,7 @@ func loadSearchIndexAll(ctx context.Context, logger *zap.Logger, storageClient *
 		// Read everything till the "packages" key in the map.
 		token, err := dec.Token()
 		if err != nil {
-			return nil, errors.Wrapf(err, "unexpected error while reading index file")
+			return nil, fmt.Errorf("unexpected error while reading index file: %w", err)
 		}
 		if key, ok := token.(string); !ok || key != "packages" {
 			continue
@@ -62,10 +63,10 @@ func loadSearchIndexAll(ctx context.Context, logger *zap.Logger, storageClient *
 		// Read the opening array now.
 		token, err = dec.Token()
 		if err != nil {
-			return nil, errors.Wrapf(err, "unexpected error while reading index file")
+			return nil, fmt.Errorf("unexpected error while reading index file: %w", err)
 		}
 		if delim, ok := token.(json.Delim); !ok || delim != '[' {
-			return nil, errors.Errorf("expected opening array, found %v", token)
+			return nil, fmt.Errorf("expected opening array, found %v", token)
 		}
 
 		// Read the array of packages one by one.
@@ -73,7 +74,7 @@ func loadSearchIndexAll(ctx context.Context, logger *zap.Logger, storageClient *
 			var p packageIndex
 			err = dec.Decode(&p)
 			if err != nil {
-				return nil, errors.Wrapf(err, "unexpected error parsing package from index file (token: %v)", token)
+				return nil, fmt.Errorf("unexpected error parsing package from index file (token: %v): %w", token, err)
 			}
 			sia.Packages = append(sia.Packages, p)
 		}
@@ -81,10 +82,10 @@ func loadSearchIndexAll(ctx context.Context, logger *zap.Logger, storageClient *
 		// Read the closing array delimiter.
 		token, err = dec.Token()
 		if err != nil {
-			return nil, errors.Wrapf(err, "unexpected error while reading index file")
+			return nil, fmt.Errorf("unexpected error while reading index file: %w", err)
 		}
 		if delim, ok := token.(json.Delim); !ok || delim != ']' {
-			return nil, errors.Errorf("expected closing array, found %v", token)
+			return nil, fmt.Errorf("expected closing array, found %v", token)
 		}
 	}
 	return &sia, nil

--- a/storage/paths.go
+++ b/storage/paths.go
@@ -5,10 +5,9 @@
 package storage
 
 import (
+	"fmt"
 	"net/url"
 	"path"
-
-	"github.com/pkg/errors"
 )
 
 const (
@@ -26,7 +25,7 @@ const (
 func extractBucketNameFromURL(anURL string) (string, string, error) {
 	u, err := url.Parse(anURL)
 	if err != nil {
-		return "", "", errors.Wrap(err, "can't parse object URL")
+		return "", "", fmt.Errorf("can't parse object URL: %w", err)
 	}
 
 	uPath := u.Path


### PR DESCRIPTION
Use standard library for errors wrapping.

Most code changes done with `github.com/xdg-go/go-rewrap-errors` and `goimports`.

Steps followed to prepare this PR:
* `find . -name "*.go" -exec go run github.com/xdg-go/go-rewrap-errors@latest -w {} \;`
* `find . -name "*.go" -exec goimports -w {} \;`
* `go mod tidy`
* `mage check`.


Based on the procedure followed in https://github.com/elastic/elastic-package/pull/1332