### PR TITLE
Fix context propagation in APM transaction for index watcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bugfixes
 
+* Fix context propagation in APM transaction for watcher backend process. [#1150](https://github.com/elastic/package-registry/issues/1150)
+
 ### Added
 
 ### Deprecated

--- a/storage/indexer.go
+++ b/storage/indexer.go
@@ -123,7 +123,7 @@ func (i *Indexer) watchIndices(ctx context.Context) {
 			tx := i.options.APMTracer.StartTransaction("updateIndex", "backend.watcher")
 			defer tx.End()
 
-			err = i.updateIndex(ctx)
+			err = i.updateIndex(apm.ContextWithTransaction(ctx, tx))
 			if err != nil {
 				i.logger.Error("can't update index file", zap.Error(err))
 			}


### PR DESCRIPTION
Spans inside `uptimeIndex` were not being reported.