### PR TITLE
Avoid propagating APM transaction from init to watcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bugfixes
 
-* Fix context propagation in APM transaction for watcher backend process. [#1150](https://github.com/elastic/package-registry/issues/1150)
+* Fix context propagation in APM transaction for watcher backend process. [#1150](https://github.com/elastic/package-registry/pull/1150) [#1152](https://github.com/elastic/package-registry/pull/1152)
 
 ### Added
 

--- a/storage/indexer.go
+++ b/storage/indexer.go
@@ -76,7 +76,7 @@ func (i *Indexer) Init(ctx context.Context) error {
 		return fmt.Errorf("can't update index file: %w", err)
 	}
 
-	go i.watchIndices(ctx)
+	go i.watchIndices(apm.ContextWithTransaction(ctx, nil))
 	return nil
 }
 


### PR DESCRIPTION
Watcher receives a context when started from init, avoid propagating the APM transaction through this context.
Currently all spans from the watcher are reported as part of the init transaction.