### PR TITLE
Support building and pushing multi-platform registry image

### DIFF
--- a/.buildkite/scripts/publish-distribution.sh
+++ b/.buildkite/scripts/publish-distribution.sh
@@ -21,6 +21,6 @@ docker buildx create --use
 if [[ ${DRY_RUN:-true} == "true" ]]; then
     docker buildx imagetools create --dry-run -t "${DOCKER_IMG_TARGET}" "${DOCKER_IMG_SOURCE}"
 else
-    docker buildx imagetools create -t "${DOCKER_IMG_TARGET}" "${DOCKER_IMG_SOURCE}"
+    retry 3 docker buildx imagetools create -t "${DOCKER_IMG_TARGET}" "${DOCKER_IMG_SOURCE}"
     echo "Docker image pushed: ${DOCKER_IMG_TARGET}"
 fi

--- a/.buildkite/scripts/publish-distribution.sh
+++ b/.buildkite/scripts/publish-distribution.sh
@@ -14,16 +14,13 @@ else
     DOCKER_IMG_TARGET="${DOCKER_REGISTRY}/package-registry/distribution:${TAG_NAME}-${DOCKER_TAG}"
 fi
 
-echo "Docker pull"
-retry 3 docker pull "${DOCKER_IMG_SOURCE}"
 echo "Docker retag"
-docker tag "${DOCKER_IMG_SOURCE}" "${DOCKER_IMG_TARGET}"
+docker buildx create --use
 
 # do not push if DRY_RUN is true
 if [[ ${DRY_RUN:-true} == "true" ]]; then
-    echo "Docker push command will be: retry 3 docker push ${DOCKER_IMG_TARGET}"
+    docker buildx imagetools create --dry-run -t "${DOCKER_IMG_TARGET}" "${DOCKER_IMG_SOURCE}"
 else
-    echo "Docker push:"
-    retry 3 docker push "${DOCKER_IMG_TARGET}"
+    docker buildx imagetools create -t "${DOCKER_IMG_TARGET}" "${DOCKER_IMG_SOURCE}"
     echo "Docker image pushed: ${DOCKER_IMG_TARGET}"
 fi

--- a/.buildkite/scripts/publish.sh
+++ b/.buildkite/scripts/publish.sh
@@ -5,18 +5,18 @@ set -euo pipefail
 
 
 pushDockerImage() {
-    docker build \
+    docker buildx create --use
+    docker buildx build --push \
+        --platform linux/amd64,linux/arm64 \
         -t "${DOCKER_IMG_TAG}" \
+        -t "${DOCKER_IMG_TAG_BRANCH}" \
         --label BRANCH_NAME="${TAG_NAME}" \
         --label GIT_SHA="${BUILDKITE_COMMIT}" \
         --label GO_VERSION="${SETUP_GOLANG_VERSION}" \
         --label TIMESTAMP="$(date +%Y-%m-%d_%H:%M)" \
         .
-    retry 3 docker push "${DOCKER_IMG_TAG}"
-    echo "Docker image pushed: ${DOCKER_IMG_TAG}"
-    docker tag "${DOCKER_IMG_TAG}" "${DOCKER_IMG_TAG_BRANCH}"
-    retry 3 docker push "${DOCKER_IMG_TAG_BRANCH}"
-    echo "Docker image pushed: ${DOCKER_IMG_TAG_BRANCH}"
+
+    echo "Docker images pushed: ${DOCKER_IMG_TAG} ${DOCKER_IMG_TAG_BRANCH}"
 }
 
 if [[ "${BUILDKITE_PULL_REQUEST}" != "false" ]]; then

--- a/.buildkite/scripts/publish.sh
+++ b/.buildkite/scripts/publish.sh
@@ -6,7 +6,19 @@ set -euo pipefail
 
 pushDockerImage() {
     docker buildx create --use
-    docker buildx build --push \
+    # first build the image without push
+    docker buildx build \
+        --platform linux/amd64,linux/arm64/v8 \
+        -t "${DOCKER_IMG_TAG}" \
+        -t "${DOCKER_IMG_TAG_BRANCH}" \
+        --label BRANCH_NAME="${TAG_NAME}" \
+        --label GIT_SHA="${BUILDKITE_COMMIT}" \
+        --label GO_VERSION="${SETUP_GOLANG_VERSION}" \
+        --label TIMESTAMP="$(date +%Y-%m-%d_%H:%M)" \
+        .
+
+    # essentially the same as above with --push flag; the build should be in the cache
+    retry 3 docker buildx build --push \
         --platform linux/amd64,linux/arm64/v8 \
         -t "${DOCKER_IMG_TAG}" \
         -t "${DOCKER_IMG_TAG_BRANCH}" \

--- a/.buildkite/scripts/publish.sh
+++ b/.buildkite/scripts/publish.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 pushDockerImage() {
     docker buildx create --use
     docker buildx build --push \
-        --platform linux/amd64,linux/arm64 \
+        --platform linux/amd64,linux/arm64/v8 \
         -t "${DOCKER_IMG_TAG}" \
         -t "${DOCKER_IMG_TAG_BRANCH}" \
         --label BRANCH_NAME="${TAG_NAME}" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Add support for multi-platform container images. [#1162](https://github.com/elastic/package-registry/pull/1162)
+
 ### Deprecated
 
 ### Known Issues

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 
 # Build binary
 ARG GO_VERSION=1.21.7
-FROM golang:${GO_VERSION} AS builder
+FROM --platform=${BUILDPLATFORM:-linux} golang:${GO_VERSION} AS builder
 
 COPY ./ /package-registry
 WORKDIR /package-registry

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,10 @@ FROM --platform=${BUILDPLATFORM:-linux} golang:${GO_VERSION} AS builder
 
 COPY ./ /package-registry
 WORKDIR /package-registry
-RUN go build .
+
+ARG TARGETPLATFORM
+
+RUN make release-${TARGETPLATFORM:-linux}
 
 
 # Run binary

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PLATFORMS ?= linux/amd64 linux/arm64
+PLATFORMS ?= linux/amd64 linux/arm64/v8 linux/arm64
 PLATFORM_TARGETS=$(addprefix release-, $(PLATFORMS))
 
 TARGET_ARCH_amd64=x86_64
@@ -15,6 +15,6 @@ $(OSS_TARGETS): release-%:
 .PHONY: $(OS_TARGETS)
 $(PLATFORM_TARGETS): release-%:
 	$(eval $@_OS := $(firstword $(subst /, ,$(lastword $(subst release-, ,$@)))))
-	$(eval $@_GO_ARCH := $(lastword $(subst /, ,$(lastword $(subst release-, ,$@)))))
+	$(eval $@_GO_ARCH := $(word 2, $(subst /, ,$(lastword $(subst release-, ,$@)))))
 	$(eval $@_ARCH := $(TARGET_ARCH_$($@_GO_ARCH)))
 	GOOS=$($@_OS) GOARCH=$($@_GO_ARCH) go build .

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+PLATFORMS ?= linux/amd64 linux/arm64
+PLATFORM_TARGETS=$(addprefix release-, $(PLATFORMS))
+
+TARGET_ARCH_amd64=x86_64
+TARGET_ARCH_arm64=arm64
+
+OSS ?= linux
+OSS_TARGETS=$(addprefix release-, $(OSS))
+
+.PHONY: $(OSS_TARGETS)
+$(OSS_TARGETS): release-%:
+	$(eval $@_OS := $(firstword $(subst /, ,$(lastword $(subst release-, ,$@)))))
+	GOOS=$($@_OS) go build .
+
+.PHONY: $(OS_TARGETS)
+$(PLATFORM_TARGETS): release-%:
+	$(eval $@_OS := $(firstword $(subst /, ,$(lastword $(subst release-, ,$@)))))
+	$(eval $@_GO_ARCH := $(lastword $(subst /, ,$(lastword $(subst release-, ,$@)))))
+	$(eval $@_ARCH := $(TARGET_ARCH_$($@_GO_ARCH)))
+	GOOS=$($@_OS) GOARCH=$($@_GO_ARCH) go build .


### PR DESCRIPTION
This PR builds `package-registry` container image as a multi-platform one, supporting linux/amd64 and linux/arm64, by utilising `docker buildx`. Having such an image of package-registry will help us achieve native execution of `elastic-package stack up` on arm64-based machines.

PS: I am not that experienced in `buildkite` to make sure that `buildx` is always installed and available on the runner 🙂