### PR TITLE
Use Wolfi base images

### DIFF
--- a/.buildkite/scripts/publish.sh
+++ b/.buildkite/scripts/publish.sh
@@ -20,6 +20,8 @@ pushDockerImage() {
     # essentially the same as above with --push flag; the build should be in the cache
     retry 3 docker buildx build --push \
         --platform linux/amd64,linux/arm64/v8 \
+	--build-arg BUILDER_IMAGE=docker.elastic.co/wolfi/go \
+	--build-arg RUNNER_IMAGE=docker.elastic.co/wolfi/chainguard-base \
         -t "${DOCKER_IMG_TAG}" \
         -t "${DOCKER_IMG_TAG_BRANCH}" \
         --label BRANCH_NAME="${TAG_NAME}" \

--- a/.buildkite/scripts/publish.sh
+++ b/.buildkite/scripts/publish.sh
@@ -24,7 +24,7 @@ push_docker_image() {
     build_docker_image
 
     # essentially the same as above with --push flag; the build should be in the cache
-    build_docker_image --push
+    retry 3 build_docker_image --push
 
     echo "Docker images pushed: ${DOCKER_IMG_TAG} ${DOCKER_IMG_TAG_BRANCH}"
 }

--- a/.buildkite/scripts/publish.sh
+++ b/.buildkite/scripts/publish.sh
@@ -3,32 +3,28 @@ source .buildkite/scripts/tooling.sh
 
 set -euo pipefail
 
-
-pushDockerImage() {
-    docker buildx create --use
-    # first build the image without push
-    docker buildx build \
+build_docker_image() {
+    docker buildx build "$@" \
         --platform linux/amd64,linux/arm64/v8 \
         -t "${DOCKER_IMG_TAG}" \
         -t "${DOCKER_IMG_TAG_BRANCH}" \
+        --build-arg BUILDER_IMAGE=docker.elastic.co/wolfi/go \
+        --build-arg RUNNER_IMAGE=docker.elastic.co/wolfi/chainguard-base \
         --label BRANCH_NAME="${TAG_NAME}" \
         --label GIT_SHA="${BUILDKITE_COMMIT}" \
         --label GO_VERSION="${SETUP_GOLANG_VERSION}" \
         --label TIMESTAMP="$(date +%Y-%m-%d_%H:%M)" \
         .
+}
+
+push_docker_image() {
+    docker buildx create --use
+
+    # first build the image without push
+    build_docker_image
 
     # essentially the same as above with --push flag; the build should be in the cache
-    retry 3 docker buildx build --push \
-        --platform linux/amd64,linux/arm64/v8 \
-	--build-arg BUILDER_IMAGE=docker.elastic.co/wolfi/go \
-	--build-arg RUNNER_IMAGE=docker.elastic.co/wolfi/chainguard-base \
-        -t "${DOCKER_IMG_TAG}" \
-        -t "${DOCKER_IMG_TAG_BRANCH}" \
-        --label BRANCH_NAME="${TAG_NAME}" \
-        --label GIT_SHA="${BUILDKITE_COMMIT}" \
-        --label GO_VERSION="${SETUP_GOLANG_VERSION}" \
-        --label TIMESTAMP="$(date +%Y-%m-%d_%H:%M)" \
-        .
+    build_docker_image --push
 
     echo "Docker images pushed: ${DOCKER_IMG_TAG} ${DOCKER_IMG_TAG_BRANCH}"
 }
@@ -49,4 +45,4 @@ fi
 DOCKER_IMG_TAG="${DOCKER_NAMESPACE}:${BUILDKITE_COMMIT}"
 DOCKER_IMG_TAG_BRANCH="${DOCKER_NAMESPACE}:${TAG_NAME}"
 
-pushDockerImage
+push_docker_image

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * Add support for multi-platform container images. [#1162](https://github.com/elastic/package-registry/pull/1162)
+* Use Wolfi as base for container images. [#1169](https://github.com/elastic/package-registry/pull/1169)
 
 ### Deprecated
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,12 @@
 # This image contains the package-registry binary.
 # It expects packages to be mounted under /packages/package-registry or have a config file loaded into /package-registry/config.yml
 
-# Build binary
 ARG GO_VERSION=1.21.7
-FROM --platform=${BUILDPLATFORM:-linux} golang:${GO_VERSION} AS builder
+ARG BUILDER_IMAGE=golang
+ARG RUNNER_IMAGE=cgr.dev/chainguard/wolfi-base
+
+# Build binary
+FROM --platform=${BUILDPLATFORM:-linux} ${BUILDER_IMAGE}:${GO_VERSION} AS builder
 
 COPY ./ /package-registry
 WORKDIR /package-registry
@@ -14,12 +17,13 @@ RUN make release-${TARGETPLATFORM:-linux}
 
 
 # Run binary
-FROM ubuntu:22.04
+FROM ${RUNNER_IMAGE}
 
 # Get dependencies
-RUN apt-get update && \
-    apt-get install -y media-types zip rsync curl && \
-    rm -rf /var/lib/apt/lists/*
+# Mailcap is installed to get mime types information.
+RUN apk update && \
+    apk add mailcap zip rsync curl && \
+    rm -rf /var/cache/apk/*
 
 # Move binary from the builder image
 COPY --from=builder /package-registry/package-registry /package-registry/package-registry


### PR DESCRIPTION
Use Wolfi docker images when possible, instead of the Ubuntu ones.

These images are smaller and better hardened.

Public images are used in the Dockerfile, but overwritten in CI to use images provided by Chainguard.