### PR TITLE
Group dependabot updates of apm dependencies in single PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,7 @@ updates:
     reviewers:
       - "elastic/ecosystem"
     open-pull-requests-limit: 10
+    groups:
+      elastic-apm:
+        patterns:
+          - "go.elastic.co/apm/*"


### PR DESCRIPTION
We use different APM packages, that are released together. Group them in dependabot PRs.