### PR TITLE
Use `core-windows-2022` instead of unmaintained `ci-windows-2022`

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -42,7 +42,7 @@ steps:
       - ".buildkite/scripts/run-tests.ps1"
     agents:
       provider: "gcp"
-      image: "family/ci-windows-2022"
+      image: "family/core-windows-2022"
     artifact_paths:
       - "tests-report-win.xml"
 


### PR DESCRIPTION
The image family `ci-windows-2022` has been unmaintained for a while and has been replaced by `core-windows-2022`. This PR updates them to this instead.

Related to [incident 505.](https://elastic.slack.com/archives/C078RND5G5C)