### PR TITLE
Add email notification if release distribution pipeline fails

### DIFF
--- a/.buildkite/release-package-registry-distribution.yml
+++ b/.buildkite/release-package-registry-distribution.yml
@@ -2,6 +2,7 @@
 
 env:
   DOCKER_REGISTRY: 'docker.elastic.co'
+  NOTIFY_TO: "ecosystem-team@elastic.co"
 
 steps:
   - label: ":thought_balloon: Notification"
@@ -44,3 +45,7 @@ steps:
     depends_on:
       - step: "validate"
         allow_failure: false
+
+notify:
+  - email: "$NOTIFY_TO"
+    if: "build.state == 'failed' && build.env('BUILDKITE_PULL_REQUEST') == 'false'"


### PR DESCRIPTION
Add email notification if release package registry distribution fails.