### PR TITLE
Include data streams summary in search responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Include summary of data streams in search responses. [#1264](https://github.com/elastic/package-registry/pull/1264)
+
 ### Deprecated
 
 ### Known Issues

--- a/packages/datastream.go
+++ b/packages/datastream.go
@@ -43,7 +43,7 @@ type DataStream struct {
 	DatasetIsPrefix bool   `config:"dataset_is_prefix" json:"dataset_is_prefix,omitempty" yaml:"dataset_is_prefix,omitempty"`
 
 	Title   string `config:"title" json:"title" validate:"required"`
-	Release string `config:"release" json:"release"`
+	Release string `config:"release" json:"release,omitempty"`
 
 	// Deprecated: Replaced by elasticsearch.ingest_pipeline.name
 	IngestPipeline string                   `config:"ingest_pipeline,omitempty" json:"ingest_pipeline,omitempty" yaml:"ingest_pipeline,omitempty"`

--- a/packages/package.go
+++ b/packages/package.go
@@ -78,6 +78,7 @@ type BasePackage struct {
 	Categories              []string             `config:"categories,omitempty" json:"categories,omitempty" yaml:"categories,omitempty"`
 	SignaturePath           string               `config:"signature_path,omitempty" json:"signature_path,omitempty" yaml:"signature_path,omitempty"`
 	Discovery               *Discovery           `config:"discovery,omitempty" json:"discovery,omitempty" yaml:"discovery,omitempty"`
+	DataStreams             []*DataStream        `config:"data_streams,omitempty" json:"data_streams,omitempty" yaml:"data_streams,omitempty"`
 }
 
 // BasePolicyTemplate is used for the package policy templates in the /search endpoint

--- a/testdata/generated/search-all-proxy.json
+++ b/testdata/generated/search-all-proxy.json
@@ -15,6 +15,13 @@
     },
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "agent_privileges.agent_privileges",
+        "title": "Agent privileges data stream"
+      }
     ]
   },
   {
@@ -35,6 +42,23 @@
     ],
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "datasources.examplelog1",
+        "title": "Example dataset with inputs"
+      },
+      {
+        "type": "logs",
+        "dataset": "datasources.examplelog2",
+        "title": "Example dataset with inputs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "datasources.examplemetric",
+        "title": "Example data stream with inputs"
+      }
     ]
   },
   {
@@ -53,6 +77,13 @@
     },
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "elasticsearch_privileges.elasticsearch_privileges",
+        "title": "Elasticsearch privileges data stream"
+      }
     ]
   },
   {
@@ -82,6 +113,13 @@
     "categories": [
       "crm",
       "azure"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "nodirentries.foo",
+        "title": "Foo"
+      }
     ]
   },
   {
@@ -114,6 +152,13 @@
     "categories": [
       "crm",
       "azure"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "example.foo",
+        "title": "Foo"
+      }
     ]
   },
   {
@@ -144,7 +189,14 @@
       "crm",
       "azure"
     ],
-    "signature_path": "/epr/example/example-1.0.1.zip.sig"
+    "signature_path": "/epr/example/example-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "example.foo",
+        "title": "Foo"
+      }
+    ]
   },
   {
     "name": "example",
@@ -179,6 +231,13 @@
     "categories": [
       "crm",
       "azure"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "example.foo",
+        "title": "Foo"
+      }
     ]
   },
   {
@@ -222,6 +281,13 @@
     },
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "hidden.hidden",
+        "title": "Hidden data stream and ilm policy overrride"
+      }
     ]
   },
   {
@@ -240,6 +306,13 @@
     },
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "ilm_policy.ilm_policy",
+        "title": "ILM policy overrride data stream"
+      }
     ]
   },
   {
@@ -333,6 +406,13 @@
     "categories": [
       "crm",
       "azure"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "integration_input.foo",
+        "title": "Foo"
+      }
     ]
   },
   {
@@ -512,6 +592,13 @@
     "path": "/package/no_stream_configs/1.0.0",
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "no_stream_configs.log",
+        "title": "Log Yaml pipeline"
+      }
     ]
   },
   {
@@ -550,6 +637,13 @@
     "categories": [
       "custom",
       "web"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "reference.reference",
+        "title": "Reference Logs Title"
+      }
     ]
   },
   {
@@ -563,6 +657,13 @@
     "path": "/package/yamlpipeline/1.0.0",
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "yamlpipeline.log",
+        "title": "Log Yaml pipeline"
+      }
     ]
   }
 ]

--- a/testdata/generated/search-all.json
+++ b/testdata/generated/search-all.json
@@ -15,6 +15,13 @@
     },
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "agent_privileges.agent_privileges",
+        "title": "Agent privileges data stream"
+      }
     ]
   },
   {
@@ -35,6 +42,23 @@
     ],
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "datasources.examplelog1",
+        "title": "Example dataset with inputs"
+      },
+      {
+        "type": "logs",
+        "dataset": "datasources.examplelog2",
+        "title": "Example dataset with inputs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "datasources.examplemetric",
+        "title": "Example data stream with inputs"
+      }
     ]
   },
   {
@@ -53,6 +77,13 @@
     },
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "elasticsearch_privileges.elasticsearch_privileges",
+        "title": "Elasticsearch privileges data stream"
+      }
     ]
   },
   {
@@ -82,6 +113,13 @@
     "categories": [
       "crm",
       "azure"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "nodirentries.foo",
+        "title": "Foo"
+      }
     ]
   },
   {
@@ -114,6 +152,13 @@
     "categories": [
       "crm",
       "azure"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "example.foo",
+        "title": "Foo"
+      }
     ]
   },
   {
@@ -144,7 +189,14 @@
       "crm",
       "azure"
     ],
-    "signature_path": "/epr/example/example-1.0.1.zip.sig"
+    "signature_path": "/epr/example/example-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "example.foo",
+        "title": "Foo"
+      }
+    ]
   },
   {
     "name": "example",
@@ -179,6 +231,13 @@
     "categories": [
       "crm",
       "azure"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "example.foo",
+        "title": "Foo"
+      }
     ]
   },
   {
@@ -222,6 +281,13 @@
     },
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "hidden.hidden",
+        "title": "Hidden data stream and ilm policy overrride"
+      }
     ]
   },
   {
@@ -240,6 +306,13 @@
     },
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "ilm_policy.ilm_policy",
+        "title": "ILM policy overrride data stream"
+      }
     ]
   },
   {
@@ -333,6 +406,13 @@
     "categories": [
       "crm",
       "azure"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "integration_input.foo",
+        "title": "Foo"
+      }
     ]
   },
   {
@@ -473,6 +553,13 @@
     "path": "/package/no_stream_configs/1.0.0",
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "no_stream_configs.log",
+        "title": "Log Yaml pipeline"
+      }
     ]
   },
   {
@@ -511,6 +598,13 @@
     "categories": [
       "custom",
       "web"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "reference.reference",
+        "title": "Reference Logs Title"
+      }
     ]
   },
   {
@@ -524,6 +618,13 @@
     "path": "/package/yamlpipeline/1.0.0",
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "yamlpipeline.log",
+        "title": "Log Yaml pipeline"
+      }
     ]
   }
 ]

--- a/testdata/generated/search-category-custom.json
+++ b/testdata/generated/search-category-custom.json
@@ -15,6 +15,13 @@
     },
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "agent_privileges.agent_privileges",
+        "title": "Agent privileges data stream"
+      }
     ]
   },
   {
@@ -35,6 +42,23 @@
     ],
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "datasources.examplelog1",
+        "title": "Example dataset with inputs"
+      },
+      {
+        "type": "logs",
+        "dataset": "datasources.examplelog2",
+        "title": "Example dataset with inputs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "datasources.examplemetric",
+        "title": "Example data stream with inputs"
+      }
     ]
   },
   {
@@ -53,6 +77,13 @@
     },
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "elasticsearch_privileges.elasticsearch_privileges",
+        "title": "Elasticsearch privileges data stream"
+      }
     ]
   },
   {
@@ -96,6 +127,13 @@
     },
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "hidden.hidden",
+        "title": "Hidden data stream and ilm policy overrride"
+      }
     ]
   },
   {
@@ -114,6 +152,13 @@
     },
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "ilm_policy.ilm_policy",
+        "title": "ILM policy overrride data stream"
+      }
     ]
   },
   {
@@ -263,6 +308,13 @@
     "path": "/package/no_stream_configs/1.0.0",
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "no_stream_configs.log",
+        "title": "Log Yaml pipeline"
+      }
     ]
   },
   {
@@ -301,6 +353,13 @@
     "categories": [
       "custom",
       "web"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "reference.reference",
+        "title": "Reference Logs Title"
+      }
     ]
   },
   {
@@ -314,6 +373,13 @@
     "path": "/package/yamlpipeline/1.0.0",
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "yamlpipeline.log",
+        "title": "Log Yaml pipeline"
+      }
     ]
   }
 ]

--- a/testdata/generated/search-category-datastore-prerelease.json
+++ b/testdata/generated/search-category-datastore-prerelease.json
@@ -35,6 +35,13 @@
     "categories": [
       "datastore",
       "monitoring"
+    ],
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "datastream_without_release.nodes",
+        "title": "Apache Spark nodes metrics"
+      }
     ]
   },
   {
@@ -78,6 +85,13 @@
       "crm",
       "azure",
       "cloud"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "example.foo",
+        "title": "Foo"
+      }
     ]
   },
   {

--- a/testdata/generated/search-category-datastore.json
+++ b/testdata/generated/search-category-datastore.json
@@ -35,6 +35,13 @@
     "categories": [
       "datastore",
       "monitoring"
+    ],
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "datastream_without_release.nodes",
+        "title": "Apache Spark nodes metrics"
+      }
     ]
   },
   {
@@ -70,6 +77,13 @@
     "categories": [
       "crm",
       "azure"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "example.foo",
+        "title": "Foo"
+      }
     ]
   },
   {

--- a/testdata/generated/search-category-observability-subcategories.json
+++ b/testdata/generated/search-category-observability-subcategories.json
@@ -90,6 +90,13 @@
     "categories": [
       "custom",
       "web"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "reference.reference",
+        "title": "Reference Logs Title"
+      }
     ]
   }
 ]

--- a/testdata/generated/search-category-web-all.json
+++ b/testdata/generated/search-category-web-all.json
@@ -142,6 +142,13 @@
     "categories": [
       "custom",
       "web"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "reference.reference",
+        "title": "Reference Logs Title"
+      }
     ]
   }
 ]

--- a/testdata/generated/search-category-web.json
+++ b/testdata/generated/search-category-web.json
@@ -90,6 +90,13 @@
     "categories": [
       "custom",
       "web"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "reference.reference",
+        "title": "Reference Logs Title"
+      }
     ]
   }
 ]

--- a/testdata/generated/search-integration-integration-package.json
+++ b/testdata/generated/search-integration-integration-package.json
@@ -29,6 +29,13 @@
     "categories": [
       "crm",
       "azure"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "integration_input.foo",
+        "title": "Foo"
+      }
     ]
   }
 ]

--- a/testdata/generated/search-just-latest-proxy.json
+++ b/testdata/generated/search-just-latest-proxy.json
@@ -15,6 +15,13 @@
     },
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "agent_privileges.agent_privileges",
+        "title": "Agent privileges data stream"
+      }
     ]
   },
   {
@@ -35,6 +42,23 @@
     ],
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "datasources.examplelog1",
+        "title": "Example dataset with inputs"
+      },
+      {
+        "type": "logs",
+        "dataset": "datasources.examplelog2",
+        "title": "Example dataset with inputs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "datasources.examplemetric",
+        "title": "Example data stream with inputs"
+      }
     ]
   },
   {
@@ -53,6 +77,13 @@
     },
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "elasticsearch_privileges.elasticsearch_privileges",
+        "title": "Elasticsearch privileges data stream"
+      }
     ]
   },
   {
@@ -82,6 +113,13 @@
     "categories": [
       "crm",
       "azure"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "nodirentries.foo",
+        "title": "Foo"
+      }
     ]
   },
   {
@@ -117,6 +155,13 @@
     "categories": [
       "crm",
       "azure"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "example.foo",
+        "title": "Foo"
+      }
     ]
   },
   {
@@ -160,6 +205,13 @@
     },
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "hidden.hidden",
+        "title": "Hidden data stream and ilm policy overrride"
+      }
     ]
   },
   {
@@ -178,6 +230,13 @@
     },
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "ilm_policy.ilm_policy",
+        "title": "ILM policy overrride data stream"
+      }
     ]
   },
   {
@@ -366,6 +425,13 @@
     "path": "/package/no_stream_configs/1.0.0",
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "no_stream_configs.log",
+        "title": "Log Yaml pipeline"
+      }
     ]
   },
   {
@@ -404,6 +470,13 @@
     "categories": [
       "custom",
       "web"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "reference.reference",
+        "title": "Reference Logs Title"
+      }
     ]
   },
   {
@@ -417,6 +490,13 @@
     "path": "/package/yamlpipeline/1.0.0",
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "yamlpipeline.log",
+        "title": "Log Yaml pipeline"
+      }
     ]
   }
 ]

--- a/testdata/generated/search-kibana652.json
+++ b/testdata/generated/search-kibana652.json
@@ -17,6 +17,23 @@
     ],
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "datasources.examplelog1",
+        "title": "Example dataset with inputs"
+      },
+      {
+        "type": "logs",
+        "dataset": "datasources.examplelog2",
+        "title": "Example dataset with inputs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "datasources.examplemetric",
+        "title": "Example data stream with inputs"
+      }
     ]
   },
   {
@@ -50,6 +67,13 @@
     "path": "/package/no_stream_configs/1.0.0",
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "no_stream_configs.log",
+        "title": "Log Yaml pipeline"
+      }
     ]
   },
   {
@@ -63,6 +87,13 @@
     "path": "/package/yamlpipeline/1.0.0",
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "yamlpipeline.log",
+        "title": "Log Yaml pipeline"
+      }
     ]
   }
 ]

--- a/testdata/generated/search-kibana721.json
+++ b/testdata/generated/search-kibana721.json
@@ -17,6 +17,23 @@
     ],
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "datasources.examplelog1",
+        "title": "Example dataset with inputs"
+      },
+      {
+        "type": "logs",
+        "dataset": "datasources.examplelog2",
+        "title": "Example dataset with inputs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "datasources.examplemetric",
+        "title": "Example data stream with inputs"
+      }
     ]
   },
   {
@@ -46,6 +63,13 @@
     "categories": [
       "crm",
       "azure"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "nodirentries.foo",
+        "title": "Foo"
+      }
     ]
   },
   {
@@ -76,7 +100,14 @@
       "crm",
       "azure"
     ],
-    "signature_path": "/epr/example/example-1.0.1.zip.sig"
+    "signature_path": "/epr/example/example-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "example.foo",
+        "title": "Foo"
+      }
+    ]
   },
   {
     "name": "foo",
@@ -119,6 +150,13 @@
     },
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "hidden.hidden",
+        "title": "Hidden data stream and ilm policy overrride"
+      }
     ]
   },
   {
@@ -137,6 +175,13 @@
     },
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "ilm_policy.ilm_policy",
+        "title": "ILM policy overrride data stream"
+      }
     ]
   },
   {
@@ -225,6 +270,13 @@
     "path": "/package/no_stream_configs/1.0.0",
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "no_stream_configs.log",
+        "title": "Log Yaml pipeline"
+      }
     ]
   },
   {
@@ -263,6 +315,13 @@
     "categories": [
       "custom",
       "web"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "reference.reference",
+        "title": "Reference Logs Title"
+      }
     ]
   },
   {
@@ -276,6 +335,13 @@
     "path": "/package/yamlpipeline/1.0.0",
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "yamlpipeline.log",
+        "title": "Log Yaml pipeline"
+      }
     ]
   }
 ]

--- a/testdata/generated/search-kibana800.json
+++ b/testdata/generated/search-kibana800.json
@@ -15,6 +15,13 @@
     },
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "agent_privileges.agent_privileges",
+        "title": "Agent privileges data stream"
+      }
     ]
   },
   {
@@ -35,6 +42,23 @@
     ],
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "datasources.examplelog1",
+        "title": "Example dataset with inputs"
+      },
+      {
+        "type": "logs",
+        "dataset": "datasources.examplelog2",
+        "title": "Example dataset with inputs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "datasources.examplemetric",
+        "title": "Example data stream with inputs"
+      }
     ]
   },
   {
@@ -53,6 +77,13 @@
     },
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "elasticsearch_privileges.elasticsearch_privileges",
+        "title": "Elasticsearch privileges data stream"
+      }
     ]
   },
   {
@@ -88,6 +119,13 @@
     "categories": [
       "crm",
       "azure"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "example.foo",
+        "title": "Foo"
+      }
     ]
   },
   {
@@ -131,6 +169,13 @@
     },
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "hidden.hidden",
+        "title": "Hidden data stream and ilm policy overrride"
+      }
     ]
   },
   {
@@ -149,6 +194,13 @@
     },
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "ilm_policy.ilm_policy",
+        "title": "ILM policy overrride data stream"
+      }
     ]
   },
   {
@@ -262,6 +314,13 @@
     "path": "/package/no_stream_configs/1.0.0",
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "no_stream_configs.log",
+        "title": "Log Yaml pipeline"
+      }
     ]
   },
   {
@@ -275,6 +334,13 @@
     "path": "/package/yamlpipeline/1.0.0",
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "yamlpipeline.log",
+        "title": "Log Yaml pipeline"
+      }
     ]
   }
 ]

--- a/testdata/generated/search-package-example-all.json
+++ b/testdata/generated/search-package-example-all.json
@@ -29,6 +29,13 @@
     "categories": [
       "crm",
       "azure"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "example.foo",
+        "title": "Foo"
+      }
     ]
   },
   {
@@ -59,7 +66,14 @@
       "crm",
       "azure"
     ],
-    "signature_path": "/epr/example/example-1.0.1.zip.sig"
+    "signature_path": "/epr/example/example-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "example.foo",
+        "title": "Foo"
+      }
+    ]
   },
   {
     "name": "example",
@@ -94,6 +108,13 @@
     "categories": [
       "crm",
       "azure"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "example.foo",
+        "title": "Foo"
+      }
     ]
   }
 ]

--- a/testdata/generated/search-package-example.json
+++ b/testdata/generated/search-package-example.json
@@ -32,6 +32,13 @@
     "categories": [
       "crm",
       "azure"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "example.foo",
+        "title": "Foo"
+      }
     ]
   }
 ]

--- a/testdata/generated/search-package-experimental.json
+++ b/testdata/generated/search-package-experimental.json
@@ -15,6 +15,13 @@
     },
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "agent_privileges.agent_privileges",
+        "title": "Agent privileges data stream"
+      }
     ]
   },
   {
@@ -53,6 +60,13 @@
     "categories": [
       "datastore",
       "monitoring"
+    ],
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "datastream_without_release.nodes",
+        "title": "Apache Spark nodes metrics"
+      }
     ]
   },
   {
@@ -66,6 +80,13 @@
     "path": "/package/dataset_is_prefix/0.0.1",
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "dataset_is_prefix.test",
+        "title": "dataset_is_prefix test data stream"
+      }
     ]
   },
   {
@@ -99,6 +120,23 @@
     ],
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "datasources.examplelog1",
+        "title": "Example dataset with inputs"
+      },
+      {
+        "type": "logs",
+        "dataset": "datasources.examplelog2",
+        "title": "Example dataset with inputs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "datasources.examplemetric",
+        "title": "Example data stream with inputs"
+      }
     ]
   },
   {
@@ -119,6 +157,13 @@
     ],
     "categories": [
       "monitoring"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ecs_style_dataset.foo",
+        "title": "Foo"
+      }
     ]
   },
   {
@@ -140,6 +185,13 @@
     "categories": [
       "containers",
       "message_queue"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "default_pipeline.foo",
+        "title": "Foo"
+      }
     ]
   },
   {
@@ -224,6 +276,13 @@
     },
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "elasticsearch_privileges.elasticsearch_privileges",
+        "title": "Elasticsearch privileges data stream"
+      }
     ]
   },
   {
@@ -253,6 +312,13 @@
     "categories": [
       "crm",
       "azure"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "nodirentries.foo",
+        "title": "Foo"
+      }
     ]
   },
   {
@@ -288,6 +354,13 @@
     "categories": [
       "crm",
       "azure"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "example.foo",
+        "title": "Foo"
+      }
     ]
   },
   {
@@ -375,6 +448,13 @@
     },
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "hidden.hidden",
+        "title": "Hidden data stream and ilm policy overrride"
+      }
     ]
   },
   {
@@ -393,6 +473,13 @@
     },
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "ilm_policy.ilm_policy",
+        "title": "ILM policy overrride data stream"
+      }
     ]
   },
   {
@@ -440,6 +527,18 @@
     "categories": [
       "aws",
       "cloud"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "input_groups.ec2_logs",
+        "title": "AWS EC2 logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "input_groups.ec2_metrics",
+        "title": "AWS EC2 metrics"
+      }
     ]
   },
   {
@@ -596,6 +695,13 @@
     ],
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "multiple_false.foo",
+        "title": "Foo"
+      }
     ]
   },
   {
@@ -609,6 +715,13 @@
     "path": "/package/no_stream_configs/1.0.0",
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "no_stream_configs.log",
+        "title": "Log Yaml pipeline"
+      }
     ]
   },
   {
@@ -630,6 +743,13 @@
     },
     "categories": [
       "monitoring"
+    ],
+    "data_streams": [
+      {
+        "type": "traces",
+        "dataset": "traces.traces",
+        "title": "notapmtraces"
+      }
     ]
   },
   {
@@ -668,6 +788,13 @@
     "categories": [
       "custom",
       "web"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "reference.reference",
+        "title": "Reference Logs Title"
+      }
     ]
   },
   {
@@ -712,6 +839,13 @@
     "path": "/package/yamlpipeline/1.0.0",
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "yamlpipeline.log",
+        "title": "Log Yaml pipeline"
+      }
     ]
   }
 ]

--- a/testdata/generated/search-package-internal.json
+++ b/testdata/generated/search-package-internal.json
@@ -15,6 +15,13 @@
     },
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "agent_privileges.agent_privileges",
+        "title": "Agent privileges data stream"
+      }
     ]
   },
   {
@@ -35,6 +42,23 @@
     ],
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "datasources.examplelog1",
+        "title": "Example dataset with inputs"
+      },
+      {
+        "type": "logs",
+        "dataset": "datasources.examplelog2",
+        "title": "Example dataset with inputs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "datasources.examplemetric",
+        "title": "Example data stream with inputs"
+      }
     ]
   },
   {
@@ -53,6 +77,13 @@
     },
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "elasticsearch_privileges.elasticsearch_privileges",
+        "title": "Elasticsearch privileges data stream"
+      }
     ]
   },
   {
@@ -82,6 +113,13 @@
     "categories": [
       "crm",
       "azure"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "nodirentries.foo",
+        "title": "Foo"
+      }
     ]
   },
   {
@@ -117,6 +155,13 @@
     "categories": [
       "crm",
       "azure"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "example.foo",
+        "title": "Foo"
+      }
     ]
   },
   {
@@ -160,6 +205,13 @@
     },
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "hidden.hidden",
+        "title": "Hidden data stream and ilm policy overrride"
+      }
     ]
   },
   {
@@ -178,6 +230,13 @@
     },
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "ilm_policy.ilm_policy",
+        "title": "ILM policy overrride data stream"
+      }
     ]
   },
   {
@@ -327,6 +386,13 @@
     "path": "/package/no_stream_configs/1.0.0",
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "no_stream_configs.log",
+        "title": "Log Yaml pipeline"
+      }
     ]
   },
   {
@@ -365,6 +431,13 @@
     "categories": [
       "custom",
       "web"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "reference.reference",
+        "title": "Reference Logs Title"
+      }
     ]
   },
   {
@@ -378,6 +451,13 @@
     "path": "/package/yamlpipeline/1.0.0",
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "yamlpipeline.log",
+        "title": "Log Yaml pipeline"
+      }
     ]
   }
 ]

--- a/testdata/generated/search-package-prerelease.json
+++ b/testdata/generated/search-package-prerelease.json
@@ -15,6 +15,13 @@
     },
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "agent_privileges.agent_privileges",
+        "title": "Agent privileges data stream"
+      }
     ]
   },
   {
@@ -53,6 +60,13 @@
     "categories": [
       "datastore",
       "monitoring"
+    ],
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "datastream_without_release.nodes",
+        "title": "Apache Spark nodes metrics"
+      }
     ]
   },
   {
@@ -66,6 +80,13 @@
     "path": "/package/dataset_is_prefix/0.0.1",
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "dataset_is_prefix.test",
+        "title": "dataset_is_prefix test data stream"
+      }
     ]
   },
   {
@@ -99,6 +120,23 @@
     ],
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "datasources.examplelog1",
+        "title": "Example dataset with inputs"
+      },
+      {
+        "type": "logs",
+        "dataset": "datasources.examplelog2",
+        "title": "Example dataset with inputs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "datasources.examplemetric",
+        "title": "Example data stream with inputs"
+      }
     ]
   },
   {
@@ -119,6 +157,13 @@
     ],
     "categories": [
       "monitoring"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ecs_style_dataset.foo",
+        "title": "Foo"
+      }
     ]
   },
   {
@@ -140,6 +185,13 @@
     "categories": [
       "containers",
       "message_queue"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "default_pipeline.foo",
+        "title": "Foo"
+      }
     ]
   },
   {
@@ -224,6 +276,13 @@
     },
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "elasticsearch_privileges.elasticsearch_privileges",
+        "title": "Elasticsearch privileges data stream"
+      }
     ]
   },
   {
@@ -253,6 +312,13 @@
     "categories": [
       "crm",
       "azure"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "nodirentries.foo",
+        "title": "Foo"
+      }
     ]
   },
   {
@@ -296,6 +362,13 @@
       "crm",
       "azure",
       "cloud"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "example.foo",
+        "title": "Foo"
+      }
     ]
   },
   {
@@ -383,6 +456,13 @@
     },
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "hidden.hidden",
+        "title": "Hidden data stream and ilm policy overrride"
+      }
     ]
   },
   {
@@ -401,6 +481,13 @@
     },
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "ilm_policy.ilm_policy",
+        "title": "ILM policy overrride data stream"
+      }
     ]
   },
   {
@@ -448,6 +535,18 @@
     "categories": [
       "aws",
       "cloud"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "input_groups.ec2_logs",
+        "title": "AWS EC2 logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "input_groups.ec2_metrics",
+        "title": "AWS EC2 metrics"
+      }
     ]
   },
   {
@@ -604,6 +703,13 @@
     ],
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "multiple_false.foo",
+        "title": "Foo"
+      }
     ]
   },
   {
@@ -617,6 +723,13 @@
     "path": "/package/no_stream_configs/1.0.0",
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "no_stream_configs.log",
+        "title": "Log Yaml pipeline"
+      }
     ]
   },
   {
@@ -638,6 +751,13 @@
     },
     "categories": [
       "monitoring"
+    ],
+    "data_streams": [
+      {
+        "type": "traces",
+        "dataset": "traces.traces",
+        "title": "notapmtraces"
+      }
     ]
   },
   {
@@ -676,6 +796,13 @@
     "categories": [
       "custom",
       "web"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "reference.reference",
+        "title": "Reference Logs Title"
+      }
     ]
   },
   {
@@ -720,6 +847,13 @@
     "path": "/package/yamlpipeline/1.0.0",
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "yamlpipeline.log",
+        "title": "Log Yaml pipeline"
+      }
     ]
   }
 ]

--- a/testdata/generated/search-prerelease-capabilities-none.json
+++ b/testdata/generated/search-prerelease-capabilities-none.json
@@ -15,6 +15,13 @@
     },
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "agent_privileges.agent_privileges",
+        "title": "Agent privileges data stream"
+      }
     ]
   },
   {
@@ -53,6 +60,13 @@
     "categories": [
       "datastore",
       "monitoring"
+    ],
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "datastream_without_release.nodes",
+        "title": "Apache Spark nodes metrics"
+      }
     ]
   },
   {
@@ -66,6 +80,13 @@
     "path": "/package/dataset_is_prefix/0.0.1",
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "dataset_is_prefix.test",
+        "title": "dataset_is_prefix test data stream"
+      }
     ]
   },
   {
@@ -99,6 +120,23 @@
     ],
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "datasources.examplelog1",
+        "title": "Example dataset with inputs"
+      },
+      {
+        "type": "logs",
+        "dataset": "datasources.examplelog2",
+        "title": "Example dataset with inputs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "datasources.examplemetric",
+        "title": "Example data stream with inputs"
+      }
     ]
   },
   {
@@ -119,6 +157,13 @@
     ],
     "categories": [
       "monitoring"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ecs_style_dataset.foo",
+        "title": "Foo"
+      }
     ]
   },
   {
@@ -140,6 +185,13 @@
     "categories": [
       "containers",
       "message_queue"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "default_pipeline.foo",
+        "title": "Foo"
+      }
     ]
   },
   {
@@ -224,6 +276,13 @@
     },
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "elasticsearch_privileges.elasticsearch_privileges",
+        "title": "Elasticsearch privileges data stream"
+      }
     ]
   },
   {
@@ -253,6 +312,13 @@
     "categories": [
       "crm",
       "azure"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "nodirentries.foo",
+        "title": "Foo"
+      }
     ]
   },
   {
@@ -288,6 +354,13 @@
     "categories": [
       "crm",
       "azure"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "example.foo",
+        "title": "Foo"
+      }
     ]
   },
   {
@@ -350,6 +423,13 @@
     },
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "hidden.hidden",
+        "title": "Hidden data stream and ilm policy overrride"
+      }
     ]
   },
   {
@@ -368,6 +448,13 @@
     },
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "ilm_policy.ilm_policy",
+        "title": "ILM policy overrride data stream"
+      }
     ]
   },
   {
@@ -415,6 +502,18 @@
     "categories": [
       "aws",
       "cloud"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "input_groups.ec2_logs",
+        "title": "AWS EC2 logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "input_groups.ec2_metrics",
+        "title": "AWS EC2 metrics"
+      }
     ]
   },
   {
@@ -571,6 +670,13 @@
     ],
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "multiple_false.foo",
+        "title": "Foo"
+      }
     ]
   },
   {
@@ -584,6 +690,13 @@
     "path": "/package/no_stream_configs/1.0.0",
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "no_stream_configs.log",
+        "title": "Log Yaml pipeline"
+      }
     ]
   },
   {
@@ -605,6 +718,13 @@
     },
     "categories": [
       "monitoring"
+    ],
+    "data_streams": [
+      {
+        "type": "traces",
+        "dataset": "traces.traces",
+        "title": "notapmtraces"
+      }
     ]
   },
   {
@@ -643,6 +763,13 @@
     "categories": [
       "custom",
       "web"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "reference.reference",
+        "title": "Reference Logs Title"
+      }
     ]
   },
   {
@@ -687,6 +814,13 @@
     "path": "/package/yamlpipeline/1.0.0",
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "yamlpipeline.log",
+        "title": "Log Yaml pipeline"
+      }
     ]
   }
 ]

--- a/testdata/generated/search-prerelease-capabilities-observability-security.json
+++ b/testdata/generated/search-prerelease-capabilities-observability-security.json
@@ -15,6 +15,13 @@
     },
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "agent_privileges.agent_privileges",
+        "title": "Agent privileges data stream"
+      }
     ]
   },
   {
@@ -53,6 +60,13 @@
     "categories": [
       "datastore",
       "monitoring"
+    ],
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "datastream_without_release.nodes",
+        "title": "Apache Spark nodes metrics"
+      }
     ]
   },
   {
@@ -66,6 +80,13 @@
     "path": "/package/dataset_is_prefix/0.0.1",
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "dataset_is_prefix.test",
+        "title": "dataset_is_prefix test data stream"
+      }
     ]
   },
   {
@@ -99,6 +120,23 @@
     ],
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "datasources.examplelog1",
+        "title": "Example dataset with inputs"
+      },
+      {
+        "type": "logs",
+        "dataset": "datasources.examplelog2",
+        "title": "Example dataset with inputs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "datasources.examplemetric",
+        "title": "Example data stream with inputs"
+      }
     ]
   },
   {
@@ -119,6 +157,13 @@
     ],
     "categories": [
       "monitoring"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ecs_style_dataset.foo",
+        "title": "Foo"
+      }
     ]
   },
   {
@@ -140,6 +185,13 @@
     "categories": [
       "containers",
       "message_queue"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "default_pipeline.foo",
+        "title": "Foo"
+      }
     ]
   },
   {
@@ -224,6 +276,13 @@
     },
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "elasticsearch_privileges.elasticsearch_privileges",
+        "title": "Elasticsearch privileges data stream"
+      }
     ]
   },
   {
@@ -253,6 +312,13 @@
     "categories": [
       "crm",
       "azure"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "nodirentries.foo",
+        "title": "Foo"
+      }
     ]
   },
   {
@@ -296,6 +362,13 @@
       "crm",
       "azure",
       "cloud"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "example.foo",
+        "title": "Foo"
+      }
     ]
   },
   {
@@ -358,6 +431,13 @@
     },
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "hidden.hidden",
+        "title": "Hidden data stream and ilm policy overrride"
+      }
     ]
   },
   {
@@ -376,6 +456,13 @@
     },
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "ilm_policy.ilm_policy",
+        "title": "ILM policy overrride data stream"
+      }
     ]
   },
   {
@@ -423,6 +510,18 @@
     "categories": [
       "aws",
       "cloud"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "input_groups.ec2_logs",
+        "title": "AWS EC2 logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "input_groups.ec2_metrics",
+        "title": "AWS EC2 metrics"
+      }
     ]
   },
   {
@@ -579,6 +678,13 @@
     ],
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "multiple_false.foo",
+        "title": "Foo"
+      }
     ]
   },
   {
@@ -592,6 +698,13 @@
     "path": "/package/no_stream_configs/1.0.0",
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "no_stream_configs.log",
+        "title": "Log Yaml pipeline"
+      }
     ]
   },
   {
@@ -613,6 +726,13 @@
     },
     "categories": [
       "monitoring"
+    ],
+    "data_streams": [
+      {
+        "type": "traces",
+        "dataset": "traces.traces",
+        "title": "notapmtraces"
+      }
     ]
   },
   {
@@ -651,6 +771,13 @@
     "categories": [
       "custom",
       "web"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "reference.reference",
+        "title": "Reference Logs Title"
+      }
     ]
   },
   {
@@ -695,6 +822,13 @@
     "path": "/package/yamlpipeline/1.0.0",
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "yamlpipeline.log",
+        "title": "Log Yaml pipeline"
+      }
     ]
   }
 ]

--- a/testdata/generated/search-spec-max-2.10.0.json
+++ b/testdata/generated/search-spec-max-2.10.0.json
@@ -15,6 +15,13 @@
     },
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "agent_privileges.agent_privileges",
+        "title": "Agent privileges data stream"
+      }
     ]
   },
   {
@@ -53,6 +60,13 @@
     "categories": [
       "datastore",
       "monitoring"
+    ],
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "datastream_without_release.nodes",
+        "title": "Apache Spark nodes metrics"
+      }
     ]
   },
   {
@@ -66,6 +80,13 @@
     "path": "/package/dataset_is_prefix/0.0.1",
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "dataset_is_prefix.test",
+        "title": "dataset_is_prefix test data stream"
+      }
     ]
   },
   {
@@ -99,6 +120,23 @@
     ],
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "datasources.examplelog1",
+        "title": "Example dataset with inputs"
+      },
+      {
+        "type": "logs",
+        "dataset": "datasources.examplelog2",
+        "title": "Example dataset with inputs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "datasources.examplemetric",
+        "title": "Example data stream with inputs"
+      }
     ]
   },
   {
@@ -119,6 +157,13 @@
     ],
     "categories": [
       "monitoring"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ecs_style_dataset.foo",
+        "title": "Foo"
+      }
     ]
   },
   {
@@ -140,6 +185,13 @@
     "categories": [
       "containers",
       "message_queue"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "default_pipeline.foo",
+        "title": "Foo"
+      }
     ]
   },
   {
@@ -158,6 +210,13 @@
     },
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "elasticsearch_privileges.elasticsearch_privileges",
+        "title": "Elasticsearch privileges data stream"
+      }
     ]
   },
   {
@@ -187,6 +246,13 @@
     "categories": [
       "crm",
       "azure"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "nodirentries.foo",
+        "title": "Foo"
+      }
     ]
   },
   {
@@ -222,6 +288,13 @@
     "categories": [
       "crm",
       "azure"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "example.foo",
+        "title": "Foo"
+      }
     ]
   },
   {
@@ -265,6 +338,13 @@
     },
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "hidden.hidden",
+        "title": "Hidden data stream and ilm policy overrride"
+      }
     ]
   },
   {
@@ -283,6 +363,13 @@
     },
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "ilm_policy.ilm_policy",
+        "title": "ILM policy overrride data stream"
+      }
     ]
   },
   {
@@ -330,6 +417,18 @@
     "categories": [
       "aws",
       "cloud"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "input_groups.ec2_logs",
+        "title": "AWS EC2 logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "input_groups.ec2_metrics",
+        "title": "AWS EC2 metrics"
+      }
     ]
   },
   {
@@ -486,6 +585,13 @@
     ],
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "multiple_false.foo",
+        "title": "Foo"
+      }
     ]
   },
   {
@@ -499,6 +605,13 @@
     "path": "/package/no_stream_configs/1.0.0",
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "no_stream_configs.log",
+        "title": "Log Yaml pipeline"
+      }
     ]
   },
   {
@@ -520,6 +633,13 @@
     },
     "categories": [
       "monitoring"
+    ],
+    "data_streams": [
+      {
+        "type": "traces",
+        "dataset": "traces.traces",
+        "title": "notapmtraces"
+      }
     ]
   },
   {
@@ -558,6 +678,13 @@
     "categories": [
       "custom",
       "web"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "reference.reference",
+        "title": "Reference Logs Title"
+      }
     ]
   },
   {
@@ -602,6 +729,13 @@
     "path": "/package/yamlpipeline/1.0.0",
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "yamlpipeline.log",
+        "title": "Log Yaml pipeline"
+      }
     ]
   }
 ]

--- a/testdata/generated/search-spec-min-1.1.0-max-2.10.0.json
+++ b/testdata/generated/search-spec-min-1.1.0-max-2.10.0.json
@@ -32,6 +32,13 @@
     "categories": [
       "crm",
       "azure"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "example.foo",
+        "title": "Foo"
+      }
     ]
   },
   {

--- a/testdata/generated/search.json
+++ b/testdata/generated/search.json
@@ -15,6 +15,13 @@
     },
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "agent_privileges.agent_privileges",
+        "title": "Agent privileges data stream"
+      }
     ]
   },
   {
@@ -35,6 +42,23 @@
     ],
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "datasources.examplelog1",
+        "title": "Example dataset with inputs"
+      },
+      {
+        "type": "logs",
+        "dataset": "datasources.examplelog2",
+        "title": "Example dataset with inputs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "datasources.examplemetric",
+        "title": "Example data stream with inputs"
+      }
     ]
   },
   {
@@ -53,6 +77,13 @@
     },
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "elasticsearch_privileges.elasticsearch_privileges",
+        "title": "Elasticsearch privileges data stream"
+      }
     ]
   },
   {
@@ -82,6 +113,13 @@
     "categories": [
       "crm",
       "azure"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "nodirentries.foo",
+        "title": "Foo"
+      }
     ]
   },
   {
@@ -117,6 +155,13 @@
     "categories": [
       "crm",
       "azure"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "example.foo",
+        "title": "Foo"
+      }
     ]
   },
   {
@@ -160,6 +205,13 @@
     },
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "hidden.hidden",
+        "title": "Hidden data stream and ilm policy overrride"
+      }
     ]
   },
   {
@@ -178,6 +230,13 @@
     },
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "ilm_policy.ilm_policy",
+        "title": "ILM policy overrride data stream"
+      }
     ]
   },
   {
@@ -327,6 +386,13 @@
     "path": "/package/no_stream_configs/1.0.0",
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "no_stream_configs.log",
+        "title": "Log Yaml pipeline"
+      }
     ]
   },
   {
@@ -365,6 +431,13 @@
     "categories": [
       "custom",
       "web"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "reference.reference",
+        "title": "Reference Logs Title"
+      }
     ]
   },
   {
@@ -378,6 +451,13 @@
     "path": "/package/yamlpipeline/1.0.0",
     "categories": [
       "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "yamlpipeline.log",
+        "title": "Log Yaml pipeline"
+      }
     ]
   }
 ]

--- a/testdata/generated/storage-indexer/search-all.json
+++ b/testdata/generated/storage-indexer/search-all.json
@@ -35,7 +35,19 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/1password/1password-1.4.0.zip.sig"
+    "signature_path": "/epr/1password/1password-1.4.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "1password.item_usages",
+        "title": "Collect 1Password item usages events"
+      },
+      {
+        "type": "logs",
+        "dataset": "1password.signin_attempts",
+        "title": "1Password sign-in attempt events"
+      }
+    ]
   },
   {
     "name": "1password",
@@ -73,7 +85,19 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/1password/1password-1.0.0.zip.sig"
+    "signature_path": "/epr/1password/1password-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "1password.item_usages",
+        "title": "Collect 1Password item usages events"
+      },
+      {
+        "type": "logs",
+        "dataset": "1password.signin_attempts",
+        "title": "1Password sign-in attempt events"
+      }
+    ]
   },
   {
     "name": "1password",
@@ -111,7 +135,19 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/1password/1password-1.1.0.zip.sig"
+    "signature_path": "/epr/1password/1password-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "1password.item_usages",
+        "title": "Collect 1Password item usages events"
+      },
+      {
+        "type": "logs",
+        "dataset": "1password.signin_attempts",
+        "title": "1Password sign-in attempt events"
+      }
+    ]
   },
   {
     "name": "1password",
@@ -149,7 +185,19 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/1password/1password-1.1.1.zip.sig"
+    "signature_path": "/epr/1password/1password-1.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "1password.item_usages",
+        "title": "Collect 1Password item usages events"
+      },
+      {
+        "type": "logs",
+        "dataset": "1password.signin_attempts",
+        "title": "1Password sign-in attempt events"
+      }
+    ]
   },
   {
     "name": "1password",
@@ -187,7 +235,19 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/1password/1password-1.2.0.zip.sig"
+    "signature_path": "/epr/1password/1password-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "1password.item_usages",
+        "title": "Collect 1Password item usages events"
+      },
+      {
+        "type": "logs",
+        "dataset": "1password.signin_attempts",
+        "title": "1Password sign-in attempt events"
+      }
+    ]
   },
   {
     "name": "1password",
@@ -225,7 +285,19 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/1password/1password-1.2.1.zip.sig"
+    "signature_path": "/epr/1password/1password-1.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "1password.item_usages",
+        "title": "Collect 1Password item usages events"
+      },
+      {
+        "type": "logs",
+        "dataset": "1password.signin_attempts",
+        "title": "1Password sign-in attempt events"
+      }
+    ]
   },
   {
     "name": "1password",
@@ -263,7 +335,19 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/1password/1password-1.2.2.zip.sig"
+    "signature_path": "/epr/1password/1password-1.2.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "1password.item_usages",
+        "title": "Collect 1Password item usages events"
+      },
+      {
+        "type": "logs",
+        "dataset": "1password.signin_attempts",
+        "title": "1Password sign-in attempt events"
+      }
+    ]
   },
   {
     "name": "1password",
@@ -301,7 +385,19 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/1password/1password-1.3.0.zip.sig"
+    "signature_path": "/epr/1password/1password-1.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "1password.item_usages",
+        "title": "Collect 1Password item usages events"
+      },
+      {
+        "type": "logs",
+        "dataset": "1password.signin_attempts",
+        "title": "1Password sign-in attempt events"
+      }
+    ]
   },
   {
     "name": "aws",
@@ -596,7 +692,119 @@
       "aws",
       "cloud"
     ],
-    "signature_path": "/epr/aws/aws-1.0.0.zip.sig"
+    "signature_path": "/epr/aws/aws-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "aws.billing",
+        "title": "AWS billing metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.cloudtrail",
+        "title": "AWS CloudTrail logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.cloudwatch_logs",
+        "title": "AWS CloudWatch logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.cloudwatch_metrics",
+        "title": "AWS CloudWatch metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.dynamodb",
+        "title": "AWS DynamoDB metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.ebs",
+        "title": "AWS EBS metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.ec2_logs",
+        "title": "AWS EC2 logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.ec2_metrics",
+        "title": "AWS EC2 metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.elb_logs",
+        "title": "AWS ELB logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.elb_metrics",
+        "title": "AWS ELB metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.lambda",
+        "title": "AWS Lambda metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.natgateway",
+        "title": "AWS NAT gateway metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.rds",
+        "title": "AWS RDS metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.s3_daily_storage",
+        "title": "AWS S3 daily storage metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.s3_request",
+        "title": "AWS S3 request metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.s3access",
+        "title": "AWS s3access logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.sns",
+        "title": "AWS SNS metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.sqs",
+        "title": "AWS SQS metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.transitgateway",
+        "title": "AWS Transit Gateway metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.usage",
+        "title": "AWS usage metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.vpcflow",
+        "title": "AWS vpcflow logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.vpn",
+        "title": "AWS VPN metrics"
+      }
+    ]
   },
   {
     "name": "aws",
@@ -891,7 +1099,119 @@
       "aws",
       "cloud"
     ],
-    "signature_path": "/epr/aws/aws-1.1.0.zip.sig"
+    "signature_path": "/epr/aws/aws-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "aws.billing",
+        "title": "AWS billing metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.cloudtrail",
+        "title": "AWS CloudTrail logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.cloudwatch_logs",
+        "title": "AWS CloudWatch logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.cloudwatch_metrics",
+        "title": "AWS CloudWatch metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.dynamodb",
+        "title": "AWS DynamoDB metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.ebs",
+        "title": "AWS EBS metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.ec2_logs",
+        "title": "AWS EC2 logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.ec2_metrics",
+        "title": "AWS EC2 metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.elb_logs",
+        "title": "AWS ELB logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.elb_metrics",
+        "title": "AWS ELB metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.lambda",
+        "title": "AWS Lambda metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.natgateway",
+        "title": "AWS NAT gateway metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.rds",
+        "title": "AWS RDS metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.s3_daily_storage",
+        "title": "AWS S3 daily storage metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.s3_request",
+        "title": "AWS S3 request metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.s3access",
+        "title": "AWS s3access logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.sns",
+        "title": "AWS SNS metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.sqs",
+        "title": "AWS SQS metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.transitgateway",
+        "title": "AWS Transit Gateway metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.usage",
+        "title": "AWS usage metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.vpcflow",
+        "title": "AWS vpcflow logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.vpn",
+        "title": "AWS VPN metrics"
+      }
+    ]
   },
   {
     "name": "aws",
@@ -1252,7 +1572,149 @@
       "aws",
       "cloud"
     ],
-    "signature_path": "/epr/aws/aws-1.10.2.zip.sig"
+    "signature_path": "/epr/aws/aws-1.10.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "aws.billing",
+        "title": "AWS Billing Metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.cloudtrail",
+        "title": "AWS CloudTrail Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.cloudwatch_logs",
+        "title": "AWS CloudWatch logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.cloudwatch_metrics",
+        "title": "AWS CloudWatch metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.dynamodb",
+        "title": "AWS DynamoDB metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.ebs",
+        "title": "AWS EBS metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.ec2_logs",
+        "title": "AWS EC2 logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.ec2_metrics",
+        "title": "AWS EC2 metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.elb_logs",
+        "title": "AWS ELB logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.elb_metrics",
+        "title": "AWS ELB metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.firewall_logs",
+        "title": "AWS Network Firewall logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.firewall_metrics",
+        "title": "AWS Network Firewall metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.lambda",
+        "title": "AWS Lambda metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.natgateway",
+        "title": "AWS NAT gateway metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.rds",
+        "title": "AWS RDS metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.route53_public_logs",
+        "title": "AWS Route 53 Public Zone Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.route53_resolver_logs",
+        "title": "AWS Route 53 Resolver Query Logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.s3_daily_storage",
+        "title": "AWS S3 daily storage metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.s3_request",
+        "title": "AWS S3 request metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.s3_storage_lens",
+        "title": "AWS S3 Storage Lens metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.s3access",
+        "title": "AWS s3access logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.sns",
+        "title": "AWS SNS metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.sqs",
+        "title": "AWS SQS metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.transitgateway",
+        "title": "AWS Transit Gateway metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.usage",
+        "title": "AWS usage metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.vpcflow",
+        "title": "AWS vpcflow logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.vpn",
+        "title": "AWS VPN metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.waf",
+        "title": "AWS WAF logs"
+      }
+    ]
   },
   {
     "name": "aws",
@@ -1613,7 +2075,149 @@
       "aws",
       "cloud"
     ],
-    "signature_path": "/epr/aws/aws-1.11.0.zip.sig"
+    "signature_path": "/epr/aws/aws-1.11.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "aws.billing",
+        "title": "AWS Billing Metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.cloudtrail",
+        "title": "AWS CloudTrail Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.cloudwatch_logs",
+        "title": "AWS CloudWatch logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.cloudwatch_metrics",
+        "title": "AWS CloudWatch metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.dynamodb",
+        "title": "AWS DynamoDB metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.ebs",
+        "title": "AWS EBS metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.ec2_logs",
+        "title": "AWS EC2 logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.ec2_metrics",
+        "title": "AWS EC2 metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.elb_logs",
+        "title": "AWS ELB logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.elb_metrics",
+        "title": "AWS ELB metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.firewall_logs",
+        "title": "AWS Network Firewall logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.firewall_metrics",
+        "title": "AWS Network Firewall metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.lambda",
+        "title": "AWS Lambda metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.natgateway",
+        "title": "AWS NAT gateway metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.rds",
+        "title": "AWS RDS metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.route53_public_logs",
+        "title": "AWS Route 53 Public Zone Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.route53_resolver_logs",
+        "title": "AWS Route 53 Resolver Query Logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.s3_daily_storage",
+        "title": "AWS S3 daily storage metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.s3_request",
+        "title": "AWS S3 request metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.s3_storage_lens",
+        "title": "AWS S3 Storage Lens metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.s3access",
+        "title": "AWS s3access logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.sns",
+        "title": "AWS SNS metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.sqs",
+        "title": "AWS SQS metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.transitgateway",
+        "title": "AWS Transit Gateway metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.usage",
+        "title": "AWS usage metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.vpcflow",
+        "title": "AWS vpcflow logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.vpn",
+        "title": "AWS VPN metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.waf",
+        "title": "AWS WAF logs"
+      }
+    ]
   },
   {
     "name": "aws",
@@ -1988,7 +2592,154 @@
       "aws",
       "cloud"
     ],
-    "signature_path": "/epr/aws/aws-1.12.1.zip.sig"
+    "signature_path": "/epr/aws/aws-1.12.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "aws.billing",
+        "title": "AWS Billing Metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.cloudfront_logs",
+        "title": "AWS CloudFront logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.cloudtrail",
+        "title": "AWS CloudTrail Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.cloudwatch_logs",
+        "title": "AWS CloudWatch logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.cloudwatch_metrics",
+        "title": "AWS CloudWatch metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.dynamodb",
+        "title": "AWS DynamoDB metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.ebs",
+        "title": "AWS EBS metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.ec2_logs",
+        "title": "AWS EC2 logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.ec2_metrics",
+        "title": "AWS EC2 metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.elb_logs",
+        "title": "AWS ELB logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.elb_metrics",
+        "title": "AWS ELB metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.firewall_logs",
+        "title": "AWS Network Firewall logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.firewall_metrics",
+        "title": "AWS Network Firewall metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.lambda",
+        "title": "AWS Lambda metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.natgateway",
+        "title": "AWS NAT gateway metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.rds",
+        "title": "AWS RDS metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.route53_public_logs",
+        "title": "AWS Route 53 Public Zone Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.route53_resolver_logs",
+        "title": "AWS Route 53 Resolver Query Logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.s3_daily_storage",
+        "title": "AWS S3 daily storage metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.s3_request",
+        "title": "AWS S3 request metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.s3_storage_lens",
+        "title": "AWS S3 Storage Lens metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.s3access",
+        "title": "AWS s3access logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.sns",
+        "title": "AWS SNS metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.sqs",
+        "title": "AWS SQS metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.transitgateway",
+        "title": "AWS Transit Gateway metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.usage",
+        "title": "AWS usage metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.vpcflow",
+        "title": "AWS vpcflow logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.vpn",
+        "title": "AWS VPN metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.waf",
+        "title": "AWS WAF logs"
+      }
+    ]
   },
   {
     "name": "aws",
@@ -2363,7 +3114,154 @@
       "aws",
       "cloud"
     ],
-    "signature_path": "/epr/aws/aws-1.13.0.zip.sig"
+    "signature_path": "/epr/aws/aws-1.13.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "aws.billing",
+        "title": "AWS Billing Metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.cloudfront_logs",
+        "title": "AWS CloudFront logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.cloudtrail",
+        "title": "AWS CloudTrail Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.cloudwatch_logs",
+        "title": "AWS CloudWatch logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.cloudwatch_metrics",
+        "title": "AWS CloudWatch metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.dynamodb",
+        "title": "AWS DynamoDB metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.ebs",
+        "title": "AWS EBS metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.ec2_logs",
+        "title": "AWS EC2 logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.ec2_metrics",
+        "title": "AWS EC2 metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.elb_logs",
+        "title": "AWS ELB logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.elb_metrics",
+        "title": "AWS ELB metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.firewall_logs",
+        "title": "AWS Network Firewall logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.firewall_metrics",
+        "title": "AWS Network Firewall metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.lambda",
+        "title": "AWS Lambda metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.natgateway",
+        "title": "AWS NAT gateway metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.rds",
+        "title": "AWS RDS metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.route53_public_logs",
+        "title": "AWS Route 53 Public Zone Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.route53_resolver_logs",
+        "title": "AWS Route 53 Resolver Query Logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.s3_daily_storage",
+        "title": "AWS S3 daily storage metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.s3_request",
+        "title": "AWS S3 request metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.s3_storage_lens",
+        "title": "AWS S3 Storage Lens metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.s3access",
+        "title": "AWS s3access logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.sns",
+        "title": "AWS SNS metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.sqs",
+        "title": "AWS SQS metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.transitgateway",
+        "title": "AWS Transit Gateway metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.usage",
+        "title": "AWS usage metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.vpcflow",
+        "title": "AWS vpcflow logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.vpn",
+        "title": "AWS VPN metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.waf",
+        "title": "AWS WAF logs"
+      }
+    ]
   },
   {
     "name": "aws",
@@ -2738,7 +3636,154 @@
       "aws",
       "cloud"
     ],
-    "signature_path": "/epr/aws/aws-1.13.1.zip.sig"
+    "signature_path": "/epr/aws/aws-1.13.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "aws.billing",
+        "title": "AWS Billing Metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.cloudfront_logs",
+        "title": "AWS CloudFront logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.cloudtrail",
+        "title": "AWS CloudTrail Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.cloudwatch_logs",
+        "title": "AWS CloudWatch logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.cloudwatch_metrics",
+        "title": "AWS CloudWatch metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.dynamodb",
+        "title": "AWS DynamoDB metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.ebs",
+        "title": "AWS EBS metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.ec2_logs",
+        "title": "AWS EC2 logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.ec2_metrics",
+        "title": "AWS EC2 metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.elb_logs",
+        "title": "AWS ELB logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.elb_metrics",
+        "title": "AWS ELB metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.firewall_logs",
+        "title": "AWS Network Firewall logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.firewall_metrics",
+        "title": "AWS Network Firewall metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.lambda",
+        "title": "AWS Lambda metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.natgateway",
+        "title": "AWS NAT gateway metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.rds",
+        "title": "AWS RDS metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.route53_public_logs",
+        "title": "AWS Route 53 Public Zone Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.route53_resolver_logs",
+        "title": "AWS Route 53 Resolver Query Logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.s3_daily_storage",
+        "title": "AWS S3 daily storage metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.s3_request",
+        "title": "AWS S3 request metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.s3_storage_lens",
+        "title": "AWS S3 Storage Lens metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.s3access",
+        "title": "AWS s3access logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.sns",
+        "title": "AWS SNS metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.sqs",
+        "title": "AWS SQS metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.transitgateway",
+        "title": "AWS Transit Gateway metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.usage",
+        "title": "AWS usage metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.vpcflow",
+        "title": "AWS vpcflow logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.vpn",
+        "title": "AWS VPN metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.waf",
+        "title": "AWS WAF logs"
+      }
+    ]
   },
   {
     "name": "aws",
@@ -3113,7 +4158,154 @@
       "aws",
       "cloud"
     ],
-    "signature_path": "/epr/aws/aws-1.14.0.zip.sig"
+    "signature_path": "/epr/aws/aws-1.14.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "aws.billing",
+        "title": "AWS Billing Metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.cloudfront_logs",
+        "title": "AWS CloudFront logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.cloudtrail",
+        "title": "AWS CloudTrail Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.cloudwatch_logs",
+        "title": "AWS CloudWatch logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.cloudwatch_metrics",
+        "title": "AWS CloudWatch metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.dynamodb",
+        "title": "AWS DynamoDB metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.ebs",
+        "title": "AWS EBS metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.ec2_logs",
+        "title": "AWS EC2 logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.ec2_metrics",
+        "title": "AWS EC2 metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.elb_logs",
+        "title": "AWS ELB logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.elb_metrics",
+        "title": "AWS ELB metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.firewall_logs",
+        "title": "AWS Network Firewall logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.firewall_metrics",
+        "title": "AWS Network Firewall metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.lambda",
+        "title": "AWS Lambda metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.natgateway",
+        "title": "AWS NAT gateway metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.rds",
+        "title": "AWS RDS metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.route53_public_logs",
+        "title": "AWS Route 53 Public Zone Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.route53_resolver_logs",
+        "title": "AWS Route 53 Resolver Query Logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.s3_daily_storage",
+        "title": "AWS S3 daily storage metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.s3_request",
+        "title": "AWS S3 request metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.s3_storage_lens",
+        "title": "AWS S3 Storage Lens metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.s3access",
+        "title": "AWS s3access logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.sns",
+        "title": "AWS SNS metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.sqs",
+        "title": "AWS SQS metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.transitgateway",
+        "title": "AWS Transit Gateway metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.usage",
+        "title": "AWS usage metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.vpcflow",
+        "title": "AWS vpcflow logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.vpn",
+        "title": "AWS VPN metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.waf",
+        "title": "AWS WAF logs"
+      }
+    ]
   },
   {
     "name": "aws",
@@ -3488,7 +4680,154 @@
       "aws",
       "cloud"
     ],
-    "signature_path": "/epr/aws/aws-1.14.5.zip.sig"
+    "signature_path": "/epr/aws/aws-1.14.5.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "aws.billing",
+        "title": "AWS Billing Metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.cloudfront_logs",
+        "title": "AWS CloudFront logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.cloudtrail",
+        "title": "AWS CloudTrail Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.cloudwatch_logs",
+        "title": "AWS CloudWatch logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.cloudwatch_metrics",
+        "title": "AWS CloudWatch metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.dynamodb",
+        "title": "AWS DynamoDB metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.ebs",
+        "title": "AWS EBS metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.ec2_logs",
+        "title": "AWS EC2 logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.ec2_metrics",
+        "title": "AWS EC2 metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.elb_logs",
+        "title": "AWS ELB logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.elb_metrics",
+        "title": "AWS ELB metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.firewall_logs",
+        "title": "AWS Network Firewall logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.firewall_metrics",
+        "title": "AWS Network Firewall metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.lambda",
+        "title": "AWS Lambda metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.natgateway",
+        "title": "AWS NAT gateway metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.rds",
+        "title": "AWS RDS metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.route53_public_logs",
+        "title": "AWS Route 53 Public Zone Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.route53_resolver_logs",
+        "title": "AWS Route 53 Resolver Query Logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.s3_daily_storage",
+        "title": "AWS S3 daily storage metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.s3_request",
+        "title": "AWS S3 request metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.s3_storage_lens",
+        "title": "AWS S3 Storage Lens metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.s3access",
+        "title": "AWS s3access logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.sns",
+        "title": "AWS SNS metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.sqs",
+        "title": "AWS SQS metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.transitgateway",
+        "title": "AWS Transit Gateway metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.usage",
+        "title": "AWS usage metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.vpcflow",
+        "title": "AWS vpcflow logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.vpn",
+        "title": "AWS VPN metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.waf",
+        "title": "AWS WAF logs"
+      }
+    ]
   },
   {
     "name": "aws",
@@ -3863,7 +5202,154 @@
       "aws",
       "cloud"
     ],
-    "signature_path": "/epr/aws/aws-1.14.7.zip.sig"
+    "signature_path": "/epr/aws/aws-1.14.7.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "aws.billing",
+        "title": "AWS Billing Metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.cloudfront_logs",
+        "title": "AWS CloudFront logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.cloudtrail",
+        "title": "AWS CloudTrail Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.cloudwatch_logs",
+        "title": "AWS CloudWatch logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.cloudwatch_metrics",
+        "title": "AWS CloudWatch metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.dynamodb",
+        "title": "AWS DynamoDB metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.ebs",
+        "title": "AWS EBS metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.ec2_logs",
+        "title": "AWS EC2 logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.ec2_metrics",
+        "title": "AWS EC2 metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.elb_logs",
+        "title": "AWS ELB logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.elb_metrics",
+        "title": "AWS ELB metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.firewall_logs",
+        "title": "AWS Network Firewall logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.firewall_metrics",
+        "title": "AWS Network Firewall metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.lambda",
+        "title": "AWS Lambda metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.natgateway",
+        "title": "AWS NAT gateway metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.rds",
+        "title": "AWS RDS metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.route53_public_logs",
+        "title": "AWS Route 53 Public Zone Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.route53_resolver_logs",
+        "title": "AWS Route 53 Resolver Query Logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.s3_daily_storage",
+        "title": "AWS S3 daily storage metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.s3_request",
+        "title": "AWS S3 request metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.s3_storage_lens",
+        "title": "AWS S3 Storage Lens metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.s3access",
+        "title": "AWS s3access logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.sns",
+        "title": "AWS SNS metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.sqs",
+        "title": "AWS SQS metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.transitgateway",
+        "title": "AWS Transit Gateway metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.usage",
+        "title": "AWS usage metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.vpcflow",
+        "title": "AWS vpcflow logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.vpn",
+        "title": "AWS VPN metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.waf",
+        "title": "AWS WAF logs"
+      }
+    ]
   },
   {
     "name": "aws",
@@ -4238,7 +5724,154 @@
       "aws",
       "cloud"
     ],
-    "signature_path": "/epr/aws/aws-1.14.8.zip.sig"
+    "signature_path": "/epr/aws/aws-1.14.8.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "aws.billing",
+        "title": "AWS Billing Metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.cloudfront_logs",
+        "title": "AWS CloudFront logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.cloudtrail",
+        "title": "AWS CloudTrail Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.cloudwatch_logs",
+        "title": "AWS CloudWatch logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.cloudwatch_metrics",
+        "title": "AWS CloudWatch metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.dynamodb",
+        "title": "AWS DynamoDB metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.ebs",
+        "title": "AWS EBS metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.ec2_logs",
+        "title": "AWS EC2 logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.ec2_metrics",
+        "title": "AWS EC2 metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.elb_logs",
+        "title": "AWS ELB logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.elb_metrics",
+        "title": "AWS ELB metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.firewall_logs",
+        "title": "AWS Network Firewall logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.firewall_metrics",
+        "title": "AWS Network Firewall metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.lambda",
+        "title": "AWS Lambda metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.natgateway",
+        "title": "AWS NAT gateway metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.rds",
+        "title": "AWS RDS metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.route53_public_logs",
+        "title": "AWS Route 53 Public Zone Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.route53_resolver_logs",
+        "title": "AWS Route 53 Resolver Query Logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.s3_daily_storage",
+        "title": "AWS S3 daily storage metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.s3_request",
+        "title": "AWS S3 request metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.s3_storage_lens",
+        "title": "AWS S3 Storage Lens metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.s3access",
+        "title": "AWS s3access logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.sns",
+        "title": "AWS SNS metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.sqs",
+        "title": "AWS SQS metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.transitgateway",
+        "title": "AWS Transit Gateway metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.usage",
+        "title": "AWS usage metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.vpcflow",
+        "title": "AWS vpcflow logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.vpn",
+        "title": "AWS VPN metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.waf",
+        "title": "AWS WAF logs"
+      }
+    ]
   },
   {
     "name": "aws",
@@ -4613,7 +6246,154 @@
       "aws",
       "cloud"
     ],
-    "signature_path": "/epr/aws/aws-1.16.0.zip.sig"
+    "signature_path": "/epr/aws/aws-1.16.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "aws.billing",
+        "title": "AWS Billing Metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.cloudfront_logs",
+        "title": "AWS CloudFront logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.cloudtrail",
+        "title": "AWS CloudTrail Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.cloudwatch_logs",
+        "title": "AWS CloudWatch logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.cloudwatch_metrics",
+        "title": "AWS CloudWatch metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.dynamodb",
+        "title": "AWS DynamoDB metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.ebs",
+        "title": "AWS EBS metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.ec2_logs",
+        "title": "AWS EC2 logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.ec2_metrics",
+        "title": "AWS EC2 metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.elb_logs",
+        "title": "AWS ELB logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.elb_metrics",
+        "title": "AWS ELB metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.firewall_logs",
+        "title": "AWS Network Firewall logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.firewall_metrics",
+        "title": "AWS Network Firewall metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.lambda",
+        "title": "AWS Lambda metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.natgateway",
+        "title": "AWS NAT gateway metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.rds",
+        "title": "AWS RDS metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.route53_public_logs",
+        "title": "AWS Route 53 Public Zone Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.route53_resolver_logs",
+        "title": "AWS Route 53 Resolver Query Logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.s3_daily_storage",
+        "title": "AWS S3 daily storage metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.s3_request",
+        "title": "AWS S3 request metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.s3_storage_lens",
+        "title": "AWS S3 Storage Lens metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.s3access",
+        "title": "AWS s3access logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.sns",
+        "title": "AWS SNS metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.sqs",
+        "title": "AWS SQS metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.transitgateway",
+        "title": "AWS Transit Gateway metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.usage",
+        "title": "AWS usage metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.vpcflow",
+        "title": "AWS vpcflow logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.vpn",
+        "title": "AWS VPN metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.waf",
+        "title": "AWS WAF logs"
+      }
+    ]
   },
   {
     "name": "aws",
@@ -4988,7 +6768,154 @@
       "aws",
       "cloud"
     ],
-    "signature_path": "/epr/aws/aws-1.16.4.zip.sig"
+    "signature_path": "/epr/aws/aws-1.16.4.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "aws.billing",
+        "title": "AWS Billing Metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.cloudfront_logs",
+        "title": "AWS CloudFront logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.cloudtrail",
+        "title": "AWS CloudTrail Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.cloudwatch_logs",
+        "title": "AWS CloudWatch logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.cloudwatch_metrics",
+        "title": "AWS CloudWatch metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.dynamodb",
+        "title": "AWS DynamoDB metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.ebs",
+        "title": "AWS EBS metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.ec2_logs",
+        "title": "AWS EC2 logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.ec2_metrics",
+        "title": "AWS EC2 metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.elb_logs",
+        "title": "AWS ELB logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.elb_metrics",
+        "title": "AWS ELB metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.firewall_logs",
+        "title": "AWS Network Firewall logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.firewall_metrics",
+        "title": "AWS Network Firewall metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.lambda",
+        "title": "AWS Lambda metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.natgateway",
+        "title": "AWS NAT gateway metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.rds",
+        "title": "AWS RDS metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.route53_public_logs",
+        "title": "AWS Route 53 Public Zone Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.route53_resolver_logs",
+        "title": "AWS Route 53 Resolver Query Logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.s3_daily_storage",
+        "title": "AWS S3 daily storage metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.s3_request",
+        "title": "AWS S3 request metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.s3_storage_lens",
+        "title": "AWS S3 Storage Lens metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.s3access",
+        "title": "AWS s3access logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.sns",
+        "title": "AWS SNS metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.sqs",
+        "title": "AWS SQS metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.transitgateway",
+        "title": "AWS Transit Gateway metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.usage",
+        "title": "AWS usage metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.vpcflow",
+        "title": "AWS vpcflow logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.vpn",
+        "title": "AWS VPN metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.waf",
+        "title": "AWS WAF logs"
+      }
+    ]
   },
   {
     "name": "aws",
@@ -5318,7 +7245,129 @@
       "aws",
       "cloud"
     ],
-    "signature_path": "/epr/aws/aws-1.4.1.zip.sig"
+    "signature_path": "/epr/aws/aws-1.4.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "aws.billing",
+        "title": "AWS Billing Metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.cloudtrail",
+        "title": "AWS CloudTrail Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.cloudwatch_logs",
+        "title": "AWS CloudWatch logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.cloudwatch_metrics",
+        "title": "AWS CloudWatch metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.dynamodb",
+        "title": "AWS DynamoDB metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.ebs",
+        "title": "AWS EBS metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.ec2_logs",
+        "title": "AWS EC2 logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.ec2_metrics",
+        "title": "AWS EC2 metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.elb_logs",
+        "title": "AWS ELB logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.elb_metrics",
+        "title": "AWS ELB metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.lambda",
+        "title": "AWS Lambda metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.natgateway",
+        "title": "AWS NAT gateway metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.rds",
+        "title": "AWS RDS metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.s3_daily_storage",
+        "title": "AWS S3 daily storage metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.s3_request",
+        "title": "AWS S3 request metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.s3_storage_lens",
+        "title": "AWS S3 Storage Lens metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.s3access",
+        "title": "AWS s3access logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.sns",
+        "title": "AWS SNS metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.sqs",
+        "title": "AWS SQS metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.transitgateway",
+        "title": "AWS Transit Gateway metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.usage",
+        "title": "AWS usage metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.vpcflow",
+        "title": "AWS vpcflow logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.vpn",
+        "title": "AWS VPN metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.waf",
+        "title": "AWS WAF logs"
+      }
+    ]
   },
   {
     "name": "aws",
@@ -5648,7 +7697,129 @@
       "aws",
       "cloud"
     ],
-    "signature_path": "/epr/aws/aws-1.5.0.zip.sig"
+    "signature_path": "/epr/aws/aws-1.5.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "aws.billing",
+        "title": "AWS Billing Metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.cloudtrail",
+        "title": "AWS CloudTrail Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.cloudwatch_logs",
+        "title": "AWS CloudWatch logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.cloudwatch_metrics",
+        "title": "AWS CloudWatch metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.dynamodb",
+        "title": "AWS DynamoDB metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.ebs",
+        "title": "AWS EBS metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.ec2_logs",
+        "title": "AWS EC2 logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.ec2_metrics",
+        "title": "AWS EC2 metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.elb_logs",
+        "title": "AWS ELB logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.elb_metrics",
+        "title": "AWS ELB metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.lambda",
+        "title": "AWS Lambda metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.natgateway",
+        "title": "AWS NAT gateway metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.rds",
+        "title": "AWS RDS metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.s3_daily_storage",
+        "title": "AWS S3 daily storage metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.s3_request",
+        "title": "AWS S3 request metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.s3_storage_lens",
+        "title": "AWS S3 Storage Lens metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.s3access",
+        "title": "AWS s3access logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.sns",
+        "title": "AWS SNS metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.sqs",
+        "title": "AWS SQS metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.transitgateway",
+        "title": "AWS Transit Gateway metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.usage",
+        "title": "AWS usage metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.vpcflow",
+        "title": "AWS vpcflow logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.vpn",
+        "title": "AWS VPN metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.waf",
+        "title": "AWS WAF logs"
+      }
+    ]
   },
   {
     "name": "aws",
@@ -5978,7 +8149,129 @@
       "aws",
       "cloud"
     ],
-    "signature_path": "/epr/aws/aws-1.5.1.zip.sig"
+    "signature_path": "/epr/aws/aws-1.5.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "aws.billing",
+        "title": "AWS Billing Metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.cloudtrail",
+        "title": "AWS CloudTrail Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.cloudwatch_logs",
+        "title": "AWS CloudWatch logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.cloudwatch_metrics",
+        "title": "AWS CloudWatch metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.dynamodb",
+        "title": "AWS DynamoDB metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.ebs",
+        "title": "AWS EBS metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.ec2_logs",
+        "title": "AWS EC2 logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.ec2_metrics",
+        "title": "AWS EC2 metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.elb_logs",
+        "title": "AWS ELB logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.elb_metrics",
+        "title": "AWS ELB metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.lambda",
+        "title": "AWS Lambda metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.natgateway",
+        "title": "AWS NAT gateway metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.rds",
+        "title": "AWS RDS metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.s3_daily_storage",
+        "title": "AWS S3 daily storage metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.s3_request",
+        "title": "AWS S3 request metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.s3_storage_lens",
+        "title": "AWS S3 Storage Lens metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.s3access",
+        "title": "AWS s3access logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.sns",
+        "title": "AWS SNS metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.sqs",
+        "title": "AWS SQS metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.transitgateway",
+        "title": "AWS Transit Gateway metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.usage",
+        "title": "AWS usage metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.vpcflow",
+        "title": "AWS vpcflow logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.vpn",
+        "title": "AWS VPN metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.waf",
+        "title": "AWS WAF logs"
+      }
+    ]
   },
   {
     "name": "aws",
@@ -6308,7 +8601,129 @@
       "aws",
       "cloud"
     ],
-    "signature_path": "/epr/aws/aws-1.6.1.zip.sig"
+    "signature_path": "/epr/aws/aws-1.6.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "aws.billing",
+        "title": "AWS Billing Metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.cloudtrail",
+        "title": "AWS CloudTrail Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.cloudwatch_logs",
+        "title": "AWS CloudWatch logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.cloudwatch_metrics",
+        "title": "AWS CloudWatch metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.dynamodb",
+        "title": "AWS DynamoDB metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.ebs",
+        "title": "AWS EBS metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.ec2_logs",
+        "title": "AWS EC2 logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.ec2_metrics",
+        "title": "AWS EC2 metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.elb_logs",
+        "title": "AWS ELB logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.elb_metrics",
+        "title": "AWS ELB metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.lambda",
+        "title": "AWS Lambda metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.natgateway",
+        "title": "AWS NAT gateway metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.rds",
+        "title": "AWS RDS metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.s3_daily_storage",
+        "title": "AWS S3 daily storage metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.s3_request",
+        "title": "AWS S3 request metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.s3_storage_lens",
+        "title": "AWS S3 Storage Lens metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.s3access",
+        "title": "AWS s3access logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.sns",
+        "title": "AWS SNS metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.sqs",
+        "title": "AWS SQS metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.transitgateway",
+        "title": "AWS Transit Gateway metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.usage",
+        "title": "AWS usage metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.vpcflow",
+        "title": "AWS vpcflow logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.vpn",
+        "title": "AWS VPN metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.waf",
+        "title": "AWS WAF logs"
+      }
+    ]
   },
   {
     "name": "aws",
@@ -6669,7 +9084,149 @@
       "aws",
       "cloud"
     ],
-    "signature_path": "/epr/aws/aws-1.9.0.zip.sig"
+    "signature_path": "/epr/aws/aws-1.9.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "aws.billing",
+        "title": "AWS Billing Metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.cloudtrail",
+        "title": "AWS CloudTrail Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.cloudwatch_logs",
+        "title": "AWS CloudWatch logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.cloudwatch_metrics",
+        "title": "AWS CloudWatch metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.dynamodb",
+        "title": "AWS DynamoDB metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.ebs",
+        "title": "AWS EBS metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.ec2_logs",
+        "title": "AWS EC2 logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.ec2_metrics",
+        "title": "AWS EC2 metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.elb_logs",
+        "title": "AWS ELB logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.elb_metrics",
+        "title": "AWS ELB metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.firewall_logs",
+        "title": "AWS Network Firewall logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.firewall_metrics",
+        "title": "AWS Network Firewall metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.lambda",
+        "title": "AWS Lambda metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.natgateway",
+        "title": "AWS NAT gateway metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.rds",
+        "title": "AWS RDS metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.route53_public_logs",
+        "title": "AWS Route 53 Public Zone Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.route53_resolver_logs",
+        "title": "AWS Route 53 Resolver Query Logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.s3_daily_storage",
+        "title": "AWS S3 daily storage metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.s3_request",
+        "title": "AWS S3 request metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.s3_storage_lens",
+        "title": "AWS S3 Storage Lens metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.s3access",
+        "title": "AWS s3access logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.sns",
+        "title": "AWS SNS metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.sqs",
+        "title": "AWS SQS metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.transitgateway",
+        "title": "AWS Transit Gateway metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.usage",
+        "title": "AWS usage metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.vpcflow",
+        "title": "AWS vpcflow logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.vpn",
+        "title": "AWS VPN metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.waf",
+        "title": "AWS WAF logs"
+      }
+    ]
   },
   {
     "name": "ti_abusech",
@@ -6707,7 +9264,24 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/ti_abusech/ti_abusech-1.0.4.zip.sig"
+    "signature_path": "/epr/ti_abusech/ti_abusech-1.0.4.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_abusech.malware",
+        "title": "AbuseCH Malware logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "ti_abusech.malwarebazaar",
+        "title": "AbuseCH MalwareBazaar logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "ti_abusech.url",
+        "title": "AbuseCH URL logs"
+      }
+    ]
   },
   {
     "name": "ti_abusech",
@@ -6745,7 +9319,24 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/ti_abusech/ti_abusech-1.1.0.zip.sig"
+    "signature_path": "/epr/ti_abusech/ti_abusech-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_abusech.malware",
+        "title": "AbuseCH Malware logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "ti_abusech.malwarebazaar",
+        "title": "AbuseCH MalwareBazaar logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "ti_abusech.url",
+        "title": "AbuseCH URL logs"
+      }
+    ]
   },
   {
     "name": "ti_abusech",
@@ -6783,7 +9374,24 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/ti_abusech/ti_abusech-1.1.4.zip.sig"
+    "signature_path": "/epr/ti_abusech/ti_abusech-1.1.4.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_abusech.malware",
+        "title": "AbuseCH Malware logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "ti_abusech.malwarebazaar",
+        "title": "AbuseCH MalwareBazaar logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "ti_abusech.url",
+        "title": "AbuseCH URL logs"
+      }
+    ]
   },
   {
     "name": "ti_abusech",
@@ -6821,7 +9429,24 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/ti_abusech/ti_abusech-1.1.5.zip.sig"
+    "signature_path": "/epr/ti_abusech/ti_abusech-1.1.5.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_abusech.malware",
+        "title": "AbuseCH Malware logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "ti_abusech.malwarebazaar",
+        "title": "AbuseCH MalwareBazaar logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "ti_abusech.url",
+        "title": "AbuseCH URL logs"
+      }
+    ]
   },
   {
     "name": "ti_abusech",
@@ -6859,7 +9484,24 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/ti_abusech/ti_abusech-1.2.0.zip.sig"
+    "signature_path": "/epr/ti_abusech/ti_abusech-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_abusech.malware",
+        "title": "AbuseCH Malware logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "ti_abusech.malwarebazaar",
+        "title": "AbuseCH MalwareBazaar logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "ti_abusech.url",
+        "title": "AbuseCH URL logs"
+      }
+    ]
   },
   {
     "name": "ti_abusech",
@@ -6897,7 +9539,24 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/ti_abusech/ti_abusech-1.2.2.zip.sig"
+    "signature_path": "/epr/ti_abusech/ti_abusech-1.2.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_abusech.malware",
+        "title": "AbuseCH Malware logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "ti_abusech.malwarebazaar",
+        "title": "AbuseCH MalwareBazaar logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "ti_abusech.url",
+        "title": "AbuseCH URL logs"
+      }
+    ]
   },
   {
     "name": "ti_abusech",
@@ -6935,7 +9594,24 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/ti_abusech/ti_abusech-1.2.3.zip.sig"
+    "signature_path": "/epr/ti_abusech/ti_abusech-1.2.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_abusech.malware",
+        "title": "AbuseCH Malware logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "ti_abusech.malwarebazaar",
+        "title": "AbuseCH MalwareBazaar logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "ti_abusech.url",
+        "title": "AbuseCH URL logs"
+      }
+    ]
   },
   {
     "name": "akamai",
@@ -6976,7 +9652,14 @@
       "web",
       "cloud"
     ],
-    "signature_path": "/epr/akamai/akamai-1.0.0.zip.sig"
+    "signature_path": "/epr/akamai/akamai-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "akamai.siem",
+        "title": "Akamai SIEM Logs"
+      }
+    ]
   },
   {
     "name": "ti_otx",
@@ -7014,7 +9697,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/ti_otx/ti_otx-1.0.2.zip.sig"
+    "signature_path": "/epr/ti_otx/ti_otx-1.0.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_otx.threat",
+        "title": "Alienvault OTX logs"
+      }
+    ]
   },
   {
     "name": "ti_otx",
@@ -7052,7 +9742,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/ti_otx/ti_otx-1.0.3.zip.sig"
+    "signature_path": "/epr/ti_otx/ti_otx-1.0.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_otx.threat",
+        "title": "Alienvault OTX logs"
+      }
+    ]
   },
   {
     "name": "ti_otx",
@@ -7090,7 +9787,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/ti_otx/ti_otx-1.1.0.zip.sig"
+    "signature_path": "/epr/ti_otx/ti_otx-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_otx.threat",
+        "title": "Alienvault OTX logs"
+      }
+    ]
   },
   {
     "name": "ti_otx",
@@ -7128,7 +9832,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/ti_otx/ti_otx-1.2.0.zip.sig"
+    "signature_path": "/epr/ti_otx/ti_otx-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_otx.threat",
+        "title": "Alienvault OTX logs"
+      }
+    ]
   },
   {
     "name": "ti_otx",
@@ -7166,7 +9877,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/ti_otx/ti_otx-1.2.1.zip.sig"
+    "signature_path": "/epr/ti_otx/ti_otx-1.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_otx.threat",
+        "title": "Alienvault OTX logs"
+      }
+    ]
   },
   {
     "name": "ti_otx",
@@ -7204,7 +9922,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/ti_otx/ti_otx-1.2.2.zip.sig"
+    "signature_path": "/epr/ti_otx/ti_otx-1.2.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_otx.threat",
+        "title": "Alienvault OTX logs"
+      }
+    ]
   },
   {
     "name": "ti_anomali",
@@ -7242,7 +9967,19 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/ti_anomali/ti_anomali-1.0.2.zip.sig"
+    "signature_path": "/epr/ti_anomali/ti_anomali-1.0.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_anomali.limo",
+        "title": "Anomali Limo"
+      },
+      {
+        "type": "logs",
+        "dataset": "ti_anomali.threatstream",
+        "title": "Anomali Threatstream"
+      }
+    ]
   },
   {
     "name": "ti_anomali",
@@ -7280,7 +10017,19 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/ti_anomali/ti_anomali-1.1.3.zip.sig"
+    "signature_path": "/epr/ti_anomali/ti_anomali-1.1.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_anomali.limo",
+        "title": "Anomali Limo"
+      },
+      {
+        "type": "logs",
+        "dataset": "ti_anomali.threatstream",
+        "title": "Anomali Threatstream"
+      }
+    ]
   },
   {
     "name": "ti_anomali",
@@ -7318,7 +10067,19 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/ti_anomali/ti_anomali-1.2.0.zip.sig"
+    "signature_path": "/epr/ti_anomali/ti_anomali-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_anomali.limo",
+        "title": "Anomali Limo"
+      },
+      {
+        "type": "logs",
+        "dataset": "ti_anomali.threatstream",
+        "title": "Anomali Threatstream"
+      }
+    ]
   },
   {
     "name": "ti_anomali",
@@ -7356,7 +10117,19 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/ti_anomali/ti_anomali-1.2.1.zip.sig"
+    "signature_path": "/epr/ti_anomali/ti_anomali-1.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_anomali.limo",
+        "title": "Anomali Limo"
+      },
+      {
+        "type": "logs",
+        "dataset": "ti_anomali.threatstream",
+        "title": "Anomali Threatstream"
+      }
+    ]
   },
   {
     "name": "ti_anomali",
@@ -7394,7 +10167,19 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/ti_anomali/ti_anomali-1.2.2.zip.sig"
+    "signature_path": "/epr/ti_anomali/ti_anomali-1.2.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_anomali.limo",
+        "title": "Anomali Limo"
+      },
+      {
+        "type": "logs",
+        "dataset": "ti_anomali.threatstream",
+        "title": "Anomali Threatstream"
+      }
+    ]
   },
   {
     "name": "ti_anomali",
@@ -7432,7 +10217,19 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/ti_anomali/ti_anomali-1.2.3.zip.sig"
+    "signature_path": "/epr/ti_anomali/ti_anomali-1.2.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_anomali.limo",
+        "title": "Anomali Limo"
+      },
+      {
+        "type": "logs",
+        "dataset": "ti_anomali.threatstream",
+        "title": "Anomali Threatstream"
+      }
+    ]
   },
   {
     "name": "apache",
@@ -7470,7 +10267,24 @@
     "categories": [
       "web"
     ],
-    "signature_path": "/epr/apache/apache-1.1.0.zip.sig"
+    "signature_path": "/epr/apache/apache-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "apache.access",
+        "title": "Apache access logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "apache.error",
+        "title": "Apache error logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apache.status",
+        "title": "Apache status metrics"
+      }
+    ]
   },
   {
     "name": "apache",
@@ -7508,7 +10322,24 @@
     "categories": [
       "web"
     ],
-    "signature_path": "/epr/apache/apache-1.3.0.zip.sig"
+    "signature_path": "/epr/apache/apache-1.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "apache.access",
+        "title": "Apache access logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "apache.error",
+        "title": "Apache error logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apache.status",
+        "title": "Apache status metrics"
+      }
+    ]
   },
   {
     "name": "apache",
@@ -7546,7 +10377,24 @@
     "categories": [
       "web"
     ],
-    "signature_path": "/epr/apache/apache-1.3.2.zip.sig"
+    "signature_path": "/epr/apache/apache-1.3.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "apache.access",
+        "title": "Apache access logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "apache.error",
+        "title": "Apache error logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apache.status",
+        "title": "Apache status metrics"
+      }
+    ]
   },
   {
     "name": "apache",
@@ -7584,7 +10432,24 @@
     "categories": [
       "web"
     ],
-    "signature_path": "/epr/apache/apache-1.3.5.zip.sig"
+    "signature_path": "/epr/apache/apache-1.3.5.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "apache.access",
+        "title": "Apache access logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "apache.error",
+        "title": "Apache error logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apache.status",
+        "title": "Apache status metrics"
+      }
+    ]
   },
   {
     "name": "tomcat",
@@ -7623,7 +10488,14 @@
       "web",
       "security"
     ],
-    "signature_path": "/epr/tomcat/tomcat-1.0.0.zip.sig"
+    "signature_path": "/epr/tomcat/tomcat-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "tomcat.log",
+        "title": "Apache Tomcat logs"
+      }
+    ]
   },
   {
     "name": "tomcat",
@@ -7662,7 +10534,14 @@
       "web",
       "security"
     ],
-    "signature_path": "/epr/tomcat/tomcat-1.1.0.zip.sig"
+    "signature_path": "/epr/tomcat/tomcat-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "tomcat.log",
+        "title": "Apache Tomcat logs"
+      }
+    ]
   },
   {
     "name": "tomcat",
@@ -7701,7 +10580,14 @@
       "web",
       "security"
     ],
-    "signature_path": "/epr/tomcat/tomcat-1.1.4.zip.sig"
+    "signature_path": "/epr/tomcat/tomcat-1.1.4.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "tomcat.log",
+        "title": "Apache Tomcat logs"
+      }
+    ]
   },
   {
     "name": "tomcat",
@@ -7740,7 +10626,14 @@
       "web",
       "security"
     ],
-    "signature_path": "/epr/tomcat/tomcat-1.2.0.zip.sig"
+    "signature_path": "/epr/tomcat/tomcat-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "tomcat.log",
+        "title": "Apache Tomcat logs"
+      }
+    ]
   },
   {
     "name": "tomcat",
@@ -7779,7 +10672,14 @@
       "web",
       "security"
     ],
-    "signature_path": "/epr/tomcat/tomcat-1.2.1.zip.sig"
+    "signature_path": "/epr/tomcat/tomcat-1.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "tomcat.log",
+        "title": "Apache Tomcat logs"
+      }
+    ]
   },
   {
     "name": "tomcat",
@@ -7818,7 +10718,14 @@
       "web",
       "security"
     ],
-    "signature_path": "/epr/tomcat/tomcat-1.3.0.zip.sig"
+    "signature_path": "/epr/tomcat/tomcat-1.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "tomcat.log",
+        "title": "Apache Tomcat logs"
+      }
+    ]
   },
   {
     "name": "tomcat",
@@ -7857,7 +10764,14 @@
       "web",
       "security"
     ],
-    "signature_path": "/epr/tomcat/tomcat-1.3.1.zip.sig"
+    "signature_path": "/epr/tomcat/tomcat-1.3.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "tomcat.log",
+        "title": "Apache Tomcat logs"
+      }
+    ]
   },
   {
     "name": "atlassian_bitbucket",
@@ -7896,7 +10810,14 @@
       "security",
       "web"
     ],
-    "signature_path": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.0.0.zip.sig"
+    "signature_path": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_bitbucket.audit",
+        "title": "Bitbucket Audit Logs"
+      }
+    ]
   },
   {
     "name": "atlassian_bitbucket",
@@ -7935,7 +10856,14 @@
       "security",
       "web"
     ],
-    "signature_path": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.0.1.zip.sig"
+    "signature_path": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_bitbucket.audit",
+        "title": "Bitbucket Audit Logs"
+      }
+    ]
   },
   {
     "name": "atlassian_bitbucket",
@@ -7974,7 +10902,14 @@
       "security",
       "web"
     ],
-    "signature_path": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.1.0.zip.sig"
+    "signature_path": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_bitbucket.audit",
+        "title": "Bitbucket Audit Logs"
+      }
+    ]
   },
   {
     "name": "atlassian_bitbucket",
@@ -8013,7 +10948,14 @@
       "security",
       "web"
     ],
-    "signature_path": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.1.1.zip.sig"
+    "signature_path": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_bitbucket.audit",
+        "title": "Bitbucket Audit Logs"
+      }
+    ]
   },
   {
     "name": "atlassian_bitbucket",
@@ -8052,7 +10994,14 @@
       "security",
       "web"
     ],
-    "signature_path": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.2.1.zip.sig"
+    "signature_path": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_bitbucket.audit",
+        "title": "Bitbucket Audit Logs"
+      }
+    ]
   },
   {
     "name": "atlassian_confluence",
@@ -8091,7 +11040,14 @@
       "security",
       "web"
     ],
-    "signature_path": "/epr/atlassian_confluence/atlassian_confluence-1.0.1.zip.sig"
+    "signature_path": "/epr/atlassian_confluence/atlassian_confluence-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_confluence.audit",
+        "title": "Confluence Audit Logs"
+      }
+    ]
   },
   {
     "name": "atlassian_confluence",
@@ -8130,7 +11086,14 @@
       "security",
       "web"
     ],
-    "signature_path": "/epr/atlassian_confluence/atlassian_confluence-1.1.0.zip.sig"
+    "signature_path": "/epr/atlassian_confluence/atlassian_confluence-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_confluence.audit",
+        "title": "Confluence Audit Logs"
+      }
+    ]
   },
   {
     "name": "atlassian_confluence",
@@ -8169,7 +11132,14 @@
       "security",
       "web"
     ],
-    "signature_path": "/epr/atlassian_confluence/atlassian_confluence-1.1.1.zip.sig"
+    "signature_path": "/epr/atlassian_confluence/atlassian_confluence-1.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_confluence.audit",
+        "title": "Confluence Audit Logs"
+      }
+    ]
   },
   {
     "name": "atlassian_confluence",
@@ -8208,7 +11178,14 @@
       "security",
       "web"
     ],
-    "signature_path": "/epr/atlassian_confluence/atlassian_confluence-1.1.2.zip.sig"
+    "signature_path": "/epr/atlassian_confluence/atlassian_confluence-1.1.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_confluence.audit",
+        "title": "Confluence Audit Logs"
+      }
+    ]
   },
   {
     "name": "atlassian_confluence",
@@ -8247,7 +11224,14 @@
       "security",
       "web"
     ],
-    "signature_path": "/epr/atlassian_confluence/atlassian_confluence-1.3.0.zip.sig"
+    "signature_path": "/epr/atlassian_confluence/atlassian_confluence-1.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_confluence.audit",
+        "title": "Confluence Audit Logs"
+      }
+    ]
   },
   {
     "name": "atlassian_jira",
@@ -8286,7 +11270,14 @@
       "security",
       "web"
     ],
-    "signature_path": "/epr/atlassian_jira/atlassian_jira-1.0.0.zip.sig"
+    "signature_path": "/epr/atlassian_jira/atlassian_jira-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_jira.audit",
+        "title": "Jira Audit Logs"
+      }
+    ]
   },
   {
     "name": "atlassian_jira",
@@ -8325,7 +11316,14 @@
       "security",
       "web"
     ],
-    "signature_path": "/epr/atlassian_jira/atlassian_jira-1.0.1.zip.sig"
+    "signature_path": "/epr/atlassian_jira/atlassian_jira-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_jira.audit",
+        "title": "Jira Audit Logs"
+      }
+    ]
   },
   {
     "name": "atlassian_jira",
@@ -8364,7 +11362,14 @@
       "security",
       "web"
     ],
-    "signature_path": "/epr/atlassian_jira/atlassian_jira-1.1.0.zip.sig"
+    "signature_path": "/epr/atlassian_jira/atlassian_jira-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_jira.audit",
+        "title": "Jira Audit Logs"
+      }
+    ]
   },
   {
     "name": "atlassian_jira",
@@ -8403,7 +11408,14 @@
       "security",
       "web"
     ],
-    "signature_path": "/epr/atlassian_jira/atlassian_jira-1.1.1.zip.sig"
+    "signature_path": "/epr/atlassian_jira/atlassian_jira-1.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_jira.audit",
+        "title": "Jira Audit Logs"
+      }
+    ]
   },
   {
     "name": "atlassian_jira",
@@ -8442,7 +11454,14 @@
       "security",
       "web"
     ],
-    "signature_path": "/epr/atlassian_jira/atlassian_jira-1.1.2.zip.sig"
+    "signature_path": "/epr/atlassian_jira/atlassian_jira-1.1.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_jira.audit",
+        "title": "Jira Audit Logs"
+      }
+    ]
   },
   {
     "name": "atlassian_jira",
@@ -8481,7 +11500,14 @@
       "security",
       "web"
     ],
-    "signature_path": "/epr/atlassian_jira/atlassian_jira-1.2.0.zip.sig"
+    "signature_path": "/epr/atlassian_jira/atlassian_jira-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_jira.audit",
+        "title": "Jira Audit Logs"
+      }
+    ]
   },
   {
     "name": "atlassian_jira",
@@ -8520,7 +11546,14 @@
       "security",
       "web"
     ],
-    "signature_path": "/epr/atlassian_jira/atlassian_jira-1.3.0.zip.sig"
+    "signature_path": "/epr/atlassian_jira/atlassian_jira-1.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_jira.audit",
+        "title": "Jira Audit Logs"
+      }
+    ]
   },
   {
     "name": "auditd",
@@ -8558,7 +11591,14 @@
     "categories": [
       "os_system"
     ],
-    "signature_path": "/epr/auditd/auditd-1.0.0.zip.sig"
+    "signature_path": "/epr/auditd/auditd-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "auditd.log",
+        "title": "Auditd logs"
+      }
+    ]
   },
   {
     "name": "auditd",
@@ -8596,7 +11636,14 @@
     "categories": [
       "os_system"
     ],
-    "signature_path": "/epr/auditd/auditd-1.2.0.zip.sig"
+    "signature_path": "/epr/auditd/auditd-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "auditd.log",
+        "title": "Auditd logs"
+      }
+    ]
   },
   {
     "name": "auditd",
@@ -8634,7 +11681,14 @@
     "categories": [
       "os_system"
     ],
-    "signature_path": "/epr/auditd/auditd-1.2.2.zip.sig"
+    "signature_path": "/epr/auditd/auditd-1.2.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "auditd.log",
+        "title": "Auditd logs"
+      }
+    ]
   },
   {
     "name": "auditd",
@@ -8672,7 +11726,14 @@
     "categories": [
       "os_system"
     ],
-    "signature_path": "/epr/auditd/auditd-1.2.4.zip.sig"
+    "signature_path": "/epr/auditd/auditd-1.2.4.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "auditd.log",
+        "title": "Auditd logs"
+      }
+    ]
   },
   {
     "name": "auditd",
@@ -8710,7 +11771,14 @@
     "categories": [
       "os_system"
     ],
-    "signature_path": "/epr/auditd/auditd-1.3.0.zip.sig"
+    "signature_path": "/epr/auditd/auditd-1.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "auditd.log",
+        "title": "Auditd logs"
+      }
+    ]
   },
   {
     "name": "auditd",
@@ -8748,7 +11816,14 @@
     "categories": [
       "os_system"
     ],
-    "signature_path": "/epr/auditd/auditd-1.3.1.zip.sig"
+    "signature_path": "/epr/auditd/auditd-1.3.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "auditd.log",
+        "title": "Auditd logs"
+      }
+    ]
   },
   {
     "name": "auditd",
@@ -8786,7 +11861,14 @@
     "categories": [
       "os_system"
     ],
-    "signature_path": "/epr/auditd/auditd-2.0.0.zip.sig"
+    "signature_path": "/epr/auditd/auditd-2.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "auditd.log",
+        "title": "Auditd logs"
+      }
+    ]
   },
   {
     "name": "auditd",
@@ -8824,7 +11906,14 @@
     "categories": [
       "os_system"
     ],
-    "signature_path": "/epr/auditd/auditd-2.1.0.zip.sig"
+    "signature_path": "/epr/auditd/auditd-2.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "auditd.log",
+        "title": "Auditd logs"
+      }
+    ]
   },
   {
     "name": "auditd",
@@ -8862,7 +11951,14 @@
     "categories": [
       "os_system"
     ],
-    "signature_path": "/epr/auditd/auditd-2.1.1.zip.sig"
+    "signature_path": "/epr/auditd/auditd-2.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "auditd.log",
+        "title": "Auditd logs"
+      }
+    ]
   },
   {
     "name": "auditd",
@@ -8900,7 +11996,14 @@
     "categories": [
       "os_system"
     ],
-    "signature_path": "/epr/auditd/auditd-2.1.2.zip.sig"
+    "signature_path": "/epr/auditd/auditd-2.1.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "auditd.log",
+        "title": "Auditd logs"
+      }
+    ]
   },
   {
     "name": "auditd",
@@ -8938,7 +12041,14 @@
     "categories": [
       "os_system"
     ],
-    "signature_path": "/epr/auditd/auditd-2.2.0.zip.sig"
+    "signature_path": "/epr/auditd/auditd-2.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "auditd.log",
+        "title": "Auditd logs"
+      }
+    ]
   },
   {
     "name": "auditd",
@@ -8976,7 +12086,14 @@
     "categories": [
       "os_system"
     ],
-    "signature_path": "/epr/auditd/auditd-3.0.0.zip.sig"
+    "signature_path": "/epr/auditd/auditd-3.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "auditd.log",
+        "title": "Auditd logs"
+      }
+    ]
   },
   {
     "name": "auditd",
@@ -9014,7 +12131,14 @@
     "categories": [
       "os_system"
     ],
-    "signature_path": "/epr/auditd/auditd-3.1.0.zip.sig"
+    "signature_path": "/epr/auditd/auditd-3.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "auditd.log",
+        "title": "Auditd logs"
+      }
+    ]
   },
   {
     "name": "auditd_manager",
@@ -9053,7 +12177,14 @@
       "os_system",
       "security"
     ],
-    "signature_path": "/epr/auditd_manager/auditd_manager-1.0.0.zip.sig"
+    "signature_path": "/epr/auditd_manager/auditd_manager-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "auditd_manager.auditd",
+        "title": "Auditd Manager"
+      }
+    ]
   },
   {
     "name": "auth0",
@@ -9093,7 +12224,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/auth0/auth0-1.0.0.zip.sig"
+    "signature_path": "/epr/auth0/auth0-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "auth0.logs",
+        "title": "Auth0 logs via Webhooks"
+      }
+    ]
   },
   {
     "name": "azure_application_insights",
@@ -9155,7 +12293,19 @@
       "azure",
       "web"
     ],
-    "signature_path": "/epr/azure_application_insights/azure_application_insights-1.0.0.zip.sig"
+    "signature_path": "/epr/azure_application_insights/azure_application_insights-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "azure.app_insights",
+        "title": "Azure Application Insights"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.app_state",
+        "title": "Azure Application State"
+      }
+    ]
   },
   {
     "name": "azure_application_insights",
@@ -9217,7 +12367,19 @@
       "azure",
       "web"
     ],
-    "signature_path": "/epr/azure_application_insights/azure_application_insights-1.0.1.zip.sig"
+    "signature_path": "/epr/azure_application_insights/azure_application_insights-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "azure.app_insights",
+        "title": "Azure Application Insights"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.app_state",
+        "title": "Azure Application State"
+      }
+    ]
   },
   {
     "name": "azure_billing",
@@ -9264,7 +12426,14 @@
     "categories": [
       "azure"
     ],
-    "signature_path": "/epr/azure_billing/azure_billing-1.0.0.zip.sig"
+    "signature_path": "/epr/azure_billing/azure_billing-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "azure.billing",
+        "title": "Azure Billing Metrics"
+      }
+    ]
   },
   {
     "name": "azure_billing",
@@ -9311,7 +12480,14 @@
     "categories": [
       "azure"
     ],
-    "signature_path": "/epr/azure_billing/azure_billing-1.0.1.zip.sig"
+    "signature_path": "/epr/azure_billing/azure_billing-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "azure.billing",
+        "title": "Azure Billing Metrics"
+      }
+    ]
   },
   {
     "name": "azure",
@@ -9417,7 +12593,39 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/azure/azure-1.0.0.zip.sig"
+    "signature_path": "/epr/azure/azure-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "azure.activitylogs",
+        "title": "Azure activity logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "azure.auditlogs",
+        "title": "Azure audit logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "azure.eventhub",
+        "title": "Azure Event Hub Input"
+      },
+      {
+        "type": "logs",
+        "dataset": "azure.platformlogs",
+        "title": "Azure platform logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "azure.signinlogs",
+        "title": "Azure signin logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "azure.springcloudlogs",
+        "title": "Azure Spring Cloud logs"
+      }
+    ]
   },
   {
     "name": "azure",
@@ -9523,7 +12731,39 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/azure/azure-1.0.1.zip.sig"
+    "signature_path": "/epr/azure/azure-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "azure.activitylogs",
+        "title": "Azure activity logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "azure.auditlogs",
+        "title": "Azure audit logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "azure.eventhub",
+        "title": "Azure Event Hub Input"
+      },
+      {
+        "type": "logs",
+        "dataset": "azure.platformlogs",
+        "title": "Azure platform logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "azure.signinlogs",
+        "title": "Azure signin logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "azure.springcloudlogs",
+        "title": "Azure Spring Cloud logs"
+      }
+    ]
   },
   {
     "name": "azure",
@@ -9629,7 +12869,39 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/azure/azure-1.1.2.zip.sig"
+    "signature_path": "/epr/azure/azure-1.1.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "azure.activitylogs",
+        "title": "Azure activity logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "azure.auditlogs",
+        "title": "Azure audit logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "azure.eventhub",
+        "title": "Azure Event Hub Input"
+      },
+      {
+        "type": "logs",
+        "dataset": "azure.platformlogs",
+        "title": "Azure platform logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "azure.signinlogs",
+        "title": "Azure signin logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "azure.springcloudlogs",
+        "title": "Azure Spring Cloud logs"
+      }
+    ]
   },
   {
     "name": "azure",
@@ -9735,7 +13007,39 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/azure/azure-1.1.6.zip.sig"
+    "signature_path": "/epr/azure/azure-1.1.6.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "azure.activitylogs",
+        "title": "Azure activity logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "azure.auditlogs",
+        "title": "Azure audit logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "azure.eventhub",
+        "title": "Azure Event Hub Input"
+      },
+      {
+        "type": "logs",
+        "dataset": "azure.platformlogs",
+        "title": "Azure platform logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "azure.signinlogs",
+        "title": "Azure signin logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "azure.springcloudlogs",
+        "title": "Azure Spring Cloud logs"
+      }
+    ]
   },
   {
     "name": "azure",
@@ -9841,7 +13145,39 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/azure/azure-1.1.7.zip.sig"
+    "signature_path": "/epr/azure/azure-1.1.7.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "azure.activitylogs",
+        "title": "Azure activity logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "azure.auditlogs",
+        "title": "Azure audit logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "azure.eventhub",
+        "title": "Azure Event Hub Input"
+      },
+      {
+        "type": "logs",
+        "dataset": "azure.platformlogs",
+        "title": "Azure platform logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "azure.signinlogs",
+        "title": "Azure signin logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "azure.springcloudlogs",
+        "title": "Azure Spring Cloud logs"
+      }
+    ]
   },
   {
     "name": "azure",
@@ -9947,7 +13283,39 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/azure/azure-1.1.8.zip.sig"
+    "signature_path": "/epr/azure/azure-1.1.8.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "azure.activitylogs",
+        "title": "Azure Activity Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "azure.auditlogs",
+        "title": "Azure Audit Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "azure.eventhub",
+        "title": "Azure Event Hub Input"
+      },
+      {
+        "type": "logs",
+        "dataset": "azure.platformlogs",
+        "title": "Azure Platform Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "azure.signinlogs",
+        "title": "Azure Signin Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "azure.springcloudlogs",
+        "title": "Azure Spring Cloud Logs"
+      }
+    ]
   },
   {
     "name": "azure_metrics",
@@ -10093,7 +13461,49 @@
       "azure",
       "web"
     ],
-    "signature_path": "/epr/azure_metrics/azure_metrics-1.0.0.zip.sig"
+    "signature_path": "/epr/azure_metrics/azure_metrics-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "azure.compute_vm",
+        "title": "Compute VM"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.compute_vm_scaleset",
+        "title": "Compute VM Scaleset"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.container_instance",
+        "title": "Container Instance"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.container_registry",
+        "title": "Container Registry"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.container_service",
+        "title": "Container Service"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.database_account",
+        "title": "Database Account"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.monitor",
+        "title": "Monitor"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.storage_account",
+        "title": "Storage Account"
+      }
+    ]
   },
   {
     "name": "azure_metrics",
@@ -10239,7 +13649,49 @@
       "azure",
       "web"
     ],
-    "signature_path": "/epr/azure_metrics/azure_metrics-1.0.1.zip.sig"
+    "signature_path": "/epr/azure_metrics/azure_metrics-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "azure.compute_vm",
+        "title": "Compute VM"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.compute_vm_scaleset",
+        "title": "Compute VM Scaleset"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.container_instance",
+        "title": "Container Instance"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.container_registry",
+        "title": "Container Registry"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.container_service",
+        "title": "Container Service"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.database_account",
+        "title": "Database Account"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.monitor",
+        "title": "Monitor"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.storage_account",
+        "title": "Storage Account"
+      }
+    ]
   },
   {
     "name": "azure_metrics",
@@ -10385,7 +13837,49 @@
       "azure",
       "web"
     ],
-    "signature_path": "/epr/azure_metrics/azure_metrics-1.0.3.zip.sig"
+    "signature_path": "/epr/azure_metrics/azure_metrics-1.0.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "azure.compute_vm",
+        "title": "Compute VM"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.compute_vm_scaleset",
+        "title": "Compute VM Scaleset"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.container_instance",
+        "title": "Container Instance"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.container_registry",
+        "title": "Container Registry"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.container_service",
+        "title": "Container Service"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.database_account",
+        "title": "Database Account"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.monitor",
+        "title": "Monitor"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.storage_account",
+        "title": "Storage Account"
+      }
+    ]
   },
   {
     "name": "cef",
@@ -10415,7 +13909,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/cef/cef-1.2.0.zip.sig"
+    "signature_path": "/epr/cef/cef-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cef.log",
+        "title": "CEF log logs"
+      }
+    ]
   },
   {
     "name": "cef",
@@ -10445,7 +13946,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/cef/cef-1.2.2.zip.sig"
+    "signature_path": "/epr/cef/cef-1.2.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cef.log",
+        "title": "CEF log logs"
+      }
+    ]
   },
   {
     "name": "cef",
@@ -10475,7 +13983,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/cef/cef-1.3.0.zip.sig"
+    "signature_path": "/epr/cef/cef-1.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cef.log",
+        "title": "CEF log logs"
+      }
+    ]
   },
   {
     "name": "cef",
@@ -10505,7 +14020,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/cef/cef-1.3.1.zip.sig"
+    "signature_path": "/epr/cef/cef-1.3.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cef.log",
+        "title": "CEF log logs"
+      }
+    ]
   },
   {
     "name": "cef",
@@ -10535,7 +14057,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/cef/cef-1.4.0.zip.sig"
+    "signature_path": "/epr/cef/cef-1.4.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cef.log",
+        "title": "CEF log logs"
+      }
+    ]
   },
   {
     "name": "cef",
@@ -10565,7 +14094,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/cef/cef-1.4.2.zip.sig"
+    "signature_path": "/epr/cef/cef-1.4.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cef.log",
+        "title": "CEF log logs"
+      }
+    ]
   },
   {
     "name": "cef",
@@ -10595,7 +14131,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/cef/cef-1.4.3.zip.sig"
+    "signature_path": "/epr/cef/cef-1.4.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cef.log",
+        "title": "CEF log logs"
+      }
+    ]
   },
   {
     "name": "cef",
@@ -10625,7 +14168,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/cef/cef-1.5.0.zip.sig"
+    "signature_path": "/epr/cef/cef-1.5.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cef.log",
+        "title": "CEF log logs"
+      }
+    ]
   },
   {
     "name": "cef",
@@ -10655,7 +14205,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/cef/cef-2.0.0.zip.sig"
+    "signature_path": "/epr/cef/cef-2.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cef.log",
+        "title": "CEF log logs"
+      }
+    ]
   },
   {
     "name": "cassandra",
@@ -10694,7 +14251,19 @@
       "datastore",
       "monitoring"
     ],
-    "signature_path": "/epr/cassandra/cassandra-1.1.0.zip.sig"
+    "signature_path": "/epr/cassandra/cassandra-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cassandra.log",
+        "title": "Cassandra System Logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "cassandra.metrics",
+        "title": "metrics"
+      }
+    ]
   },
   {
     "name": "checkpoint",
@@ -10732,7 +14301,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/checkpoint/checkpoint-1.1.2.zip.sig"
+    "signature_path": "/epr/checkpoint/checkpoint-1.1.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "checkpoint.firewall",
+        "title": "Check Point firewall logs"
+      }
+    ]
   },
   {
     "name": "checkpoint",
@@ -10770,7 +14346,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/checkpoint/checkpoint-1.2.0.zip.sig"
+    "signature_path": "/epr/checkpoint/checkpoint-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "checkpoint.firewall",
+        "title": "Check Point firewall logs"
+      }
+    ]
   },
   {
     "name": "checkpoint",
@@ -10808,7 +14391,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/checkpoint/checkpoint-1.2.2.zip.sig"
+    "signature_path": "/epr/checkpoint/checkpoint-1.2.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "checkpoint.firewall",
+        "title": "Check Point firewall logs"
+      }
+    ]
   },
   {
     "name": "checkpoint",
@@ -10846,7 +14436,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/checkpoint/checkpoint-1.3.0.zip.sig"
+    "signature_path": "/epr/checkpoint/checkpoint-1.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "checkpoint.firewall",
+        "title": "Check Point firewall logs"
+      }
+    ]
   },
   {
     "name": "checkpoint",
@@ -10884,7 +14481,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/checkpoint/checkpoint-1.3.1.zip.sig"
+    "signature_path": "/epr/checkpoint/checkpoint-1.3.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "checkpoint.firewall",
+        "title": "Check Point firewall logs"
+      }
+    ]
   },
   {
     "name": "checkpoint",
@@ -10922,7 +14526,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/checkpoint/checkpoint-1.3.4.zip.sig"
+    "signature_path": "/epr/checkpoint/checkpoint-1.3.4.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "checkpoint.firewall",
+        "title": "Check Point firewall logs"
+      }
+    ]
   },
   {
     "name": "checkpoint",
@@ -10960,7 +14571,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/checkpoint/checkpoint-1.3.5.zip.sig"
+    "signature_path": "/epr/checkpoint/checkpoint-1.3.5.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "checkpoint.firewall",
+        "title": "Check Point firewall logs"
+      }
+    ]
   },
   {
     "name": "checkpoint",
@@ -10998,7 +14616,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/checkpoint/checkpoint-1.3.6.zip.sig"
+    "signature_path": "/epr/checkpoint/checkpoint-1.3.6.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "checkpoint.firewall",
+        "title": "Check Point firewall logs"
+      }
+    ]
   },
   {
     "name": "checkpoint",
@@ -11036,7 +14661,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/checkpoint/checkpoint-1.4.0.zip.sig"
+    "signature_path": "/epr/checkpoint/checkpoint-1.4.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "checkpoint.firewall",
+        "title": "Check Point firewall logs"
+      }
+    ]
   },
   {
     "name": "checkpoint",
@@ -11074,7 +14706,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/checkpoint/checkpoint-1.5.0.zip.sig"
+    "signature_path": "/epr/checkpoint/checkpoint-1.5.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "checkpoint.firewall",
+        "title": "Check Point firewall logs"
+      }
+    ]
   },
   {
     "name": "cisco_asa",
@@ -11113,7 +14752,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/cisco_asa/cisco_asa-1.2.2.zip.sig"
+    "signature_path": "/epr/cisco_asa/cisco_asa-1.2.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco_asa.log",
+        "title": "Cisco ASA logs"
+      }
+    ]
   },
   {
     "name": "cisco_asa",
@@ -11152,7 +14798,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/cisco_asa/cisco_asa-1.3.0.zip.sig"
+    "signature_path": "/epr/cisco_asa/cisco_asa-1.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco_asa.log",
+        "title": "Cisco ASA logs"
+      }
+    ]
   },
   {
     "name": "cisco_asa",
@@ -11191,7 +14844,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/cisco_asa/cisco_asa-1.3.2.zip.sig"
+    "signature_path": "/epr/cisco_asa/cisco_asa-1.3.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco_asa.log",
+        "title": "Cisco ASA logs"
+      }
+    ]
   },
   {
     "name": "cisco_asa",
@@ -11230,7 +14890,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/cisco_asa/cisco_asa-2.0.1.zip.sig"
+    "signature_path": "/epr/cisco_asa/cisco_asa-2.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco_asa.log",
+        "title": "Cisco ASA logs"
+      }
+    ]
   },
   {
     "name": "cisco_asa",
@@ -11269,7 +14936,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/cisco_asa/cisco_asa-2.1.0.zip.sig"
+    "signature_path": "/epr/cisco_asa/cisco_asa-2.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco_asa.log",
+        "title": "Cisco ASA logs"
+      }
+    ]
   },
   {
     "name": "cisco_asa",
@@ -11308,7 +14982,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/cisco_asa/cisco_asa-2.2.0.zip.sig"
+    "signature_path": "/epr/cisco_asa/cisco_asa-2.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco_asa.log",
+        "title": "Cisco ASA logs"
+      }
+    ]
   },
   {
     "name": "cisco_asa",
@@ -11347,7 +15028,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/cisco_asa/cisco_asa-2.2.1.zip.sig"
+    "signature_path": "/epr/cisco_asa/cisco_asa-2.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco_asa.log",
+        "title": "Cisco ASA logs"
+      }
+    ]
   },
   {
     "name": "cisco_asa",
@@ -11386,7 +15074,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/cisco_asa/cisco_asa-2.3.0.zip.sig"
+    "signature_path": "/epr/cisco_asa/cisco_asa-2.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco_asa.log",
+        "title": "Cisco ASA logs"
+      }
+    ]
   },
   {
     "name": "cisco_asa",
@@ -11425,7 +15120,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/cisco_asa/cisco_asa-2.4.1.zip.sig"
+    "signature_path": "/epr/cisco_asa/cisco_asa-2.4.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco_asa.log",
+        "title": "Cisco ASA logs"
+      }
+    ]
   },
   {
     "name": "cisco_duo",
@@ -11463,7 +15165,34 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/cisco_duo/cisco_duo-1.0.0.zip.sig"
+    "signature_path": "/epr/cisco_duo/cisco_duo-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco_duo.admin",
+        "title": "Cisco Duo administrator logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "cisco_duo.auth",
+        "title": "Cisco Duo authentication logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "cisco_duo.offline_enrollment",
+        "title": "Cisco Duo offline enrollment logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "cisco_duo.summary",
+        "title": "Cisco Duo summary logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "cisco_duo.telephony",
+        "title": "Cisco Duo telephony logs"
+      }
+    ]
   },
   {
     "name": "cisco_duo",
@@ -11501,7 +15230,34 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/cisco_duo/cisco_duo-1.1.0.zip.sig"
+    "signature_path": "/epr/cisco_duo/cisco_duo-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco_duo.admin",
+        "title": "Cisco Duo administrator logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "cisco_duo.auth",
+        "title": "Cisco Duo authentication logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "cisco_duo.offline_enrollment",
+        "title": "Cisco Duo offline enrollment logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "cisco_duo.summary",
+        "title": "Cisco Duo summary logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "cisco_duo.telephony",
+        "title": "Cisco Duo telephony logs"
+      }
+    ]
   },
   {
     "name": "cisco_duo",
@@ -11539,7 +15295,34 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/cisco_duo/cisco_duo-1.1.1.zip.sig"
+    "signature_path": "/epr/cisco_duo/cisco_duo-1.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco_duo.admin",
+        "title": "Cisco Duo administrator logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "cisco_duo.auth",
+        "title": "Cisco Duo authentication logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "cisco_duo.offline_enrollment",
+        "title": "Cisco Duo offline enrollment logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "cisco_duo.summary",
+        "title": "Cisco Duo summary logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "cisco_duo.telephony",
+        "title": "Cisco Duo telephony logs"
+      }
+    ]
   },
   {
     "name": "cisco_duo",
@@ -11577,7 +15360,34 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/cisco_duo/cisco_duo-1.1.4.zip.sig"
+    "signature_path": "/epr/cisco_duo/cisco_duo-1.1.4.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco_duo.admin",
+        "title": "Cisco Duo administrator logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "cisco_duo.auth",
+        "title": "Cisco Duo authentication logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "cisco_duo.offline_enrollment",
+        "title": "Cisco Duo offline enrollment logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "cisco_duo.summary",
+        "title": "Cisco Duo summary logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "cisco_duo.telephony",
+        "title": "Cisco Duo telephony logs"
+      }
+    ]
   },
   {
     "name": "cisco_duo",
@@ -11615,7 +15425,34 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/cisco_duo/cisco_duo-1.2.1.zip.sig"
+    "signature_path": "/epr/cisco_duo/cisco_duo-1.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco_duo.admin",
+        "title": "Cisco Duo administrator logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "cisco_duo.auth",
+        "title": "Cisco Duo authentication logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "cisco_duo.offline_enrollment",
+        "title": "Cisco Duo offline enrollment logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "cisco_duo.summary",
+        "title": "Cisco Duo summary logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "cisco_duo.telephony",
+        "title": "Cisco Duo telephony logs"
+      }
+    ]
   },
   {
     "name": "cisco_duo",
@@ -11653,7 +15490,34 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/cisco_duo/cisco_duo-1.2.2.zip.sig"
+    "signature_path": "/epr/cisco_duo/cisco_duo-1.2.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco_duo.admin",
+        "title": "Cisco Duo administrator logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "cisco_duo.auth",
+        "title": "Cisco Duo authentication logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "cisco_duo.offline_enrollment",
+        "title": "Cisco Duo offline enrollment logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "cisco_duo.summary",
+        "title": "Cisco Duo summary logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "cisco_duo.telephony",
+        "title": "Cisco Duo telephony logs"
+      }
+    ]
   },
   {
     "name": "cisco_duo",
@@ -11691,7 +15555,34 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/cisco_duo/cisco_duo-1.2.4.zip.sig"
+    "signature_path": "/epr/cisco_duo/cisco_duo-1.2.4.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco_duo.admin",
+        "title": "Cisco Duo administrator logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "cisco_duo.auth",
+        "title": "Cisco Duo authentication logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "cisco_duo.offline_enrollment",
+        "title": "Cisco Duo offline enrollment logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "cisco_duo.summary",
+        "title": "Cisco Duo summary logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "cisco_duo.telephony",
+        "title": "Cisco Duo telephony logs"
+      }
+    ]
   },
   {
     "name": "cisco_ftd",
@@ -11730,7 +15621,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/cisco_ftd/cisco_ftd-1.1.2.zip.sig"
+    "signature_path": "/epr/cisco_ftd/cisco_ftd-1.1.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco_ftd.log",
+        "title": "Cisco FTD logs"
+      }
+    ]
   },
   {
     "name": "cisco_ftd",
@@ -11769,7 +15667,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/cisco_ftd/cisco_ftd-1.2.0.zip.sig"
+    "signature_path": "/epr/cisco_ftd/cisco_ftd-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco_ftd.log",
+        "title": "Cisco FTD logs"
+      }
+    ]
   },
   {
     "name": "cisco_ftd",
@@ -11808,7 +15713,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/cisco_ftd/cisco_ftd-1.2.2.zip.sig"
+    "signature_path": "/epr/cisco_ftd/cisco_ftd-1.2.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco_ftd.log",
+        "title": "Cisco FTD logs"
+      }
+    ]
   },
   {
     "name": "cisco_ftd",
@@ -11847,7 +15759,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/cisco_ftd/cisco_ftd-2.0.0.zip.sig"
+    "signature_path": "/epr/cisco_ftd/cisco_ftd-2.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco_ftd.log",
+        "title": "Cisco FTD logs"
+      }
+    ]
   },
   {
     "name": "cisco_ftd",
@@ -11886,7 +15805,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/cisco_ftd/cisco_ftd-2.0.1.zip.sig"
+    "signature_path": "/epr/cisco_ftd/cisco_ftd-2.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco_ftd.log",
+        "title": "Cisco FTD logs"
+      }
+    ]
   },
   {
     "name": "cisco_ftd",
@@ -11925,7 +15851,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/cisco_ftd/cisco_ftd-2.0.3.zip.sig"
+    "signature_path": "/epr/cisco_ftd/cisco_ftd-2.0.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco_ftd.log",
+        "title": "Cisco FTD logs"
+      }
+    ]
   },
   {
     "name": "cisco_ftd",
@@ -11964,7 +15897,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/cisco_ftd/cisco_ftd-2.0.4.zip.sig"
+    "signature_path": "/epr/cisco_ftd/cisco_ftd-2.0.4.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco_ftd.log",
+        "title": "Cisco FTD logs"
+      }
+    ]
   },
   {
     "name": "cisco_ftd",
@@ -12003,7 +15943,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/cisco_ftd/cisco_ftd-2.1.0.zip.sig"
+    "signature_path": "/epr/cisco_ftd/cisco_ftd-2.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco_ftd.log",
+        "title": "Cisco FTD logs"
+      }
+    ]
   },
   {
     "name": "cisco_ftd",
@@ -12042,7 +15989,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/cisco_ftd/cisco_ftd-2.1.1.zip.sig"
+    "signature_path": "/epr/cisco_ftd/cisco_ftd-2.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco_ftd.log",
+        "title": "Cisco FTD logs"
+      }
+    ]
   },
   {
     "name": "cisco_ftd",
@@ -12081,7 +16035,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/cisco_ftd/cisco_ftd-2.2.1.zip.sig"
+    "signature_path": "/epr/cisco_ftd/cisco_ftd-2.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco_ftd.log",
+        "title": "Cisco FTD logs"
+      }
+    ]
   },
   {
     "name": "cisco_ios",
@@ -12120,7 +16081,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/cisco_ios/cisco_ios-1.1.2.zip.sig"
+    "signature_path": "/epr/cisco_ios/cisco_ios-1.1.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco_ios.log",
+        "title": "Cisco IOS logs"
+      }
+    ]
   },
   {
     "name": "cisco_ios",
@@ -12159,7 +16127,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/cisco_ios/cisco_ios-1.2.0.zip.sig"
+    "signature_path": "/epr/cisco_ios/cisco_ios-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco_ios.log",
+        "title": "Cisco IOS logs"
+      }
+    ]
   },
   {
     "name": "cisco_ios",
@@ -12198,7 +16173,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/cisco_ios/cisco_ios-1.2.2.zip.sig"
+    "signature_path": "/epr/cisco_ios/cisco_ios-1.2.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco_ios.log",
+        "title": "Cisco IOS logs"
+      }
+    ]
   },
   {
     "name": "cisco_ios",
@@ -12237,7 +16219,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/cisco_ios/cisco_ios-1.3.0.zip.sig"
+    "signature_path": "/epr/cisco_ios/cisco_ios-1.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco_ios.log",
+        "title": "Cisco IOS logs"
+      }
+    ]
   },
   {
     "name": "cisco_ios",
@@ -12276,7 +16265,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/cisco_ios/cisco_ios-1.4.1.zip.sig"
+    "signature_path": "/epr/cisco_ios/cisco_ios-1.4.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco_ios.log",
+        "title": "Cisco IOS logs"
+      }
+    ]
   },
   {
     "name": "cisco_ios",
@@ -12315,7 +16311,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/cisco_ios/cisco_ios-1.4.2.zip.sig"
+    "signature_path": "/epr/cisco_ios/cisco_ios-1.4.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco_ios.log",
+        "title": "Cisco IOS logs"
+      }
+    ]
   },
   {
     "name": "cisco_ios",
@@ -12354,7 +16357,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/cisco_ios/cisco_ios-1.5.0.zip.sig"
+    "signature_path": "/epr/cisco_ios/cisco_ios-1.5.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco_ios.log",
+        "title": "Cisco IOS logs"
+      }
+    ]
   },
   {
     "name": "cisco_ios",
@@ -12393,7 +16403,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/cisco_ios/cisco_ios-1.6.0.zip.sig"
+    "signature_path": "/epr/cisco_ios/cisco_ios-1.6.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco_ios.log",
+        "title": "Cisco IOS logs"
+      }
+    ]
   },
   {
     "name": "cisco_secure_endpoint",
@@ -12432,7 +16449,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/cisco_secure_endpoint/cisco_secure_endpoint-1.0.0.zip.sig"
+    "signature_path": "/epr/cisco_secure_endpoint/cisco_secure_endpoint-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco_secure_endpoint.event",
+        "title": "Cisco Secure Endpoint logs"
+      }
+    ]
   },
   {
     "name": "cisco_secure_endpoint",
@@ -12471,7 +16495,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/cisco_secure_endpoint/cisco_secure_endpoint-2.0.0.zip.sig"
+    "signature_path": "/epr/cisco_secure_endpoint/cisco_secure_endpoint-2.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco_secure_endpoint.event",
+        "title": "Cisco Secure Endpoint logs"
+      }
+    ]
   },
   {
     "name": "cisco_secure_endpoint",
@@ -12510,7 +16541,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/cisco_secure_endpoint/cisco_secure_endpoint-2.1.0.zip.sig"
+    "signature_path": "/epr/cisco_secure_endpoint/cisco_secure_endpoint-2.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco_secure_endpoint.event",
+        "title": "Cisco Secure Endpoint logs"
+      }
+    ]
   },
   {
     "name": "cisco_secure_endpoint",
@@ -12549,7 +16587,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/cisco_secure_endpoint/cisco_secure_endpoint-2.1.1.zip.sig"
+    "signature_path": "/epr/cisco_secure_endpoint/cisco_secure_endpoint-2.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco_secure_endpoint.event",
+        "title": "Cisco Secure Endpoint logs"
+      }
+    ]
   },
   {
     "name": "cisco_secure_endpoint",
@@ -12588,7 +16633,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/cisco_secure_endpoint/cisco_secure_endpoint-2.2.0.zip.sig"
+    "signature_path": "/epr/cisco_secure_endpoint/cisco_secure_endpoint-2.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco_secure_endpoint.event",
+        "title": "Cisco Secure Endpoint logs"
+      }
+    ]
   },
   {
     "name": "cisco_secure_endpoint",
@@ -12627,7 +16679,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/cisco_secure_endpoint/cisco_secure_endpoint-2.3.1.zip.sig"
+    "signature_path": "/epr/cisco_secure_endpoint/cisco_secure_endpoint-2.3.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco_secure_endpoint.event",
+        "title": "Cisco Secure Endpoint logs"
+      }
+    ]
   },
   {
     "name": "cisco_secure_endpoint",
@@ -12666,7 +16725,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/cisco_secure_endpoint/cisco_secure_endpoint-2.4.0.zip.sig"
+    "signature_path": "/epr/cisco_secure_endpoint/cisco_secure_endpoint-2.4.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco_secure_endpoint.event",
+        "title": "Cisco Secure Endpoint logs"
+      }
+    ]
   },
   {
     "name": "cisco_secure_endpoint",
@@ -12705,7 +16771,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/cisco_secure_endpoint/cisco_secure_endpoint-2.4.1.zip.sig"
+    "signature_path": "/epr/cisco_secure_endpoint/cisco_secure_endpoint-2.4.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco_secure_endpoint.event",
+        "title": "Cisco Secure Endpoint logs"
+      }
+    ]
   },
   {
     "name": "cisco_umbrella",
@@ -12744,7 +16817,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/cisco_umbrella/cisco_umbrella-1.0.0.zip.sig"
+    "signature_path": "/epr/cisco_umbrella/cisco_umbrella-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco_umbrella.log",
+        "title": "Cisco Umbrella logs"
+      }
+    ]
   },
   {
     "name": "cloudflare",
@@ -12784,7 +16864,14 @@
       "network",
       "web"
     ],
-    "signature_path": "/epr/cloudflare/cloudflare-1.0.2.zip.sig"
+    "signature_path": "/epr/cloudflare/cloudflare-1.0.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cloudflare.logpull",
+        "title": "Cloudflare Logpull"
+      }
+    ]
   },
   {
     "name": "cloudflare",
@@ -12824,7 +16911,14 @@
       "network",
       "web"
     ],
-    "signature_path": "/epr/cloudflare/cloudflare-1.0.3.zip.sig"
+    "signature_path": "/epr/cloudflare/cloudflare-1.0.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cloudflare.logpull",
+        "title": "Cloudflare Logpull"
+      }
+    ]
   },
   {
     "name": "cloudflare",
@@ -12864,7 +16958,14 @@
       "network",
       "web"
     ],
-    "signature_path": "/epr/cloudflare/cloudflare-1.1.0.zip.sig"
+    "signature_path": "/epr/cloudflare/cloudflare-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cloudflare.logpull",
+        "title": "Cloudflare Logpull"
+      }
+    ]
   },
   {
     "name": "cloudflare",
@@ -12905,7 +17006,19 @@
       "web",
       "cloud"
     ],
-    "signature_path": "/epr/cloudflare/cloudflare-1.2.1.zip.sig"
+    "signature_path": "/epr/cloudflare/cloudflare-1.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cloudflare.audit",
+        "title": "Cloudflare Audit Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "cloudflare.logpull",
+        "title": "Cloudflare Logpull"
+      }
+    ]
   },
   {
     "name": "cloudflare",
@@ -12946,7 +17059,19 @@
       "web",
       "cloud"
     ],
-    "signature_path": "/epr/cloudflare/cloudflare-1.3.0.zip.sig"
+    "signature_path": "/epr/cloudflare/cloudflare-1.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cloudflare.audit",
+        "title": "Cloudflare Audit Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "cloudflare.logpull",
+        "title": "Cloudflare Logpull"
+      }
+    ]
   },
   {
     "name": "cloudflare",
@@ -12987,7 +17112,19 @@
       "web",
       "cloud"
     ],
-    "signature_path": "/epr/cloudflare/cloudflare-1.3.1.zip.sig"
+    "signature_path": "/epr/cloudflare/cloudflare-1.3.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cloudflare.audit",
+        "title": "Cloudflare Audit Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "cloudflare.logpull",
+        "title": "Cloudflare Logpull"
+      }
+    ]
   },
   {
     "name": "cloudflare",
@@ -13028,7 +17165,19 @@
       "web",
       "cloud"
     ],
-    "signature_path": "/epr/cloudflare/cloudflare-1.3.2.zip.sig"
+    "signature_path": "/epr/cloudflare/cloudflare-1.3.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cloudflare.audit",
+        "title": "Cloudflare Audit Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "cloudflare.logpull",
+        "title": "Cloudflare Logpull"
+      }
+    ]
   },
   {
     "name": "cloudflare",
@@ -13069,7 +17218,19 @@
       "web",
       "cloud"
     ],
-    "signature_path": "/epr/cloudflare/cloudflare-1.4.2.zip.sig"
+    "signature_path": "/epr/cloudflare/cloudflare-1.4.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cloudflare.audit",
+        "title": "Cloudflare Audit Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "cloudflare.logpull",
+        "title": "Cloudflare Logpull"
+      }
+    ]
   },
   {
     "name": "cloudflare",
@@ -13110,7 +17271,19 @@
       "web",
       "cloud"
     ],
-    "signature_path": "/epr/cloudflare/cloudflare-2.0.0.zip.sig"
+    "signature_path": "/epr/cloudflare/cloudflare-2.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cloudflare.audit",
+        "title": "Cloudflare Audit Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "cloudflare.logpull",
+        "title": "Cloudflare Logpull"
+      }
+    ]
   },
   {
     "name": "crowdstrike",
@@ -13148,7 +17321,19 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/crowdstrike/crowdstrike-1.0.2.zip.sig"
+    "signature_path": "/epr/crowdstrike/crowdstrike-1.0.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "crowdstrike.falcon",
+        "title": "Crowdstrike falcon logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "crowdstrike.fdr",
+        "title": "Falcon Data Replicator"
+      }
+    ]
   },
   {
     "name": "crowdstrike",
@@ -13186,7 +17371,19 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/crowdstrike/crowdstrike-1.0.3.zip.sig"
+    "signature_path": "/epr/crowdstrike/crowdstrike-1.0.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "crowdstrike.falcon",
+        "title": "Crowdstrike falcon logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "crowdstrike.fdr",
+        "title": "Falcon Data Replicator"
+      }
+    ]
   },
   {
     "name": "crowdstrike",
@@ -13224,7 +17421,19 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/crowdstrike/crowdstrike-1.0.4.zip.sig"
+    "signature_path": "/epr/crowdstrike/crowdstrike-1.0.4.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "crowdstrike.falcon",
+        "title": "Crowdstrike falcon logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "crowdstrike.fdr",
+        "title": "Falcon Data Replicator"
+      }
+    ]
   },
   {
     "name": "crowdstrike",
@@ -13262,7 +17471,19 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/crowdstrike/crowdstrike-1.1.0.zip.sig"
+    "signature_path": "/epr/crowdstrike/crowdstrike-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "crowdstrike.falcon",
+        "title": "Crowdstrike falcon logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "crowdstrike.fdr",
+        "title": "Falcon Data Replicator"
+      }
+    ]
   },
   {
     "name": "crowdstrike",
@@ -13300,7 +17521,19 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/crowdstrike/crowdstrike-1.1.2.zip.sig"
+    "signature_path": "/epr/crowdstrike/crowdstrike-1.1.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "crowdstrike.falcon",
+        "title": "Crowdstrike falcon logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "crowdstrike.fdr",
+        "title": "Falcon Data Replicator"
+      }
+    ]
   },
   {
     "name": "crowdstrike",
@@ -13338,7 +17571,19 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/crowdstrike/crowdstrike-1.2.1.zip.sig"
+    "signature_path": "/epr/crowdstrike/crowdstrike-1.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "crowdstrike.falcon",
+        "title": "Crowdstrike falcon logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "crowdstrike.fdr",
+        "title": "Falcon Data Replicator"
+      }
+    ]
   },
   {
     "name": "crowdstrike",
@@ -13376,7 +17621,19 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/crowdstrike/crowdstrike-1.2.2.zip.sig"
+    "signature_path": "/epr/crowdstrike/crowdstrike-1.2.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "crowdstrike.falcon",
+        "title": "Crowdstrike falcon logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "crowdstrike.fdr",
+        "title": "Falcon Data Replicator"
+      }
+    ]
   },
   {
     "name": "crowdstrike",
@@ -13414,7 +17671,19 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/crowdstrike/crowdstrike-1.2.3.zip.sig"
+    "signature_path": "/epr/crowdstrike/crowdstrike-1.2.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "crowdstrike.falcon",
+        "title": "Crowdstrike falcon logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "crowdstrike.fdr",
+        "title": "Falcon Data Replicator"
+      }
+    ]
   },
   {
     "name": "crowdstrike",
@@ -13452,7 +17721,19 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/crowdstrike/crowdstrike-1.2.5.zip.sig"
+    "signature_path": "/epr/crowdstrike/crowdstrike-1.2.5.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "crowdstrike.falcon",
+        "title": "Crowdstrike falcon logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "crowdstrike.fdr",
+        "title": "Falcon Data Replicator"
+      }
+    ]
   },
   {
     "name": "crowdstrike",
@@ -13490,7 +17771,19 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/crowdstrike/crowdstrike-1.2.6.zip.sig"
+    "signature_path": "/epr/crowdstrike/crowdstrike-1.2.6.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "crowdstrike.falcon",
+        "title": "Crowdstrike falcon logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "crowdstrike.fdr",
+        "title": "Falcon Data Replicator"
+      }
+    ]
   },
   {
     "name": "crowdstrike",
@@ -13528,7 +17821,19 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/crowdstrike/crowdstrike-1.2.7.zip.sig"
+    "signature_path": "/epr/crowdstrike/crowdstrike-1.2.7.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "crowdstrike.falcon",
+        "title": "Crowdstrike falcon logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "crowdstrike.fdr",
+        "title": "Falcon Data Replicator"
+      }
+    ]
   },
   {
     "name": "crowdstrike",
@@ -13566,7 +17871,19 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/crowdstrike/crowdstrike-1.3.1.zip.sig"
+    "signature_path": "/epr/crowdstrike/crowdstrike-1.3.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "crowdstrike.falcon",
+        "title": "Crowdstrike falcon logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "crowdstrike.fdr",
+        "title": "Falcon Data Replicator"
+      }
+    ]
   },
   {
     "name": "crowdstrike",
@@ -13604,7 +17921,19 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/crowdstrike/crowdstrike-1.3.2.zip.sig"
+    "signature_path": "/epr/crowdstrike/crowdstrike-1.3.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "crowdstrike.falcon",
+        "title": "Crowdstrike falcon logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "crowdstrike.fdr",
+        "title": "Falcon Data Replicator"
+      }
+    ]
   },
   {
     "name": "crowdstrike",
@@ -13642,7 +17971,19 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/crowdstrike/crowdstrike-1.3.3.zip.sig"
+    "signature_path": "/epr/crowdstrike/crowdstrike-1.3.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "crowdstrike.falcon",
+        "title": "Crowdstrike falcon logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "crowdstrike.fdr",
+        "title": "Falcon Data Replicator"
+      }
+    ]
   },
   {
     "name": "gcp_pubsub",
@@ -13682,7 +18023,14 @@
       "cloud",
       "custom"
     ],
-    "signature_path": "/epr/gcp_pubsub/gcp_pubsub-1.0.0.zip.sig"
+    "signature_path": "/epr/gcp_pubsub/gcp_pubsub-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "gcp_pubsub.generic",
+        "title": "Custom Google Pub/Sub Logs"
+      }
+    ]
   },
   {
     "name": "http_endpoint",
@@ -13718,7 +18066,14 @@
     "categories": [
       "custom"
     ],
-    "signature_path": "/epr/http_endpoint/http_endpoint-1.0.1.zip.sig"
+    "signature_path": "/epr/http_endpoint/http_endpoint-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "http_endpoint.generic",
+        "title": "Custom HTTP Endpoint Logs"
+      }
+    ]
   },
   {
     "name": "httpjson",
@@ -13747,7 +18102,14 @@
     "categories": [
       "custom"
     ],
-    "signature_path": "/epr/httpjson/httpjson-1.0.0.zip.sig"
+    "signature_path": "/epr/httpjson/httpjson-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "httpjson.generic",
+        "title": "Custom HTTPJSON Input"
+      }
+    ]
   },
   {
     "name": "httpjson",
@@ -13776,7 +18138,14 @@
     "categories": [
       "custom"
     ],
-    "signature_path": "/epr/httpjson/httpjson-1.1.0.zip.sig"
+    "signature_path": "/epr/httpjson/httpjson-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "httpjson.generic",
+        "title": "Custom HTTPJSON Input"
+      }
+    ]
   },
   {
     "name": "httpjson",
@@ -13805,7 +18174,14 @@
     "categories": [
       "custom"
     ],
-    "signature_path": "/epr/httpjson/httpjson-1.1.1.zip.sig"
+    "signature_path": "/epr/httpjson/httpjson-1.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "httpjson.generic",
+        "title": "Custom HTTPJSON Input"
+      }
+    ]
   },
   {
     "name": "log",
@@ -13836,7 +18212,14 @@
     "categories": [
       "custom"
     ],
-    "signature_path": "/epr/log/log-1.0.0.zip.sig"
+    "signature_path": "/epr/log/log-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "log.log",
+        "title": "Log Dataset"
+      }
+    ]
   },
   {
     "name": "tcp",
@@ -13872,7 +18255,14 @@
     "categories": [
       "custom"
     ],
-    "signature_path": "/epr/tcp/tcp-1.0.0.zip.sig"
+    "signature_path": "/epr/tcp/tcp-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "tcp.generic",
+        "title": "Custom TCP Logs"
+      }
+    ]
   },
   {
     "name": "udp",
@@ -13908,7 +18298,14 @@
     "categories": [
       "custom"
     ],
-    "signature_path": "/epr/udp/udp-1.0.0.zip.sig"
+    "signature_path": "/epr/udp/udp-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "udp.generic",
+        "title": "Custom UDP Logs"
+      }
+    ]
   },
   {
     "name": "udp",
@@ -13944,7 +18341,14 @@
     "categories": [
       "custom"
     ],
-    "signature_path": "/epr/udp/udp-1.0.1.zip.sig"
+    "signature_path": "/epr/udp/udp-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "udp.generic",
+        "title": "Custom UDP Logs"
+      }
+    ]
   },
   {
     "name": "winlog",
@@ -13980,7 +18384,14 @@
     "categories": [
       "custom"
     ],
-    "signature_path": "/epr/winlog/winlog-1.1.2.zip.sig"
+    "signature_path": "/epr/winlog/winlog-1.1.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "winlog.winlog",
+        "title": "Custom Windows Event Log Dataset"
+      }
+    ]
   },
   {
     "name": "winlog",
@@ -14016,7 +18427,14 @@
     "categories": [
       "custom"
     ],
-    "signature_path": "/epr/winlog/winlog-1.2.0.zip.sig"
+    "signature_path": "/epr/winlog/winlog-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "winlog.winlog",
+        "title": "Custom Windows Event Log Dataset"
+      }
+    ]
   },
   {
     "name": "winlog",
@@ -14052,7 +18470,14 @@
     "categories": [
       "custom"
     ],
-    "signature_path": "/epr/winlog/winlog-1.3.0.zip.sig"
+    "signature_path": "/epr/winlog/winlog-1.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "winlog.winlog",
+        "title": "Custom Windows Event Log Dataset"
+      }
+    ]
   },
   {
     "name": "winlog",
@@ -14088,7 +18513,14 @@
     "categories": [
       "custom"
     ],
-    "signature_path": "/epr/winlog/winlog-1.4.0.zip.sig"
+    "signature_path": "/epr/winlog/winlog-1.4.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "winlog.winlog",
+        "title": "Custom Windows Event Log Dataset"
+      }
+    ]
   },
   {
     "name": "winlog",
@@ -14124,7 +18556,14 @@
     "categories": [
       "custom"
     ],
-    "signature_path": "/epr/winlog/winlog-1.0.3.zip.sig"
+    "signature_path": "/epr/winlog/winlog-1.0.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "winlog.winlog",
+        "title": "Custom Windows Event Log Dataset"
+      }
+    ]
   },
   {
     "name": "winlog",
@@ -14160,7 +18599,14 @@
     "categories": [
       "custom"
     ],
-    "signature_path": "/epr/winlog/winlog-1.1.0.zip.sig"
+    "signature_path": "/epr/winlog/winlog-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "winlog.winlog",
+        "title": "Custom Windows Event Log Dataset"
+      }
+    ]
   },
   {
     "name": "cyberarkpas",
@@ -14198,7 +18644,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/cyberarkpas/cyberarkpas-1.0.0.zip.sig"
+    "signature_path": "/epr/cyberarkpas/cyberarkpas-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cyberarkpas.audit",
+        "title": "CyberArk PAS audit logs"
+      }
+    ]
   },
   {
     "name": "cyberarkpas",
@@ -14236,7 +18689,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/cyberarkpas/cyberarkpas-1.1.0.zip.sig"
+    "signature_path": "/epr/cyberarkpas/cyberarkpas-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cyberarkpas.audit",
+        "title": "CyberArk PAS audit logs"
+      }
+    ]
   },
   {
     "name": "cyberarkpas",
@@ -14274,7 +18734,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/cyberarkpas/cyberarkpas-1.2.3.zip.sig"
+    "signature_path": "/epr/cyberarkpas/cyberarkpas-1.2.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cyberarkpas.audit",
+        "title": "CyberArk PAS audit logs"
+      }
+    ]
   },
   {
     "name": "cyberarkpas",
@@ -14312,7 +18779,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/cyberarkpas/cyberarkpas-2.1.2.zip.sig"
+    "signature_path": "/epr/cyberarkpas/cyberarkpas-2.1.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cyberarkpas.audit",
+        "title": "CyberArk PAS audit logs"
+      }
+    ]
   },
   {
     "name": "cyberarkpas",
@@ -14350,7 +18824,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/cyberarkpas/cyberarkpas-2.1.4.zip.sig"
+    "signature_path": "/epr/cyberarkpas/cyberarkpas-2.1.4.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cyberarkpas.audit",
+        "title": "CyberArk PAS audit logs"
+      }
+    ]
   },
   {
     "name": "cyberarkpas",
@@ -14388,7 +18869,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/cyberarkpas/cyberarkpas-2.2.0.zip.sig"
+    "signature_path": "/epr/cyberarkpas/cyberarkpas-2.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cyberarkpas.audit",
+        "title": "CyberArk PAS audit logs"
+      }
+    ]
   },
   {
     "name": "cyberarkpas",
@@ -14426,7 +18914,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/cyberarkpas/cyberarkpas-2.2.2.zip.sig"
+    "signature_path": "/epr/cyberarkpas/cyberarkpas-2.2.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cyberarkpas.audit",
+        "title": "CyberArk PAS audit logs"
+      }
+    ]
   },
   {
     "name": "cyberarkpas",
@@ -14464,7 +18959,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/cyberarkpas/cyberarkpas-2.3.0.zip.sig"
+    "signature_path": "/epr/cyberarkpas/cyberarkpas-2.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cyberarkpas.audit",
+        "title": "CyberArk PAS audit logs"
+      }
+    ]
   },
   {
     "name": "cyberarkpas",
@@ -14502,7 +19004,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/cyberarkpas/cyberarkpas-2.3.2.zip.sig"
+    "signature_path": "/epr/cyberarkpas/cyberarkpas-2.3.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cyberarkpas.audit",
+        "title": "CyberArk PAS audit logs"
+      }
+    ]
   },
   {
     "name": "cyberarkpas",
@@ -14540,7 +19049,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/cyberarkpas/cyberarkpas-2.4.0.zip.sig"
+    "signature_path": "/epr/cyberarkpas/cyberarkpas-2.4.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cyberarkpas.audit",
+        "title": "CyberArk PAS audit logs"
+      }
+    ]
   },
   {
     "name": "cyberarkpas",
@@ -14578,7 +19094,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/cyberarkpas/cyberarkpas-2.4.2.zip.sig"
+    "signature_path": "/epr/cyberarkpas/cyberarkpas-2.4.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cyberarkpas.audit",
+        "title": "CyberArk PAS audit logs"
+      }
+    ]
   },
   {
     "name": "ti_cybersixgill",
@@ -14617,7 +19140,14 @@
       "security",
       "productivity"
     ],
-    "signature_path": "/epr/ti_cybersixgill/ti_cybersixgill-1.0.0.zip.sig"
+    "signature_path": "/epr/ti_cybersixgill/ti_cybersixgill-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_cybersixgill.threat",
+        "title": "Cybersixgill webhook logs"
+      }
+    ]
   },
   {
     "name": "ti_cybersixgill",
@@ -14656,7 +19186,14 @@
       "security",
       "productivity"
     ],
-    "signature_path": "/epr/ti_cybersixgill/ti_cybersixgill-1.1.0.zip.sig"
+    "signature_path": "/epr/ti_cybersixgill/ti_cybersixgill-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_cybersixgill.threat",
+        "title": "Cybersixgill webhook logs"
+      }
+    ]
   },
   {
     "name": "ti_cybersixgill",
@@ -14695,7 +19232,14 @@
       "security",
       "productivity"
     ],
-    "signature_path": "/epr/ti_cybersixgill/ti_cybersixgill-1.2.0.zip.sig"
+    "signature_path": "/epr/ti_cybersixgill/ti_cybersixgill-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_cybersixgill.threat",
+        "title": "Cybersixgill webhook logs"
+      }
+    ]
   },
   {
     "name": "ti_cybersixgill",
@@ -14734,7 +19278,14 @@
       "security",
       "productivity"
     ],
-    "signature_path": "/epr/ti_cybersixgill/ti_cybersixgill-1.3.0.zip.sig"
+    "signature_path": "/epr/ti_cybersixgill/ti_cybersixgill-1.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_cybersixgill.threat",
+        "title": "Cybersixgill Darkfeed Logs"
+      }
+    ]
   },
   {
     "name": "ti_cybersixgill",
@@ -14773,7 +19324,14 @@
       "security",
       "productivity"
     ],
-    "signature_path": "/epr/ti_cybersixgill/ti_cybersixgill-1.3.1.zip.sig"
+    "signature_path": "/epr/ti_cybersixgill/ti_cybersixgill-1.3.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_cybersixgill.threat",
+        "title": "Cybersixgill Darkfeed Logs"
+      }
+    ]
   },
   {
     "name": "ti_cybersixgill",
@@ -14812,7 +19370,14 @@
       "security",
       "productivity"
     ],
-    "signature_path": "/epr/ti_cybersixgill/ti_cybersixgill-1.3.2.zip.sig"
+    "signature_path": "/epr/ti_cybersixgill/ti_cybersixgill-1.3.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_cybersixgill.threat",
+        "title": "Cybersixgill Darkfeed Logs"
+      }
+    ]
   },
   {
     "name": "docker",
@@ -14851,7 +19416,54 @@
       "containers",
       "os_system"
     ],
-    "signature_path": "/epr/docker/docker-1.0.0.zip.sig"
+    "signature_path": "/epr/docker/docker-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "docker.container",
+        "title": "Docker container metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "docker.cpu",
+        "title": "Docker cpu metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "docker.diskio",
+        "title": "Docker diskio metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "docker.event",
+        "title": "Docker event metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "docker.healthcheck",
+        "title": "Docker healthcheck metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "docker.image",
+        "title": "Docker image metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "docker.info",
+        "title": "Docker info metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "docker.memory",
+        "title": "Docker memory metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "docker.network",
+        "title": "Docker network metrics"
+      }
+    ]
   },
   {
     "name": "docker",
@@ -14890,7 +19502,54 @@
       "containers",
       "os_system"
     ],
-    "signature_path": "/epr/docker/docker-1.2.0.zip.sig"
+    "signature_path": "/epr/docker/docker-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "docker.container",
+        "title": "Docker container metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "docker.cpu",
+        "title": "Docker cpu metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "docker.diskio",
+        "title": "Docker diskio metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "docker.event",
+        "title": "Docker event metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "docker.healthcheck",
+        "title": "Docker healthcheck metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "docker.image",
+        "title": "Docker image metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "docker.info",
+        "title": "Docker info metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "docker.memory",
+        "title": "Docker memory metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "docker.network",
+        "title": "Docker network metrics"
+      }
+    ]
   },
   {
     "name": "apm",
@@ -14929,7 +19588,39 @@
       "elastic_stack",
       "monitoring"
     ],
-    "signature_path": "/epr/apm/apm-7.16.0.zip.sig"
+    "signature_path": "/epr/apm/apm-7.16.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "apm.app",
+        "title": "APM application metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "apm.error",
+        "title": "APM logs and errors"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.internal",
+        "title": "APM internal metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.profiling",
+        "title": "APM profiles"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm.sampled",
+        "title": "APM tail-sampled traces"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm",
+        "title": "APM traces"
+      }
+    ]
   },
   {
     "name": "apm",
@@ -14968,7 +19659,39 @@
       "elastic_stack",
       "monitoring"
     ],
-    "signature_path": "/epr/apm/apm-7.16.1.zip.sig"
+    "signature_path": "/epr/apm/apm-7.16.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "apm.app",
+        "title": "APM application metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "apm.error",
+        "title": "APM logs and errors"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.internal",
+        "title": "APM internal metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.profiling",
+        "title": "APM profiles"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm.sampled",
+        "title": "APM tail-sampled traces"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm",
+        "title": "APM traces"
+      }
+    ]
   },
   {
     "name": "apm",
@@ -15007,7 +19730,44 @@
       "elastic_stack",
       "monitoring"
     ],
-    "signature_path": "/epr/apm/apm-7.16.2.zip.sig"
+    "signature_path": "/epr/apm/apm-7.16.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "apm.app",
+        "title": "APM application logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.app",
+        "title": "APM application metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "apm.error",
+        "title": "APM logs and errors"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.internal",
+        "title": "APM internal metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.profiling",
+        "title": "APM profiles"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm.sampled",
+        "title": "APM tail-sampled traces"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm",
+        "title": "APM traces"
+      }
+    ]
   },
   {
     "name": "apm",
@@ -15046,7 +19806,44 @@
       "elastic_stack",
       "monitoring"
     ],
-    "signature_path": "/epr/apm/apm-7.17.0.zip.sig"
+    "signature_path": "/epr/apm/apm-7.17.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "apm.app",
+        "title": "APM application logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.app",
+        "title": "APM application metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "apm.error",
+        "title": "APM logs and errors"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.internal",
+        "title": "APM internal metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.profiling",
+        "title": "APM profiles"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm.sampled",
+        "title": "APM tail-sampled traces"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm",
+        "title": "APM traces"
+      }
+    ]
   },
   {
     "name": "apm",
@@ -15085,7 +19882,49 @@
       "elastic_stack",
       "monitoring"
     ],
-    "signature_path": "/epr/apm/apm-8.0.0.zip.sig"
+    "signature_path": "/epr/apm/apm-8.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "apm.app",
+        "title": "APM application logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.app",
+        "title": "APM application metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "apm.error",
+        "title": "APM errors"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.internal",
+        "title": "APM internal metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.profiling",
+        "title": "APM profiles"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm.rum",
+        "title": "APM RUM traces"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm.sampled",
+        "title": "APM tail-sampled traces"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm",
+        "title": "APM traces"
+      }
+    ]
   },
   {
     "name": "apm",
@@ -15124,7 +19963,49 @@
       "elastic_stack",
       "monitoring"
     ],
-    "signature_path": "/epr/apm/apm-8.1.0.zip.sig"
+    "signature_path": "/epr/apm/apm-8.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "apm.app",
+        "title": "APM application logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.app",
+        "title": "APM application metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "apm.error",
+        "title": "APM errors"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.internal",
+        "title": "APM internal metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.profiling",
+        "title": "APM profiles"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm.rum",
+        "title": "APM RUM traces"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm.sampled",
+        "title": "APM tail-sampled traces"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm",
+        "title": "APM traces"
+      }
+    ]
   },
   {
     "name": "apm",
@@ -15163,7 +20044,49 @@
       "elastic_stack",
       "monitoring"
     ],
-    "signature_path": "/epr/apm/apm-8.1.2.zip.sig"
+    "signature_path": "/epr/apm/apm-8.1.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "apm.app",
+        "title": "APM application logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.app",
+        "title": "APM application metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "apm.error",
+        "title": "APM errors"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.internal",
+        "title": "APM internal metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.profiling",
+        "title": "APM profiles"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm.rum",
+        "title": "APM RUM traces"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm.sampled",
+        "title": "APM tail-sampled traces"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm",
+        "title": "APM traces"
+      }
+    ]
   },
   {
     "name": "apm",
@@ -15202,7 +20125,49 @@
       "elastic_stack",
       "monitoring"
     ],
-    "signature_path": "/epr/apm/apm-8.2.0.zip.sig"
+    "signature_path": "/epr/apm/apm-8.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "apm.app",
+        "title": "APM application logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.app",
+        "title": "APM application metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "apm.error",
+        "title": "APM errors"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.internal",
+        "title": "APM internal metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.profiling",
+        "title": "APM profiles"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm.rum",
+        "title": "APM RUM traces"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm.sampled",
+        "title": "APM tail-sampled traces"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm",
+        "title": "APM traces"
+      }
+    ]
   },
   {
     "name": "elastic_agent",
@@ -15233,7 +20198,14 @@
     "categories": [
       "elastic_stack"
     ],
-    "signature_path": "/epr/elastic_agent/elastic_agent-1.0.0.zip.sig"
+    "signature_path": "/epr/elastic_agent/elastic_agent-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.elastic_agent",
+        "title": "Elastic Agent"
+      }
+    ]
   },
   {
     "name": "elastic_agent",
@@ -15264,7 +20236,109 @@
     "categories": [
       "elastic_stack"
     ],
-    "signature_path": "/epr/elastic_agent/elastic_agent-1.1.1.zip.sig"
+    "signature_path": "/epr/elastic_agent/elastic_agent-1.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.apm_server",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.apm_server",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.auditbeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.auditbeat",
+        "title": "Elastic Agent Auditbeat Metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.elastic_agent",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.endpoint_security",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.endpoint_security",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.filebeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.filebeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.fleet_server",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.fleet_server",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.heartbeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.heartbeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.metricbeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.metricbeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.osquerybeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.osquerybeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.packetbeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.packetbeat",
+        "title": "Elastic Agent"
+      }
+    ]
   },
   {
     "name": "elastic_agent",
@@ -15295,7 +20369,109 @@
     "categories": [
       "elastic_stack"
     ],
-    "signature_path": "/epr/elastic_agent/elastic_agent-1.2.0.zip.sig"
+    "signature_path": "/epr/elastic_agent/elastic_agent-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.apm_server",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.apm_server",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.auditbeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.auditbeat",
+        "title": "Elastic Agent Auditbeat Metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.elastic_agent",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.endpoint_security",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.endpoint_security",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.filebeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.filebeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.fleet_server",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.fleet_server",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.heartbeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.heartbeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.metricbeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.metricbeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.osquerybeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.osquerybeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.packetbeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.packetbeat",
+        "title": "Elastic Agent"
+      }
+    ]
   },
   {
     "name": "elastic_agent",
@@ -15326,7 +20502,109 @@
     "categories": [
       "elastic_stack"
     ],
-    "signature_path": "/epr/elastic_agent/elastic_agent-1.2.1.zip.sig"
+    "signature_path": "/epr/elastic_agent/elastic_agent-1.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.apm_server",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.apm_server",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.auditbeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.auditbeat",
+        "title": "Elastic Agent Auditbeat Metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.elastic_agent",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.endpoint_security",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.endpoint_security",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.filebeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.filebeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.fleet_server",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.fleet_server",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.heartbeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.heartbeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.metricbeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.metricbeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.osquerybeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.osquerybeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.packetbeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.packetbeat",
+        "title": "Elastic Agent"
+      }
+    ]
   },
   {
     "name": "elastic_agent",
@@ -15357,7 +20635,109 @@
     "categories": [
       "elastic_stack"
     ],
-    "signature_path": "/epr/elastic_agent/elastic_agent-1.3.0.zip.sig"
+    "signature_path": "/epr/elastic_agent/elastic_agent-1.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.apm_server",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.apm_server",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.auditbeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.auditbeat",
+        "title": "Elastic Agent Auditbeat Metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.elastic_agent",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.endpoint_security",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.endpoint_security",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.filebeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.filebeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.fleet_server",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.fleet_server",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.heartbeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.heartbeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.metricbeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.metricbeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.osquerybeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.osquerybeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.packetbeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.packetbeat",
+        "title": "Elastic Agent"
+      }
+    ]
   },
   {
     "name": "elastic_agent",
@@ -15388,7 +20768,109 @@
     "categories": [
       "elastic_stack"
     ],
-    "signature_path": "/epr/elastic_agent/elastic_agent-1.3.1.zip.sig"
+    "signature_path": "/epr/elastic_agent/elastic_agent-1.3.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.apm_server",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.apm_server",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.auditbeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.auditbeat",
+        "title": "Elastic Agent Auditbeat Metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.elastic_agent",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.endpoint_security",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.endpoint_security",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.filebeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.filebeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.fleet_server",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.fleet_server",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.heartbeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.heartbeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.metricbeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.metricbeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.osquerybeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.osquerybeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.packetbeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.packetbeat",
+        "title": "Elastic Agent"
+      }
+    ]
   },
   {
     "name": "endpoint",
@@ -15425,7 +20907,64 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/endpoint/endpoint-1.0.0.zip.sig"
+    "signature_path": "/epr/endpoint/endpoint-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "endpoint.alerts",
+        "title": "Endpoint Alerts"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.diagnostic.collection",
+        "title": "Endpoint Alert Collection"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.file",
+        "title": "Endpoint File Events"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.library",
+        "title": "Endpoint Library and Driver Events"
+      },
+      {
+        "type": "metrics",
+        "dataset": "endpoint.metadata",
+        "title": "Endpoint Metadata"
+      },
+      {
+        "type": "metrics",
+        "dataset": "endpoint.metrics",
+        "title": "Endpoint Metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.network",
+        "title": "Endpoint Network Events"
+      },
+      {
+        "type": "metrics",
+        "dataset": "endpoint.policy",
+        "title": "Endpoint Policy Response"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.process",
+        "title": "Endpoint Process Events"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.registry",
+        "title": "Endpoint Registry Events"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.security",
+        "title": "Endpoint Security Events"
+      }
+    ]
   },
   {
     "name": "endpoint",
@@ -15462,7 +21001,64 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/endpoint/endpoint-1.1.0.zip.sig"
+    "signature_path": "/epr/endpoint/endpoint-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "endpoint.alerts",
+        "title": "Endpoint Alerts"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.diagnostic.collection",
+        "title": "Endpoint Alert Collection"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.file",
+        "title": "Endpoint File Events"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.library",
+        "title": "Endpoint Library and Driver Events"
+      },
+      {
+        "type": "metrics",
+        "dataset": "endpoint.metadata",
+        "title": "Endpoint Metadata"
+      },
+      {
+        "type": "metrics",
+        "dataset": "endpoint.metrics",
+        "title": "Endpoint Metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.network",
+        "title": "Endpoint Network Events"
+      },
+      {
+        "type": "metrics",
+        "dataset": "endpoint.policy",
+        "title": "Endpoint Policy Response"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.process",
+        "title": "Endpoint Process Events"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.registry",
+        "title": "Endpoint Registry Events"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.security",
+        "title": "Endpoint Security Events"
+      }
+    ]
   },
   {
     "name": "endpoint",
@@ -15499,7 +21095,64 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/endpoint/endpoint-1.1.1.zip.sig"
+    "signature_path": "/epr/endpoint/endpoint-1.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "endpoint.alerts",
+        "title": "Endpoint Alerts"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.diagnostic.collection",
+        "title": "Endpoint Alert Collection"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.file",
+        "title": "Endpoint File Events"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.library",
+        "title": "Endpoint Library and Driver Events"
+      },
+      {
+        "type": "metrics",
+        "dataset": "endpoint.metadata",
+        "title": "Endpoint Metadata"
+      },
+      {
+        "type": "metrics",
+        "dataset": "endpoint.metrics",
+        "title": "Endpoint Metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.network",
+        "title": "Endpoint Network Events"
+      },
+      {
+        "type": "metrics",
+        "dataset": "endpoint.policy",
+        "title": "Endpoint Policy Response"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.process",
+        "title": "Endpoint Process Events"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.registry",
+        "title": "Endpoint Registry Events"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.security",
+        "title": "Endpoint Security Events"
+      }
+    ]
   },
   {
     "name": "endpoint",
@@ -15536,7 +21189,74 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/endpoint/endpoint-1.2.0.zip.sig"
+    "signature_path": "/epr/endpoint/endpoint-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "endpoint.action.responses",
+        "title": "Endpoint Action Responses"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.actions",
+        "title": "Endpoint Actions"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.alerts",
+        "title": "Endpoint Alerts"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.diagnostic.collection",
+        "title": "Endpoint Alert Collection"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.file",
+        "title": "Endpoint File Events"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.library",
+        "title": "Endpoint Library and Driver Events"
+      },
+      {
+        "type": "metrics",
+        "dataset": "endpoint.metadata",
+        "title": "Endpoint Metadata"
+      },
+      {
+        "type": "metrics",
+        "dataset": "endpoint.metrics",
+        "title": "Endpoint Metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.network",
+        "title": "Endpoint Network Events"
+      },
+      {
+        "type": "metrics",
+        "dataset": "endpoint.policy",
+        "title": "Endpoint Policy Response"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.process",
+        "title": "Endpoint Process Events"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.registry",
+        "title": "Endpoint Registry Events"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.security",
+        "title": "Endpoint Security Events"
+      }
+    ]
   },
   {
     "name": "endpoint",
@@ -15573,7 +21293,74 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/endpoint/endpoint-1.2.1.zip.sig"
+    "signature_path": "/epr/endpoint/endpoint-1.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "endpoint.action.responses",
+        "title": "Endpoint Action Responses"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.actions",
+        "title": "Endpoint Actions"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.alerts",
+        "title": "Endpoint Alerts"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.diagnostic.collection",
+        "title": "Endpoint Alert Collection"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.file",
+        "title": "Endpoint File Events"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.library",
+        "title": "Endpoint Library and Driver Events"
+      },
+      {
+        "type": "metrics",
+        "dataset": "endpoint.metadata",
+        "title": "Endpoint Metadata"
+      },
+      {
+        "type": "metrics",
+        "dataset": "endpoint.metrics",
+        "title": "Endpoint Metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.network",
+        "title": "Endpoint Network Events"
+      },
+      {
+        "type": "metrics",
+        "dataset": "endpoint.policy",
+        "title": "Endpoint Policy Response"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.process",
+        "title": "Endpoint Process Events"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.registry",
+        "title": "Endpoint Registry Events"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.security",
+        "title": "Endpoint Security Events"
+      }
+    ]
   },
   {
     "name": "endpoint",
@@ -15610,7 +21397,74 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/endpoint/endpoint-1.2.2.zip.sig"
+    "signature_path": "/epr/endpoint/endpoint-1.2.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "endpoint.action.responses",
+        "title": "Endpoint Action Responses"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.actions",
+        "title": "Endpoint Actions"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.alerts",
+        "title": "Endpoint Alerts"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.diagnostic.collection",
+        "title": "Endpoint Alert Collection"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.file",
+        "title": "Endpoint File Events"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.library",
+        "title": "Endpoint Library and Driver Events"
+      },
+      {
+        "type": "metrics",
+        "dataset": "endpoint.metadata",
+        "title": "Endpoint Metadata"
+      },
+      {
+        "type": "metrics",
+        "dataset": "endpoint.metrics",
+        "title": "Endpoint Metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.network",
+        "title": "Endpoint Network Events"
+      },
+      {
+        "type": "metrics",
+        "dataset": "endpoint.policy",
+        "title": "Endpoint Policy Response"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.process",
+        "title": "Endpoint Process Events"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.registry",
+        "title": "Endpoint Registry Events"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.security",
+        "title": "Endpoint Security Events"
+      }
+    ]
   },
   {
     "name": "endpoint",
@@ -15647,7 +21501,74 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/endpoint/endpoint-1.3.0.zip.sig"
+    "signature_path": "/epr/endpoint/endpoint-1.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "endpoint.action.responses",
+        "title": "Endpoint Action Responses"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.actions",
+        "title": "Endpoint Actions"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.alerts",
+        "title": "Endpoint Alerts"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.diagnostic.collection",
+        "title": "Endpoint Alert Collection"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.file",
+        "title": "Endpoint File Events"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.library",
+        "title": "Endpoint Library and Driver Events"
+      },
+      {
+        "type": "metrics",
+        "dataset": "endpoint.metadata",
+        "title": "Endpoint Metadata"
+      },
+      {
+        "type": "metrics",
+        "dataset": "endpoint.metrics",
+        "title": "Endpoint Metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.network",
+        "title": "Endpoint Network Events"
+      },
+      {
+        "type": "metrics",
+        "dataset": "endpoint.policy",
+        "title": "Endpoint Policy Response"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.process",
+        "title": "Endpoint Process Events"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.registry",
+        "title": "Endpoint Registry Events"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.security",
+        "title": "Endpoint Security Events"
+      }
+    ]
   },
   {
     "name": "endpoint",
@@ -15684,7 +21605,74 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/endpoint/endpoint-1.4.0.zip.sig"
+    "signature_path": "/epr/endpoint/endpoint-1.4.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "endpoint.action.responses",
+        "title": "Endpoint Action Responses"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.actions",
+        "title": "Endpoint Actions"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.alerts",
+        "title": "Endpoint Alerts"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.diagnostic.collection",
+        "title": "Endpoint Alert Collection"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.file",
+        "title": "Endpoint File Events"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.library",
+        "title": "Endpoint Library and Driver Events"
+      },
+      {
+        "type": "metrics",
+        "dataset": "endpoint.metadata",
+        "title": "Endpoint Metadata"
+      },
+      {
+        "type": "metrics",
+        "dataset": "endpoint.metrics",
+        "title": "Endpoint Metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.network",
+        "title": "Endpoint Network Events"
+      },
+      {
+        "type": "metrics",
+        "dataset": "endpoint.policy",
+        "title": "Endpoint Policy Response"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.process",
+        "title": "Endpoint Process Events"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.registry",
+        "title": "Endpoint Registry Events"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.security",
+        "title": "Endpoint Security Events"
+      }
+    ]
   },
   {
     "name": "endpoint",
@@ -15721,7 +21709,74 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/endpoint/endpoint-1.4.1.zip.sig"
+    "signature_path": "/epr/endpoint/endpoint-1.4.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "endpoint.action.responses",
+        "title": "Endpoint Action Responses"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.actions",
+        "title": "Endpoint Actions"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.alerts",
+        "title": "Endpoint Alerts"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.diagnostic.collection",
+        "title": "Endpoint Alert Collection"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.file",
+        "title": "Endpoint File Events"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.library",
+        "title": "Endpoint Library and Driver Events"
+      },
+      {
+        "type": "metrics",
+        "dataset": "endpoint.metadata",
+        "title": "Endpoint Metadata"
+      },
+      {
+        "type": "metrics",
+        "dataset": "endpoint.metrics",
+        "title": "Endpoint Metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.network",
+        "title": "Endpoint Network Events"
+      },
+      {
+        "type": "metrics",
+        "dataset": "endpoint.policy",
+        "title": "Endpoint Policy Response"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.process",
+        "title": "Endpoint Process Events"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.registry",
+        "title": "Endpoint Registry Events"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.security",
+        "title": "Endpoint Security Events"
+      }
+    ]
   },
   {
     "name": "endpoint",
@@ -15758,7 +21813,74 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/endpoint/endpoint-1.5.0.zip.sig"
+    "signature_path": "/epr/endpoint/endpoint-1.5.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "endpoint.action.responses",
+        "title": "Endpoint Action Responses"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.actions",
+        "title": "Endpoint Actions"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.alerts",
+        "title": "Endpoint Alerts"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.diagnostic.collection",
+        "title": "Endpoint Alert Collection"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.file",
+        "title": "Endpoint File Events"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.library",
+        "title": "Endpoint Library and Driver Events"
+      },
+      {
+        "type": "metrics",
+        "dataset": "endpoint.metadata",
+        "title": "Endpoint Metadata"
+      },
+      {
+        "type": "metrics",
+        "dataset": "endpoint.metrics",
+        "title": "Endpoint Metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.network",
+        "title": "Endpoint Network Events"
+      },
+      {
+        "type": "metrics",
+        "dataset": "endpoint.policy",
+        "title": "Endpoint Policy Response"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.process",
+        "title": "Endpoint Process Events"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.registry",
+        "title": "Endpoint Registry Events"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.security",
+        "title": "Endpoint Security Events"
+      }
+    ]
   },
   {
     "name": "endpoint",
@@ -15795,7 +21917,74 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/endpoint/endpoint-8.2.0.zip.sig"
+    "signature_path": "/epr/endpoint/endpoint-8.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "endpoint.action.responses",
+        "title": "Endpoint Action Responses"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.actions",
+        "title": "Endpoint Actions"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.alerts",
+        "title": "Endpoint Alerts"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.diagnostic.collection",
+        "title": "Endpoint Alert Collection"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.file",
+        "title": "Endpoint File Events"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.library",
+        "title": "Endpoint Library and Driver Events"
+      },
+      {
+        "type": "metrics",
+        "dataset": "endpoint.metadata",
+        "title": "Endpoint Metadata"
+      },
+      {
+        "type": "metrics",
+        "dataset": "endpoint.metrics",
+        "title": "Endpoint Metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.network",
+        "title": "Endpoint Network Events"
+      },
+      {
+        "type": "metrics",
+        "dataset": "endpoint.policy",
+        "title": "Endpoint Policy Response"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.process",
+        "title": "Endpoint Process Events"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.registry",
+        "title": "Endpoint Registry Events"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.security",
+        "title": "Endpoint Security Events"
+      }
+    ]
   },
   {
     "name": "endpoint",
@@ -15833,7 +22022,74 @@
       "security",
       "cloud"
     ],
-    "signature_path": "/epr/endpoint/endpoint-8.3.0.zip.sig"
+    "signature_path": "/epr/endpoint/endpoint-8.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "endpoint.action.responses",
+        "title": "Endpoint Action Responses"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.actions",
+        "title": "Endpoint Actions"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.alerts",
+        "title": "Endpoint Alerts"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.diagnostic.collection",
+        "title": "Endpoint Alert Collection"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.file",
+        "title": "Endpoint File Events"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.library",
+        "title": "Endpoint Library and Driver Events"
+      },
+      {
+        "type": "metrics",
+        "dataset": "endpoint.metadata",
+        "title": "Endpoint Metadata"
+      },
+      {
+        "type": "metrics",
+        "dataset": "endpoint.metrics",
+        "title": "Endpoint Metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.network",
+        "title": "Endpoint Network Events"
+      },
+      {
+        "type": "metrics",
+        "dataset": "endpoint.policy",
+        "title": "Endpoint Policy Response"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.process",
+        "title": "Endpoint Process Events"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.registry",
+        "title": "Endpoint Registry Events"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.security",
+        "title": "Endpoint Security Events"
+      }
+    ]
   },
   {
     "name": "fim",
@@ -15873,7 +22129,14 @@
       "os_system",
       "security"
     ],
-    "signature_path": "/epr/fim/fim-1.0.0.zip.sig"
+    "signature_path": "/epr/fim/fim-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "fim.event",
+        "title": "Filesystem events"
+      }
+    ]
   },
   {
     "name": "fireeye",
@@ -15913,7 +22176,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/fireeye/fireeye-1.0.0.zip.sig"
+    "signature_path": "/epr/fireeye/fireeye-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "fireeye.nx",
+        "title": "Fireeye NX"
+      }
+    ]
   },
   {
     "name": "fireeye",
@@ -15953,7 +22223,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/fireeye/fireeye-1.1.0.zip.sig"
+    "signature_path": "/epr/fireeye/fireeye-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "fireeye.nx",
+        "title": "Fireeye NX"
+      }
+    ]
   },
   {
     "name": "fireeye",
@@ -15993,7 +22270,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/fireeye/fireeye-1.1.2.zip.sig"
+    "signature_path": "/epr/fireeye/fireeye-1.1.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "fireeye.nx",
+        "title": "Fireeye NX"
+      }
+    ]
   },
   {
     "name": "fireeye",
@@ -16033,7 +22317,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/fireeye/fireeye-1.2.0.zip.sig"
+    "signature_path": "/epr/fireeye/fireeye-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "fireeye.nx",
+        "title": "Fireeye NX"
+      }
+    ]
   },
   {
     "name": "fireeye",
@@ -16073,7 +22364,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/fireeye/fireeye-1.2.2.zip.sig"
+    "signature_path": "/epr/fireeye/fireeye-1.2.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "fireeye.nx",
+        "title": "Fireeye NX"
+      }
+    ]
   },
   {
     "name": "fireeye",
@@ -16113,7 +22411,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/fireeye/fireeye-1.3.0.zip.sig"
+    "signature_path": "/epr/fireeye/fireeye-1.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "fireeye.nx",
+        "title": "Fireeye NX"
+      }
+    ]
   },
   {
     "name": "fireeye",
@@ -16153,7 +22458,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/fireeye/fireeye-1.3.1.zip.sig"
+    "signature_path": "/epr/fireeye/fireeye-1.3.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "fireeye.nx",
+        "title": "Fireeye NX"
+      }
+    ]
   },
   {
     "name": "fleet_server",
@@ -16334,7 +22646,29 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/fortinet/fortinet-1.1.2.zip.sig"
+    "signature_path": "/epr/fortinet/fortinet-1.1.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "fortinet.clientendpoint",
+        "title": "Fortinet FortiClient Endpoint Security logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "fortinet.firewall",
+        "title": "Fortinet firewall logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "fortinet.fortimail",
+        "title": "Fortinet FortiMail logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "fortinet.fortimanager",
+        "title": "Fortinet Manager/Analyzer logs"
+      }
+    ]
   },
   {
     "name": "fortinet",
@@ -16372,7 +22706,29 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/fortinet/fortinet-1.2.0.zip.sig"
+    "signature_path": "/epr/fortinet/fortinet-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "fortinet.clientendpoint",
+        "title": "Fortinet FortiClient Endpoint Security logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "fortinet.firewall",
+        "title": "Fortinet firewall logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "fortinet.fortimail",
+        "title": "Fortinet FortiMail logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "fortinet.fortimanager",
+        "title": "Fortinet Manager/Analyzer logs"
+      }
+    ]
   },
   {
     "name": "fortinet",
@@ -16410,7 +22766,29 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/fortinet/fortinet-1.2.4.zip.sig"
+    "signature_path": "/epr/fortinet/fortinet-1.2.4.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "fortinet.clientendpoint",
+        "title": "Fortinet FortiClient Endpoint Security logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "fortinet.firewall",
+        "title": "Fortinet firewall logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "fortinet.fortimail",
+        "title": "Fortinet FortiMail logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "fortinet.fortimanager",
+        "title": "Fortinet Manager/Analyzer logs"
+      }
+    ]
   },
   {
     "name": "fortinet",
@@ -16448,7 +22826,29 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/fortinet/fortinet-1.3.0.zip.sig"
+    "signature_path": "/epr/fortinet/fortinet-1.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "fortinet.clientendpoint",
+        "title": "Fortinet FortiClient Endpoint Security logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "fortinet.firewall",
+        "title": "Fortinet firewall logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "fortinet.fortimail",
+        "title": "Fortinet FortiMail logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "fortinet.fortimanager",
+        "title": "Fortinet Manager/Analyzer logs"
+      }
+    ]
   },
   {
     "name": "fortinet",
@@ -16486,7 +22886,29 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/fortinet/fortinet-1.3.2.zip.sig"
+    "signature_path": "/epr/fortinet/fortinet-1.3.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "fortinet.clientendpoint",
+        "title": "Fortinet FortiClient Endpoint Security logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "fortinet.firewall",
+        "title": "Fortinet firewall logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "fortinet.fortimail",
+        "title": "Fortinet FortiMail logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "fortinet.fortimanager",
+        "title": "Fortinet Manager/Analyzer logs"
+      }
+    ]
   },
   {
     "name": "fortinet",
@@ -16524,7 +22946,29 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/fortinet/fortinet-1.4.0.zip.sig"
+    "signature_path": "/epr/fortinet/fortinet-1.4.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "fortinet.clientendpoint",
+        "title": "Fortinet FortiClient Endpoint Security logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "fortinet.firewall",
+        "title": "Fortinet firewall logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "fortinet.fortimail",
+        "title": "Fortinet FortiMail logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "fortinet.fortimanager",
+        "title": "Fortinet Manager/Analyzer logs"
+      }
+    ]
   },
   {
     "name": "fortinet",
@@ -16562,7 +23006,29 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/fortinet/fortinet-1.4.1.zip.sig"
+    "signature_path": "/epr/fortinet/fortinet-1.4.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "fortinet.clientendpoint",
+        "title": "Fortinet FortiClient Endpoint Security logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "fortinet.firewall",
+        "title": "Fortinet firewall logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "fortinet.fortimail",
+        "title": "Fortinet FortiMail logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "fortinet.fortimanager",
+        "title": "Fortinet Manager/Analyzer logs"
+      }
+    ]
   },
   {
     "name": "fortinet",
@@ -16600,7 +23066,29 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/fortinet/fortinet-1.4.2.zip.sig"
+    "signature_path": "/epr/fortinet/fortinet-1.4.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "fortinet.clientendpoint",
+        "title": "Fortinet FortiClient Endpoint Security logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "fortinet.firewall",
+        "title": "Fortinet firewall logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "fortinet.fortimail",
+        "title": "Fortinet FortiMail logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "fortinet.fortimanager",
+        "title": "Fortinet Manager/Analyzer logs"
+      }
+    ]
   },
   {
     "name": "fortinet",
@@ -16638,7 +23126,29 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/fortinet/fortinet-1.4.3.zip.sig"
+    "signature_path": "/epr/fortinet/fortinet-1.4.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "fortinet.clientendpoint",
+        "title": "Fortinet FortiClient Endpoint Security logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "fortinet.firewall",
+        "title": "Fortinet firewall logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "fortinet.fortimail",
+        "title": "Fortinet FortiMail logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "fortinet.fortimanager",
+        "title": "Fortinet Manager/Analyzer logs"
+      }
+    ]
   },
   {
     "name": "fortinet",
@@ -16676,7 +23186,29 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/fortinet/fortinet-1.5.0.zip.sig"
+    "signature_path": "/epr/fortinet/fortinet-1.5.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "fortinet.clientendpoint",
+        "title": "Fortinet FortiClient Endpoint Security logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "fortinet.firewall",
+        "title": "Fortinet firewall logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "fortinet.fortimail",
+        "title": "Fortinet FortiMail logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "fortinet.fortimanager",
+        "title": "Fortinet Manager/Analyzer logs"
+      }
+    ]
   },
   {
     "name": "fortinet",
@@ -16714,7 +23246,29 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/fortinet/fortinet-1.6.1.zip.sig"
+    "signature_path": "/epr/fortinet/fortinet-1.6.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "fortinet.clientendpoint",
+        "title": "Fortinet FortiClient Endpoint Security logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "fortinet.firewall",
+        "title": "Fortinet firewall logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "fortinet.fortimail",
+        "title": "Fortinet FortiMail logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "fortinet.fortimanager",
+        "title": "Fortinet Manager/Analyzer logs"
+      }
+    ]
   },
   {
     "name": "github",
@@ -16752,7 +23306,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/github/github-1.0.0.zip.sig"
+    "signature_path": "/epr/github/github-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "github.audit",
+        "title": "GitHub Audit Logs"
+      }
+    ]
   },
   {
     "name": "gcp",
@@ -16793,7 +23354,24 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/gcp/gcp-1.1.2.zip.sig"
+    "signature_path": "/epr/gcp/gcp-1.1.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "gcp.audit",
+        "title": "Google Cloud Platform (GCP) audit logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "gcp.firewall",
+        "title": "Google Cloud Platform (GCP) firewall logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "gcp.vpcflow",
+        "title": "Google Cloud Platform (GCP) vpcflow logs"
+      }
+    ]
   },
   {
     "name": "gcp",
@@ -16834,7 +23412,24 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/gcp/gcp-1.2.0.zip.sig"
+    "signature_path": "/epr/gcp/gcp-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "gcp.audit",
+        "title": "Google Cloud Platform (GCP) audit logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "gcp.firewall",
+        "title": "Google Cloud Platform (GCP) firewall logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "gcp.vpcflow",
+        "title": "Google Cloud Platform (GCP) vpcflow logs"
+      }
+    ]
   },
   {
     "name": "gcp",
@@ -16875,7 +23470,24 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/gcp/gcp-1.2.2.zip.sig"
+    "signature_path": "/epr/gcp/gcp-1.2.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "gcp.audit",
+        "title": "Google Cloud Platform (GCP) audit logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "gcp.firewall",
+        "title": "Google Cloud Platform (GCP) firewall logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "gcp.vpcflow",
+        "title": "Google Cloud Platform (GCP) vpcflow logs"
+      }
+    ]
   },
   {
     "name": "gcp",
@@ -16916,7 +23528,24 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/gcp/gcp-1.3.0.zip.sig"
+    "signature_path": "/epr/gcp/gcp-1.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "gcp.audit",
+        "title": "Google Cloud Platform (GCP) audit logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "gcp.firewall",
+        "title": "Google Cloud Platform (GCP) firewall logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "gcp.vpcflow",
+        "title": "Google Cloud Platform (GCP) vpcflow logs"
+      }
+    ]
   },
   {
     "name": "gcp",
@@ -16957,7 +23586,24 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/gcp/gcp-1.3.1.zip.sig"
+    "signature_path": "/epr/gcp/gcp-1.3.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "gcp.audit",
+        "title": "Google Cloud Platform (GCP) audit logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "gcp.firewall",
+        "title": "Google Cloud Platform (GCP) firewall logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "gcp.vpcflow",
+        "title": "Google Cloud Platform (GCP) vpcflow logs"
+      }
+    ]
   },
   {
     "name": "gcp",
@@ -16998,7 +23644,29 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/gcp/gcp-1.4.1.zip.sig"
+    "signature_path": "/epr/gcp/gcp-1.4.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "gcp.audit",
+        "title": "Google Cloud Platform (GCP) audit logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "gcp.dns",
+        "title": "Google Cloud Platform (GCP) DNS logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "gcp.firewall",
+        "title": "Google Cloud Platform (GCP) firewall logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "gcp.vpcflow",
+        "title": "Google Cloud Platform (GCP) vpcflow logs"
+      }
+    ]
   },
   {
     "name": "gcp",
@@ -17039,7 +23707,29 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/gcp/gcp-1.4.2.zip.sig"
+    "signature_path": "/epr/gcp/gcp-1.4.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "gcp.audit",
+        "title": "Google Cloud Platform (GCP) audit logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "gcp.dns",
+        "title": "Google Cloud Platform (GCP) DNS logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "gcp.firewall",
+        "title": "Google Cloud Platform (GCP) firewall logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "gcp.vpcflow",
+        "title": "Google Cloud Platform (GCP) vpcflow logs"
+      }
+    ]
   },
   {
     "name": "gcp",
@@ -17080,7 +23770,29 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/gcp/gcp-1.5.0.zip.sig"
+    "signature_path": "/epr/gcp/gcp-1.5.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "gcp.audit",
+        "title": "Google Cloud Platform (GCP) audit logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "gcp.dns",
+        "title": "Google Cloud Platform (GCP) DNS logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "gcp.firewall",
+        "title": "Google Cloud Platform (GCP) firewall logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "gcp.vpcflow",
+        "title": "Google Cloud Platform (GCP) vpcflow logs"
+      }
+    ]
   },
   {
     "name": "gcp",
@@ -17121,7 +23833,29 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/gcp/gcp-1.5.1.zip.sig"
+    "signature_path": "/epr/gcp/gcp-1.5.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "gcp.audit",
+        "title": "Google Cloud Platform (GCP) audit logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "gcp.dns",
+        "title": "Google Cloud Platform (GCP) DNS logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "gcp.firewall",
+        "title": "Google Cloud Platform (GCP) firewall logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "gcp.vpcflow",
+        "title": "Google Cloud Platform (GCP) vpcflow logs"
+      }
+    ]
   },
   {
     "name": "gcp",
@@ -17162,7 +23896,29 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/gcp/gcp-1.6.1.zip.sig"
+    "signature_path": "/epr/gcp/gcp-1.6.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "gcp.audit",
+        "title": "Google Cloud Platform (GCP) audit logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "gcp.dns",
+        "title": "Google Cloud Platform (GCP) DNS logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "gcp.firewall",
+        "title": "Google Cloud Platform (GCP) firewall logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "gcp.vpcflow",
+        "title": "Google Cloud Platform (GCP) vpcflow logs"
+      }
+    ]
   },
   {
     "name": "gcp",
@@ -17203,7 +23959,29 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/gcp/gcp-1.8.0.zip.sig"
+    "signature_path": "/epr/gcp/gcp-1.8.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "gcp.audit",
+        "title": "Google Cloud Platform (GCP) audit logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "gcp.dns",
+        "title": "Google Cloud Platform (GCP) DNS logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "gcp.firewall",
+        "title": "Google Cloud Platform (GCP) firewall logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "gcp.vpcflow",
+        "title": "Google Cloud Platform (GCP) vpcflow logs"
+      }
+    ]
   },
   {
     "name": "gcp",
@@ -17244,7 +24022,29 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/gcp/gcp-1.9.0.zip.sig"
+    "signature_path": "/epr/gcp/gcp-1.9.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "gcp.audit",
+        "title": "Google Cloud Platform (GCP) audit logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "gcp.dns",
+        "title": "Google Cloud Platform (GCP) DNS logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "gcp.firewall",
+        "title": "Google Cloud Platform (GCP) firewall logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "gcp.vpcflow",
+        "title": "Google Cloud Platform (GCP) vpcflow logs"
+      }
+    ]
   },
   {
     "name": "gcp",
@@ -17285,7 +24085,24 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/gcp/gcp-1.1.0.zip.sig"
+    "signature_path": "/epr/gcp/gcp-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "gcp.audit",
+        "title": "Google Cloud Platform (GCP) audit logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "gcp.firewall",
+        "title": "Google Cloud Platform (GCP) firewall logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "gcp.vpcflow",
+        "title": "Google Cloud Platform (GCP) vpcflow logs"
+      }
+    ]
   },
   {
     "name": "santa",
@@ -17323,7 +24140,14 @@
       "security",
       "os_system"
     ],
-    "signature_path": "/epr/santa/santa-1.0.2.zip.sig"
+    "signature_path": "/epr/santa/santa-1.0.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "santa.log",
+        "title": "Google Santa log logs"
+      }
+    ]
   },
   {
     "name": "santa",
@@ -17361,7 +24185,14 @@
       "security",
       "os_system"
     ],
-    "signature_path": "/epr/santa/santa-1.0.3.zip.sig"
+    "signature_path": "/epr/santa/santa-1.0.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "santa.log",
+        "title": "Google Santa log logs"
+      }
+    ]
   },
   {
     "name": "santa",
@@ -17399,7 +24230,14 @@
       "security",
       "os_system"
     ],
-    "signature_path": "/epr/santa/santa-1.1.0.zip.sig"
+    "signature_path": "/epr/santa/santa-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "santa.log",
+        "title": "Google Santa log logs"
+      }
+    ]
   },
   {
     "name": "santa",
@@ -17437,7 +24275,14 @@
       "security",
       "os_system"
     ],
-    "signature_path": "/epr/santa/santa-2.0.0.zip.sig"
+    "signature_path": "/epr/santa/santa-2.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "santa.log",
+        "title": "Google Santa log logs"
+      }
+    ]
   },
   {
     "name": "santa",
@@ -17475,7 +24320,14 @@
       "security",
       "os_system"
     ],
-    "signature_path": "/epr/santa/santa-2.0.1.zip.sig"
+    "signature_path": "/epr/santa/santa-2.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "santa.log",
+        "title": "Google Santa log logs"
+      }
+    ]
   },
   {
     "name": "google_workspace",
@@ -17513,7 +24365,39 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/google_workspace/google_workspace-1.1.2.zip.sig"
+    "signature_path": "/epr/google_workspace/google_workspace-1.1.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "google_workspace.admin",
+        "title": "Admin logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "google_workspace.drive",
+        "title": "Drive logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "google_workspace.groups",
+        "title": "Groups logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "google_workspace.login",
+        "title": "Login logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "google_workspace.saml",
+        "title": "SAML logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "google_workspace.user_accounts",
+        "title": "User accounts logs"
+      }
+    ]
   },
   {
     "name": "google_workspace",
@@ -17551,7 +24435,39 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/google_workspace/google_workspace-1.1.3.zip.sig"
+    "signature_path": "/epr/google_workspace/google_workspace-1.1.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "google_workspace.admin",
+        "title": "Admin logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "google_workspace.drive",
+        "title": "Drive logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "google_workspace.groups",
+        "title": "Groups logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "google_workspace.login",
+        "title": "Login logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "google_workspace.saml",
+        "title": "SAML logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "google_workspace.user_accounts",
+        "title": "User accounts logs"
+      }
+    ]
   },
   {
     "name": "google_workspace",
@@ -17589,7 +24505,39 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/google_workspace/google_workspace-1.2.0.zip.sig"
+    "signature_path": "/epr/google_workspace/google_workspace-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "google_workspace.admin",
+        "title": "Admin logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "google_workspace.drive",
+        "title": "Drive logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "google_workspace.groups",
+        "title": "Groups logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "google_workspace.login",
+        "title": "Login logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "google_workspace.saml",
+        "title": "SAML logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "google_workspace.user_accounts",
+        "title": "User accounts logs"
+      }
+    ]
   },
   {
     "name": "google_workspace",
@@ -17627,7 +24575,39 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/google_workspace/google_workspace-1.2.2.zip.sig"
+    "signature_path": "/epr/google_workspace/google_workspace-1.2.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "google_workspace.admin",
+        "title": "Admin logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "google_workspace.drive",
+        "title": "Drive logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "google_workspace.groups",
+        "title": "Groups logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "google_workspace.login",
+        "title": "Login logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "google_workspace.saml",
+        "title": "SAML logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "google_workspace.user_accounts",
+        "title": "User accounts logs"
+      }
+    ]
   },
   {
     "name": "google_workspace",
@@ -17665,7 +24645,39 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/google_workspace/google_workspace-1.3.0.zip.sig"
+    "signature_path": "/epr/google_workspace/google_workspace-1.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "google_workspace.admin",
+        "title": "Admin logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "google_workspace.drive",
+        "title": "Drive logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "google_workspace.groups",
+        "title": "Groups logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "google_workspace.login",
+        "title": "Login logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "google_workspace.saml",
+        "title": "SAML logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "google_workspace.user_accounts",
+        "title": "User accounts logs"
+      }
+    ]
   },
   {
     "name": "google_workspace",
@@ -17703,7 +24715,39 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/google_workspace/google_workspace-1.3.1.zip.sig"
+    "signature_path": "/epr/google_workspace/google_workspace-1.3.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "google_workspace.admin",
+        "title": "Admin logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "google_workspace.drive",
+        "title": "Drive logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "google_workspace.groups",
+        "title": "Groups logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "google_workspace.login",
+        "title": "Login logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "google_workspace.saml",
+        "title": "SAML logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "google_workspace.user_accounts",
+        "title": "User accounts logs"
+      }
+    ]
   },
   {
     "name": "google_workspace",
@@ -17741,7 +24785,39 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/google_workspace/google_workspace-1.3.2.zip.sig"
+    "signature_path": "/epr/google_workspace/google_workspace-1.3.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "google_workspace.admin",
+        "title": "Admin logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "google_workspace.drive",
+        "title": "Drive logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "google_workspace.groups",
+        "title": "Groups logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "google_workspace.login",
+        "title": "Login logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "google_workspace.saml",
+        "title": "SAML logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "google_workspace.user_accounts",
+        "title": "User accounts logs"
+      }
+    ]
   },
   {
     "name": "google_workspace",
@@ -17779,7 +24855,39 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/google_workspace/google_workspace-1.3.3.zip.sig"
+    "signature_path": "/epr/google_workspace/google_workspace-1.3.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "google_workspace.admin",
+        "title": "Admin logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "google_workspace.drive",
+        "title": "Drive logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "google_workspace.groups",
+        "title": "Groups logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "google_workspace.login",
+        "title": "Login logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "google_workspace.saml",
+        "title": "SAML logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "google_workspace.user_accounts",
+        "title": "User accounts logs"
+      }
+    ]
   },
   {
     "name": "google_workspace",
@@ -17817,7 +24925,39 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/google_workspace/google_workspace-1.4.0.zip.sig"
+    "signature_path": "/epr/google_workspace/google_workspace-1.4.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "google_workspace.admin",
+        "title": "Admin logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "google_workspace.drive",
+        "title": "Drive logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "google_workspace.groups",
+        "title": "Groups logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "google_workspace.login",
+        "title": "Login logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "google_workspace.saml",
+        "title": "SAML logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "google_workspace.user_accounts",
+        "title": "User accounts logs"
+      }
+    ]
   },
   {
     "name": "google_workspace",
@@ -17855,7 +24995,39 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/google_workspace/google_workspace-1.5.0.zip.sig"
+    "signature_path": "/epr/google_workspace/google_workspace-1.5.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "google_workspace.admin",
+        "title": "Admin logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "google_workspace.drive",
+        "title": "Drive logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "google_workspace.groups",
+        "title": "Groups logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "google_workspace.login",
+        "title": "Login logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "google_workspace.saml",
+        "title": "SAML logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "google_workspace.user_accounts",
+        "title": "User accounts logs"
+      }
+    ]
   },
   {
     "name": "hashicorp_vault",
@@ -17893,7 +25065,24 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/hashicorp_vault/hashicorp_vault-1.1.3.zip.sig"
+    "signature_path": "/epr/hashicorp_vault/hashicorp_vault-1.1.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "hashicorp_vault.audit",
+        "title": "Hashicorp Vault Audit Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "hashicorp_vault.log",
+        "title": "Hashicorp Vault Operational Logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "hashicorp_vault.metrics",
+        "title": "Hashicorp Vault Metrics"
+      }
+    ]
   },
   {
     "name": "hashicorp_vault",
@@ -17931,7 +25120,24 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/hashicorp_vault/hashicorp_vault-1.1.4.zip.sig"
+    "signature_path": "/epr/hashicorp_vault/hashicorp_vault-1.1.4.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "hashicorp_vault.audit",
+        "title": "Hashicorp Vault Audit Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "hashicorp_vault.log",
+        "title": "Hashicorp Vault Operational Logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "hashicorp_vault.metrics",
+        "title": "Hashicorp Vault Metrics"
+      }
+    ]
   },
   {
     "name": "hashicorp_vault",
@@ -17969,7 +25175,24 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/hashicorp_vault/hashicorp_vault-1.2.0.zip.sig"
+    "signature_path": "/epr/hashicorp_vault/hashicorp_vault-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "hashicorp_vault.audit",
+        "title": "Hashicorp Vault Audit Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "hashicorp_vault.log",
+        "title": "Hashicorp Vault Operational Logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "hashicorp_vault.metrics",
+        "title": "Hashicorp Vault Metrics"
+      }
+    ]
   },
   {
     "name": "hashicorp_vault",
@@ -18007,7 +25230,24 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/hashicorp_vault/hashicorp_vault-1.2.3.zip.sig"
+    "signature_path": "/epr/hashicorp_vault/hashicorp_vault-1.2.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "hashicorp_vault.audit",
+        "title": "Hashicorp Vault Audit Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "hashicorp_vault.log",
+        "title": "Hashicorp Vault Operational Logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "hashicorp_vault.metrics",
+        "title": "Hashicorp Vault Metrics"
+      }
+    ]
   },
   {
     "name": "hashicorp_vault",
@@ -18045,7 +25285,24 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/hashicorp_vault/hashicorp_vault-1.3.1.zip.sig"
+    "signature_path": "/epr/hashicorp_vault/hashicorp_vault-1.3.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "hashicorp_vault.audit",
+        "title": "Hashicorp Vault Audit Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "hashicorp_vault.log",
+        "title": "Hashicorp Vault Operational Logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "hashicorp_vault.metrics",
+        "title": "Hashicorp Vault Metrics"
+      }
+    ]
   },
   {
     "name": "hashicorp_vault",
@@ -18083,7 +25340,24 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/hashicorp_vault/hashicorp_vault-1.3.3.zip.sig"
+    "signature_path": "/epr/hashicorp_vault/hashicorp_vault-1.3.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "hashicorp_vault.audit",
+        "title": "Hashicorp Vault Audit Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "hashicorp_vault.log",
+        "title": "Hashicorp Vault Operational Logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "hashicorp_vault.metrics",
+        "title": "Hashicorp Vault Metrics"
+      }
+    ]
   },
   {
     "name": "hid_bravura_monitor",
@@ -18121,7 +25395,19 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/hid_bravura_monitor/hid_bravura_monitor-1.0.0.zip.sig"
+    "signature_path": "/epr/hid_bravura_monitor/hid_bravura_monitor-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "hid_bravura_monitor.log",
+        "title": "Hitachi ID Bravura Monitor"
+      },
+      {
+        "type": "logs",
+        "dataset": "hid_bravura_monitor.winlog",
+        "title": "Hitachi ID Security Fabric logs"
+      }
+    ]
   },
   {
     "name": "hid_bravura_monitor",
@@ -18159,7 +25445,19 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/hid_bravura_monitor/hid_bravura_monitor-1.0.1.zip.sig"
+    "signature_path": "/epr/hid_bravura_monitor/hid_bravura_monitor-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "hid_bravura_monitor.log",
+        "title": "Hitachi ID Bravura Monitor"
+      },
+      {
+        "type": "logs",
+        "dataset": "hid_bravura_monitor.winlog",
+        "title": "Hitachi ID Security Fabric logs"
+      }
+    ]
   },
   {
     "name": "hid_bravura_monitor",
@@ -18197,7 +25495,19 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/hid_bravura_monitor/hid_bravura_monitor-1.0.2.zip.sig"
+    "signature_path": "/epr/hid_bravura_monitor/hid_bravura_monitor-1.0.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "hid_bravura_monitor.log",
+        "title": "Hitachi ID Bravura Monitor"
+      },
+      {
+        "type": "logs",
+        "dataset": "hid_bravura_monitor.winlog",
+        "title": "Hitachi ID Security Fabric logs"
+      }
+    ]
   },
   {
     "name": "juniper",
@@ -18236,7 +25546,24 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/juniper/juniper-1.0.4.zip.sig"
+    "signature_path": "/epr/juniper/juniper-1.0.4.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "juniper.junos",
+        "title": "Juniper JUNOS logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "juniper.netscreen",
+        "title": "Netscreen logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "juniper.srx",
+        "title": "Juniper SRX logs"
+      }
+    ]
   },
   {
     "name": "juniper",
@@ -18275,7 +25602,24 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/juniper/juniper-1.0.7.zip.sig"
+    "signature_path": "/epr/juniper/juniper-1.0.7.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "juniper.junos",
+        "title": "Juniper JUNOS logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "juniper.netscreen",
+        "title": "Netscreen logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "juniper.srx",
+        "title": "Juniper SRX logs"
+      }
+    ]
   },
   {
     "name": "juniper",
@@ -18314,7 +25658,24 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/juniper/juniper-1.1.0.zip.sig"
+    "signature_path": "/epr/juniper/juniper-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "juniper.junos",
+        "title": "Juniper JUNOS logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "juniper.netscreen",
+        "title": "Netscreen logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "juniper.srx",
+        "title": "Juniper SRX logs"
+      }
+    ]
   },
   {
     "name": "juniper_srx",
@@ -18353,7 +25714,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/juniper_srx/juniper_srx-1.0.0.zip.sig"
+    "signature_path": "/epr/juniper_srx/juniper_srx-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "juniper_srx.log",
+        "title": "Juniper SRX logs"
+      }
+    ]
   },
   {
     "name": "juniper_srx",
@@ -18392,7 +25760,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/juniper_srx/juniper_srx-1.0.1.zip.sig"
+    "signature_path": "/epr/juniper_srx/juniper_srx-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "juniper_srx.log",
+        "title": "Juniper SRX logs"
+      }
+    ]
   },
   {
     "name": "juniper_srx",
@@ -18431,7 +25806,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/juniper_srx/juniper_srx-1.1.0.zip.sig"
+    "signature_path": "/epr/juniper_srx/juniper_srx-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "juniper_srx.log",
+        "title": "Juniper SRX logs"
+      }
+    ]
   },
   {
     "name": "juniper_srx",
@@ -18470,7 +25852,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/juniper_srx/juniper_srx-1.1.1.zip.sig"
+    "signature_path": "/epr/juniper_srx/juniper_srx-1.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "juniper_srx.log",
+        "title": "Juniper SRX logs"
+      }
+    ]
   },
   {
     "name": "juniper_srx",
@@ -18509,7 +25898,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/juniper_srx/juniper_srx-1.1.2.zip.sig"
+    "signature_path": "/epr/juniper_srx/juniper_srx-1.1.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "juniper_srx.log",
+        "title": "Juniper SRX logs"
+      }
+    ]
   },
   {
     "name": "kafka",
@@ -18547,7 +25943,29 @@
     "categories": [
       "message_queue"
     ],
-    "signature_path": "/epr/kafka/kafka-1.1.0.zip.sig"
+    "signature_path": "/epr/kafka/kafka-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "kafka.broker",
+        "title": "Kafka broker metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kafka.consumergroup",
+        "title": "Kafka consumergroup metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "kafka.log",
+        "title": "Kafka log logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kafka.partition",
+        "title": "Kafka partition metrics"
+      }
+    ]
   },
   {
     "name": "kafka",
@@ -18585,7 +26003,29 @@
     "categories": [
       "message_queue"
     ],
-    "signature_path": "/epr/kafka/kafka-1.2.2.zip.sig"
+    "signature_path": "/epr/kafka/kafka-1.2.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "kafka.broker",
+        "title": "Kafka broker metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kafka.consumergroup",
+        "title": "Kafka consumergroup metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "kafka.log",
+        "title": "Kafka log logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kafka.partition",
+        "title": "Kafka partition metrics"
+      }
+    ]
   },
   {
     "name": "keycloak",
@@ -18625,7 +26065,14 @@
       "network",
       "web"
     ],
-    "signature_path": "/epr/keycloak/keycloak-1.0.0.zip.sig"
+    "signature_path": "/epr/keycloak/keycloak-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "keycloak.log",
+        "title": "Keycloak"
+      }
+    ]
   },
   {
     "name": "keycloak",
@@ -18665,7 +26112,14 @@
       "network",
       "web"
     ],
-    "signature_path": "/epr/keycloak/keycloak-1.1.0.zip.sig"
+    "signature_path": "/epr/keycloak/keycloak-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "keycloak.log",
+        "title": "Keycloak"
+      }
+    ]
   },
   {
     "name": "keycloak",
@@ -18705,7 +26159,14 @@
       "network",
       "web"
     ],
-    "signature_path": "/epr/keycloak/keycloak-1.2.0.zip.sig"
+    "signature_path": "/epr/keycloak/keycloak-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "keycloak.log",
+        "title": "Keycloak"
+      }
+    ]
   },
   {
     "name": "keycloak",
@@ -18745,7 +26206,14 @@
       "network",
       "web"
     ],
-    "signature_path": "/epr/keycloak/keycloak-1.2.1.zip.sig"
+    "signature_path": "/epr/keycloak/keycloak-1.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "keycloak.log",
+        "title": "Keycloak"
+      }
+    ]
   },
   {
     "name": "kibana",
@@ -18783,7 +26251,29 @@
     "categories": [
       "elastic_stack"
     ],
-    "signature_path": "/epr/kibana/kibana-1.0.0.zip.sig"
+    "signature_path": "/epr/kibana/kibana-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "kibana.audit",
+        "title": "kibana audit logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "kibana.log",
+        "title": "Kibana logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kibana.stats",
+        "title": "Kibana stats metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kibana.status",
+        "title": "Kibana status metrics"
+      }
+    ]
   },
   {
     "name": "kubernetes",
@@ -18929,7 +26419,134 @@
       "containers",
       "kubernetes"
     ],
-    "signature_path": "/epr/kubernetes/kubernetes-1.1.0.zip.sig"
+    "signature_path": "/epr/kubernetes/kubernetes-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.apiserver",
+        "title": "Kubernetes API Server metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.container",
+        "title": "Kubernetes Container metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "kubernetes.container_logs",
+        "title": "Kubernetes container logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.controllermanager",
+        "title": "Kubernetes Controller Manager metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.event",
+        "title": "Kubernetes Event metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.node",
+        "title": "Kubernetes Node metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.pod",
+        "title": "Kubernetes Pod metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.proxy",
+        "title": "Kubernetes Proxy metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.scheduler",
+        "title": "Kubernetes Scheduler metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_container",
+        "title": "Kubernetes Container metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_cronjob",
+        "title": "Kubernetes Cronjob metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_daemonset",
+        "title": "Kubernetes Deamonset metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_deployment",
+        "title": "Kubernetes Deployment metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_job",
+        "title": "Kubernetes Job metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_node",
+        "title": "Kubernetes Node metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_persistentvolume",
+        "title": "Kubernetes PersistentVolume metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_persistentvolumeclaim",
+        "title": "Kubernetes PersistentVolumeClaim metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_pod",
+        "title": "Kubernetes Pod metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_replicaset",
+        "title": "Kubernetes state_replicaset metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_resourcequota",
+        "title": "Kubernetes ResourceQuota metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_service",
+        "title": "Kubernetes Service metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_statefulset",
+        "title": "Kubernetes StatefulSet metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_storageclass",
+        "title": "Kubernetes StorageClass metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.system",
+        "title": "Kubernetes System metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.volume",
+        "title": "Kubernetes Volume metrics"
+      }
+    ]
   },
   {
     "name": "kubernetes",
@@ -19075,7 +26692,134 @@
       "containers",
       "kubernetes"
     ],
-    "signature_path": "/epr/kubernetes/kubernetes-1.1.2.zip.sig"
+    "signature_path": "/epr/kubernetes/kubernetes-1.1.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.apiserver",
+        "title": "Kubernetes API Server metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.container",
+        "title": "Kubernetes Container metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "kubernetes.container_logs",
+        "title": "Kubernetes container logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.controllermanager",
+        "title": "Kubernetes Controller Manager metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.event",
+        "title": "Kubernetes Event metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.node",
+        "title": "Kubernetes Node metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.pod",
+        "title": "Kubernetes Pod metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.proxy",
+        "title": "Kubernetes Proxy metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.scheduler",
+        "title": "Kubernetes Scheduler metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_container",
+        "title": "Kubernetes Container metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_cronjob",
+        "title": "Kubernetes Cronjob metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_daemonset",
+        "title": "Kubernetes Deamonset metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_deployment",
+        "title": "Kubernetes Deployment metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_job",
+        "title": "Kubernetes Job metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_node",
+        "title": "Kubernetes Node metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_persistentvolume",
+        "title": "Kubernetes PersistentVolume metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_persistentvolumeclaim",
+        "title": "Kubernetes PersistentVolumeClaim metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_pod",
+        "title": "Kubernetes Pod metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_replicaset",
+        "title": "Kubernetes state_replicaset metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_resourcequota",
+        "title": "Kubernetes ResourceQuota metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_service",
+        "title": "Kubernetes Service metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_statefulset",
+        "title": "Kubernetes StatefulSet metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_storageclass",
+        "title": "Kubernetes StorageClass metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.system",
+        "title": "Kubernetes System metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.volume",
+        "title": "Kubernetes Volume metrics"
+      }
+    ]
   },
   {
     "name": "kubernetes",
@@ -19221,7 +26965,134 @@
       "containers",
       "kubernetes"
     ],
-    "signature_path": "/epr/kubernetes/kubernetes-1.1.3.zip.sig"
+    "signature_path": "/epr/kubernetes/kubernetes-1.1.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.apiserver",
+        "title": "Kubernetes API Server metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.container",
+        "title": "Kubernetes Container metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "kubernetes.container_logs",
+        "title": "Kubernetes container logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.controllermanager",
+        "title": "Kubernetes Controller Manager metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.event",
+        "title": "Kubernetes Event metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.node",
+        "title": "Kubernetes Node metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.pod",
+        "title": "Kubernetes Pod metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.proxy",
+        "title": "Kubernetes Proxy metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.scheduler",
+        "title": "Kubernetes Scheduler metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_container",
+        "title": "Kubernetes Container metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_cronjob",
+        "title": "Kubernetes Cronjob metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_daemonset",
+        "title": "Kubernetes Deamonset metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_deployment",
+        "title": "Kubernetes Deployment metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_job",
+        "title": "Kubernetes Job metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_node",
+        "title": "Kubernetes Node metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_persistentvolume",
+        "title": "Kubernetes PersistentVolume metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_persistentvolumeclaim",
+        "title": "Kubernetes PersistentVolumeClaim metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_pod",
+        "title": "Kubernetes Pod metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_replicaset",
+        "title": "Kubernetes state_replicaset metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_resourcequota",
+        "title": "Kubernetes ResourceQuota metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_service",
+        "title": "Kubernetes Service metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_statefulset",
+        "title": "Kubernetes StatefulSet metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_storageclass",
+        "title": "Kubernetes StorageClass metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.system",
+        "title": "Kubernetes System metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.volume",
+        "title": "Kubernetes Volume metrics"
+      }
+    ]
   },
   {
     "name": "kubernetes",
@@ -19381,7 +27252,139 @@
       "containers",
       "kubernetes"
     ],
-    "signature_path": "/epr/kubernetes/kubernetes-1.17.2.zip.sig"
+    "signature_path": "/epr/kubernetes/kubernetes-1.17.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.apiserver",
+        "title": "Kubernetes API Server metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "kubernetes.audit_logs",
+        "title": "Kubernetes audit logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.container",
+        "title": "Kubernetes Container metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "kubernetes.container_logs",
+        "title": "Kubernetes container logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.controllermanager",
+        "title": "Kubernetes Controller Manager metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.event",
+        "title": "Kubernetes Event metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.node",
+        "title": "Kubernetes Node metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.pod",
+        "title": "Kubernetes Pod metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.proxy",
+        "title": "Kubernetes Proxy metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.scheduler",
+        "title": "Kubernetes Scheduler metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_container",
+        "title": "Kubernetes Container metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_cronjob",
+        "title": "Kubernetes Cronjob metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_daemonset",
+        "title": "Kubernetes Deamonset metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_deployment",
+        "title": "Kubernetes Deployment metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_job",
+        "title": "Kubernetes Job metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_node",
+        "title": "Kubernetes Node metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_persistentvolume",
+        "title": "Kubernetes PersistentVolume metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_persistentvolumeclaim",
+        "title": "Kubernetes PersistentVolumeClaim metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_pod",
+        "title": "Kubernetes Pod metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_replicaset",
+        "title": "Kubernetes state_replicaset metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_resourcequota",
+        "title": "Kubernetes ResourceQuota metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_service",
+        "title": "Kubernetes Service metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_statefulset",
+        "title": "Kubernetes StatefulSet metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_storageclass",
+        "title": "Kubernetes StorageClass metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.system",
+        "title": "Kubernetes System metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.volume",
+        "title": "Kubernetes Volume metrics"
+      }
+    ]
   },
   {
     "name": "kubernetes",
@@ -19527,7 +27530,134 @@
       "containers",
       "kubernetes"
     ],
-    "signature_path": "/epr/kubernetes/kubernetes-1.4.1.zip.sig"
+    "signature_path": "/epr/kubernetes/kubernetes-1.4.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.apiserver",
+        "title": "Kubernetes API Server metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.container",
+        "title": "Kubernetes Container metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "kubernetes.container_logs",
+        "title": "Kubernetes container logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.controllermanager",
+        "title": "Kubernetes Controller Manager metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.event",
+        "title": "Kubernetes Event metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.node",
+        "title": "Kubernetes Node metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.pod",
+        "title": "Kubernetes Pod metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.proxy",
+        "title": "Kubernetes Proxy metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.scheduler",
+        "title": "Kubernetes Scheduler metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_container",
+        "title": "Kubernetes Container metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_cronjob",
+        "title": "Kubernetes Cronjob metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_daemonset",
+        "title": "Kubernetes Deamonset metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_deployment",
+        "title": "Kubernetes Deployment metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_job",
+        "title": "Kubernetes Job metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_node",
+        "title": "Kubernetes Node metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_persistentvolume",
+        "title": "Kubernetes PersistentVolume metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_persistentvolumeclaim",
+        "title": "Kubernetes PersistentVolumeClaim metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_pod",
+        "title": "Kubernetes Pod metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_replicaset",
+        "title": "Kubernetes state_replicaset metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_resourcequota",
+        "title": "Kubernetes ResourceQuota metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_service",
+        "title": "Kubernetes Service metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_statefulset",
+        "title": "Kubernetes StatefulSet metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_storageclass",
+        "title": "Kubernetes StorageClass metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.system",
+        "title": "Kubernetes System metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.volume",
+        "title": "Kubernetes Volume metrics"
+      }
+    ]
   },
   {
     "name": "kubernetes",
@@ -19673,7 +27803,134 @@
       "containers",
       "kubernetes"
     ],
-    "signature_path": "/epr/kubernetes/kubernetes-1.5.0.zip.sig"
+    "signature_path": "/epr/kubernetes/kubernetes-1.5.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.apiserver",
+        "title": "Kubernetes API Server metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.container",
+        "title": "Kubernetes Container metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "kubernetes.container_logs",
+        "title": "Kubernetes container logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.controllermanager",
+        "title": "Kubernetes Controller Manager metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.event",
+        "title": "Kubernetes Event metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.node",
+        "title": "Kubernetes Node metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.pod",
+        "title": "Kubernetes Pod metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.proxy",
+        "title": "Kubernetes Proxy metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.scheduler",
+        "title": "Kubernetes Scheduler metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_container",
+        "title": "Kubernetes Container metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_cronjob",
+        "title": "Kubernetes Cronjob metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_daemonset",
+        "title": "Kubernetes Deamonset metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_deployment",
+        "title": "Kubernetes Deployment metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_job",
+        "title": "Kubernetes Job metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_node",
+        "title": "Kubernetes Node metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_persistentvolume",
+        "title": "Kubernetes PersistentVolume metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_persistentvolumeclaim",
+        "title": "Kubernetes PersistentVolumeClaim metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_pod",
+        "title": "Kubernetes Pod metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_replicaset",
+        "title": "Kubernetes state_replicaset metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_resourcequota",
+        "title": "Kubernetes ResourceQuota metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_service",
+        "title": "Kubernetes Service metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_statefulset",
+        "title": "Kubernetes StatefulSet metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_storageclass",
+        "title": "Kubernetes StorageClass metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.system",
+        "title": "Kubernetes System metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.volume",
+        "title": "Kubernetes Volume metrics"
+      }
+    ]
   },
   {
     "name": "kubernetes",
@@ -19819,7 +28076,134 @@
       "containers",
       "kubernetes"
     ],
-    "signature_path": "/epr/kubernetes/kubernetes-1.6.0.zip.sig"
+    "signature_path": "/epr/kubernetes/kubernetes-1.6.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.apiserver",
+        "title": "Kubernetes API Server metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.container",
+        "title": "Kubernetes Container metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "kubernetes.container_logs",
+        "title": "Kubernetes container logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.controllermanager",
+        "title": "Kubernetes Controller Manager metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.event",
+        "title": "Kubernetes Event metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.node",
+        "title": "Kubernetes Node metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.pod",
+        "title": "Kubernetes Pod metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.proxy",
+        "title": "Kubernetes Proxy metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.scheduler",
+        "title": "Kubernetes Scheduler metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_container",
+        "title": "Kubernetes Container metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_cronjob",
+        "title": "Kubernetes Cronjob metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_daemonset",
+        "title": "Kubernetes Deamonset metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_deployment",
+        "title": "Kubernetes Deployment metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_job",
+        "title": "Kubernetes Job metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_node",
+        "title": "Kubernetes Node metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_persistentvolume",
+        "title": "Kubernetes PersistentVolume metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_persistentvolumeclaim",
+        "title": "Kubernetes PersistentVolumeClaim metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_pod",
+        "title": "Kubernetes Pod metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_replicaset",
+        "title": "Kubernetes state_replicaset metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_resourcequota",
+        "title": "Kubernetes ResourceQuota metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_service",
+        "title": "Kubernetes Service metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_statefulset",
+        "title": "Kubernetes StatefulSet metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_storageclass",
+        "title": "Kubernetes StorageClass metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.system",
+        "title": "Kubernetes System metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.volume",
+        "title": "Kubernetes Volume metrics"
+      }
+    ]
   },
   {
     "name": "kubernetes",
@@ -19979,7 +28363,139 @@
       "containers",
       "kubernetes"
     ],
-    "signature_path": "/epr/kubernetes/kubernetes-1.7.0.zip.sig"
+    "signature_path": "/epr/kubernetes/kubernetes-1.7.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.apiserver",
+        "title": "Kubernetes API Server metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "kubernetes.audit_logs",
+        "title": "Kubernetes audit logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.container",
+        "title": "Kubernetes Container metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "kubernetes.container_logs",
+        "title": "Kubernetes container logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.controllermanager",
+        "title": "Kubernetes Controller Manager metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.event",
+        "title": "Kubernetes Event metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.node",
+        "title": "Kubernetes Node metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.pod",
+        "title": "Kubernetes Pod metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.proxy",
+        "title": "Kubernetes Proxy metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.scheduler",
+        "title": "Kubernetes Scheduler metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_container",
+        "title": "Kubernetes Container metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_cronjob",
+        "title": "Kubernetes Cronjob metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_daemonset",
+        "title": "Kubernetes Deamonset metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_deployment",
+        "title": "Kubernetes Deployment metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_job",
+        "title": "Kubernetes Job metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_node",
+        "title": "Kubernetes Node metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_persistentvolume",
+        "title": "Kubernetes PersistentVolume metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_persistentvolumeclaim",
+        "title": "Kubernetes PersistentVolumeClaim metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_pod",
+        "title": "Kubernetes Pod metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_replicaset",
+        "title": "Kubernetes state_replicaset metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_resourcequota",
+        "title": "Kubernetes ResourceQuota metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_service",
+        "title": "Kubernetes Service metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_statefulset",
+        "title": "Kubernetes StatefulSet metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_storageclass",
+        "title": "Kubernetes StorageClass metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.system",
+        "title": "Kubernetes System metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.volume",
+        "title": "Kubernetes Volume metrics"
+      }
+    ]
   },
   {
     "name": "kubernetes",
@@ -20139,7 +28655,139 @@
       "containers",
       "kubernetes"
     ],
-    "signature_path": "/epr/kubernetes/kubernetes-1.8.0.zip.sig"
+    "signature_path": "/epr/kubernetes/kubernetes-1.8.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.apiserver",
+        "title": "Kubernetes API Server metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "kubernetes.audit_logs",
+        "title": "Kubernetes audit logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.container",
+        "title": "Kubernetes Container metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "kubernetes.container_logs",
+        "title": "Kubernetes container logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.controllermanager",
+        "title": "Kubernetes Controller Manager metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.event",
+        "title": "Kubernetes Event metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.node",
+        "title": "Kubernetes Node metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.pod",
+        "title": "Kubernetes Pod metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.proxy",
+        "title": "Kubernetes Proxy metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.scheduler",
+        "title": "Kubernetes Scheduler metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_container",
+        "title": "Kubernetes Container metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_cronjob",
+        "title": "Kubernetes Cronjob metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_daemonset",
+        "title": "Kubernetes Deamonset metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_deployment",
+        "title": "Kubernetes Deployment metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_job",
+        "title": "Kubernetes Job metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_node",
+        "title": "Kubernetes Node metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_persistentvolume",
+        "title": "Kubernetes PersistentVolume metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_persistentvolumeclaim",
+        "title": "Kubernetes PersistentVolumeClaim metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_pod",
+        "title": "Kubernetes Pod metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_replicaset",
+        "title": "Kubernetes state_replicaset metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_resourcequota",
+        "title": "Kubernetes ResourceQuota metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_service",
+        "title": "Kubernetes Service metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_statefulset",
+        "title": "Kubernetes StatefulSet metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_storageclass",
+        "title": "Kubernetes StorageClass metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.system",
+        "title": "Kubernetes System metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.volume",
+        "title": "Kubernetes Volume metrics"
+      }
+    ]
   },
   {
     "name": "kubernetes",
@@ -20299,7 +28947,139 @@
       "containers",
       "kubernetes"
     ],
-    "signature_path": "/epr/kubernetes/kubernetes-1.8.1.zip.sig"
+    "signature_path": "/epr/kubernetes/kubernetes-1.8.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.apiserver",
+        "title": "Kubernetes API Server metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "kubernetes.audit_logs",
+        "title": "Kubernetes audit logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.container",
+        "title": "Kubernetes Container metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "kubernetes.container_logs",
+        "title": "Kubernetes container logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.controllermanager",
+        "title": "Kubernetes Controller Manager metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.event",
+        "title": "Kubernetes Event metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.node",
+        "title": "Kubernetes Node metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.pod",
+        "title": "Kubernetes Pod metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.proxy",
+        "title": "Kubernetes Proxy metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.scheduler",
+        "title": "Kubernetes Scheduler metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_container",
+        "title": "Kubernetes Container metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_cronjob",
+        "title": "Kubernetes Cronjob metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_daemonset",
+        "title": "Kubernetes Deamonset metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_deployment",
+        "title": "Kubernetes Deployment metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_job",
+        "title": "Kubernetes Job metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_node",
+        "title": "Kubernetes Node metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_persistentvolume",
+        "title": "Kubernetes PersistentVolume metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_persistentvolumeclaim",
+        "title": "Kubernetes PersistentVolumeClaim metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_pod",
+        "title": "Kubernetes Pod metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_replicaset",
+        "title": "Kubernetes state_replicaset metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_resourcequota",
+        "title": "Kubernetes ResourceQuota metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_service",
+        "title": "Kubernetes Service metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_statefulset",
+        "title": "Kubernetes StatefulSet metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_storageclass",
+        "title": "Kubernetes StorageClass metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.system",
+        "title": "Kubernetes System metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.volume",
+        "title": "Kubernetes Volume metrics"
+      }
+    ]
   },
   {
     "name": "kubernetes",
@@ -20459,7 +29239,139 @@
       "containers",
       "kubernetes"
     ],
-    "signature_path": "/epr/kubernetes/kubernetes-1.9.0.zip.sig"
+    "signature_path": "/epr/kubernetes/kubernetes-1.9.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.apiserver",
+        "title": "Kubernetes API Server metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "kubernetes.audit_logs",
+        "title": "Kubernetes audit logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.container",
+        "title": "Kubernetes Container metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "kubernetes.container_logs",
+        "title": "Kubernetes container logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.controllermanager",
+        "title": "Kubernetes Controller Manager metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.event",
+        "title": "Kubernetes Event metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.node",
+        "title": "Kubernetes Node metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.pod",
+        "title": "Kubernetes Pod metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.proxy",
+        "title": "Kubernetes Proxy metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.scheduler",
+        "title": "Kubernetes Scheduler metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_container",
+        "title": "Kubernetes Container metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_cronjob",
+        "title": "Kubernetes Cronjob metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_daemonset",
+        "title": "Kubernetes Deamonset metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_deployment",
+        "title": "Kubernetes Deployment metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_job",
+        "title": "Kubernetes Job metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_node",
+        "title": "Kubernetes Node metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_persistentvolume",
+        "title": "Kubernetes PersistentVolume metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_persistentvolumeclaim",
+        "title": "Kubernetes PersistentVolumeClaim metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_pod",
+        "title": "Kubernetes Pod metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_replicaset",
+        "title": "Kubernetes state_replicaset metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_resourcequota",
+        "title": "Kubernetes ResourceQuota metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_service",
+        "title": "Kubernetes Service metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_statefulset",
+        "title": "Kubernetes StatefulSet metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_storageclass",
+        "title": "Kubernetes StorageClass metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.system",
+        "title": "Kubernetes System metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.volume",
+        "title": "Kubernetes Volume metrics"
+      }
+    ]
   },
   {
     "name": "logstash",
@@ -20497,7 +29409,29 @@
     "categories": [
       "elastic_stack"
     ],
-    "signature_path": "/epr/logstash/logstash-1.0.0.zip.sig"
+    "signature_path": "/epr/logstash/logstash-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "logstash.log",
+        "title": "Logstash logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "logstash.node",
+        "title": "Logstash node metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "logstash.node_stats",
+        "title": "Logstash node_stats metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "logstash.slowlog",
+        "title": "logstash slowlog logs"
+      }
+    ]
   },
   {
     "name": "m365_defender",
@@ -20537,7 +29471,14 @@
       "security",
       "azure"
     ],
-    "signature_path": "/epr/m365_defender/m365_defender-1.0.1.zip.sig"
+    "signature_path": "/epr/m365_defender/m365_defender-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "m365_defender.log",
+        "title": "M365 Defender Logs"
+      }
+    ]
   },
   {
     "name": "m365_defender",
@@ -20577,7 +29518,14 @@
       "security",
       "azure"
     ],
-    "signature_path": "/epr/m365_defender/m365_defender-1.0.3.zip.sig"
+    "signature_path": "/epr/m365_defender/m365_defender-1.0.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "m365_defender.log",
+        "title": "M365 Defender Logs"
+      }
+    ]
   },
   {
     "name": "ti_misp",
@@ -20615,7 +29563,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/ti_misp/ti_misp-1.0.1.zip.sig"
+    "signature_path": "/epr/ti_misp/ti_misp-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_misp.threat",
+        "title": "MISP"
+      }
+    ]
   },
   {
     "name": "ti_misp",
@@ -20653,7 +29608,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/ti_misp/ti_misp-1.0.2.zip.sig"
+    "signature_path": "/epr/ti_misp/ti_misp-1.0.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_misp.threat",
+        "title": "MISP"
+      }
+    ]
   },
   {
     "name": "ti_misp",
@@ -20691,7 +29653,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/ti_misp/ti_misp-1.1.0.zip.sig"
+    "signature_path": "/epr/ti_misp/ti_misp-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_misp.threat",
+        "title": "MISP"
+      }
+    ]
   },
   {
     "name": "ti_misp",
@@ -20729,7 +29698,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/ti_misp/ti_misp-1.2.0.zip.sig"
+    "signature_path": "/epr/ti_misp/ti_misp-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_misp.threat",
+        "title": "MISP"
+      }
+    ]
   },
   {
     "name": "ti_misp",
@@ -20767,7 +29743,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/ti_misp/ti_misp-1.2.1.zip.sig"
+    "signature_path": "/epr/ti_misp/ti_misp-1.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_misp.threat",
+        "title": "MISP"
+      }
+    ]
   },
   {
     "name": "ti_misp",
@@ -20805,7 +29788,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/ti_misp/ti_misp-1.2.2.zip.sig"
+    "signature_path": "/epr/ti_misp/ti_misp-1.2.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_misp.threat",
+        "title": "MISP"
+      }
+    ]
   },
   {
     "name": "mattermost",
@@ -20844,7 +29834,14 @@
       "security",
       "web"
     ],
-    "signature_path": "/epr/mattermost/mattermost-1.0.0.zip.sig"
+    "signature_path": "/epr/mattermost/mattermost-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "mattermost.audit",
+        "title": "Audit Logs"
+      }
+    ]
   },
   {
     "name": "mattermost",
@@ -20883,7 +29880,14 @@
       "security",
       "web"
     ],
-    "signature_path": "/epr/mattermost/mattermost-1.1.0.zip.sig"
+    "signature_path": "/epr/mattermost/mattermost-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "mattermost.audit",
+        "title": "Audit Logs"
+      }
+    ]
   },
   {
     "name": "mattermost",
@@ -20922,7 +29926,14 @@
       "security",
       "web"
     ],
-    "signature_path": "/epr/mattermost/mattermost-1.1.1.zip.sig"
+    "signature_path": "/epr/mattermost/mattermost-1.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "mattermost.audit",
+        "title": "Audit Logs"
+      }
+    ]
   },
   {
     "name": "microsoft",
@@ -20962,7 +29973,19 @@
       "security",
       "azure"
     ],
-    "signature_path": "/epr/microsoft/microsoft-1.0.0.zip.sig"
+    "signature_path": "/epr/microsoft/microsoft-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "microsoft.defender_atp",
+        "title": "Microsoft Defender for Endpoint"
+      },
+      {
+        "type": "logs",
+        "dataset": "microsoft.dhcp",
+        "title": "Microsoft DHCP logs"
+      }
+    ]
   },
   {
     "name": "microsoft_dhcp",
@@ -21000,7 +30023,14 @@
     "categories": [
       "network"
     ],
-    "signature_path": "/epr/microsoft_dhcp/microsoft_dhcp-1.1.0.zip.sig"
+    "signature_path": "/epr/microsoft_dhcp/microsoft_dhcp-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "microsoft_dhcp.log",
+        "title": "Microsoft DHCP Logs"
+      }
+    ]
   },
   {
     "name": "microsoft_dhcp",
@@ -21038,7 +30068,14 @@
     "categories": [
       "network"
     ],
-    "signature_path": "/epr/microsoft_dhcp/microsoft_dhcp-1.3.0.zip.sig"
+    "signature_path": "/epr/microsoft_dhcp/microsoft_dhcp-1.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "microsoft_dhcp.log",
+        "title": "Microsoft DHCP Logs"
+      }
+    ]
   },
   {
     "name": "microsoft_dhcp",
@@ -21076,7 +30113,14 @@
     "categories": [
       "network"
     ],
-    "signature_path": "/epr/microsoft_dhcp/microsoft_dhcp-1.3.1.zip.sig"
+    "signature_path": "/epr/microsoft_dhcp/microsoft_dhcp-1.3.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "microsoft_dhcp.log",
+        "title": "Microsoft DHCP Logs"
+      }
+    ]
   },
   {
     "name": "microsoft_defender_endpoint",
@@ -21116,7 +30160,14 @@
       "security",
       "azure"
     ],
-    "signature_path": "/epr/microsoft_defender_endpoint/microsoft_defender_endpoint-1.0.2.zip.sig"
+    "signature_path": "/epr/microsoft_defender_endpoint/microsoft_defender_endpoint-1.0.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "microsoft_defender_endpoint.log",
+        "title": "Microsoft Defender for Endpoint logs"
+      }
+    ]
   },
   {
     "name": "microsoft_defender_endpoint",
@@ -21156,7 +30207,14 @@
       "security",
       "azure"
     ],
-    "signature_path": "/epr/microsoft_defender_endpoint/microsoft_defender_endpoint-1.1.0.zip.sig"
+    "signature_path": "/epr/microsoft_defender_endpoint/microsoft_defender_endpoint-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "microsoft_defender_endpoint.log",
+        "title": "Microsoft Defender for Endpoint logs"
+      }
+    ]
   },
   {
     "name": "microsoft_defender_endpoint",
@@ -21196,7 +30254,14 @@
       "security",
       "azure"
     ],
-    "signature_path": "/epr/microsoft_defender_endpoint/microsoft_defender_endpoint-2.0.0.zip.sig"
+    "signature_path": "/epr/microsoft_defender_endpoint/microsoft_defender_endpoint-2.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "microsoft_defender_endpoint.log",
+        "title": "Microsoft Defender for Endpoint logs"
+      }
+    ]
   },
   {
     "name": "microsoft_defender_endpoint",
@@ -21236,7 +30301,14 @@
       "security",
       "azure"
     ],
-    "signature_path": "/epr/microsoft_defender_endpoint/microsoft_defender_endpoint-2.0.1.zip.sig"
+    "signature_path": "/epr/microsoft_defender_endpoint/microsoft_defender_endpoint-2.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "microsoft_defender_endpoint.log",
+        "title": "Microsoft Defender for Endpoint logs"
+      }
+    ]
   },
   {
     "name": "microsoft_defender_endpoint",
@@ -21276,7 +30348,14 @@
       "security",
       "azure"
     ],
-    "signature_path": "/epr/microsoft_defender_endpoint/microsoft_defender_endpoint-2.1.0.zip.sig"
+    "signature_path": "/epr/microsoft_defender_endpoint/microsoft_defender_endpoint-2.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "microsoft_defender_endpoint.log",
+        "title": "Microsoft Defender for Endpoint logs"
+      }
+    ]
   },
   {
     "name": "mongodb",
@@ -21314,7 +30393,39 @@
     "categories": [
       "datastore"
     ],
-    "signature_path": "/epr/mongodb/mongodb-1.1.0.zip.sig"
+    "signature_path": "/epr/mongodb/mongodb-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "mongodb.collstats",
+        "title": "MongoDB collstats metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "mongodb.dbstats",
+        "title": "MongoDB dbstats metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "mongodb.log",
+        "title": "mongodb log logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "mongodb.metrics",
+        "title": "MongoDB metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "mongodb.replstatus",
+        "title": "MongoDB replstatus metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "mongodb.status",
+        "title": "MongoDB status metrics"
+      }
+    ]
   },
   {
     "name": "mongodb",
@@ -21352,7 +30463,39 @@
     "categories": [
       "datastore"
     ],
-    "signature_path": "/epr/mongodb/mongodb-1.2.0.zip.sig"
+    "signature_path": "/epr/mongodb/mongodb-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "mongodb.collstats",
+        "title": "MongoDB collstats metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "mongodb.dbstats",
+        "title": "MongoDB dbstats metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "mongodb.log",
+        "title": "mongodb log logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "mongodb.metrics",
+        "title": "MongoDB metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "mongodb.replstatus",
+        "title": "MongoDB replstatus metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "mongodb.status",
+        "title": "MongoDB status metrics"
+      }
+    ]
   },
   {
     "name": "mongodb",
@@ -21390,7 +30533,39 @@
     "categories": [
       "datastore"
     ],
-    "signature_path": "/epr/mongodb/mongodb-1.3.1.zip.sig"
+    "signature_path": "/epr/mongodb/mongodb-1.3.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "mongodb.collstats",
+        "title": "MongoDB collstats metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "mongodb.dbstats",
+        "title": "MongoDB dbstats metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "mongodb.log",
+        "title": "mongodb log logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "mongodb.metrics",
+        "title": "MongoDB metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "mongodb.replstatus",
+        "title": "MongoDB replstatus metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "mongodb.status",
+        "title": "MongoDB status metrics"
+      }
+    ]
   },
   {
     "name": "mysql",
@@ -21428,7 +30603,34 @@
     "categories": [
       "datastore"
     ],
-    "signature_path": "/epr/mysql/mysql-1.1.0.zip.sig"
+    "signature_path": "/epr/mysql/mysql-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "mysql.error",
+        "title": "MySQL error logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "mysql.galera_status",
+        "title": "MySQL galera_status metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "mysql.performance",
+        "title": "MySQL performance metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "mysql.slowlog",
+        "title": "MySQL slowlog logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "mysql.status",
+        "title": "MySQL status metrics"
+      }
+    ]
   },
   {
     "name": "mysql",
@@ -21466,7 +30668,34 @@
     "categories": [
       "datastore"
     ],
-    "signature_path": "/epr/mysql/mysql-1.2.1.zip.sig"
+    "signature_path": "/epr/mysql/mysql-1.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "mysql.error",
+        "title": "MySQL error logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "mysql.galera_status",
+        "title": "MySQL galera_status metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "mysql.performance",
+        "title": "MySQL performance metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "mysql.slowlog",
+        "title": "MySQL slowlog logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "mysql.status",
+        "title": "MySQL status metrics"
+      }
+    ]
   },
   {
     "name": "mysql_enterprise",
@@ -21505,7 +30734,14 @@
       "security",
       "datastore"
     ],
-    "signature_path": "/epr/mysql_enterprise/mysql_enterprise-1.0.0.zip.sig"
+    "signature_path": "/epr/mysql_enterprise/mysql_enterprise-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "mysql_enterprise.audit",
+        "title": "MySQL Enterprise Audit Log"
+      }
+    ]
   },
   {
     "name": "mysql_enterprise",
@@ -21544,7 +30780,14 @@
       "security",
       "datastore"
     ],
-    "signature_path": "/epr/mysql_enterprise/mysql_enterprise-1.0.1.zip.sig"
+    "signature_path": "/epr/mysql_enterprise/mysql_enterprise-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "mysql_enterprise.audit",
+        "title": "MySQL Enterprise Audit Log"
+      }
+    ]
   },
   {
     "name": "nats",
@@ -21582,7 +30825,44 @@
     "categories": [
       "message_queue"
     ],
-    "signature_path": "/epr/nats/nats-1.1.0.zip.sig"
+    "signature_path": "/epr/nats/nats-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "nats.connection",
+        "title": "NATS connection metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "nats.connections",
+        "title": "NATS connections metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "nats.log",
+        "title": "NATS logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "nats.route",
+        "title": "NATS route metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "nats.routes",
+        "title": "NATS routes metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "nats.stats",
+        "title": "NATS stats metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "nats.subscriptions",
+        "title": "NATS subscriptions metrics"
+      }
+    ]
   },
   {
     "name": "nats",
@@ -21620,7 +30900,44 @@
     "categories": [
       "message_queue"
     ],
-    "signature_path": "/epr/nats/nats-1.2.0.zip.sig"
+    "signature_path": "/epr/nats/nats-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "nats.connection",
+        "title": "NATS connection metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "nats.connections",
+        "title": "NATS connections metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "nats.log",
+        "title": "NATS logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "nats.route",
+        "title": "NATS route metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "nats.routes",
+        "title": "NATS routes metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "nats.stats",
+        "title": "NATS stats metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "nats.subscriptions",
+        "title": "NATS subscriptions metrics"
+      }
+    ]
   },
   {
     "name": "netflow",
@@ -21650,7 +30967,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/netflow/netflow-1.0.0.zip.sig"
+    "signature_path": "/epr/netflow/netflow-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "netflow.log",
+        "title": "NetFlow logs"
+      }
+    ]
   },
   {
     "name": "netflow",
@@ -21680,7 +31004,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/netflow/netflow-1.2.0.zip.sig"
+    "signature_path": "/epr/netflow/netflow-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "netflow.log",
+        "title": "NetFlow logs"
+      }
+    ]
   },
   {
     "name": "netflow",
@@ -21710,7 +31041,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/netflow/netflow-1.2.3.zip.sig"
+    "signature_path": "/epr/netflow/netflow-1.2.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "netflow.log",
+        "title": "NetFlow logs"
+      }
+    ]
   },
   {
     "name": "netflow",
@@ -21740,7 +31078,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/netflow/netflow-1.3.0.zip.sig"
+    "signature_path": "/epr/netflow/netflow-1.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "netflow.log",
+        "title": "NetFlow logs"
+      }
+    ]
   },
   {
     "name": "netflow",
@@ -21770,7 +31115,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/netflow/netflow-1.4.0.zip.sig"
+    "signature_path": "/epr/netflow/netflow-1.4.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "netflow.log",
+        "title": "NetFlow logs"
+      }
+    ]
   },
   {
     "name": "netflow",
@@ -21800,7 +31152,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/netflow/netflow-1.4.1.zip.sig"
+    "signature_path": "/epr/netflow/netflow-1.4.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "netflow.log",
+        "title": "NetFlow logs"
+      }
+    ]
   },
   {
     "name": "netflow",
@@ -21830,7 +31189,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/netflow/netflow-1.4.2.zip.sig"
+    "signature_path": "/epr/netflow/netflow-1.4.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "netflow.log",
+        "title": "NetFlow logs"
+      }
+    ]
   },
   {
     "name": "nginx",
@@ -21869,7 +31235,24 @@
       "web",
       "security"
     ],
-    "signature_path": "/epr/nginx/nginx-1.1.0.zip.sig"
+    "signature_path": "/epr/nginx/nginx-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "nginx.access",
+        "title": "Nginx access logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "nginx.error",
+        "title": "Nginx error logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "nginx.stubstatus",
+        "title": "Nginx stubstatus metrics"
+      }
+    ]
   },
   {
     "name": "nginx",
@@ -21908,7 +31291,24 @@
       "web",
       "security"
     ],
-    "signature_path": "/epr/nginx/nginx-1.2.0.zip.sig"
+    "signature_path": "/epr/nginx/nginx-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "nginx.access",
+        "title": "Nginx access logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "nginx.error",
+        "title": "Nginx error logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "nginx.stubstatus",
+        "title": "Nginx stubstatus metrics"
+      }
+    ]
   },
   {
     "name": "nginx",
@@ -21947,7 +31347,24 @@
       "web",
       "security"
     ],
-    "signature_path": "/epr/nginx/nginx-1.2.1.zip.sig"
+    "signature_path": "/epr/nginx/nginx-1.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "nginx.access",
+        "title": "Nginx access logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "nginx.error",
+        "title": "Nginx error logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "nginx.stubstatus",
+        "title": "Nginx stubstatus metrics"
+      }
+    ]
   },
   {
     "name": "nginx",
@@ -21986,7 +31403,24 @@
       "web",
       "security"
     ],
-    "signature_path": "/epr/nginx/nginx-1.3.1.zip.sig"
+    "signature_path": "/epr/nginx/nginx-1.3.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "nginx.access",
+        "title": "Nginx access logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "nginx.error",
+        "title": "Nginx error logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "nginx.stubstatus",
+        "title": "Nginx stubstatus metrics"
+      }
+    ]
   },
   {
     "name": "nginx_ingress_controller",
@@ -22025,7 +31459,19 @@
       "web",
       "security"
     ],
-    "signature_path": "/epr/nginx_ingress_controller/nginx_ingress_controller-1.0.0.zip.sig"
+    "signature_path": "/epr/nginx_ingress_controller/nginx_ingress_controller-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "nginx_ingress_controller.access",
+        "title": "Nginx Ingress Controller access logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "nginx_ingress_controller.error",
+        "title": "Nginx Ingress Controller error logs"
+      }
+    ]
   },
   {
     "name": "nginx_ingress_controller",
@@ -22064,7 +31510,19 @@
       "web",
       "security"
     ],
-    "signature_path": "/epr/nginx_ingress_controller/nginx_ingress_controller-1.2.0.zip.sig"
+    "signature_path": "/epr/nginx_ingress_controller/nginx_ingress_controller-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "nginx_ingress_controller.access",
+        "title": "Nginx Ingress Controller access logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "nginx_ingress_controller.error",
+        "title": "Nginx Ingress Controller error logs"
+      }
+    ]
   },
   {
     "name": "o365",
@@ -22102,7 +31560,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/o365/o365-1.0.0.zip.sig"
+    "signature_path": "/epr/o365/o365-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "o365.audit",
+        "title": "Office 365 audit logs"
+      }
+    ]
   },
   {
     "name": "o365",
@@ -22140,7 +31605,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/o365/o365-1.1.4.zip.sig"
+    "signature_path": "/epr/o365/o365-1.1.4.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "o365.audit",
+        "title": "Office 365 audit logs"
+      }
+    ]
   },
   {
     "name": "o365",
@@ -22178,7 +31650,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/o365/o365-1.2.3.zip.sig"
+    "signature_path": "/epr/o365/o365-1.2.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "o365.audit",
+        "title": "Office 365 audit logs"
+      }
+    ]
   },
   {
     "name": "o365",
@@ -22216,7 +31695,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/o365/o365-1.2.4.zip.sig"
+    "signature_path": "/epr/o365/o365-1.2.4.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "o365.audit",
+        "title": "Office 365 audit logs"
+      }
+    ]
   },
   {
     "name": "o365",
@@ -22254,7 +31740,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/o365/o365-1.3.0.zip.sig"
+    "signature_path": "/epr/o365/o365-1.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "o365.audit",
+        "title": "Office 365 audit logs"
+      }
+    ]
   },
   {
     "name": "o365",
@@ -22292,7 +31785,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/o365/o365-1.3.2.zip.sig"
+    "signature_path": "/epr/o365/o365-1.3.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "o365.audit",
+        "title": "Office 365 audit logs"
+      }
+    ]
   },
   {
     "name": "o365",
@@ -22330,7 +31830,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/o365/o365-1.4.0.zip.sig"
+    "signature_path": "/epr/o365/o365-1.4.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "o365.audit",
+        "title": "Office 365 audit logs"
+      }
+    ]
   },
   {
     "name": "o365",
@@ -22368,7 +31875,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/o365/o365-1.4.1.zip.sig"
+    "signature_path": "/epr/o365/o365-1.4.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "o365.audit",
+        "title": "Office 365 audit logs"
+      }
+    ]
   },
   {
     "name": "o365",
@@ -22406,7 +31920,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/o365/o365-1.4.2.zip.sig"
+    "signature_path": "/epr/o365/o365-1.4.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "o365.audit",
+        "title": "Office 365 audit logs"
+      }
+    ]
   },
   {
     "name": "o365",
@@ -22444,7 +31965,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/o365/o365-1.4.3.zip.sig"
+    "signature_path": "/epr/o365/o365-1.4.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "o365.audit",
+        "title": "Office 365 audit logs"
+      }
+    ]
   },
   {
     "name": "okta",
@@ -22482,7 +32010,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/okta/okta-1.0.0.zip.sig"
+    "signature_path": "/epr/okta/okta-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "okta.system",
+        "title": "Okta system logs"
+      }
+    ]
   },
   {
     "name": "okta",
@@ -22520,7 +32055,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/okta/okta-1.1.0.zip.sig"
+    "signature_path": "/epr/okta/okta-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "okta.system",
+        "title": "Okta system logs"
+      }
+    ]
   },
   {
     "name": "okta",
@@ -22558,7 +32100,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/okta/okta-1.2.0.zip.sig"
+    "signature_path": "/epr/okta/okta-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "okta.system",
+        "title": "Okta system logs"
+      }
+    ]
   },
   {
     "name": "okta",
@@ -22596,7 +32145,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/okta/okta-1.2.3.zip.sig"
+    "signature_path": "/epr/okta/okta-1.2.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "okta.system",
+        "title": "Okta system logs"
+      }
+    ]
   },
   {
     "name": "okta",
@@ -22634,7 +32190,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/okta/okta-1.3.0.zip.sig"
+    "signature_path": "/epr/okta/okta-1.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "okta.system",
+        "title": "Okta system logs"
+      }
+    ]
   },
   {
     "name": "okta",
@@ -22672,7 +32235,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/okta/okta-1.3.2.zip.sig"
+    "signature_path": "/epr/okta/okta-1.3.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "okta.system",
+        "title": "Okta system logs"
+      }
+    ]
   },
   {
     "name": "okta",
@@ -22710,7 +32280,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/okta/okta-1.4.0.zip.sig"
+    "signature_path": "/epr/okta/okta-1.4.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "okta.system",
+        "title": "Okta system logs"
+      }
+    ]
   },
   {
     "name": "okta",
@@ -22748,7 +32325,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/okta/okta-1.5.0.zip.sig"
+    "signature_path": "/epr/okta/okta-1.5.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "okta.system",
+        "title": "Okta system logs"
+      }
+    ]
   },
   {
     "name": "okta",
@@ -22786,7 +32370,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/okta/okta-1.5.1.zip.sig"
+    "signature_path": "/epr/okta/okta-1.5.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "okta.system",
+        "title": "Okta system logs"
+      }
+    ]
   },
   {
     "name": "okta",
@@ -22824,7 +32415,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/okta/okta-1.5.2.zip.sig"
+    "signature_path": "/epr/okta/okta-1.5.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "okta.system",
+        "title": "Okta system logs"
+      }
+    ]
   },
   {
     "name": "oracle",
@@ -22863,7 +32461,14 @@
       "security",
       "datastore"
     ],
-    "signature_path": "/epr/oracle/oracle-1.0.0.zip.sig"
+    "signature_path": "/epr/oracle/oracle-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "oracle.database_audit",
+        "title": "Oracle Audit Log"
+      }
+    ]
   },
   {
     "name": "oracle",
@@ -22902,7 +32507,14 @@
       "security",
       "datastore"
     ],
-    "signature_path": "/epr/oracle/oracle-1.0.1.zip.sig"
+    "signature_path": "/epr/oracle/oracle-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "oracle.database_audit",
+        "title": "Oracle Audit Log"
+      }
+    ]
   },
   {
     "name": "osquery",
@@ -22941,7 +32553,14 @@
       "security",
       "os_system"
     ],
-    "signature_path": "/epr/osquery/osquery-1.0.3.zip.sig"
+    "signature_path": "/epr/osquery/osquery-1.0.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "osquery.result",
+        "title": "Osquery result logs"
+      }
+    ]
   },
   {
     "name": "osquery",
@@ -22980,7 +32599,14 @@
       "security",
       "os_system"
     ],
-    "signature_path": "/epr/osquery/osquery-1.1.0.zip.sig"
+    "signature_path": "/epr/osquery/osquery-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "osquery.result",
+        "title": "Osquery result logs"
+      }
+    ]
   },
   {
     "name": "osquery",
@@ -23019,7 +32645,14 @@
       "security",
       "os_system"
     ],
-    "signature_path": "/epr/osquery/osquery-1.2.0.zip.sig"
+    "signature_path": "/epr/osquery/osquery-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "osquery.result",
+        "title": "Osquery result logs"
+      }
+    ]
   },
   {
     "name": "osquery",
@@ -23058,7 +32691,14 @@
       "security",
       "os_system"
     ],
-    "signature_path": "/epr/osquery/osquery-1.2.1.zip.sig"
+    "signature_path": "/epr/osquery/osquery-1.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "osquery.result",
+        "title": "Osquery result logs"
+      }
+    ]
   },
   {
     "name": "osquery_manager",
@@ -23098,7 +32738,14 @@
       "os_system",
       "config_management"
     ],
-    "signature_path": "/epr/osquery_manager/osquery_manager-1.0.0.zip.sig"
+    "signature_path": "/epr/osquery_manager/osquery_manager-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "osquery_manager.result",
+        "title": "Osquery Manager queries"
+      }
+    ]
   },
   {
     "name": "osquery_manager",
@@ -23138,7 +32785,14 @@
       "os_system",
       "config_management"
     ],
-    "signature_path": "/epr/osquery_manager/osquery_manager-1.2.0.zip.sig"
+    "signature_path": "/epr/osquery_manager/osquery_manager-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "osquery_manager.result",
+        "title": "Osquery Manager queries"
+      }
+    ]
   },
   {
     "name": "osquery_manager",
@@ -23178,7 +32832,14 @@
       "os_system",
       "config_management"
     ],
-    "signature_path": "/epr/osquery_manager/osquery_manager-1.2.1.zip.sig"
+    "signature_path": "/epr/osquery_manager/osquery_manager-1.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "osquery_manager.result",
+        "title": "Osquery Manager queries"
+      }
+    ]
   },
   {
     "name": "panw_cortex_xdr",
@@ -23216,7 +32877,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/panw_cortex_xdr/panw_cortex_xdr-1.0.0.zip.sig"
+    "signature_path": "/epr/panw_cortex_xdr/panw_cortex_xdr-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "panw_cortex_xdr.alerts",
+        "title": "Palo Alto Cortex XDR API"
+      }
+    ]
   },
   {
     "name": "panw_cortex_xdr",
@@ -23254,7 +32922,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/panw_cortex_xdr/panw_cortex_xdr-1.1.0.zip.sig"
+    "signature_path": "/epr/panw_cortex_xdr/panw_cortex_xdr-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "panw_cortex_xdr.alerts",
+        "title": "Palo Alto Cortex XDR API"
+      }
+    ]
   },
   {
     "name": "panw_cortex_xdr",
@@ -23292,7 +32967,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/panw_cortex_xdr/panw_cortex_xdr-1.1.1.zip.sig"
+    "signature_path": "/epr/panw_cortex_xdr/panw_cortex_xdr-1.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "panw_cortex_xdr.alerts",
+        "title": "Palo Alto Cortex XDR API"
+      }
+    ]
   },
   {
     "name": "panw",
@@ -23330,7 +33012,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/panw/panw-1.0.0.zip.sig"
+    "signature_path": "/epr/panw/panw-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "panw.panos",
+        "title": "Palo Alto Networks PAN-OS firewall logs"
+      }
+    ]
   },
   {
     "name": "panw",
@@ -23368,7 +33057,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/panw/panw-1.1.3.zip.sig"
+    "signature_path": "/epr/panw/panw-1.1.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "panw.panos",
+        "title": "Palo Alto Networks PAN-OS firewall logs"
+      }
+    ]
   },
   {
     "name": "panw",
@@ -23406,7 +33102,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/panw/panw-1.2.3.zip.sig"
+    "signature_path": "/epr/panw/panw-1.2.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "panw.panos",
+        "title": "Palo Alto Networks PAN-OS firewall logs"
+      }
+    ]
   },
   {
     "name": "panw",
@@ -23444,7 +33147,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/panw/panw-1.3.0.zip.sig"
+    "signature_path": "/epr/panw/panw-1.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "panw.panos",
+        "title": "Palo Alto Networks PAN-OS firewall logs"
+      }
+    ]
   },
   {
     "name": "panw",
@@ -23482,7 +33192,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/panw/panw-1.3.2.zip.sig"
+    "signature_path": "/epr/panw/panw-1.3.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "panw.panos",
+        "title": "Palo Alto Networks PAN-OS firewall logs"
+      }
+    ]
   },
   {
     "name": "panw",
@@ -23520,7 +33237,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/panw/panw-1.4.0.zip.sig"
+    "signature_path": "/epr/panw/panw-1.4.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "panw.panos",
+        "title": "Palo Alto Networks PAN-OS firewall logs"
+      }
+    ]
   },
   {
     "name": "panw",
@@ -23558,7 +33282,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/panw/panw-1.5.1.zip.sig"
+    "signature_path": "/epr/panw/panw-1.5.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "panw.panos",
+        "title": "Palo Alto Networks PAN-OS firewall logs"
+      }
+    ]
   },
   {
     "name": "panw",
@@ -23596,7 +33327,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/panw/panw-1.5.2.zip.sig"
+    "signature_path": "/epr/panw/panw-1.5.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "panw.panos",
+        "title": "Palo Alto Networks PAN-OS firewall logs"
+      }
+    ]
   },
   {
     "name": "panw",
@@ -23634,7 +33372,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/panw/panw-1.5.3.zip.sig"
+    "signature_path": "/epr/panw/panw-1.5.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "panw.panos",
+        "title": "Palo Alto Networks PAN-OS firewall logs"
+      }
+    ]
   },
   {
     "name": "postgresql",
@@ -23672,7 +33417,34 @@
     "categories": [
       "datastore"
     ],
-    "signature_path": "/epr/postgresql/postgresql-1.1.0.zip.sig"
+    "signature_path": "/epr/postgresql/postgresql-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "postgresql.activity",
+        "title": "PostgreSQL activity metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "postgresql.bgwriter",
+        "title": "PostgreSQL bgwriter metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "postgresql.database",
+        "title": "PostgreSQL database metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "postgresql.log",
+        "title": "PostgreSQL logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "postgresql.statement",
+        "title": "PostgreSQL statement metrics"
+      }
+    ]
   },
   {
     "name": "postgresql",
@@ -23710,7 +33482,34 @@
     "categories": [
       "datastore"
     ],
-    "signature_path": "/epr/postgresql/postgresql-1.2.0.zip.sig"
+    "signature_path": "/epr/postgresql/postgresql-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "postgresql.activity",
+        "title": "PostgreSQL activity metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "postgresql.bgwriter",
+        "title": "PostgreSQL bgwriter metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "postgresql.database",
+        "title": "PostgreSQL database metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "postgresql.log",
+        "title": "PostgreSQL logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "postgresql.statement",
+        "title": "PostgreSQL statement metrics"
+      }
+    ]
   },
   {
     "name": "security_detection_engine",
@@ -23808,7 +33607,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/qnap_nas/qnap_nas-1.0.1.zip.sig"
+    "signature_path": "/epr/qnap_nas/qnap_nas-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "qnap_nas.log",
+        "title": "QNAP NAS logs"
+      }
+    ]
   },
   {
     "name": "qnap_nas",
@@ -23846,7 +33652,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/qnap_nas/qnap_nas-1.1.0.zip.sig"
+    "signature_path": "/epr/qnap_nas/qnap_nas-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "qnap_nas.log",
+        "title": "QNAP NAS logs"
+      }
+    ]
   },
   {
     "name": "qnap_nas",
@@ -23884,7 +33697,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/qnap_nas/qnap_nas-1.1.1.zip.sig"
+    "signature_path": "/epr/qnap_nas/qnap_nas-1.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "qnap_nas.log",
+        "title": "QNAP NAS logs"
+      }
+    ]
   },
   {
     "name": "rabbitmq",
@@ -23922,7 +33742,34 @@
     "categories": [
       "message_queue"
     ],
-    "signature_path": "/epr/rabbitmq/rabbitmq-1.0.0.zip.sig"
+    "signature_path": "/epr/rabbitmq/rabbitmq-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "rabbitmq.connection",
+        "title": "RabbitMQ connection metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "rabbitmq.exchange",
+        "title": "RabbitMQ exchange metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "rabbitmq.log",
+        "title": "RabbitMQ application logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "rabbitmq.node",
+        "title": "RabbitMQ node metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "rabbitmq.queue",
+        "title": "RabbitMQ queue metrics"
+      }
+    ]
   },
   {
     "name": "rabbitmq",
@@ -23960,7 +33807,34 @@
     "categories": [
       "message_queue"
     ],
-    "signature_path": "/epr/rabbitmq/rabbitmq-1.2.0.zip.sig"
+    "signature_path": "/epr/rabbitmq/rabbitmq-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "rabbitmq.connection",
+        "title": "RabbitMQ connection metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "rabbitmq.exchange",
+        "title": "RabbitMQ exchange metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "rabbitmq.log",
+        "title": "RabbitMQ application logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "rabbitmq.node",
+        "title": "RabbitMQ node metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "rabbitmq.queue",
+        "title": "RabbitMQ queue metrics"
+      }
+    ]
   },
   {
     "name": "redis",
@@ -23999,7 +33873,34 @@
       "datastore",
       "message_queue"
     ],
-    "signature_path": "/epr/redis/redis-1.1.0.zip.sig"
+    "signature_path": "/epr/redis/redis-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "redis.info",
+        "title": "Redis info metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "redis.key",
+        "title": "Redis key metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "redis.keyspace",
+        "title": "Redis keyspace metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "redis.log",
+        "title": "Redis application logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "redis.slowlog",
+        "title": "Redis slow logs"
+      }
+    ]
   },
   {
     "name": "redis",
@@ -24038,7 +33939,34 @@
       "datastore",
       "message_queue"
     ],
-    "signature_path": "/epr/redis/redis-1.2.0.zip.sig"
+    "signature_path": "/epr/redis/redis-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "redis.info",
+        "title": "Redis info metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "redis.key",
+        "title": "Redis key metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "redis.keyspace",
+        "title": "Redis keyspace metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "redis.log",
+        "title": "Redis application logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "redis.slowlog",
+        "title": "Redis slow logs"
+      }
+    ]
   },
   {
     "name": "stan",
@@ -24077,7 +34005,29 @@
       "message_queue",
       "kubernetes"
     ],
-    "signature_path": "/epr/stan/stan-1.1.0.zip.sig"
+    "signature_path": "/epr/stan/stan-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "stan.channels",
+        "title": "Stan channels metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "stan.log",
+        "title": "STAN logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "stan.stats",
+        "title": "Stan stats metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "stan.subscriptions",
+        "title": "Stan subscriptions metrics"
+      }
+    ]
   },
   {
     "name": "stan",
@@ -24116,7 +34066,29 @@
       "message_queue",
       "kubernetes"
     ],
-    "signature_path": "/epr/stan/stan-1.2.0.zip.sig"
+    "signature_path": "/epr/stan/stan-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "stan.channels",
+        "title": "Stan channels metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "stan.log",
+        "title": "STAN logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "stan.stats",
+        "title": "Stan stats metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "stan.subscriptions",
+        "title": "Stan subscriptions metrics"
+      }
+    ]
   },
   {
     "name": "snyk",
@@ -24154,7 +34126,19 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/snyk/snyk-1.0.0.zip.sig"
+    "signature_path": "/epr/snyk/snyk-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "snyk.audit",
+        "title": "Collect Snyk Audit Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "snyk.vulnerabilities",
+        "title": "Collect Snyk Vulnerability Data"
+      }
+    ]
   },
   {
     "name": "snyk",
@@ -24192,7 +34176,19 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/snyk/snyk-1.1.0.zip.sig"
+    "signature_path": "/epr/snyk/snyk-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "snyk.audit",
+        "title": "Collect Snyk Audit Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "snyk.vulnerabilities",
+        "title": "Collect Snyk Vulnerability Data"
+      }
+    ]
   },
   {
     "name": "snyk",
@@ -24230,7 +34226,19 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/snyk/snyk-1.1.1.zip.sig"
+    "signature_path": "/epr/snyk/snyk-1.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "snyk.audit",
+        "title": "Collect Snyk Audit Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "snyk.vulnerabilities",
+        "title": "Collect Snyk Vulnerability Data"
+      }
+    ]
   },
   {
     "name": "snyk",
@@ -24268,7 +34276,19 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/snyk/snyk-1.1.2.zip.sig"
+    "signature_path": "/epr/snyk/snyk-1.1.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "snyk.audit",
+        "title": "Collect Snyk Audit Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "snyk.vulnerabilities",
+        "title": "Collect Snyk Vulnerability Data"
+      }
+    ]
   },
   {
     "name": "sophos",
@@ -24306,7 +34326,19 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/sophos/sophos-1.0.6.zip.sig"
+    "signature_path": "/epr/sophos/sophos-1.0.6.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "sophos.utm",
+        "title": "Sophos UTM logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "sophos.xg",
+        "title": "Sophos XG logs"
+      }
+    ]
   },
   {
     "name": "sophos",
@@ -24344,7 +34376,19 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/sophos/sophos-1.1.0.zip.sig"
+    "signature_path": "/epr/sophos/sophos-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "sophos.utm",
+        "title": "Sophos UTM logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "sophos.xg",
+        "title": "Sophos XG logs"
+      }
+    ]
   },
   {
     "name": "sophos",
@@ -24382,7 +34426,19 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/sophos/sophos-1.1.3.zip.sig"
+    "signature_path": "/epr/sophos/sophos-1.1.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "sophos.utm",
+        "title": "Sophos UTM logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "sophos.xg",
+        "title": "Sophos XG logs"
+      }
+    ]
   },
   {
     "name": "sophos",
@@ -24420,7 +34476,19 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/sophos/sophos-1.2.0.zip.sig"
+    "signature_path": "/epr/sophos/sophos-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "sophos.utm",
+        "title": "Sophos UTM logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "sophos.xg",
+        "title": "Sophos XG logs"
+      }
+    ]
   },
   {
     "name": "sophos",
@@ -24458,7 +34526,19 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/sophos/sophos-1.2.1.zip.sig"
+    "signature_path": "/epr/sophos/sophos-1.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "sophos.utm",
+        "title": "Sophos UTM logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "sophos.xg",
+        "title": "Sophos XG logs"
+      }
+    ]
   },
   {
     "name": "sophos",
@@ -24496,7 +34576,19 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/sophos/sophos-1.2.2.zip.sig"
+    "signature_path": "/epr/sophos/sophos-1.2.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "sophos.utm",
+        "title": "Sophos UTM logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "sophos.xg",
+        "title": "Sophos XG logs"
+      }
+    ]
   },
   {
     "name": "suricata",
@@ -24535,7 +34627,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/suricata/suricata-1.0.0.zip.sig"
+    "signature_path": "/epr/suricata/suricata-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "suricata.eve",
+        "title": "Suricata eve logs"
+      }
+    ]
   },
   {
     "name": "suricata",
@@ -24574,7 +34673,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/suricata/suricata-1.2.0.zip.sig"
+    "signature_path": "/epr/suricata/suricata-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "suricata.eve",
+        "title": "Suricata eve logs"
+      }
+    ]
   },
   {
     "name": "suricata",
@@ -24613,7 +34719,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/suricata/suricata-1.2.3.zip.sig"
+    "signature_path": "/epr/suricata/suricata-1.2.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "suricata.eve",
+        "title": "Suricata eve logs"
+      }
+    ]
   },
   {
     "name": "suricata",
@@ -24652,7 +34765,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/suricata/suricata-1.3.0.zip.sig"
+    "signature_path": "/epr/suricata/suricata-1.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "suricata.eve",
+        "title": "Suricata eve logs"
+      }
+    ]
   },
   {
     "name": "suricata",
@@ -24691,7 +34811,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/suricata/suricata-1.3.2.zip.sig"
+    "signature_path": "/epr/suricata/suricata-1.3.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "suricata.eve",
+        "title": "Suricata eve logs"
+      }
+    ]
   },
   {
     "name": "suricata",
@@ -24730,7 +34857,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/suricata/suricata-1.5.0.zip.sig"
+    "signature_path": "/epr/suricata/suricata-1.5.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "suricata.eve",
+        "title": "Suricata eve logs"
+      }
+    ]
   },
   {
     "name": "suricata",
@@ -24769,7 +34903,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/suricata/suricata-1.6.0.zip.sig"
+    "signature_path": "/epr/suricata/suricata-1.6.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "suricata.eve",
+        "title": "Suricata eve logs"
+      }
+    ]
   },
   {
     "name": "suricata",
@@ -24808,7 +34949,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/suricata/suricata-1.6.1.zip.sig"
+    "signature_path": "/epr/suricata/suricata-1.6.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "suricata.eve",
+        "title": "Suricata eve logs"
+      }
+    ]
   },
   {
     "name": "system",
@@ -24847,7 +34995,94 @@
       "os_system",
       "security"
     ],
-    "signature_path": "/epr/system/system-1.0.0.zip.sig"
+    "signature_path": "/epr/system/system-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "system.application",
+        "title": "Windows Application Events"
+      },
+      {
+        "type": "logs",
+        "dataset": "system.auth",
+        "title": "System auth logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.core",
+        "title": "System core metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.cpu",
+        "title": "System cpu metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.diskio",
+        "title": "System diskio metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.filesystem",
+        "title": "System filesystem metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.fsstat",
+        "title": "System fsstat metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.load",
+        "title": "System load metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.memory",
+        "title": "System memory metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.network",
+        "title": "System network metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.process",
+        "title": "System process metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.process.summary",
+        "title": "System process_summary metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "system.security",
+        "title": "Security logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.socket_summary",
+        "title": "System socket_summary metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "system.syslog",
+        "title": "System syslog logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "system.system",
+        "title": "Windows System Events"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.uptime",
+        "title": "System uptime metrics"
+      }
+    ]
   },
   {
     "name": "system",
@@ -24886,7 +35121,94 @@
       "os_system",
       "security"
     ],
-    "signature_path": "/epr/system/system-1.1.2.zip.sig"
+    "signature_path": "/epr/system/system-1.1.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "system.application",
+        "title": "Windows Application Events"
+      },
+      {
+        "type": "logs",
+        "dataset": "system.auth",
+        "title": "System auth logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.core",
+        "title": "System core metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.cpu",
+        "title": "System cpu metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.diskio",
+        "title": "System diskio metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.filesystem",
+        "title": "System filesystem metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.fsstat",
+        "title": "System fsstat metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.load",
+        "title": "System load metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.memory",
+        "title": "System memory metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.network",
+        "title": "System network metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.process",
+        "title": "System process metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.process.summary",
+        "title": "System process_summary metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "system.security",
+        "title": "Security logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.socket_summary",
+        "title": "System socket_summary metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "system.syslog",
+        "title": "System syslog logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "system.system",
+        "title": "Windows System Events"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.uptime",
+        "title": "System uptime metrics"
+      }
+    ]
   },
   {
     "name": "system",
@@ -24925,7 +35247,94 @@
       "os_system",
       "security"
     ],
-    "signature_path": "/epr/system/system-1.4.0.zip.sig"
+    "signature_path": "/epr/system/system-1.4.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "system.application",
+        "title": "Windows Application Events"
+      },
+      {
+        "type": "logs",
+        "dataset": "system.auth",
+        "title": "System auth logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.core",
+        "title": "System core metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.cpu",
+        "title": "System cpu metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.diskio",
+        "title": "System diskio metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.filesystem",
+        "title": "System filesystem metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.fsstat",
+        "title": "System fsstat metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.load",
+        "title": "System load metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.memory",
+        "title": "System memory metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.network",
+        "title": "System network metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.process",
+        "title": "System process metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.process.summary",
+        "title": "System process_summary metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "system.security",
+        "title": "Security logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.socket_summary",
+        "title": "System socket_summary metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "system.syslog",
+        "title": "System syslog logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "system.system",
+        "title": "Windows System Events"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.uptime",
+        "title": "System uptime metrics"
+      }
+    ]
   },
   {
     "name": "system",
@@ -24964,7 +35373,94 @@
       "os_system",
       "security"
     ],
-    "signature_path": "/epr/system/system-1.6.2.zip.sig"
+    "signature_path": "/epr/system/system-1.6.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "system.application",
+        "title": "Windows Application Events"
+      },
+      {
+        "type": "logs",
+        "dataset": "system.auth",
+        "title": "System auth logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.core",
+        "title": "System core metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.cpu",
+        "title": "System cpu metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.diskio",
+        "title": "System diskio metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.filesystem",
+        "title": "System filesystem metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.fsstat",
+        "title": "System fsstat metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.load",
+        "title": "System load metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.memory",
+        "title": "System memory metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.network",
+        "title": "System network metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.process",
+        "title": "System process metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.process.summary",
+        "title": "System process_summary metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "system.security",
+        "title": "Security logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.socket_summary",
+        "title": "System socket_summary metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "system.syslog",
+        "title": "System syslog logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "system.system",
+        "title": "Windows System Events"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.uptime",
+        "title": "System uptime metrics"
+      }
+    ]
   },
   {
     "name": "system",
@@ -25003,7 +35499,94 @@
       "os_system",
       "security"
     ],
-    "signature_path": "/epr/system/system-1.6.3.zip.sig"
+    "signature_path": "/epr/system/system-1.6.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "system.application",
+        "title": "Windows Application Events"
+      },
+      {
+        "type": "logs",
+        "dataset": "system.auth",
+        "title": "System auth logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.core",
+        "title": "System core metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.cpu",
+        "title": "System cpu metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.diskio",
+        "title": "System diskio metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.filesystem",
+        "title": "System filesystem metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.fsstat",
+        "title": "System fsstat metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.load",
+        "title": "System load metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.memory",
+        "title": "System memory metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.network",
+        "title": "System network metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.process",
+        "title": "System process metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.process.summary",
+        "title": "System process_summary metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "system.security",
+        "title": "Security logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.socket_summary",
+        "title": "System socket_summary metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "system.syslog",
+        "title": "System syslog logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "system.system",
+        "title": "Windows System Events"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.uptime",
+        "title": "System uptime metrics"
+      }
+    ]
   },
   {
     "name": "system",
@@ -25042,7 +35625,94 @@
       "os_system",
       "security"
     ],
-    "signature_path": "/epr/system/system-1.6.4.zip.sig"
+    "signature_path": "/epr/system/system-1.6.4.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "system.application",
+        "title": "Windows Application Events"
+      },
+      {
+        "type": "logs",
+        "dataset": "system.auth",
+        "title": "System auth logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.core",
+        "title": "System core metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.cpu",
+        "title": "System cpu metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.diskio",
+        "title": "System diskio metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.filesystem",
+        "title": "System filesystem metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.fsstat",
+        "title": "System fsstat metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.load",
+        "title": "System load metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.memory",
+        "title": "System memory metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.network",
+        "title": "System network metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.process",
+        "title": "System process metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.process.summary",
+        "title": "System process_summary metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "system.security",
+        "title": "Security logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.socket_summary",
+        "title": "System socket_summary metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "system.syslog",
+        "title": "System syslog logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "system.system",
+        "title": "Windows System Events"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.uptime",
+        "title": "System uptime metrics"
+      }
+    ]
   },
   {
     "name": "tenable_sc",
@@ -25080,7 +35750,24 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/tenable_sc/tenable_sc-1.0.0.zip.sig"
+    "signature_path": "/epr/tenable_sc/tenable_sc-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "tenable_sc.asset",
+        "title": "Tenable.sc asset logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "tenable_sc.plugin",
+        "title": "Tenable.sc plugin logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "tenable_sc.vulnerability",
+        "title": "Tenable.sc vulnerability logs"
+      }
+    ]
   },
   {
     "name": "tenable_sc",
@@ -25118,7 +35805,24 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/tenable_sc/tenable_sc-1.1.0.zip.sig"
+    "signature_path": "/epr/tenable_sc/tenable_sc-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "tenable_sc.asset",
+        "title": "Tenable.sc asset logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "tenable_sc.plugin",
+        "title": "Tenable.sc plugin logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "tenable_sc.vulnerability",
+        "title": "Tenable.sc vulnerability logs"
+      }
+    ]
   },
   {
     "name": "tenable_sc",
@@ -25156,7 +35860,24 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/tenable_sc/tenable_sc-1.1.1.zip.sig"
+    "signature_path": "/epr/tenable_sc/tenable_sc-1.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "tenable_sc.asset",
+        "title": "Tenable.sc asset logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "tenable_sc.plugin",
+        "title": "Tenable.sc plugin logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "tenable_sc.vulnerability",
+        "title": "Tenable.sc vulnerability logs"
+      }
+    ]
   },
   {
     "name": "ti_threatq",
@@ -25194,7 +35915,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/ti_threatq/ti_threatq-1.0.1.zip.sig"
+    "signature_path": "/epr/ti_threatq/ti_threatq-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_threatq.threat",
+        "title": "ThreatQ"
+      }
+    ]
   },
   {
     "name": "ti_threatq",
@@ -25232,7 +35960,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/ti_threatq/ti_threatq-1.0.2.zip.sig"
+    "signature_path": "/epr/ti_threatq/ti_threatq-1.0.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_threatq.threat",
+        "title": "ThreatQ"
+      }
+    ]
   },
   {
     "name": "ti_threatq",
@@ -25270,7 +36005,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/ti_threatq/ti_threatq-1.1.0.zip.sig"
+    "signature_path": "/epr/ti_threatq/ti_threatq-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_threatq.threat",
+        "title": "ThreatQ"
+      }
+    ]
   },
   {
     "name": "ti_threatq",
@@ -25308,7 +36050,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/ti_threatq/ti_threatq-1.2.0.zip.sig"
+    "signature_path": "/epr/ti_threatq/ti_threatq-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_threatq.threat",
+        "title": "ThreatQ"
+      }
+    ]
   },
   {
     "name": "ti_threatq",
@@ -25346,7 +36095,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/ti_threatq/ti_threatq-1.2.1.zip.sig"
+    "signature_path": "/epr/ti_threatq/ti_threatq-1.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_threatq.threat",
+        "title": "ThreatQ"
+      }
+    ]
   },
   {
     "name": "ti_threatq",
@@ -25384,7 +36140,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/ti_threatq/ti_threatq-1.2.2.zip.sig"
+    "signature_path": "/epr/ti_threatq/ti_threatq-1.2.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_threatq.threat",
+        "title": "ThreatQ"
+      }
+    ]
   },
   {
     "name": "traefik",
@@ -25423,7 +36186,19 @@
       "web",
       "security"
     ],
-    "signature_path": "/epr/traefik/traefik-1.1.0.zip.sig"
+    "signature_path": "/epr/traefik/traefik-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "traefik.access",
+        "title": "Traefik access logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "traefik.health",
+        "title": "Traefik health metrics"
+      }
+    ]
   },
   {
     "name": "traefik",
@@ -25462,7 +36237,19 @@
       "web",
       "security"
     ],
-    "signature_path": "/epr/traefik/traefik-1.2.0.zip.sig"
+    "signature_path": "/epr/traefik/traefik-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "traefik.access",
+        "title": "Traefik access logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "traefik.health",
+        "title": "Traefik health metrics"
+      }
+    ]
   },
   {
     "name": "carbon_black_cloud",
@@ -25500,7 +36287,34 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/carbon_black_cloud/carbon_black_cloud-1.0.1.zip.sig"
+    "signature_path": "/epr/carbon_black_cloud/carbon_black_cloud-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.alert",
+        "title": "Alert"
+      },
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.asset_vulnerability_summary",
+        "title": "Asset Vulnerability Summary"
+      },
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.audit",
+        "title": "Audit"
+      },
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.endpoint_event",
+        "title": "Endpoint Event"
+      },
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.watchlist_hit",
+        "title": "Watchlist Hit"
+      }
+    ]
   },
   {
     "name": "carbon_black_cloud",
@@ -25538,7 +36352,34 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/carbon_black_cloud/carbon_black_cloud-1.0.2.zip.sig"
+    "signature_path": "/epr/carbon_black_cloud/carbon_black_cloud-1.0.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.alert",
+        "title": "Alert"
+      },
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.asset_vulnerability_summary",
+        "title": "Asset Vulnerability Summary"
+      },
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.audit",
+        "title": "Audit"
+      },
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.endpoint_event",
+        "title": "Endpoint Event"
+      },
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.watchlist_hit",
+        "title": "Watchlist Hit"
+      }
+    ]
   },
   {
     "name": "carbonblack_edr",
@@ -25576,7 +36417,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/carbonblack_edr/carbonblack_edr-1.0.0.zip.sig"
+    "signature_path": "/epr/carbonblack_edr/carbonblack_edr-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "carbonblack_edr.log",
+        "title": "Carbon Black EDR logs"
+      }
+    ]
   },
   {
     "name": "carbonblack_edr",
@@ -25614,7 +36462,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/carbonblack_edr/carbonblack_edr-1.1.0.zip.sig"
+    "signature_path": "/epr/carbonblack_edr/carbonblack_edr-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "carbonblack_edr.log",
+        "title": "Carbon Black EDR logs"
+      }
+    ]
   },
   {
     "name": "carbonblack_edr",
@@ -25652,7 +36507,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/carbonblack_edr/carbonblack_edr-1.1.1.zip.sig"
+    "signature_path": "/epr/carbonblack_edr/carbonblack_edr-1.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "carbonblack_edr.log",
+        "title": "Carbon Black EDR logs"
+      }
+    ]
   },
   {
     "name": "carbonblack_edr",
@@ -25690,7 +36552,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/carbonblack_edr/carbonblack_edr-1.2.0.zip.sig"
+    "signature_path": "/epr/carbonblack_edr/carbonblack_edr-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "carbonblack_edr.log",
+        "title": "Carbon Black EDR logs"
+      }
+    ]
   },
   {
     "name": "windows",
@@ -25729,7 +36598,39 @@
       "os_system",
       "security"
     ],
-    "signature_path": "/epr/windows/windows-1.0.0.zip.sig"
+    "signature_path": "/epr/windows/windows-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "windows.forwarded",
+        "title": "Windows forwarded events"
+      },
+      {
+        "type": "metrics",
+        "dataset": "windows.perfmon",
+        "title": "Windows perfmon metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "windows.powershell",
+        "title": "Windows Powershell logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "windows.powershell_operational",
+        "title": "Windows Powershell/Operational logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "windows.service",
+        "title": "Windows service metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "windows.sysmon_operational",
+        "title": "Windows Sysmon/Operational events"
+      }
+    ]
   },
   {
     "name": "windows",
@@ -25768,7 +36669,39 @@
       "os_system",
       "security"
     ],
-    "signature_path": "/epr/windows/windows-1.2.2.zip.sig"
+    "signature_path": "/epr/windows/windows-1.2.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "windows.forwarded",
+        "title": "Windows forwarded events"
+      },
+      {
+        "type": "metrics",
+        "dataset": "windows.perfmon",
+        "title": "Windows perfmon metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "windows.powershell",
+        "title": "Windows Powershell logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "windows.powershell_operational",
+        "title": "Windows Powershell/Operational logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "windows.service",
+        "title": "Windows service metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "windows.sysmon_operational",
+        "title": "Windows Sysmon/Operational events"
+      }
+    ]
   },
   {
     "name": "windows",
@@ -25807,7 +36740,39 @@
       "os_system",
       "security"
     ],
-    "signature_path": "/epr/windows/windows-1.5.0.zip.sig"
+    "signature_path": "/epr/windows/windows-1.5.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "windows.forwarded",
+        "title": "Windows forwarded events"
+      },
+      {
+        "type": "metrics",
+        "dataset": "windows.perfmon",
+        "title": "Windows perfmon metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "windows.powershell",
+        "title": "Windows Powershell logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "windows.powershell_operational",
+        "title": "Windows Powershell/Operational logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "windows.service",
+        "title": "Windows service metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "windows.sysmon_operational",
+        "title": "Windows Sysmon/Operational events"
+      }
+    ]
   },
   {
     "name": "zeek",
@@ -25847,7 +36812,194 @@
       "monitoring",
       "security"
     ],
-    "signature_path": "/epr/zeek/zeek-1.0.0.zip.sig"
+    "signature_path": "/epr/zeek/zeek-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "zeek.capture_loss",
+        "title": "Zeek capture_loss logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.connection",
+        "title": "Zeek connection logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.dce_rpc",
+        "title": "Zeek dce_rpc logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.dhcp",
+        "title": "Zeek dhcp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.dnp3",
+        "title": "Zeek dnp3 logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.dns",
+        "title": "Zeek dns logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.dpd",
+        "title": "Zeek dpd logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.files",
+        "title": "Zeek files logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.ftp",
+        "title": "Zeek ftp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.http",
+        "title": "Zeek http logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.intel",
+        "title": "Zeek intel logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.irc",
+        "title": "Zeek irc logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.kerberos",
+        "title": "Zeek kerberos logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.modbus",
+        "title": "Zeek modbus logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.mysql",
+        "title": "Zeek mysql logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.notice",
+        "title": "Zeek notice logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.ntlm",
+        "title": "Zeek ntlm logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.ocsp",
+        "title": "Zeek ocsp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.pe",
+        "title": "Zeek pe logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.radius",
+        "title": "Zeek radius logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.rdp",
+        "title": "Zeek rdp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.rfb",
+        "title": "Zeek rfb logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.sip",
+        "title": "Zeek sip logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.smb_cmd",
+        "title": "Zeek smb_cmd logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.smb_files",
+        "title": "Zeek smb_files logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.smb_mapping",
+        "title": "Zeek smb_mapping logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.smtp",
+        "title": "Zeek smtp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.snmp",
+        "title": "Zeek snmp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.socks",
+        "title": "Zeek socks logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.ssh",
+        "title": "Zeek ssh logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.ssl",
+        "title": "Zeek ssl logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.stats",
+        "title": "Zeek stats logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.syslog",
+        "title": "Zeek syslog logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.traceroute",
+        "title": "Zeek traceroute logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.tunnel",
+        "title": "Zeek tunnel logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.weird",
+        "title": "Zeek weird logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.x509",
+        "title": "Zeek x509 logs"
+      }
+    ]
   },
   {
     "name": "zeek",
@@ -25887,7 +37039,204 @@
       "monitoring",
       "security"
     ],
-    "signature_path": "/epr/zeek/zeek-1.3.0.zip.sig"
+    "signature_path": "/epr/zeek/zeek-1.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "zeek.capture_loss",
+        "title": "Zeek capture_loss logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.connection",
+        "title": "Zeek connection logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.dce_rpc",
+        "title": "Zeek dce_rpc logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.dhcp",
+        "title": "Zeek dhcp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.dnp3",
+        "title": "Zeek dnp3 logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.dns",
+        "title": "Zeek dns logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.dpd",
+        "title": "Zeek dpd logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.files",
+        "title": "Zeek files logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.ftp",
+        "title": "Zeek ftp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.http",
+        "title": "Zeek http logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.intel",
+        "title": "Zeek intel logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.irc",
+        "title": "Zeek irc logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.kerberos",
+        "title": "Zeek kerberos logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.modbus",
+        "title": "Zeek modbus logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.mysql",
+        "title": "Zeek mysql logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.notice",
+        "title": "Zeek notice logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.ntlm",
+        "title": "Zeek ntlm logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.ntp",
+        "title": "Zeek ntp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.ocsp",
+        "title": "Zeek ocsp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.pe",
+        "title": "Zeek pe logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.radius",
+        "title": "Zeek radius logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.rdp",
+        "title": "Zeek rdp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.rfb",
+        "title": "Zeek rfb logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.signature",
+        "title": "Zeek signature logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.sip",
+        "title": "Zeek sip logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.smb_cmd",
+        "title": "Zeek smb_cmd logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.smb_files",
+        "title": "Zeek smb_files logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.smb_mapping",
+        "title": "Zeek smb_mapping logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.smtp",
+        "title": "Zeek smtp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.snmp",
+        "title": "Zeek snmp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.socks",
+        "title": "Zeek socks logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.ssh",
+        "title": "Zeek ssh logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.ssl",
+        "title": "Zeek ssl logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.stats",
+        "title": "Zeek stats logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.syslog",
+        "title": "Zeek syslog logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.traceroute",
+        "title": "Zeek traceroute logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.tunnel",
+        "title": "Zeek tunnel logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.weird",
+        "title": "Zeek weird logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.x509",
+        "title": "Zeek x509 logs"
+      }
+    ]
   },
   {
     "name": "zeek",
@@ -25927,7 +37276,204 @@
       "monitoring",
       "security"
     ],
-    "signature_path": "/epr/zeek/zeek-1.4.3.zip.sig"
+    "signature_path": "/epr/zeek/zeek-1.4.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "zeek.capture_loss",
+        "title": "Zeek capture_loss logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.connection",
+        "title": "Zeek connection logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.dce_rpc",
+        "title": "Zeek dce_rpc logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.dhcp",
+        "title": "Zeek dhcp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.dnp3",
+        "title": "Zeek dnp3 logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.dns",
+        "title": "Zeek dns logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.dpd",
+        "title": "Zeek dpd logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.files",
+        "title": "Zeek files logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.ftp",
+        "title": "Zeek ftp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.http",
+        "title": "Zeek http logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.intel",
+        "title": "Zeek intel logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.irc",
+        "title": "Zeek irc logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.kerberos",
+        "title": "Zeek kerberos logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.modbus",
+        "title": "Zeek modbus logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.mysql",
+        "title": "Zeek mysql logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.notice",
+        "title": "Zeek notice logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.ntlm",
+        "title": "Zeek ntlm logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.ntp",
+        "title": "Zeek ntp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.ocsp",
+        "title": "Zeek ocsp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.pe",
+        "title": "Zeek pe logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.radius",
+        "title": "Zeek radius logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.rdp",
+        "title": "Zeek rdp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.rfb",
+        "title": "Zeek rfb logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.signature",
+        "title": "Zeek signature logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.sip",
+        "title": "Zeek sip logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.smb_cmd",
+        "title": "Zeek smb_cmd logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.smb_files",
+        "title": "Zeek smb_files logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.smb_mapping",
+        "title": "Zeek smb_mapping logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.smtp",
+        "title": "Zeek smtp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.snmp",
+        "title": "Zeek snmp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.socks",
+        "title": "Zeek socks logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.ssh",
+        "title": "Zeek ssh logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.ssl",
+        "title": "Zeek ssl logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.stats",
+        "title": "Zeek stats logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.syslog",
+        "title": "Zeek syslog logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.traceroute",
+        "title": "Zeek traceroute logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.tunnel",
+        "title": "Zeek tunnel logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.weird",
+        "title": "Zeek weird logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.x509",
+        "title": "Zeek x509 logs"
+      }
+    ]
   },
   {
     "name": "zeek",
@@ -25967,7 +37513,204 @@
       "monitoring",
       "security"
     ],
-    "signature_path": "/epr/zeek/zeek-1.5.0.zip.sig"
+    "signature_path": "/epr/zeek/zeek-1.5.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "zeek.capture_loss",
+        "title": "Zeek capture_loss logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.connection",
+        "title": "Zeek connection logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.dce_rpc",
+        "title": "Zeek dce_rpc logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.dhcp",
+        "title": "Zeek dhcp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.dnp3",
+        "title": "Zeek dnp3 logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.dns",
+        "title": "Zeek dns logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.dpd",
+        "title": "Zeek dpd logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.files",
+        "title": "Zeek files logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.ftp",
+        "title": "Zeek ftp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.http",
+        "title": "Zeek http logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.intel",
+        "title": "Zeek intel logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.irc",
+        "title": "Zeek irc logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.kerberos",
+        "title": "Zeek kerberos logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.modbus",
+        "title": "Zeek modbus logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.mysql",
+        "title": "Zeek mysql logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.notice",
+        "title": "Zeek notice logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.ntlm",
+        "title": "Zeek ntlm logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.ntp",
+        "title": "Zeek ntp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.ocsp",
+        "title": "Zeek ocsp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.pe",
+        "title": "Zeek pe logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.radius",
+        "title": "Zeek radius logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.rdp",
+        "title": "Zeek rdp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.rfb",
+        "title": "Zeek rfb logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.signature",
+        "title": "Zeek signature logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.sip",
+        "title": "Zeek sip logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.smb_cmd",
+        "title": "Zeek smb_cmd logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.smb_files",
+        "title": "Zeek smb_files logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.smb_mapping",
+        "title": "Zeek smb_mapping logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.smtp",
+        "title": "Zeek smtp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.snmp",
+        "title": "Zeek snmp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.socks",
+        "title": "Zeek socks logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.ssh",
+        "title": "Zeek ssh logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.ssl",
+        "title": "Zeek ssl logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.stats",
+        "title": "Zeek stats logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.syslog",
+        "title": "Zeek syslog logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.traceroute",
+        "title": "Zeek traceroute logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.tunnel",
+        "title": "Zeek tunnel logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.weird",
+        "title": "Zeek weird logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.x509",
+        "title": "Zeek x509 logs"
+      }
+    ]
   },
   {
     "name": "zeek",
@@ -26007,7 +37750,204 @@
       "monitoring",
       "security"
     ],
-    "signature_path": "/epr/zeek/zeek-1.5.2.zip.sig"
+    "signature_path": "/epr/zeek/zeek-1.5.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "zeek.capture_loss",
+        "title": "Zeek capture_loss logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.connection",
+        "title": "Zeek connection logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.dce_rpc",
+        "title": "Zeek dce_rpc logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.dhcp",
+        "title": "Zeek dhcp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.dnp3",
+        "title": "Zeek dnp3 logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.dns",
+        "title": "Zeek dns logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.dpd",
+        "title": "Zeek dpd logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.files",
+        "title": "Zeek files logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.ftp",
+        "title": "Zeek ftp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.http",
+        "title": "Zeek http logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.intel",
+        "title": "Zeek intel logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.irc",
+        "title": "Zeek irc logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.kerberos",
+        "title": "Zeek kerberos logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.modbus",
+        "title": "Zeek modbus logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.mysql",
+        "title": "Zeek mysql logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.notice",
+        "title": "Zeek notice logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.ntlm",
+        "title": "Zeek ntlm logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.ntp",
+        "title": "Zeek ntp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.ocsp",
+        "title": "Zeek ocsp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.pe",
+        "title": "Zeek pe logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.radius",
+        "title": "Zeek radius logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.rdp",
+        "title": "Zeek rdp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.rfb",
+        "title": "Zeek rfb logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.signature",
+        "title": "Zeek signature logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.sip",
+        "title": "Zeek sip logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.smb_cmd",
+        "title": "Zeek smb_cmd logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.smb_files",
+        "title": "Zeek smb_files logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.smb_mapping",
+        "title": "Zeek smb_mapping logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.smtp",
+        "title": "Zeek smtp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.snmp",
+        "title": "Zeek snmp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.socks",
+        "title": "Zeek socks logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.ssh",
+        "title": "Zeek ssh logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.ssl",
+        "title": "Zeek ssl logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.stats",
+        "title": "Zeek stats logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.syslog",
+        "title": "Zeek syslog logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.traceroute",
+        "title": "Zeek traceroute logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.tunnel",
+        "title": "Zeek tunnel logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.weird",
+        "title": "Zeek weird logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.x509",
+        "title": "Zeek x509 logs"
+      }
+    ]
   },
   {
     "name": "zeek",
@@ -26047,7 +37987,204 @@
       "monitoring",
       "security"
     ],
-    "signature_path": "/epr/zeek/zeek-1.5.4.zip.sig"
+    "signature_path": "/epr/zeek/zeek-1.5.4.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "zeek.capture_loss",
+        "title": "Zeek capture_loss logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.connection",
+        "title": "Zeek connection logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.dce_rpc",
+        "title": "Zeek dce_rpc logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.dhcp",
+        "title": "Zeek dhcp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.dnp3",
+        "title": "Zeek dnp3 logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.dns",
+        "title": "Zeek dns logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.dpd",
+        "title": "Zeek dpd logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.files",
+        "title": "Zeek files logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.ftp",
+        "title": "Zeek ftp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.http",
+        "title": "Zeek http logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.intel",
+        "title": "Zeek intel logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.irc",
+        "title": "Zeek irc logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.kerberos",
+        "title": "Zeek kerberos logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.modbus",
+        "title": "Zeek modbus logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.mysql",
+        "title": "Zeek mysql logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.notice",
+        "title": "Zeek notice logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.ntlm",
+        "title": "Zeek ntlm logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.ntp",
+        "title": "Zeek ntp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.ocsp",
+        "title": "Zeek ocsp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.pe",
+        "title": "Zeek pe logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.radius",
+        "title": "Zeek radius logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.rdp",
+        "title": "Zeek rdp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.rfb",
+        "title": "Zeek rfb logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.signature",
+        "title": "Zeek signature logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.sip",
+        "title": "Zeek sip logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.smb_cmd",
+        "title": "Zeek smb_cmd logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.smb_files",
+        "title": "Zeek smb_files logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.smb_mapping",
+        "title": "Zeek smb_mapping logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.smtp",
+        "title": "Zeek smtp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.snmp",
+        "title": "Zeek snmp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.socks",
+        "title": "Zeek socks logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.ssh",
+        "title": "Zeek ssh logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.ssl",
+        "title": "Zeek ssl logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.stats",
+        "title": "Zeek stats logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.syslog",
+        "title": "Zeek syslog logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.traceroute",
+        "title": "Zeek traceroute logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.tunnel",
+        "title": "Zeek tunnel logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.weird",
+        "title": "Zeek weird logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.x509",
+        "title": "Zeek x509 logs"
+      }
+    ]
   },
   {
     "name": "zeek",
@@ -26087,7 +38224,204 @@
       "monitoring",
       "security"
     ],
-    "signature_path": "/epr/zeek/zeek-1.6.0.zip.sig"
+    "signature_path": "/epr/zeek/zeek-1.6.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "zeek.capture_loss",
+        "title": "Zeek capture_loss logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.connection",
+        "title": "Zeek connection logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.dce_rpc",
+        "title": "Zeek dce_rpc logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.dhcp",
+        "title": "Zeek dhcp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.dnp3",
+        "title": "Zeek dnp3 logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.dns",
+        "title": "Zeek dns logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.dpd",
+        "title": "Zeek dpd logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.files",
+        "title": "Zeek files logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.ftp",
+        "title": "Zeek ftp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.http",
+        "title": "Zeek http logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.intel",
+        "title": "Zeek intel logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.irc",
+        "title": "Zeek irc logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.kerberos",
+        "title": "Zeek kerberos logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.modbus",
+        "title": "Zeek modbus logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.mysql",
+        "title": "Zeek mysql logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.notice",
+        "title": "Zeek notice logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.ntlm",
+        "title": "Zeek ntlm logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.ntp",
+        "title": "Zeek ntp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.ocsp",
+        "title": "Zeek ocsp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.pe",
+        "title": "Zeek pe logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.radius",
+        "title": "Zeek radius logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.rdp",
+        "title": "Zeek rdp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.rfb",
+        "title": "Zeek rfb logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.signature",
+        "title": "Zeek signature logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.sip",
+        "title": "Zeek sip logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.smb_cmd",
+        "title": "Zeek smb_cmd logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.smb_files",
+        "title": "Zeek smb_files logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.smb_mapping",
+        "title": "Zeek smb_mapping logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.smtp",
+        "title": "Zeek smtp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.snmp",
+        "title": "Zeek snmp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.socks",
+        "title": "Zeek socks logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.ssh",
+        "title": "Zeek ssh logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.ssl",
+        "title": "Zeek ssl logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.stats",
+        "title": "Zeek stats logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.syslog",
+        "title": "Zeek syslog logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.traceroute",
+        "title": "Zeek traceroute logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.tunnel",
+        "title": "Zeek tunnel logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.weird",
+        "title": "Zeek weird logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.x509",
+        "title": "Zeek x509 logs"
+      }
+    ]
   },
   {
     "name": "zeek",
@@ -26127,7 +38461,204 @@
       "monitoring",
       "security"
     ],
-    "signature_path": "/epr/zeek/zeek-1.6.1.zip.sig"
+    "signature_path": "/epr/zeek/zeek-1.6.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "zeek.capture_loss",
+        "title": "Zeek capture_loss logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.connection",
+        "title": "Zeek connection logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.dce_rpc",
+        "title": "Zeek dce_rpc logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.dhcp",
+        "title": "Zeek dhcp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.dnp3",
+        "title": "Zeek dnp3 logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.dns",
+        "title": "Zeek dns logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.dpd",
+        "title": "Zeek dpd logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.files",
+        "title": "Zeek files logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.ftp",
+        "title": "Zeek ftp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.http",
+        "title": "Zeek http logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.intel",
+        "title": "Zeek intel logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.irc",
+        "title": "Zeek irc logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.kerberos",
+        "title": "Zeek kerberos logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.modbus",
+        "title": "Zeek modbus logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.mysql",
+        "title": "Zeek mysql logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.notice",
+        "title": "Zeek notice logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.ntlm",
+        "title": "Zeek ntlm logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.ntp",
+        "title": "Zeek ntp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.ocsp",
+        "title": "Zeek ocsp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.pe",
+        "title": "Zeek pe logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.radius",
+        "title": "Zeek radius logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.rdp",
+        "title": "Zeek rdp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.rfb",
+        "title": "Zeek rfb logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.signature",
+        "title": "Zeek signature logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.sip",
+        "title": "Zeek sip logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.smb_cmd",
+        "title": "Zeek smb_cmd logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.smb_files",
+        "title": "Zeek smb_files logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.smb_mapping",
+        "title": "Zeek smb_mapping logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.smtp",
+        "title": "Zeek smtp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.snmp",
+        "title": "Zeek snmp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.socks",
+        "title": "Zeek socks logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.ssh",
+        "title": "Zeek ssh logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.ssl",
+        "title": "Zeek ssl logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.stats",
+        "title": "Zeek stats logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.syslog",
+        "title": "Zeek syslog logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.traceroute",
+        "title": "Zeek traceroute logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.tunnel",
+        "title": "Zeek tunnel logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.weird",
+        "title": "Zeek weird logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.x509",
+        "title": "Zeek x509 logs"
+      }
+    ]
   },
   {
     "name": "zerofox",
@@ -26166,7 +38697,14 @@
       "cloud",
       "security"
     ],
-    "signature_path": "/epr/zerofox/zerofox-1.0.3.zip.sig"
+    "signature_path": "/epr/zerofox/zerofox-1.0.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "zerofox.alerts",
+        "title": "Alerts"
+      }
+    ]
   },
   {
     "name": "zerofox",
@@ -26205,7 +38743,14 @@
       "cloud",
       "security"
     ],
-    "signature_path": "/epr/zerofox/zerofox-1.1.0.zip.sig"
+    "signature_path": "/epr/zerofox/zerofox-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "zerofox.alerts",
+        "title": "Alerts"
+      }
+    ]
   },
   {
     "name": "zerofox",
@@ -26244,7 +38789,14 @@
       "cloud",
       "security"
     ],
-    "signature_path": "/epr/zerofox/zerofox-1.2.0.zip.sig"
+    "signature_path": "/epr/zerofox/zerofox-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "zerofox.alerts",
+        "title": "Alerts"
+      }
+    ]
   },
   {
     "name": "zerofox",
@@ -26283,7 +38835,14 @@
       "cloud",
       "security"
     ],
-    "signature_path": "/epr/zerofox/zerofox-1.2.1.zip.sig"
+    "signature_path": "/epr/zerofox/zerofox-1.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "zerofox.alerts",
+        "title": "Alerts"
+      }
+    ]
   },
   {
     "name": "zookeeper",
@@ -26322,7 +38881,24 @@
       "datastore",
       "config_management"
     ],
-    "signature_path": "/epr/zookeeper/zookeeper-1.1.0.zip.sig"
+    "signature_path": "/epr/zookeeper/zookeeper-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "zookeeper.connection",
+        "title": "ZooKeeper connection metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "zookeeper.mntr",
+        "title": "ZooKeeper mntr metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "zookeeper.server",
+        "title": "ZooKeeper server metrics"
+      }
+    ]
   },
   {
     "name": "zookeeper",
@@ -26361,7 +38937,24 @@
       "datastore",
       "config_management"
     ],
-    "signature_path": "/epr/zookeeper/zookeeper-1.2.0.zip.sig"
+    "signature_path": "/epr/zookeeper/zookeeper-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "zookeeper.connection",
+        "title": "ZooKeeper connection metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "zookeeper.mntr",
+        "title": "ZooKeeper mntr metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "zookeeper.server",
+        "title": "ZooKeeper server metrics"
+      }
+    ]
   },
   {
     "name": "zoom",
@@ -26400,7 +38993,14 @@
       "security",
       "productivity"
     ],
-    "signature_path": "/epr/zoom/zoom-1.0.3.zip.sig"
+    "signature_path": "/epr/zoom/zoom-1.0.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "zoom.webhook",
+        "title": "Zoom webhook logs"
+      }
+    ]
   },
   {
     "name": "zoom",
@@ -26439,7 +39039,14 @@
       "security",
       "productivity"
     ],
-    "signature_path": "/epr/zoom/zoom-1.1.0.zip.sig"
+    "signature_path": "/epr/zoom/zoom-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "zoom.webhook",
+        "title": "Zoom webhook logs"
+      }
+    ]
   },
   {
     "name": "zoom",
@@ -26478,7 +39085,14 @@
       "security",
       "productivity"
     ],
-    "signature_path": "/epr/zoom/zoom-1.2.0.zip.sig"
+    "signature_path": "/epr/zoom/zoom-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "zoom.webhook",
+        "title": "Zoom webhook logs"
+      }
+    ]
   },
   {
     "name": "zoom",
@@ -26517,6 +39131,13 @@
       "security",
       "productivity"
     ],
-    "signature_path": "/epr/zoom/zoom-1.2.1.zip.sig"
+    "signature_path": "/epr/zoom/zoom-1.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "zoom.webhook",
+        "title": "Zoom webhook logs"
+      }
+    ]
   }
 ]

--- a/testdata/generated/storage-indexer/search-category-custom.json
+++ b/testdata/generated/storage-indexer/search-category-custom.json
@@ -37,7 +37,14 @@
       "cloud",
       "custom"
     ],
-    "signature_path": "/epr/gcp_pubsub/gcp_pubsub-1.0.0.zip.sig"
+    "signature_path": "/epr/gcp_pubsub/gcp_pubsub-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "gcp_pubsub.generic",
+        "title": "Custom Google Pub/Sub Logs"
+      }
+    ]
   },
   {
     "name": "http_endpoint",
@@ -73,7 +80,14 @@
     "categories": [
       "custom"
     ],
-    "signature_path": "/epr/http_endpoint/http_endpoint-1.0.1.zip.sig"
+    "signature_path": "/epr/http_endpoint/http_endpoint-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "http_endpoint.generic",
+        "title": "Custom HTTP Endpoint Logs"
+      }
+    ]
   },
   {
     "name": "httpjson",
@@ -102,7 +116,14 @@
     "categories": [
       "custom"
     ],
-    "signature_path": "/epr/httpjson/httpjson-1.1.1.zip.sig"
+    "signature_path": "/epr/httpjson/httpjson-1.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "httpjson.generic",
+        "title": "Custom HTTPJSON Input"
+      }
+    ]
   },
   {
     "name": "log",
@@ -133,7 +154,14 @@
     "categories": [
       "custom"
     ],
-    "signature_path": "/epr/log/log-1.0.0.zip.sig"
+    "signature_path": "/epr/log/log-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "log.log",
+        "title": "Log Dataset"
+      }
+    ]
   },
   {
     "name": "tcp",
@@ -169,7 +197,14 @@
     "categories": [
       "custom"
     ],
-    "signature_path": "/epr/tcp/tcp-1.0.0.zip.sig"
+    "signature_path": "/epr/tcp/tcp-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "tcp.generic",
+        "title": "Custom TCP Logs"
+      }
+    ]
   },
   {
     "name": "udp",
@@ -205,7 +240,14 @@
     "categories": [
       "custom"
     ],
-    "signature_path": "/epr/udp/udp-1.0.1.zip.sig"
+    "signature_path": "/epr/udp/udp-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "udp.generic",
+        "title": "Custom UDP Logs"
+      }
+    ]
   },
   {
     "name": "winlog",
@@ -241,6 +283,13 @@
     "categories": [
       "custom"
     ],
-    "signature_path": "/epr/winlog/winlog-1.4.0.zip.sig"
+    "signature_path": "/epr/winlog/winlog-1.4.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "winlog.winlog",
+        "title": "Custom Windows Event Log Dataset"
+      }
+    ]
   }
 ]

--- a/testdata/generated/storage-indexer/search-category-datastore-prerelease.json
+++ b/testdata/generated/storage-indexer/search-category-datastore-prerelease.json
@@ -117,7 +117,154 @@
       "aws",
       "cloud"
     ],
-    "signature_path": "/epr/aws/aws-1.16.4.zip.sig"
+    "signature_path": "/epr/aws/aws-1.16.4.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "aws.billing",
+        "title": "AWS Billing Metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.cloudfront_logs",
+        "title": "AWS CloudFront logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.cloudtrail",
+        "title": "AWS CloudTrail Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.cloudwatch_logs",
+        "title": "AWS CloudWatch logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.cloudwatch_metrics",
+        "title": "AWS CloudWatch metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.dynamodb",
+        "title": "AWS DynamoDB metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.ebs",
+        "title": "AWS EBS metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.ec2_logs",
+        "title": "AWS EC2 logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.ec2_metrics",
+        "title": "AWS EC2 metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.elb_logs",
+        "title": "AWS ELB logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.elb_metrics",
+        "title": "AWS ELB metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.firewall_logs",
+        "title": "AWS Network Firewall logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.firewall_metrics",
+        "title": "AWS Network Firewall metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.lambda",
+        "title": "AWS Lambda metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.natgateway",
+        "title": "AWS NAT gateway metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.rds",
+        "title": "AWS RDS metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.route53_public_logs",
+        "title": "AWS Route 53 Public Zone Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.route53_resolver_logs",
+        "title": "AWS Route 53 Resolver Query Logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.s3_daily_storage",
+        "title": "AWS S3 daily storage metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.s3_request",
+        "title": "AWS S3 request metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.s3_storage_lens",
+        "title": "AWS S3 Storage Lens metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.s3access",
+        "title": "AWS s3access logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.sns",
+        "title": "AWS SNS metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.sqs",
+        "title": "AWS SQS metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.transitgateway",
+        "title": "AWS Transit Gateway metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.usage",
+        "title": "AWS usage metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.vpcflow",
+        "title": "AWS vpcflow logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.vpn",
+        "title": "AWS VPN metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.waf",
+        "title": "AWS WAF logs"
+      }
+    ]
   },
   {
     "name": "cassandra",
@@ -156,7 +303,19 @@
       "datastore",
       "monitoring"
     ],
-    "signature_path": "/epr/cassandra/cassandra-1.1.0.zip.sig"
+    "signature_path": "/epr/cassandra/cassandra-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cassandra.log",
+        "title": "Cassandra System Logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "cassandra.metrics",
+        "title": "metrics"
+      }
+    ]
   },
   {
     "name": "cockroachdb",
@@ -203,7 +362,14 @@
     "categories": [
       "datastore"
     ],
-    "signature_path": "/epr/cockroachdb/cockroachdb-0.2.0.zip.sig"
+    "signature_path": "/epr/cockroachdb/cockroachdb-0.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "cockroachdb.status",
+        "title": "Status"
+      }
+    ]
   },
   {
     "name": "elasticsearch",
@@ -242,7 +408,89 @@
       "elastic_stack",
       "datastore"
     ],
-    "signature_path": "/epr/elasticsearch/elasticsearch-0.2.0.zip.sig"
+    "signature_path": "/epr/elasticsearch/elasticsearch-0.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "elasticsearch.audit",
+        "title": "Elasticsearch audit logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elasticsearch.ccr",
+        "title": "Elasticsearch ccr metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elasticsearch.cluster_stats",
+        "title": "Elasticsearch cluster_stats metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "elasticsearch.deprecation",
+        "title": "Elasticsearch deprecation logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elasticsearch.enrich",
+        "title": "Elasticsearch enrich metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "elasticsearch.gc",
+        "title": "Elasticsearch gc logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elasticsearch.index",
+        "title": "Elasticsearch index metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elasticsearch.index_recovery",
+        "title": "Elasticsearch index_recovery metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elasticsearch.index_summary",
+        "title": "Elasticsearch index_summary metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elasticsearch.ml_job",
+        "title": "Elasticsearch ml_job metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elasticsearch.node",
+        "title": "Elasticsearch node metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elasticsearch.node_stats",
+        "title": "Elasticsearch node_stats metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elasticsearch.pending_tasks",
+        "title": "Elasticsearch pending_tasks metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "elasticsearch.server",
+        "title": "Elasticsearch server logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elasticsearch.shard",
+        "title": "Elasticsearch shard metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "elasticsearch.slowlog",
+        "title": "Elasticsearch slowlog logs"
+      }
+    ]
   },
   {
     "name": "microsoft_sqlserver",
@@ -281,7 +529,14 @@
       "datastore",
       "security"
     ],
-    "signature_path": "/epr/microsoft_sqlserver/microsoft_sqlserver-0.4.5.zip.sig"
+    "signature_path": "/epr/microsoft_sqlserver/microsoft_sqlserver-0.4.5.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "microsoft_sqlserver.audit",
+        "title": "SQL Server audit events"
+      }
+    ]
   },
   {
     "name": "mongodb",
@@ -319,7 +574,39 @@
     "categories": [
       "datastore"
     ],
-    "signature_path": "/epr/mongodb/mongodb-1.3.1.zip.sig"
+    "signature_path": "/epr/mongodb/mongodb-1.3.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "mongodb.collstats",
+        "title": "MongoDB collstats metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "mongodb.dbstats",
+        "title": "MongoDB dbstats metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "mongodb.log",
+        "title": "mongodb log logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "mongodb.metrics",
+        "title": "MongoDB metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "mongodb.replstatus",
+        "title": "MongoDB replstatus metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "mongodb.status",
+        "title": "MongoDB status metrics"
+      }
+    ]
   },
   {
     "name": "mysql",
@@ -357,7 +644,34 @@
     "categories": [
       "datastore"
     ],
-    "signature_path": "/epr/mysql/mysql-1.2.1.zip.sig"
+    "signature_path": "/epr/mysql/mysql-1.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "mysql.error",
+        "title": "MySQL error logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "mysql.galera_status",
+        "title": "MySQL galera_status metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "mysql.performance",
+        "title": "MySQL performance metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "mysql.slowlog",
+        "title": "MySQL slowlog logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "mysql.status",
+        "title": "MySQL status metrics"
+      }
+    ]
   },
   {
     "name": "mysql_enterprise",
@@ -396,7 +710,14 @@
       "security",
       "datastore"
     ],
-    "signature_path": "/epr/mysql_enterprise/mysql_enterprise-1.0.1.zip.sig"
+    "signature_path": "/epr/mysql_enterprise/mysql_enterprise-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "mysql_enterprise.audit",
+        "title": "MySQL Enterprise Audit Log"
+      }
+    ]
   },
   {
     "name": "oracle",
@@ -435,7 +756,14 @@
       "security",
       "datastore"
     ],
-    "signature_path": "/epr/oracle/oracle-1.0.1.zip.sig"
+    "signature_path": "/epr/oracle/oracle-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "oracle.database_audit",
+        "title": "Oracle Audit Log"
+      }
+    ]
   },
   {
     "name": "postgresql",
@@ -473,7 +801,34 @@
     "categories": [
       "datastore"
     ],
-    "signature_path": "/epr/postgresql/postgresql-1.2.0.zip.sig"
+    "signature_path": "/epr/postgresql/postgresql-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "postgresql.activity",
+        "title": "PostgreSQL activity metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "postgresql.bgwriter",
+        "title": "PostgreSQL bgwriter metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "postgresql.database",
+        "title": "PostgreSQL database metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "postgresql.log",
+        "title": "PostgreSQL logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "postgresql.statement",
+        "title": "PostgreSQL statement metrics"
+      }
+    ]
   },
   {
     "name": "prometheus",
@@ -512,7 +867,24 @@
       "monitoring",
       "datastore"
     ],
-    "signature_path": "/epr/prometheus/prometheus-0.7.0.zip.sig"
+    "signature_path": "/epr/prometheus/prometheus-0.7.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "prometheus.collector",
+        "title": "Prometheus collector metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "prometheus.query",
+        "title": "Prometheus query metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "prometheus.remote_write",
+        "title": "Prometheus remote_write metrics"
+      }
+    ]
   },
   {
     "name": "redis",
@@ -551,7 +923,34 @@
       "datastore",
       "message_queue"
     ],
-    "signature_path": "/epr/redis/redis-1.2.0.zip.sig"
+    "signature_path": "/epr/redis/redis-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "redis.info",
+        "title": "Redis info metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "redis.key",
+        "title": "Redis key metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "redis.keyspace",
+        "title": "Redis keyspace metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "redis.log",
+        "title": "Redis application logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "redis.slowlog",
+        "title": "Redis slow logs"
+      }
+    ]
   },
   {
     "name": "zookeeper",
@@ -590,6 +989,23 @@
       "datastore",
       "config_management"
     ],
-    "signature_path": "/epr/zookeeper/zookeeper-1.2.0.zip.sig"
+    "signature_path": "/epr/zookeeper/zookeeper-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "zookeeper.connection",
+        "title": "ZooKeeper connection metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "zookeeper.mntr",
+        "title": "ZooKeeper mntr metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "zookeeper.server",
+        "title": "ZooKeeper server metrics"
+      }
+    ]
   }
 ]

--- a/testdata/generated/storage-indexer/search-category-datastore.json
+++ b/testdata/generated/storage-indexer/search-category-datastore.json
@@ -117,7 +117,154 @@
       "aws",
       "cloud"
     ],
-    "signature_path": "/epr/aws/aws-1.16.4.zip.sig"
+    "signature_path": "/epr/aws/aws-1.16.4.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "aws.billing",
+        "title": "AWS Billing Metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.cloudfront_logs",
+        "title": "AWS CloudFront logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.cloudtrail",
+        "title": "AWS CloudTrail Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.cloudwatch_logs",
+        "title": "AWS CloudWatch logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.cloudwatch_metrics",
+        "title": "AWS CloudWatch metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.dynamodb",
+        "title": "AWS DynamoDB metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.ebs",
+        "title": "AWS EBS metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.ec2_logs",
+        "title": "AWS EC2 logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.ec2_metrics",
+        "title": "AWS EC2 metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.elb_logs",
+        "title": "AWS ELB logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.elb_metrics",
+        "title": "AWS ELB metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.firewall_logs",
+        "title": "AWS Network Firewall logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.firewall_metrics",
+        "title": "AWS Network Firewall metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.lambda",
+        "title": "AWS Lambda metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.natgateway",
+        "title": "AWS NAT gateway metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.rds",
+        "title": "AWS RDS metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.route53_public_logs",
+        "title": "AWS Route 53 Public Zone Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.route53_resolver_logs",
+        "title": "AWS Route 53 Resolver Query Logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.s3_daily_storage",
+        "title": "AWS S3 daily storage metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.s3_request",
+        "title": "AWS S3 request metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.s3_storage_lens",
+        "title": "AWS S3 Storage Lens metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.s3access",
+        "title": "AWS s3access logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.sns",
+        "title": "AWS SNS metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.sqs",
+        "title": "AWS SQS metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.transitgateway",
+        "title": "AWS Transit Gateway metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.usage",
+        "title": "AWS usage metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.vpcflow",
+        "title": "AWS vpcflow logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.vpn",
+        "title": "AWS VPN metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.waf",
+        "title": "AWS WAF logs"
+      }
+    ]
   },
   {
     "name": "cassandra",
@@ -156,7 +303,19 @@
       "datastore",
       "monitoring"
     ],
-    "signature_path": "/epr/cassandra/cassandra-1.1.0.zip.sig"
+    "signature_path": "/epr/cassandra/cassandra-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cassandra.log",
+        "title": "Cassandra System Logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "cassandra.metrics",
+        "title": "metrics"
+      }
+    ]
   },
   {
     "name": "cockroachdb",
@@ -203,7 +362,14 @@
     "categories": [
       "datastore"
     ],
-    "signature_path": "/epr/cockroachdb/cockroachdb-0.2.0.zip.sig"
+    "signature_path": "/epr/cockroachdb/cockroachdb-0.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "cockroachdb.status",
+        "title": "Status"
+      }
+    ]
   },
   {
     "name": "elasticsearch",
@@ -242,7 +408,89 @@
       "elastic_stack",
       "datastore"
     ],
-    "signature_path": "/epr/elasticsearch/elasticsearch-0.2.0.zip.sig"
+    "signature_path": "/epr/elasticsearch/elasticsearch-0.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "elasticsearch.audit",
+        "title": "Elasticsearch audit logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elasticsearch.ccr",
+        "title": "Elasticsearch ccr metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elasticsearch.cluster_stats",
+        "title": "Elasticsearch cluster_stats metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "elasticsearch.deprecation",
+        "title": "Elasticsearch deprecation logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elasticsearch.enrich",
+        "title": "Elasticsearch enrich metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "elasticsearch.gc",
+        "title": "Elasticsearch gc logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elasticsearch.index",
+        "title": "Elasticsearch index metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elasticsearch.index_recovery",
+        "title": "Elasticsearch index_recovery metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elasticsearch.index_summary",
+        "title": "Elasticsearch index_summary metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elasticsearch.ml_job",
+        "title": "Elasticsearch ml_job metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elasticsearch.node",
+        "title": "Elasticsearch node metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elasticsearch.node_stats",
+        "title": "Elasticsearch node_stats metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elasticsearch.pending_tasks",
+        "title": "Elasticsearch pending_tasks metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "elasticsearch.server",
+        "title": "Elasticsearch server logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elasticsearch.shard",
+        "title": "Elasticsearch shard metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "elasticsearch.slowlog",
+        "title": "Elasticsearch slowlog logs"
+      }
+    ]
   },
   {
     "name": "microsoft_sqlserver",
@@ -281,7 +529,14 @@
       "datastore",
       "security"
     ],
-    "signature_path": "/epr/microsoft_sqlserver/microsoft_sqlserver-0.4.5.zip.sig"
+    "signature_path": "/epr/microsoft_sqlserver/microsoft_sqlserver-0.4.5.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "microsoft_sqlserver.audit",
+        "title": "SQL Server audit events"
+      }
+    ]
   },
   {
     "name": "mongodb",
@@ -319,7 +574,39 @@
     "categories": [
       "datastore"
     ],
-    "signature_path": "/epr/mongodb/mongodb-1.3.1.zip.sig"
+    "signature_path": "/epr/mongodb/mongodb-1.3.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "mongodb.collstats",
+        "title": "MongoDB collstats metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "mongodb.dbstats",
+        "title": "MongoDB dbstats metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "mongodb.log",
+        "title": "mongodb log logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "mongodb.metrics",
+        "title": "MongoDB metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "mongodb.replstatus",
+        "title": "MongoDB replstatus metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "mongodb.status",
+        "title": "MongoDB status metrics"
+      }
+    ]
   },
   {
     "name": "mysql",
@@ -357,7 +644,34 @@
     "categories": [
       "datastore"
     ],
-    "signature_path": "/epr/mysql/mysql-1.2.1.zip.sig"
+    "signature_path": "/epr/mysql/mysql-1.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "mysql.error",
+        "title": "MySQL error logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "mysql.galera_status",
+        "title": "MySQL galera_status metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "mysql.performance",
+        "title": "MySQL performance metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "mysql.slowlog",
+        "title": "MySQL slowlog logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "mysql.status",
+        "title": "MySQL status metrics"
+      }
+    ]
   },
   {
     "name": "mysql_enterprise",
@@ -396,7 +710,14 @@
       "security",
       "datastore"
     ],
-    "signature_path": "/epr/mysql_enterprise/mysql_enterprise-1.0.1.zip.sig"
+    "signature_path": "/epr/mysql_enterprise/mysql_enterprise-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "mysql_enterprise.audit",
+        "title": "MySQL Enterprise Audit Log"
+      }
+    ]
   },
   {
     "name": "oracle",
@@ -435,7 +756,14 @@
       "security",
       "datastore"
     ],
-    "signature_path": "/epr/oracle/oracle-1.0.1.zip.sig"
+    "signature_path": "/epr/oracle/oracle-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "oracle.database_audit",
+        "title": "Oracle Audit Log"
+      }
+    ]
   },
   {
     "name": "postgresql",
@@ -473,7 +801,34 @@
     "categories": [
       "datastore"
     ],
-    "signature_path": "/epr/postgresql/postgresql-1.2.0.zip.sig"
+    "signature_path": "/epr/postgresql/postgresql-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "postgresql.activity",
+        "title": "PostgreSQL activity metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "postgresql.bgwriter",
+        "title": "PostgreSQL bgwriter metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "postgresql.database",
+        "title": "PostgreSQL database metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "postgresql.log",
+        "title": "PostgreSQL logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "postgresql.statement",
+        "title": "PostgreSQL statement metrics"
+      }
+    ]
   },
   {
     "name": "prometheus",
@@ -512,7 +867,24 @@
       "monitoring",
       "datastore"
     ],
-    "signature_path": "/epr/prometheus/prometheus-0.7.0.zip.sig"
+    "signature_path": "/epr/prometheus/prometheus-0.7.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "prometheus.collector",
+        "title": "Prometheus collector metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "prometheus.query",
+        "title": "Prometheus query metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "prometheus.remote_write",
+        "title": "Prometheus remote_write metrics"
+      }
+    ]
   },
   {
     "name": "redis",
@@ -551,7 +923,34 @@
       "datastore",
       "message_queue"
     ],
-    "signature_path": "/epr/redis/redis-1.2.0.zip.sig"
+    "signature_path": "/epr/redis/redis-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "redis.info",
+        "title": "Redis info metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "redis.key",
+        "title": "Redis key metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "redis.keyspace",
+        "title": "Redis keyspace metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "redis.log",
+        "title": "Redis application logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "redis.slowlog",
+        "title": "Redis slow logs"
+      }
+    ]
   },
   {
     "name": "zookeeper",
@@ -590,6 +989,23 @@
       "datastore",
       "config_management"
     ],
-    "signature_path": "/epr/zookeeper/zookeeper-1.2.0.zip.sig"
+    "signature_path": "/epr/zookeeper/zookeeper-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "zookeeper.connection",
+        "title": "ZooKeeper connection metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "zookeeper.mntr",
+        "title": "ZooKeeper mntr metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "zookeeper.server",
+        "title": "ZooKeeper server metrics"
+      }
+    ]
   }
 ]

--- a/testdata/generated/storage-indexer/search-category-web-all.json
+++ b/testdata/generated/storage-indexer/search-category-web-all.json
@@ -38,7 +38,14 @@
       "web",
       "cloud"
     ],
-    "signature_path": "/epr/akamai/akamai-1.0.0.zip.sig"
+    "signature_path": "/epr/akamai/akamai-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "akamai.siem",
+        "title": "Akamai SIEM Logs"
+      }
+    ]
   },
   {
     "name": "apache",
@@ -76,7 +83,24 @@
     "categories": [
       "web"
     ],
-    "signature_path": "/epr/apache/apache-1.1.0.zip.sig"
+    "signature_path": "/epr/apache/apache-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "apache.access",
+        "title": "Apache access logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "apache.error",
+        "title": "Apache error logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apache.status",
+        "title": "Apache status metrics"
+      }
+    ]
   },
   {
     "name": "apache",
@@ -114,7 +138,24 @@
     "categories": [
       "web"
     ],
-    "signature_path": "/epr/apache/apache-1.3.0.zip.sig"
+    "signature_path": "/epr/apache/apache-1.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "apache.access",
+        "title": "Apache access logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "apache.error",
+        "title": "Apache error logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apache.status",
+        "title": "Apache status metrics"
+      }
+    ]
   },
   {
     "name": "apache",
@@ -152,7 +193,24 @@
     "categories": [
       "web"
     ],
-    "signature_path": "/epr/apache/apache-1.3.2.zip.sig"
+    "signature_path": "/epr/apache/apache-1.3.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "apache.access",
+        "title": "Apache access logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "apache.error",
+        "title": "Apache error logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apache.status",
+        "title": "Apache status metrics"
+      }
+    ]
   },
   {
     "name": "apache",
@@ -190,7 +248,24 @@
     "categories": [
       "web"
     ],
-    "signature_path": "/epr/apache/apache-1.3.5.zip.sig"
+    "signature_path": "/epr/apache/apache-1.3.5.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "apache.access",
+        "title": "Apache access logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "apache.error",
+        "title": "Apache error logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apache.status",
+        "title": "Apache status metrics"
+      }
+    ]
   },
   {
     "name": "tomcat",
@@ -229,7 +304,14 @@
       "web",
       "security"
     ],
-    "signature_path": "/epr/tomcat/tomcat-1.0.0.zip.sig"
+    "signature_path": "/epr/tomcat/tomcat-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "tomcat.log",
+        "title": "Apache Tomcat logs"
+      }
+    ]
   },
   {
     "name": "tomcat",
@@ -268,7 +350,14 @@
       "web",
       "security"
     ],
-    "signature_path": "/epr/tomcat/tomcat-1.1.0.zip.sig"
+    "signature_path": "/epr/tomcat/tomcat-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "tomcat.log",
+        "title": "Apache Tomcat logs"
+      }
+    ]
   },
   {
     "name": "tomcat",
@@ -307,7 +396,14 @@
       "web",
       "security"
     ],
-    "signature_path": "/epr/tomcat/tomcat-1.1.4.zip.sig"
+    "signature_path": "/epr/tomcat/tomcat-1.1.4.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "tomcat.log",
+        "title": "Apache Tomcat logs"
+      }
+    ]
   },
   {
     "name": "tomcat",
@@ -346,7 +442,14 @@
       "web",
       "security"
     ],
-    "signature_path": "/epr/tomcat/tomcat-1.2.0.zip.sig"
+    "signature_path": "/epr/tomcat/tomcat-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "tomcat.log",
+        "title": "Apache Tomcat logs"
+      }
+    ]
   },
   {
     "name": "tomcat",
@@ -385,7 +488,14 @@
       "web",
       "security"
     ],
-    "signature_path": "/epr/tomcat/tomcat-1.2.1.zip.sig"
+    "signature_path": "/epr/tomcat/tomcat-1.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "tomcat.log",
+        "title": "Apache Tomcat logs"
+      }
+    ]
   },
   {
     "name": "tomcat",
@@ -424,7 +534,14 @@
       "web",
       "security"
     ],
-    "signature_path": "/epr/tomcat/tomcat-1.3.0.zip.sig"
+    "signature_path": "/epr/tomcat/tomcat-1.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "tomcat.log",
+        "title": "Apache Tomcat logs"
+      }
+    ]
   },
   {
     "name": "tomcat",
@@ -463,7 +580,14 @@
       "web",
       "security"
     ],
-    "signature_path": "/epr/tomcat/tomcat-1.3.1.zip.sig"
+    "signature_path": "/epr/tomcat/tomcat-1.3.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "tomcat.log",
+        "title": "Apache Tomcat logs"
+      }
+    ]
   },
   {
     "name": "atlassian_bitbucket",
@@ -502,7 +626,14 @@
       "security",
       "web"
     ],
-    "signature_path": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.0.0.zip.sig"
+    "signature_path": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_bitbucket.audit",
+        "title": "Bitbucket Audit Logs"
+      }
+    ]
   },
   {
     "name": "atlassian_bitbucket",
@@ -541,7 +672,14 @@
       "security",
       "web"
     ],
-    "signature_path": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.0.1.zip.sig"
+    "signature_path": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_bitbucket.audit",
+        "title": "Bitbucket Audit Logs"
+      }
+    ]
   },
   {
     "name": "atlassian_bitbucket",
@@ -580,7 +718,14 @@
       "security",
       "web"
     ],
-    "signature_path": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.1.0.zip.sig"
+    "signature_path": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_bitbucket.audit",
+        "title": "Bitbucket Audit Logs"
+      }
+    ]
   },
   {
     "name": "atlassian_bitbucket",
@@ -619,7 +764,14 @@
       "security",
       "web"
     ],
-    "signature_path": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.1.1.zip.sig"
+    "signature_path": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_bitbucket.audit",
+        "title": "Bitbucket Audit Logs"
+      }
+    ]
   },
   {
     "name": "atlassian_bitbucket",
@@ -658,7 +810,14 @@
       "security",
       "web"
     ],
-    "signature_path": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.2.1.zip.sig"
+    "signature_path": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_bitbucket.audit",
+        "title": "Bitbucket Audit Logs"
+      }
+    ]
   },
   {
     "name": "atlassian_confluence",
@@ -697,7 +856,14 @@
       "security",
       "web"
     ],
-    "signature_path": "/epr/atlassian_confluence/atlassian_confluence-1.0.1.zip.sig"
+    "signature_path": "/epr/atlassian_confluence/atlassian_confluence-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_confluence.audit",
+        "title": "Confluence Audit Logs"
+      }
+    ]
   },
   {
     "name": "atlassian_confluence",
@@ -736,7 +902,14 @@
       "security",
       "web"
     ],
-    "signature_path": "/epr/atlassian_confluence/atlassian_confluence-1.1.0.zip.sig"
+    "signature_path": "/epr/atlassian_confluence/atlassian_confluence-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_confluence.audit",
+        "title": "Confluence Audit Logs"
+      }
+    ]
   },
   {
     "name": "atlassian_confluence",
@@ -775,7 +948,14 @@
       "security",
       "web"
     ],
-    "signature_path": "/epr/atlassian_confluence/atlassian_confluence-1.1.1.zip.sig"
+    "signature_path": "/epr/atlassian_confluence/atlassian_confluence-1.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_confluence.audit",
+        "title": "Confluence Audit Logs"
+      }
+    ]
   },
   {
     "name": "atlassian_confluence",
@@ -814,7 +994,14 @@
       "security",
       "web"
     ],
-    "signature_path": "/epr/atlassian_confluence/atlassian_confluence-1.1.2.zip.sig"
+    "signature_path": "/epr/atlassian_confluence/atlassian_confluence-1.1.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_confluence.audit",
+        "title": "Confluence Audit Logs"
+      }
+    ]
   },
   {
     "name": "atlassian_confluence",
@@ -853,7 +1040,14 @@
       "security",
       "web"
     ],
-    "signature_path": "/epr/atlassian_confluence/atlassian_confluence-1.3.0.zip.sig"
+    "signature_path": "/epr/atlassian_confluence/atlassian_confluence-1.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_confluence.audit",
+        "title": "Confluence Audit Logs"
+      }
+    ]
   },
   {
     "name": "atlassian_jira",
@@ -892,7 +1086,14 @@
       "security",
       "web"
     ],
-    "signature_path": "/epr/atlassian_jira/atlassian_jira-1.0.0.zip.sig"
+    "signature_path": "/epr/atlassian_jira/atlassian_jira-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_jira.audit",
+        "title": "Jira Audit Logs"
+      }
+    ]
   },
   {
     "name": "atlassian_jira",
@@ -931,7 +1132,14 @@
       "security",
       "web"
     ],
-    "signature_path": "/epr/atlassian_jira/atlassian_jira-1.0.1.zip.sig"
+    "signature_path": "/epr/atlassian_jira/atlassian_jira-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_jira.audit",
+        "title": "Jira Audit Logs"
+      }
+    ]
   },
   {
     "name": "atlassian_jira",
@@ -970,7 +1178,14 @@
       "security",
       "web"
     ],
-    "signature_path": "/epr/atlassian_jira/atlassian_jira-1.1.0.zip.sig"
+    "signature_path": "/epr/atlassian_jira/atlassian_jira-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_jira.audit",
+        "title": "Jira Audit Logs"
+      }
+    ]
   },
   {
     "name": "atlassian_jira",
@@ -1009,7 +1224,14 @@
       "security",
       "web"
     ],
-    "signature_path": "/epr/atlassian_jira/atlassian_jira-1.1.1.zip.sig"
+    "signature_path": "/epr/atlassian_jira/atlassian_jira-1.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_jira.audit",
+        "title": "Jira Audit Logs"
+      }
+    ]
   },
   {
     "name": "atlassian_jira",
@@ -1048,7 +1270,14 @@
       "security",
       "web"
     ],
-    "signature_path": "/epr/atlassian_jira/atlassian_jira-1.1.2.zip.sig"
+    "signature_path": "/epr/atlassian_jira/atlassian_jira-1.1.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_jira.audit",
+        "title": "Jira Audit Logs"
+      }
+    ]
   },
   {
     "name": "atlassian_jira",
@@ -1087,7 +1316,14 @@
       "security",
       "web"
     ],
-    "signature_path": "/epr/atlassian_jira/atlassian_jira-1.2.0.zip.sig"
+    "signature_path": "/epr/atlassian_jira/atlassian_jira-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_jira.audit",
+        "title": "Jira Audit Logs"
+      }
+    ]
   },
   {
     "name": "atlassian_jira",
@@ -1126,7 +1362,14 @@
       "security",
       "web"
     ],
-    "signature_path": "/epr/atlassian_jira/atlassian_jira-1.3.0.zip.sig"
+    "signature_path": "/epr/atlassian_jira/atlassian_jira-1.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_jira.audit",
+        "title": "Jira Audit Logs"
+      }
+    ]
   },
   {
     "name": "azure_application_insights",
@@ -1188,7 +1431,19 @@
       "azure",
       "web"
     ],
-    "signature_path": "/epr/azure_application_insights/azure_application_insights-1.0.0.zip.sig"
+    "signature_path": "/epr/azure_application_insights/azure_application_insights-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "azure.app_insights",
+        "title": "Azure Application Insights"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.app_state",
+        "title": "Azure Application State"
+      }
+    ]
   },
   {
     "name": "azure_application_insights",
@@ -1250,7 +1505,19 @@
       "azure",
       "web"
     ],
-    "signature_path": "/epr/azure_application_insights/azure_application_insights-1.0.1.zip.sig"
+    "signature_path": "/epr/azure_application_insights/azure_application_insights-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "azure.app_insights",
+        "title": "Azure Application Insights"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.app_state",
+        "title": "Azure Application State"
+      }
+    ]
   },
   {
     "name": "azure_metrics",
@@ -1396,7 +1663,49 @@
       "azure",
       "web"
     ],
-    "signature_path": "/epr/azure_metrics/azure_metrics-1.0.0.zip.sig"
+    "signature_path": "/epr/azure_metrics/azure_metrics-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "azure.compute_vm",
+        "title": "Compute VM"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.compute_vm_scaleset",
+        "title": "Compute VM Scaleset"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.container_instance",
+        "title": "Container Instance"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.container_registry",
+        "title": "Container Registry"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.container_service",
+        "title": "Container Service"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.database_account",
+        "title": "Database Account"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.monitor",
+        "title": "Monitor"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.storage_account",
+        "title": "Storage Account"
+      }
+    ]
   },
   {
     "name": "azure_metrics",
@@ -1542,7 +1851,49 @@
       "azure",
       "web"
     ],
-    "signature_path": "/epr/azure_metrics/azure_metrics-1.0.1.zip.sig"
+    "signature_path": "/epr/azure_metrics/azure_metrics-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "azure.compute_vm",
+        "title": "Compute VM"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.compute_vm_scaleset",
+        "title": "Compute VM Scaleset"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.container_instance",
+        "title": "Container Instance"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.container_registry",
+        "title": "Container Registry"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.container_service",
+        "title": "Container Service"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.database_account",
+        "title": "Database Account"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.monitor",
+        "title": "Monitor"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.storage_account",
+        "title": "Storage Account"
+      }
+    ]
   },
   {
     "name": "azure_metrics",
@@ -1688,7 +2039,49 @@
       "azure",
       "web"
     ],
-    "signature_path": "/epr/azure_metrics/azure_metrics-1.0.3.zip.sig"
+    "signature_path": "/epr/azure_metrics/azure_metrics-1.0.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "azure.compute_vm",
+        "title": "Compute VM"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.compute_vm_scaleset",
+        "title": "Compute VM Scaleset"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.container_instance",
+        "title": "Container Instance"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.container_registry",
+        "title": "Container Registry"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.container_service",
+        "title": "Container Service"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.database_account",
+        "title": "Database Account"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.monitor",
+        "title": "Monitor"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.storage_account",
+        "title": "Storage Account"
+      }
+    ]
   },
   {
     "name": "cloudflare",
@@ -1728,7 +2121,14 @@
       "network",
       "web"
     ],
-    "signature_path": "/epr/cloudflare/cloudflare-1.0.2.zip.sig"
+    "signature_path": "/epr/cloudflare/cloudflare-1.0.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cloudflare.logpull",
+        "title": "Cloudflare Logpull"
+      }
+    ]
   },
   {
     "name": "cloudflare",
@@ -1768,7 +2168,14 @@
       "network",
       "web"
     ],
-    "signature_path": "/epr/cloudflare/cloudflare-1.0.3.zip.sig"
+    "signature_path": "/epr/cloudflare/cloudflare-1.0.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cloudflare.logpull",
+        "title": "Cloudflare Logpull"
+      }
+    ]
   },
   {
     "name": "cloudflare",
@@ -1808,7 +2215,14 @@
       "network",
       "web"
     ],
-    "signature_path": "/epr/cloudflare/cloudflare-1.1.0.zip.sig"
+    "signature_path": "/epr/cloudflare/cloudflare-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cloudflare.logpull",
+        "title": "Cloudflare Logpull"
+      }
+    ]
   },
   {
     "name": "cloudflare",
@@ -1849,7 +2263,19 @@
       "web",
       "cloud"
     ],
-    "signature_path": "/epr/cloudflare/cloudflare-1.2.1.zip.sig"
+    "signature_path": "/epr/cloudflare/cloudflare-1.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cloudflare.audit",
+        "title": "Cloudflare Audit Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "cloudflare.logpull",
+        "title": "Cloudflare Logpull"
+      }
+    ]
   },
   {
     "name": "cloudflare",
@@ -1890,7 +2316,19 @@
       "web",
       "cloud"
     ],
-    "signature_path": "/epr/cloudflare/cloudflare-1.3.0.zip.sig"
+    "signature_path": "/epr/cloudflare/cloudflare-1.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cloudflare.audit",
+        "title": "Cloudflare Audit Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "cloudflare.logpull",
+        "title": "Cloudflare Logpull"
+      }
+    ]
   },
   {
     "name": "cloudflare",
@@ -1931,7 +2369,19 @@
       "web",
       "cloud"
     ],
-    "signature_path": "/epr/cloudflare/cloudflare-1.3.1.zip.sig"
+    "signature_path": "/epr/cloudflare/cloudflare-1.3.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cloudflare.audit",
+        "title": "Cloudflare Audit Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "cloudflare.logpull",
+        "title": "Cloudflare Logpull"
+      }
+    ]
   },
   {
     "name": "cloudflare",
@@ -1972,7 +2422,19 @@
       "web",
       "cloud"
     ],
-    "signature_path": "/epr/cloudflare/cloudflare-1.3.2.zip.sig"
+    "signature_path": "/epr/cloudflare/cloudflare-1.3.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cloudflare.audit",
+        "title": "Cloudflare Audit Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "cloudflare.logpull",
+        "title": "Cloudflare Logpull"
+      }
+    ]
   },
   {
     "name": "cloudflare",
@@ -2013,7 +2475,19 @@
       "web",
       "cloud"
     ],
-    "signature_path": "/epr/cloudflare/cloudflare-1.4.2.zip.sig"
+    "signature_path": "/epr/cloudflare/cloudflare-1.4.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cloudflare.audit",
+        "title": "Cloudflare Audit Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "cloudflare.logpull",
+        "title": "Cloudflare Logpull"
+      }
+    ]
   },
   {
     "name": "cloudflare",
@@ -2054,7 +2528,19 @@
       "web",
       "cloud"
     ],
-    "signature_path": "/epr/cloudflare/cloudflare-2.0.0.zip.sig"
+    "signature_path": "/epr/cloudflare/cloudflare-2.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cloudflare.audit",
+        "title": "Cloudflare Audit Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "cloudflare.logpull",
+        "title": "Cloudflare Logpull"
+      }
+    ]
   },
   {
     "name": "keycloak",
@@ -2094,7 +2580,14 @@
       "network",
       "web"
     ],
-    "signature_path": "/epr/keycloak/keycloak-1.0.0.zip.sig"
+    "signature_path": "/epr/keycloak/keycloak-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "keycloak.log",
+        "title": "Keycloak"
+      }
+    ]
   },
   {
     "name": "keycloak",
@@ -2134,7 +2627,14 @@
       "network",
       "web"
     ],
-    "signature_path": "/epr/keycloak/keycloak-1.1.0.zip.sig"
+    "signature_path": "/epr/keycloak/keycloak-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "keycloak.log",
+        "title": "Keycloak"
+      }
+    ]
   },
   {
     "name": "keycloak",
@@ -2174,7 +2674,14 @@
       "network",
       "web"
     ],
-    "signature_path": "/epr/keycloak/keycloak-1.2.0.zip.sig"
+    "signature_path": "/epr/keycloak/keycloak-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "keycloak.log",
+        "title": "Keycloak"
+      }
+    ]
   },
   {
     "name": "keycloak",
@@ -2214,7 +2721,14 @@
       "network",
       "web"
     ],
-    "signature_path": "/epr/keycloak/keycloak-1.2.1.zip.sig"
+    "signature_path": "/epr/keycloak/keycloak-1.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "keycloak.log",
+        "title": "Keycloak"
+      }
+    ]
   },
   {
     "name": "mattermost",
@@ -2253,7 +2767,14 @@
       "security",
       "web"
     ],
-    "signature_path": "/epr/mattermost/mattermost-1.0.0.zip.sig"
+    "signature_path": "/epr/mattermost/mattermost-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "mattermost.audit",
+        "title": "Audit Logs"
+      }
+    ]
   },
   {
     "name": "mattermost",
@@ -2292,7 +2813,14 @@
       "security",
       "web"
     ],
-    "signature_path": "/epr/mattermost/mattermost-1.1.0.zip.sig"
+    "signature_path": "/epr/mattermost/mattermost-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "mattermost.audit",
+        "title": "Audit Logs"
+      }
+    ]
   },
   {
     "name": "mattermost",
@@ -2331,7 +2859,14 @@
       "security",
       "web"
     ],
-    "signature_path": "/epr/mattermost/mattermost-1.1.1.zip.sig"
+    "signature_path": "/epr/mattermost/mattermost-1.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "mattermost.audit",
+        "title": "Audit Logs"
+      }
+    ]
   },
   {
     "name": "nginx",
@@ -2370,7 +2905,24 @@
       "web",
       "security"
     ],
-    "signature_path": "/epr/nginx/nginx-1.1.0.zip.sig"
+    "signature_path": "/epr/nginx/nginx-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "nginx.access",
+        "title": "Nginx access logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "nginx.error",
+        "title": "Nginx error logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "nginx.stubstatus",
+        "title": "Nginx stubstatus metrics"
+      }
+    ]
   },
   {
     "name": "nginx",
@@ -2409,7 +2961,24 @@
       "web",
       "security"
     ],
-    "signature_path": "/epr/nginx/nginx-1.2.0.zip.sig"
+    "signature_path": "/epr/nginx/nginx-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "nginx.access",
+        "title": "Nginx access logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "nginx.error",
+        "title": "Nginx error logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "nginx.stubstatus",
+        "title": "Nginx stubstatus metrics"
+      }
+    ]
   },
   {
     "name": "nginx",
@@ -2448,7 +3017,24 @@
       "web",
       "security"
     ],
-    "signature_path": "/epr/nginx/nginx-1.2.1.zip.sig"
+    "signature_path": "/epr/nginx/nginx-1.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "nginx.access",
+        "title": "Nginx access logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "nginx.error",
+        "title": "Nginx error logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "nginx.stubstatus",
+        "title": "Nginx stubstatus metrics"
+      }
+    ]
   },
   {
     "name": "nginx",
@@ -2487,7 +3073,24 @@
       "web",
       "security"
     ],
-    "signature_path": "/epr/nginx/nginx-1.3.1.zip.sig"
+    "signature_path": "/epr/nginx/nginx-1.3.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "nginx.access",
+        "title": "Nginx access logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "nginx.error",
+        "title": "Nginx error logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "nginx.stubstatus",
+        "title": "Nginx stubstatus metrics"
+      }
+    ]
   },
   {
     "name": "nginx_ingress_controller",
@@ -2526,7 +3129,19 @@
       "web",
       "security"
     ],
-    "signature_path": "/epr/nginx_ingress_controller/nginx_ingress_controller-1.0.0.zip.sig"
+    "signature_path": "/epr/nginx_ingress_controller/nginx_ingress_controller-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "nginx_ingress_controller.access",
+        "title": "Nginx Ingress Controller access logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "nginx_ingress_controller.error",
+        "title": "Nginx Ingress Controller error logs"
+      }
+    ]
   },
   {
     "name": "nginx_ingress_controller",
@@ -2565,7 +3180,19 @@
       "web",
       "security"
     ],
-    "signature_path": "/epr/nginx_ingress_controller/nginx_ingress_controller-1.2.0.zip.sig"
+    "signature_path": "/epr/nginx_ingress_controller/nginx_ingress_controller-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "nginx_ingress_controller.access",
+        "title": "Nginx Ingress Controller access logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "nginx_ingress_controller.error",
+        "title": "Nginx Ingress Controller error logs"
+      }
+    ]
   },
   {
     "name": "traefik",
@@ -2604,7 +3231,19 @@
       "web",
       "security"
     ],
-    "signature_path": "/epr/traefik/traefik-1.1.0.zip.sig"
+    "signature_path": "/epr/traefik/traefik-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "traefik.access",
+        "title": "Traefik access logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "traefik.health",
+        "title": "Traefik health metrics"
+      }
+    ]
   },
   {
     "name": "traefik",
@@ -2643,6 +3282,18 @@
       "web",
       "security"
     ],
-    "signature_path": "/epr/traefik/traefik-1.2.0.zip.sig"
+    "signature_path": "/epr/traefik/traefik-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "traefik.access",
+        "title": "Traefik access logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "traefik.health",
+        "title": "Traefik health metrics"
+      }
+    ]
   }
 ]

--- a/testdata/generated/storage-indexer/search-category-web.json
+++ b/testdata/generated/storage-indexer/search-category-web.json
@@ -38,7 +38,14 @@
       "web",
       "cloud"
     ],
-    "signature_path": "/epr/akamai/akamai-1.0.0.zip.sig"
+    "signature_path": "/epr/akamai/akamai-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "akamai.siem",
+        "title": "Akamai SIEM Logs"
+      }
+    ]
   },
   {
     "name": "apache",
@@ -76,7 +83,24 @@
     "categories": [
       "web"
     ],
-    "signature_path": "/epr/apache/apache-1.3.5.zip.sig"
+    "signature_path": "/epr/apache/apache-1.3.5.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "apache.access",
+        "title": "Apache access logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "apache.error",
+        "title": "Apache error logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apache.status",
+        "title": "Apache status metrics"
+      }
+    ]
   },
   {
     "name": "tomcat",
@@ -115,7 +139,14 @@
       "web",
       "security"
     ],
-    "signature_path": "/epr/tomcat/tomcat-1.3.1.zip.sig"
+    "signature_path": "/epr/tomcat/tomcat-1.3.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "tomcat.log",
+        "title": "Apache Tomcat logs"
+      }
+    ]
   },
   {
     "name": "atlassian_bitbucket",
@@ -154,7 +185,14 @@
       "security",
       "web"
     ],
-    "signature_path": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.2.1.zip.sig"
+    "signature_path": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_bitbucket.audit",
+        "title": "Bitbucket Audit Logs"
+      }
+    ]
   },
   {
     "name": "atlassian_confluence",
@@ -193,7 +231,14 @@
       "security",
       "web"
     ],
-    "signature_path": "/epr/atlassian_confluence/atlassian_confluence-1.3.0.zip.sig"
+    "signature_path": "/epr/atlassian_confluence/atlassian_confluence-1.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_confluence.audit",
+        "title": "Confluence Audit Logs"
+      }
+    ]
   },
   {
     "name": "atlassian_jira",
@@ -232,7 +277,14 @@
       "security",
       "web"
     ],
-    "signature_path": "/epr/atlassian_jira/atlassian_jira-1.3.0.zip.sig"
+    "signature_path": "/epr/atlassian_jira/atlassian_jira-1.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_jira.audit",
+        "title": "Jira Audit Logs"
+      }
+    ]
   },
   {
     "name": "azure_application_insights",
@@ -294,7 +346,19 @@
       "azure",
       "web"
     ],
-    "signature_path": "/epr/azure_application_insights/azure_application_insights-1.0.1.zip.sig"
+    "signature_path": "/epr/azure_application_insights/azure_application_insights-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "azure.app_insights",
+        "title": "Azure Application Insights"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.app_state",
+        "title": "Azure Application State"
+      }
+    ]
   },
   {
     "name": "azure_metrics",
@@ -440,7 +504,49 @@
       "azure",
       "web"
     ],
-    "signature_path": "/epr/azure_metrics/azure_metrics-1.0.3.zip.sig"
+    "signature_path": "/epr/azure_metrics/azure_metrics-1.0.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "azure.compute_vm",
+        "title": "Compute VM"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.compute_vm_scaleset",
+        "title": "Compute VM Scaleset"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.container_instance",
+        "title": "Container Instance"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.container_registry",
+        "title": "Container Registry"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.container_service",
+        "title": "Container Service"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.database_account",
+        "title": "Database Account"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.monitor",
+        "title": "Monitor"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.storage_account",
+        "title": "Storage Account"
+      }
+    ]
   },
   {
     "name": "cloudflare",
@@ -481,7 +587,19 @@
       "web",
       "cloud"
     ],
-    "signature_path": "/epr/cloudflare/cloudflare-2.0.0.zip.sig"
+    "signature_path": "/epr/cloudflare/cloudflare-2.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cloudflare.audit",
+        "title": "Cloudflare Audit Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "cloudflare.logpull",
+        "title": "Cloudflare Logpull"
+      }
+    ]
   },
   {
     "name": "keycloak",
@@ -521,7 +639,14 @@
       "network",
       "web"
     ],
-    "signature_path": "/epr/keycloak/keycloak-1.2.1.zip.sig"
+    "signature_path": "/epr/keycloak/keycloak-1.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "keycloak.log",
+        "title": "Keycloak"
+      }
+    ]
   },
   {
     "name": "mattermost",
@@ -560,7 +685,14 @@
       "security",
       "web"
     ],
-    "signature_path": "/epr/mattermost/mattermost-1.1.1.zip.sig"
+    "signature_path": "/epr/mattermost/mattermost-1.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "mattermost.audit",
+        "title": "Audit Logs"
+      }
+    ]
   },
   {
     "name": "nginx",
@@ -599,7 +731,24 @@
       "web",
       "security"
     ],
-    "signature_path": "/epr/nginx/nginx-1.3.1.zip.sig"
+    "signature_path": "/epr/nginx/nginx-1.3.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "nginx.access",
+        "title": "Nginx access logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "nginx.error",
+        "title": "Nginx error logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "nginx.stubstatus",
+        "title": "Nginx stubstatus metrics"
+      }
+    ]
   },
   {
     "name": "nginx_ingress_controller",
@@ -638,7 +787,19 @@
       "web",
       "security"
     ],
-    "signature_path": "/epr/nginx_ingress_controller/nginx_ingress_controller-1.2.0.zip.sig"
+    "signature_path": "/epr/nginx_ingress_controller/nginx_ingress_controller-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "nginx_ingress_controller.access",
+        "title": "Nginx Ingress Controller access logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "nginx_ingress_controller.error",
+        "title": "Nginx Ingress Controller error logs"
+      }
+    ]
   },
   {
     "name": "traefik",
@@ -677,6 +838,18 @@
       "web",
       "security"
     ],
-    "signature_path": "/epr/traefik/traefik-1.2.0.zip.sig"
+    "signature_path": "/epr/traefik/traefik-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "traefik.access",
+        "title": "Traefik access logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "traefik.health",
+        "title": "Traefik health metrics"
+      }
+    ]
   }
 ]

--- a/testdata/generated/storage-indexer/search-kibana652.json
+++ b/testdata/generated/storage-indexer/search-kibana652.json
@@ -28,6 +28,13 @@
     "categories": [
       "custom"
     ],
-    "signature_path": "/epr/log/log-1.0.0.zip.sig"
+    "signature_path": "/epr/log/log-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "log.log",
+        "title": "Log Dataset"
+      }
+    ]
   }
 ]

--- a/testdata/generated/storage-indexer/search-kibana721.json
+++ b/testdata/generated/storage-indexer/search-kibana721.json
@@ -28,6 +28,13 @@
     "categories": [
       "custom"
     ],
-    "signature_path": "/epr/log/log-1.0.0.zip.sig"
+    "signature_path": "/epr/log/log-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "log.log",
+        "title": "Log Dataset"
+      }
+    ]
   }
 ]

--- a/testdata/generated/storage-indexer/search-kibana800.json
+++ b/testdata/generated/storage-indexer/search-kibana800.json
@@ -35,7 +35,19 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/1password/1password-1.4.0.zip.sig"
+    "signature_path": "/epr/1password/1password-1.4.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "1password.item_usages",
+        "title": "Collect 1Password item usages events"
+      },
+      {
+        "type": "logs",
+        "dataset": "1password.signin_attempts",
+        "title": "1Password sign-in attempt events"
+      }
+    ]
   },
   {
     "name": "aws",
@@ -410,7 +422,154 @@
       "aws",
       "cloud"
     ],
-    "signature_path": "/epr/aws/aws-1.16.4.zip.sig"
+    "signature_path": "/epr/aws/aws-1.16.4.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "aws.billing",
+        "title": "AWS Billing Metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.cloudfront_logs",
+        "title": "AWS CloudFront logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.cloudtrail",
+        "title": "AWS CloudTrail Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.cloudwatch_logs",
+        "title": "AWS CloudWatch logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.cloudwatch_metrics",
+        "title": "AWS CloudWatch metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.dynamodb",
+        "title": "AWS DynamoDB metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.ebs",
+        "title": "AWS EBS metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.ec2_logs",
+        "title": "AWS EC2 logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.ec2_metrics",
+        "title": "AWS EC2 metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.elb_logs",
+        "title": "AWS ELB logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.elb_metrics",
+        "title": "AWS ELB metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.firewall_logs",
+        "title": "AWS Network Firewall logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.firewall_metrics",
+        "title": "AWS Network Firewall metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.lambda",
+        "title": "AWS Lambda metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.natgateway",
+        "title": "AWS NAT gateway metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.rds",
+        "title": "AWS RDS metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.route53_public_logs",
+        "title": "AWS Route 53 Public Zone Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.route53_resolver_logs",
+        "title": "AWS Route 53 Resolver Query Logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.s3_daily_storage",
+        "title": "AWS S3 daily storage metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.s3_request",
+        "title": "AWS S3 request metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.s3_storage_lens",
+        "title": "AWS S3 Storage Lens metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.s3access",
+        "title": "AWS s3access logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.sns",
+        "title": "AWS SNS metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.sqs",
+        "title": "AWS SQS metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.transitgateway",
+        "title": "AWS Transit Gateway metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.usage",
+        "title": "AWS usage metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.vpcflow",
+        "title": "AWS vpcflow logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.vpn",
+        "title": "AWS VPN metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.waf",
+        "title": "AWS WAF logs"
+      }
+    ]
   },
   {
     "name": "ti_abusech",
@@ -448,7 +607,24 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/ti_abusech/ti_abusech-1.2.3.zip.sig"
+    "signature_path": "/epr/ti_abusech/ti_abusech-1.2.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_abusech.malware",
+        "title": "AbuseCH Malware logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "ti_abusech.malwarebazaar",
+        "title": "AbuseCH MalwareBazaar logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "ti_abusech.url",
+        "title": "AbuseCH URL logs"
+      }
+    ]
   },
   {
     "name": "akamai",
@@ -489,7 +665,14 @@
       "web",
       "cloud"
     ],
-    "signature_path": "/epr/akamai/akamai-1.0.0.zip.sig"
+    "signature_path": "/epr/akamai/akamai-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "akamai.siem",
+        "title": "Akamai SIEM Logs"
+      }
+    ]
   },
   {
     "name": "ti_otx",
@@ -527,7 +710,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/ti_otx/ti_otx-1.2.2.zip.sig"
+    "signature_path": "/epr/ti_otx/ti_otx-1.2.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_otx.threat",
+        "title": "Alienvault OTX logs"
+      }
+    ]
   },
   {
     "name": "ti_anomali",
@@ -565,7 +755,19 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/ti_anomali/ti_anomali-1.2.3.zip.sig"
+    "signature_path": "/epr/ti_anomali/ti_anomali-1.2.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_anomali.limo",
+        "title": "Anomali Limo"
+      },
+      {
+        "type": "logs",
+        "dataset": "ti_anomali.threatstream",
+        "title": "Anomali Threatstream"
+      }
+    ]
   },
   {
     "name": "apache",
@@ -603,7 +805,24 @@
     "categories": [
       "web"
     ],
-    "signature_path": "/epr/apache/apache-1.3.5.zip.sig"
+    "signature_path": "/epr/apache/apache-1.3.5.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "apache.access",
+        "title": "Apache access logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "apache.error",
+        "title": "Apache error logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apache.status",
+        "title": "Apache status metrics"
+      }
+    ]
   },
   {
     "name": "tomcat",
@@ -642,7 +861,14 @@
       "web",
       "security"
     ],
-    "signature_path": "/epr/tomcat/tomcat-1.3.1.zip.sig"
+    "signature_path": "/epr/tomcat/tomcat-1.3.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "tomcat.log",
+        "title": "Apache Tomcat logs"
+      }
+    ]
   },
   {
     "name": "atlassian_bitbucket",
@@ -681,7 +907,14 @@
       "security",
       "web"
     ],
-    "signature_path": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.2.1.zip.sig"
+    "signature_path": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_bitbucket.audit",
+        "title": "Bitbucket Audit Logs"
+      }
+    ]
   },
   {
     "name": "atlassian_confluence",
@@ -720,7 +953,14 @@
       "security",
       "web"
     ],
-    "signature_path": "/epr/atlassian_confluence/atlassian_confluence-1.3.0.zip.sig"
+    "signature_path": "/epr/atlassian_confluence/atlassian_confluence-1.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_confluence.audit",
+        "title": "Confluence Audit Logs"
+      }
+    ]
   },
   {
     "name": "atlassian_jira",
@@ -759,7 +999,14 @@
       "security",
       "web"
     ],
-    "signature_path": "/epr/atlassian_jira/atlassian_jira-1.3.0.zip.sig"
+    "signature_path": "/epr/atlassian_jira/atlassian_jira-1.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_jira.audit",
+        "title": "Jira Audit Logs"
+      }
+    ]
   },
   {
     "name": "auditd",
@@ -797,7 +1044,14 @@
     "categories": [
       "os_system"
     ],
-    "signature_path": "/epr/auditd/auditd-3.1.0.zip.sig"
+    "signature_path": "/epr/auditd/auditd-3.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "auditd.log",
+        "title": "Auditd logs"
+      }
+    ]
   },
   {
     "name": "auth0",
@@ -837,7 +1091,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/auth0/auth0-1.0.0.zip.sig"
+    "signature_path": "/epr/auth0/auth0-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "auth0.logs",
+        "title": "Auth0 logs via Webhooks"
+      }
+    ]
   },
   {
     "name": "azure_application_insights",
@@ -899,7 +1160,19 @@
       "azure",
       "web"
     ],
-    "signature_path": "/epr/azure_application_insights/azure_application_insights-1.0.1.zip.sig"
+    "signature_path": "/epr/azure_application_insights/azure_application_insights-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "azure.app_insights",
+        "title": "Azure Application Insights"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.app_state",
+        "title": "Azure Application State"
+      }
+    ]
   },
   {
     "name": "azure_billing",
@@ -946,7 +1219,14 @@
     "categories": [
       "azure"
     ],
-    "signature_path": "/epr/azure_billing/azure_billing-1.0.1.zip.sig"
+    "signature_path": "/epr/azure_billing/azure_billing-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "azure.billing",
+        "title": "Azure Billing Metrics"
+      }
+    ]
   },
   {
     "name": "azure",
@@ -1052,7 +1332,39 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/azure/azure-1.1.8.zip.sig"
+    "signature_path": "/epr/azure/azure-1.1.8.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "azure.activitylogs",
+        "title": "Azure Activity Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "azure.auditlogs",
+        "title": "Azure Audit Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "azure.eventhub",
+        "title": "Azure Event Hub Input"
+      },
+      {
+        "type": "logs",
+        "dataset": "azure.platformlogs",
+        "title": "Azure Platform Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "azure.signinlogs",
+        "title": "Azure Signin Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "azure.springcloudlogs",
+        "title": "Azure Spring Cloud Logs"
+      }
+    ]
   },
   {
     "name": "azure_metrics",
@@ -1198,7 +1510,49 @@
       "azure",
       "web"
     ],
-    "signature_path": "/epr/azure_metrics/azure_metrics-1.0.3.zip.sig"
+    "signature_path": "/epr/azure_metrics/azure_metrics-1.0.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "azure.compute_vm",
+        "title": "Compute VM"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.compute_vm_scaleset",
+        "title": "Compute VM Scaleset"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.container_instance",
+        "title": "Container Instance"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.container_registry",
+        "title": "Container Registry"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.container_service",
+        "title": "Container Service"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.database_account",
+        "title": "Database Account"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.monitor",
+        "title": "Monitor"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.storage_account",
+        "title": "Storage Account"
+      }
+    ]
   },
   {
     "name": "cef",
@@ -1228,7 +1582,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/cef/cef-2.0.0.zip.sig"
+    "signature_path": "/epr/cef/cef-2.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cef.log",
+        "title": "CEF log logs"
+      }
+    ]
   },
   {
     "name": "cassandra",
@@ -1267,7 +1628,19 @@
       "datastore",
       "monitoring"
     ],
-    "signature_path": "/epr/cassandra/cassandra-1.1.0.zip.sig"
+    "signature_path": "/epr/cassandra/cassandra-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cassandra.log",
+        "title": "Cassandra System Logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "cassandra.metrics",
+        "title": "metrics"
+      }
+    ]
   },
   {
     "name": "checkpoint",
@@ -1305,7 +1678,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/checkpoint/checkpoint-1.5.0.zip.sig"
+    "signature_path": "/epr/checkpoint/checkpoint-1.5.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "checkpoint.firewall",
+        "title": "Check Point firewall logs"
+      }
+    ]
   },
   {
     "name": "cisco_asa",
@@ -1344,7 +1724,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/cisco_asa/cisco_asa-2.4.1.zip.sig"
+    "signature_path": "/epr/cisco_asa/cisco_asa-2.4.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco_asa.log",
+        "title": "Cisco ASA logs"
+      }
+    ]
   },
   {
     "name": "cisco_duo",
@@ -1382,7 +1769,34 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/cisco_duo/cisco_duo-1.2.4.zip.sig"
+    "signature_path": "/epr/cisco_duo/cisco_duo-1.2.4.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco_duo.admin",
+        "title": "Cisco Duo administrator logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "cisco_duo.auth",
+        "title": "Cisco Duo authentication logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "cisco_duo.offline_enrollment",
+        "title": "Cisco Duo offline enrollment logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "cisco_duo.summary",
+        "title": "Cisco Duo summary logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "cisco_duo.telephony",
+        "title": "Cisco Duo telephony logs"
+      }
+    ]
   },
   {
     "name": "cisco_ftd",
@@ -1421,7 +1835,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/cisco_ftd/cisco_ftd-2.2.1.zip.sig"
+    "signature_path": "/epr/cisco_ftd/cisco_ftd-2.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco_ftd.log",
+        "title": "Cisco FTD logs"
+      }
+    ]
   },
   {
     "name": "cisco_ios",
@@ -1460,7 +1881,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/cisco_ios/cisco_ios-1.6.0.zip.sig"
+    "signature_path": "/epr/cisco_ios/cisco_ios-1.6.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco_ios.log",
+        "title": "Cisco IOS logs"
+      }
+    ]
   },
   {
     "name": "cisco_secure_endpoint",
@@ -1499,7 +1927,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/cisco_secure_endpoint/cisco_secure_endpoint-2.4.1.zip.sig"
+    "signature_path": "/epr/cisco_secure_endpoint/cisco_secure_endpoint-2.4.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco_secure_endpoint.event",
+        "title": "Cisco Secure Endpoint logs"
+      }
+    ]
   },
   {
     "name": "cisco_umbrella",
@@ -1538,7 +1973,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/cisco_umbrella/cisco_umbrella-1.0.0.zip.sig"
+    "signature_path": "/epr/cisco_umbrella/cisco_umbrella-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco_umbrella.log",
+        "title": "Cisco Umbrella logs"
+      }
+    ]
   },
   {
     "name": "cloudflare",
@@ -1579,7 +2021,19 @@
       "web",
       "cloud"
     ],
-    "signature_path": "/epr/cloudflare/cloudflare-2.0.0.zip.sig"
+    "signature_path": "/epr/cloudflare/cloudflare-2.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cloudflare.audit",
+        "title": "Cloudflare Audit Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "cloudflare.logpull",
+        "title": "Cloudflare Logpull"
+      }
+    ]
   },
   {
     "name": "crowdstrike",
@@ -1617,7 +2071,19 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/crowdstrike/crowdstrike-1.3.3.zip.sig"
+    "signature_path": "/epr/crowdstrike/crowdstrike-1.3.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "crowdstrike.falcon",
+        "title": "Crowdstrike falcon logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "crowdstrike.fdr",
+        "title": "Falcon Data Replicator"
+      }
+    ]
   },
   {
     "name": "gcp_pubsub",
@@ -1657,7 +2123,14 @@
       "cloud",
       "custom"
     ],
-    "signature_path": "/epr/gcp_pubsub/gcp_pubsub-1.0.0.zip.sig"
+    "signature_path": "/epr/gcp_pubsub/gcp_pubsub-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "gcp_pubsub.generic",
+        "title": "Custom Google Pub/Sub Logs"
+      }
+    ]
   },
   {
     "name": "http_endpoint",
@@ -1693,7 +2166,14 @@
     "categories": [
       "custom"
     ],
-    "signature_path": "/epr/http_endpoint/http_endpoint-1.0.1.zip.sig"
+    "signature_path": "/epr/http_endpoint/http_endpoint-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "http_endpoint.generic",
+        "title": "Custom HTTP Endpoint Logs"
+      }
+    ]
   },
   {
     "name": "httpjson",
@@ -1722,7 +2202,14 @@
     "categories": [
       "custom"
     ],
-    "signature_path": "/epr/httpjson/httpjson-1.1.1.zip.sig"
+    "signature_path": "/epr/httpjson/httpjson-1.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "httpjson.generic",
+        "title": "Custom HTTPJSON Input"
+      }
+    ]
   },
   {
     "name": "log",
@@ -1753,7 +2240,14 @@
     "categories": [
       "custom"
     ],
-    "signature_path": "/epr/log/log-1.0.0.zip.sig"
+    "signature_path": "/epr/log/log-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "log.log",
+        "title": "Log Dataset"
+      }
+    ]
   },
   {
     "name": "tcp",
@@ -1789,7 +2283,14 @@
     "categories": [
       "custom"
     ],
-    "signature_path": "/epr/tcp/tcp-1.0.0.zip.sig"
+    "signature_path": "/epr/tcp/tcp-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "tcp.generic",
+        "title": "Custom TCP Logs"
+      }
+    ]
   },
   {
     "name": "udp",
@@ -1825,7 +2326,14 @@
     "categories": [
       "custom"
     ],
-    "signature_path": "/epr/udp/udp-1.0.1.zip.sig"
+    "signature_path": "/epr/udp/udp-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "udp.generic",
+        "title": "Custom UDP Logs"
+      }
+    ]
   },
   {
     "name": "winlog",
@@ -1861,7 +2369,14 @@
     "categories": [
       "custom"
     ],
-    "signature_path": "/epr/winlog/winlog-1.4.0.zip.sig"
+    "signature_path": "/epr/winlog/winlog-1.4.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "winlog.winlog",
+        "title": "Custom Windows Event Log Dataset"
+      }
+    ]
   },
   {
     "name": "cyberarkpas",
@@ -1899,7 +2414,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/cyberarkpas/cyberarkpas-2.4.2.zip.sig"
+    "signature_path": "/epr/cyberarkpas/cyberarkpas-2.4.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cyberarkpas.audit",
+        "title": "CyberArk PAS audit logs"
+      }
+    ]
   },
   {
     "name": "ti_cybersixgill",
@@ -1938,7 +2460,14 @@
       "security",
       "productivity"
     ],
-    "signature_path": "/epr/ti_cybersixgill/ti_cybersixgill-1.3.2.zip.sig"
+    "signature_path": "/epr/ti_cybersixgill/ti_cybersixgill-1.3.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_cybersixgill.threat",
+        "title": "Cybersixgill Darkfeed Logs"
+      }
+    ]
   },
   {
     "name": "docker",
@@ -1977,7 +2506,54 @@
       "containers",
       "os_system"
     ],
-    "signature_path": "/epr/docker/docker-1.2.0.zip.sig"
+    "signature_path": "/epr/docker/docker-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "docker.container",
+        "title": "Docker container metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "docker.cpu",
+        "title": "Docker cpu metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "docker.diskio",
+        "title": "Docker diskio metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "docker.event",
+        "title": "Docker event metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "docker.healthcheck",
+        "title": "Docker healthcheck metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "docker.image",
+        "title": "Docker image metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "docker.info",
+        "title": "Docker info metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "docker.memory",
+        "title": "Docker memory metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "docker.network",
+        "title": "Docker network metrics"
+      }
+    ]
   },
   {
     "name": "apm",
@@ -2016,7 +2592,49 @@
       "elastic_stack",
       "monitoring"
     ],
-    "signature_path": "/epr/apm/apm-8.0.0.zip.sig"
+    "signature_path": "/epr/apm/apm-8.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "apm.app",
+        "title": "APM application logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.app",
+        "title": "APM application metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "apm.error",
+        "title": "APM errors"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.internal",
+        "title": "APM internal metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.profiling",
+        "title": "APM profiles"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm.rum",
+        "title": "APM RUM traces"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm.sampled",
+        "title": "APM tail-sampled traces"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm",
+        "title": "APM traces"
+      }
+    ]
   },
   {
     "name": "elastic_agent",
@@ -2047,7 +2665,109 @@
     "categories": [
       "elastic_stack"
     ],
-    "signature_path": "/epr/elastic_agent/elastic_agent-1.3.1.zip.sig"
+    "signature_path": "/epr/elastic_agent/elastic_agent-1.3.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.apm_server",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.apm_server",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.auditbeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.auditbeat",
+        "title": "Elastic Agent Auditbeat Metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.elastic_agent",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.endpoint_security",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.endpoint_security",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.filebeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.filebeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.fleet_server",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.fleet_server",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.heartbeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.heartbeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.metricbeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.metricbeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.osquerybeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.osquerybeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.packetbeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.packetbeat",
+        "title": "Elastic Agent"
+      }
+    ]
   },
   {
     "name": "endpoint",
@@ -2084,7 +2804,74 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/endpoint/endpoint-8.2.0.zip.sig"
+    "signature_path": "/epr/endpoint/endpoint-8.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "endpoint.action.responses",
+        "title": "Endpoint Action Responses"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.actions",
+        "title": "Endpoint Actions"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.alerts",
+        "title": "Endpoint Alerts"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.diagnostic.collection",
+        "title": "Endpoint Alert Collection"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.file",
+        "title": "Endpoint File Events"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.library",
+        "title": "Endpoint Library and Driver Events"
+      },
+      {
+        "type": "metrics",
+        "dataset": "endpoint.metadata",
+        "title": "Endpoint Metadata"
+      },
+      {
+        "type": "metrics",
+        "dataset": "endpoint.metrics",
+        "title": "Endpoint Metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.network",
+        "title": "Endpoint Network Events"
+      },
+      {
+        "type": "metrics",
+        "dataset": "endpoint.policy",
+        "title": "Endpoint Policy Response"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.process",
+        "title": "Endpoint Process Events"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.registry",
+        "title": "Endpoint Registry Events"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.security",
+        "title": "Endpoint Security Events"
+      }
+    ]
   },
   {
     "name": "fireeye",
@@ -2124,7 +2911,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/fireeye/fireeye-1.3.1.zip.sig"
+    "signature_path": "/epr/fireeye/fireeye-1.3.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "fireeye.nx",
+        "title": "Fireeye NX"
+      }
+    ]
   },
   {
     "name": "fleet_server",
@@ -2200,7 +2994,29 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/fortinet/fortinet-1.6.1.zip.sig"
+    "signature_path": "/epr/fortinet/fortinet-1.6.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "fortinet.clientendpoint",
+        "title": "Fortinet FortiClient Endpoint Security logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "fortinet.firewall",
+        "title": "Fortinet firewall logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "fortinet.fortimail",
+        "title": "Fortinet FortiMail logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "fortinet.fortimanager",
+        "title": "Fortinet Manager/Analyzer logs"
+      }
+    ]
   },
   {
     "name": "github",
@@ -2238,7 +3054,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/github/github-1.0.0.zip.sig"
+    "signature_path": "/epr/github/github-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "github.audit",
+        "title": "GitHub Audit Logs"
+      }
+    ]
   },
   {
     "name": "gcp",
@@ -2279,7 +3102,29 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/gcp/gcp-1.9.0.zip.sig"
+    "signature_path": "/epr/gcp/gcp-1.9.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "gcp.audit",
+        "title": "Google Cloud Platform (GCP) audit logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "gcp.dns",
+        "title": "Google Cloud Platform (GCP) DNS logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "gcp.firewall",
+        "title": "Google Cloud Platform (GCP) firewall logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "gcp.vpcflow",
+        "title": "Google Cloud Platform (GCP) vpcflow logs"
+      }
+    ]
   },
   {
     "name": "santa",
@@ -2317,7 +3162,14 @@
       "security",
       "os_system"
     ],
-    "signature_path": "/epr/santa/santa-2.0.1.zip.sig"
+    "signature_path": "/epr/santa/santa-2.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "santa.log",
+        "title": "Google Santa log logs"
+      }
+    ]
   },
   {
     "name": "google_workspace",
@@ -2355,7 +3207,39 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/google_workspace/google_workspace-1.4.0.zip.sig"
+    "signature_path": "/epr/google_workspace/google_workspace-1.4.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "google_workspace.admin",
+        "title": "Admin logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "google_workspace.drive",
+        "title": "Drive logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "google_workspace.groups",
+        "title": "Groups logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "google_workspace.login",
+        "title": "Login logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "google_workspace.saml",
+        "title": "SAML logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "google_workspace.user_accounts",
+        "title": "User accounts logs"
+      }
+    ]
   },
   {
     "name": "hashicorp_vault",
@@ -2393,7 +3277,24 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/hashicorp_vault/hashicorp_vault-1.3.3.zip.sig"
+    "signature_path": "/epr/hashicorp_vault/hashicorp_vault-1.3.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "hashicorp_vault.audit",
+        "title": "Hashicorp Vault Audit Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "hashicorp_vault.log",
+        "title": "Hashicorp Vault Operational Logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "hashicorp_vault.metrics",
+        "title": "Hashicorp Vault Metrics"
+      }
+    ]
   },
   {
     "name": "hid_bravura_monitor",
@@ -2431,7 +3332,19 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/hid_bravura_monitor/hid_bravura_monitor-1.0.2.zip.sig"
+    "signature_path": "/epr/hid_bravura_monitor/hid_bravura_monitor-1.0.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "hid_bravura_monitor.log",
+        "title": "Hitachi ID Bravura Monitor"
+      },
+      {
+        "type": "logs",
+        "dataset": "hid_bravura_monitor.winlog",
+        "title": "Hitachi ID Security Fabric logs"
+      }
+    ]
   },
   {
     "name": "juniper",
@@ -2470,7 +3383,24 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/juniper/juniper-1.1.0.zip.sig"
+    "signature_path": "/epr/juniper/juniper-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "juniper.junos",
+        "title": "Juniper JUNOS logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "juniper.netscreen",
+        "title": "Netscreen logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "juniper.srx",
+        "title": "Juniper SRX logs"
+      }
+    ]
   },
   {
     "name": "juniper_srx",
@@ -2509,7 +3439,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/juniper_srx/juniper_srx-1.1.2.zip.sig"
+    "signature_path": "/epr/juniper_srx/juniper_srx-1.1.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "juniper_srx.log",
+        "title": "Juniper SRX logs"
+      }
+    ]
   },
   {
     "name": "kafka",
@@ -2547,7 +3484,29 @@
     "categories": [
       "message_queue"
     ],
-    "signature_path": "/epr/kafka/kafka-1.2.2.zip.sig"
+    "signature_path": "/epr/kafka/kafka-1.2.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "kafka.broker",
+        "title": "Kafka broker metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kafka.consumergroup",
+        "title": "Kafka consumergroup metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "kafka.log",
+        "title": "Kafka log logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kafka.partition",
+        "title": "Kafka partition metrics"
+      }
+    ]
   },
   {
     "name": "keycloak",
@@ -2587,7 +3546,14 @@
       "network",
       "web"
     ],
-    "signature_path": "/epr/keycloak/keycloak-1.2.1.zip.sig"
+    "signature_path": "/epr/keycloak/keycloak-1.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "keycloak.log",
+        "title": "Keycloak"
+      }
+    ]
   },
   {
     "name": "kubernetes",
@@ -2747,7 +3713,139 @@
       "containers",
       "kubernetes"
     ],
-    "signature_path": "/epr/kubernetes/kubernetes-1.17.2.zip.sig"
+    "signature_path": "/epr/kubernetes/kubernetes-1.17.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.apiserver",
+        "title": "Kubernetes API Server metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "kubernetes.audit_logs",
+        "title": "Kubernetes audit logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.container",
+        "title": "Kubernetes Container metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "kubernetes.container_logs",
+        "title": "Kubernetes container logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.controllermanager",
+        "title": "Kubernetes Controller Manager metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.event",
+        "title": "Kubernetes Event metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.node",
+        "title": "Kubernetes Node metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.pod",
+        "title": "Kubernetes Pod metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.proxy",
+        "title": "Kubernetes Proxy metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.scheduler",
+        "title": "Kubernetes Scheduler metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_container",
+        "title": "Kubernetes Container metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_cronjob",
+        "title": "Kubernetes Cronjob metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_daemonset",
+        "title": "Kubernetes Deamonset metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_deployment",
+        "title": "Kubernetes Deployment metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_job",
+        "title": "Kubernetes Job metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_node",
+        "title": "Kubernetes Node metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_persistentvolume",
+        "title": "Kubernetes PersistentVolume metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_persistentvolumeclaim",
+        "title": "Kubernetes PersistentVolumeClaim metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_pod",
+        "title": "Kubernetes Pod metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_replicaset",
+        "title": "Kubernetes state_replicaset metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_resourcequota",
+        "title": "Kubernetes ResourceQuota metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_service",
+        "title": "Kubernetes Service metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_statefulset",
+        "title": "Kubernetes StatefulSet metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_storageclass",
+        "title": "Kubernetes StorageClass metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.system",
+        "title": "Kubernetes System metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.volume",
+        "title": "Kubernetes Volume metrics"
+      }
+    ]
   },
   {
     "name": "m365_defender",
@@ -2787,7 +3885,14 @@
       "security",
       "azure"
     ],
-    "signature_path": "/epr/m365_defender/m365_defender-1.0.3.zip.sig"
+    "signature_path": "/epr/m365_defender/m365_defender-1.0.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "m365_defender.log",
+        "title": "M365 Defender Logs"
+      }
+    ]
   },
   {
     "name": "ti_misp",
@@ -2825,7 +3930,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/ti_misp/ti_misp-1.2.2.zip.sig"
+    "signature_path": "/epr/ti_misp/ti_misp-1.2.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_misp.threat",
+        "title": "MISP"
+      }
+    ]
   },
   {
     "name": "mattermost",
@@ -2864,7 +3976,14 @@
       "security",
       "web"
     ],
-    "signature_path": "/epr/mattermost/mattermost-1.1.1.zip.sig"
+    "signature_path": "/epr/mattermost/mattermost-1.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "mattermost.audit",
+        "title": "Audit Logs"
+      }
+    ]
   },
   {
     "name": "microsoft_dhcp",
@@ -2902,7 +4021,14 @@
     "categories": [
       "network"
     ],
-    "signature_path": "/epr/microsoft_dhcp/microsoft_dhcp-1.3.1.zip.sig"
+    "signature_path": "/epr/microsoft_dhcp/microsoft_dhcp-1.3.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "microsoft_dhcp.log",
+        "title": "Microsoft DHCP Logs"
+      }
+    ]
   },
   {
     "name": "microsoft_defender_endpoint",
@@ -2942,7 +4068,14 @@
       "security",
       "azure"
     ],
-    "signature_path": "/epr/microsoft_defender_endpoint/microsoft_defender_endpoint-2.1.0.zip.sig"
+    "signature_path": "/epr/microsoft_defender_endpoint/microsoft_defender_endpoint-2.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "microsoft_defender_endpoint.log",
+        "title": "Microsoft Defender for Endpoint logs"
+      }
+    ]
   },
   {
     "name": "mongodb",
@@ -2980,7 +4113,39 @@
     "categories": [
       "datastore"
     ],
-    "signature_path": "/epr/mongodb/mongodb-1.3.1.zip.sig"
+    "signature_path": "/epr/mongodb/mongodb-1.3.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "mongodb.collstats",
+        "title": "MongoDB collstats metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "mongodb.dbstats",
+        "title": "MongoDB dbstats metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "mongodb.log",
+        "title": "mongodb log logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "mongodb.metrics",
+        "title": "MongoDB metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "mongodb.replstatus",
+        "title": "MongoDB replstatus metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "mongodb.status",
+        "title": "MongoDB status metrics"
+      }
+    ]
   },
   {
     "name": "mysql",
@@ -3018,7 +4183,34 @@
     "categories": [
       "datastore"
     ],
-    "signature_path": "/epr/mysql/mysql-1.2.1.zip.sig"
+    "signature_path": "/epr/mysql/mysql-1.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "mysql.error",
+        "title": "MySQL error logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "mysql.galera_status",
+        "title": "MySQL galera_status metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "mysql.performance",
+        "title": "MySQL performance metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "mysql.slowlog",
+        "title": "MySQL slowlog logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "mysql.status",
+        "title": "MySQL status metrics"
+      }
+    ]
   },
   {
     "name": "mysql_enterprise",
@@ -3057,7 +4249,14 @@
       "security",
       "datastore"
     ],
-    "signature_path": "/epr/mysql_enterprise/mysql_enterprise-1.0.1.zip.sig"
+    "signature_path": "/epr/mysql_enterprise/mysql_enterprise-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "mysql_enterprise.audit",
+        "title": "MySQL Enterprise Audit Log"
+      }
+    ]
   },
   {
     "name": "nats",
@@ -3095,7 +4294,44 @@
     "categories": [
       "message_queue"
     ],
-    "signature_path": "/epr/nats/nats-1.2.0.zip.sig"
+    "signature_path": "/epr/nats/nats-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "nats.connection",
+        "title": "NATS connection metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "nats.connections",
+        "title": "NATS connections metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "nats.log",
+        "title": "NATS logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "nats.route",
+        "title": "NATS route metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "nats.routes",
+        "title": "NATS routes metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "nats.stats",
+        "title": "NATS stats metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "nats.subscriptions",
+        "title": "NATS subscriptions metrics"
+      }
+    ]
   },
   {
     "name": "netflow",
@@ -3125,7 +4361,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/netflow/netflow-1.4.2.zip.sig"
+    "signature_path": "/epr/netflow/netflow-1.4.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "netflow.log",
+        "title": "NetFlow logs"
+      }
+    ]
   },
   {
     "name": "nginx",
@@ -3164,7 +4407,24 @@
       "web",
       "security"
     ],
-    "signature_path": "/epr/nginx/nginx-1.3.1.zip.sig"
+    "signature_path": "/epr/nginx/nginx-1.3.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "nginx.access",
+        "title": "Nginx access logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "nginx.error",
+        "title": "Nginx error logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "nginx.stubstatus",
+        "title": "Nginx stubstatus metrics"
+      }
+    ]
   },
   {
     "name": "nginx_ingress_controller",
@@ -3203,7 +4463,19 @@
       "web",
       "security"
     ],
-    "signature_path": "/epr/nginx_ingress_controller/nginx_ingress_controller-1.2.0.zip.sig"
+    "signature_path": "/epr/nginx_ingress_controller/nginx_ingress_controller-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "nginx_ingress_controller.access",
+        "title": "Nginx Ingress Controller access logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "nginx_ingress_controller.error",
+        "title": "Nginx Ingress Controller error logs"
+      }
+    ]
   },
   {
     "name": "o365",
@@ -3241,7 +4513,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/o365/o365-1.4.3.zip.sig"
+    "signature_path": "/epr/o365/o365-1.4.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "o365.audit",
+        "title": "Office 365 audit logs"
+      }
+    ]
   },
   {
     "name": "okta",
@@ -3279,7 +4558,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/okta/okta-1.5.2.zip.sig"
+    "signature_path": "/epr/okta/okta-1.5.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "okta.system",
+        "title": "Okta system logs"
+      }
+    ]
   },
   {
     "name": "oracle",
@@ -3318,7 +4604,14 @@
       "security",
       "datastore"
     ],
-    "signature_path": "/epr/oracle/oracle-1.0.1.zip.sig"
+    "signature_path": "/epr/oracle/oracle-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "oracle.database_audit",
+        "title": "Oracle Audit Log"
+      }
+    ]
   },
   {
     "name": "osquery",
@@ -3357,7 +4650,14 @@
       "security",
       "os_system"
     ],
-    "signature_path": "/epr/osquery/osquery-1.2.1.zip.sig"
+    "signature_path": "/epr/osquery/osquery-1.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "osquery.result",
+        "title": "Osquery result logs"
+      }
+    ]
   },
   {
     "name": "osquery_manager",
@@ -3397,7 +4697,14 @@
       "os_system",
       "config_management"
     ],
-    "signature_path": "/epr/osquery_manager/osquery_manager-1.0.0.zip.sig"
+    "signature_path": "/epr/osquery_manager/osquery_manager-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "osquery_manager.result",
+        "title": "Osquery Manager queries"
+      }
+    ]
   },
   {
     "name": "panw_cortex_xdr",
@@ -3435,7 +4742,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/panw_cortex_xdr/panw_cortex_xdr-1.1.1.zip.sig"
+    "signature_path": "/epr/panw_cortex_xdr/panw_cortex_xdr-1.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "panw_cortex_xdr.alerts",
+        "title": "Palo Alto Cortex XDR API"
+      }
+    ]
   },
   {
     "name": "panw",
@@ -3473,7 +4787,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/panw/panw-1.5.3.zip.sig"
+    "signature_path": "/epr/panw/panw-1.5.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "panw.panos",
+        "title": "Palo Alto Networks PAN-OS firewall logs"
+      }
+    ]
   },
   {
     "name": "postgresql",
@@ -3511,7 +4832,34 @@
     "categories": [
       "datastore"
     ],
-    "signature_path": "/epr/postgresql/postgresql-1.2.0.zip.sig"
+    "signature_path": "/epr/postgresql/postgresql-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "postgresql.activity",
+        "title": "PostgreSQL activity metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "postgresql.bgwriter",
+        "title": "PostgreSQL bgwriter metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "postgresql.database",
+        "title": "PostgreSQL database metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "postgresql.log",
+        "title": "PostgreSQL logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "postgresql.statement",
+        "title": "PostgreSQL statement metrics"
+      }
+    ]
   },
   {
     "name": "security_detection_engine",
@@ -3579,7 +4927,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/qnap_nas/qnap_nas-1.1.1.zip.sig"
+    "signature_path": "/epr/qnap_nas/qnap_nas-1.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "qnap_nas.log",
+        "title": "QNAP NAS logs"
+      }
+    ]
   },
   {
     "name": "rabbitmq",
@@ -3617,7 +4972,34 @@
     "categories": [
       "message_queue"
     ],
-    "signature_path": "/epr/rabbitmq/rabbitmq-1.2.0.zip.sig"
+    "signature_path": "/epr/rabbitmq/rabbitmq-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "rabbitmq.connection",
+        "title": "RabbitMQ connection metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "rabbitmq.exchange",
+        "title": "RabbitMQ exchange metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "rabbitmq.log",
+        "title": "RabbitMQ application logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "rabbitmq.node",
+        "title": "RabbitMQ node metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "rabbitmq.queue",
+        "title": "RabbitMQ queue metrics"
+      }
+    ]
   },
   {
     "name": "redis",
@@ -3656,7 +5038,34 @@
       "datastore",
       "message_queue"
     ],
-    "signature_path": "/epr/redis/redis-1.2.0.zip.sig"
+    "signature_path": "/epr/redis/redis-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "redis.info",
+        "title": "Redis info metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "redis.key",
+        "title": "Redis key metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "redis.keyspace",
+        "title": "Redis keyspace metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "redis.log",
+        "title": "Redis application logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "redis.slowlog",
+        "title": "Redis slow logs"
+      }
+    ]
   },
   {
     "name": "stan",
@@ -3695,7 +5104,29 @@
       "message_queue",
       "kubernetes"
     ],
-    "signature_path": "/epr/stan/stan-1.2.0.zip.sig"
+    "signature_path": "/epr/stan/stan-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "stan.channels",
+        "title": "Stan channels metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "stan.log",
+        "title": "STAN logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "stan.stats",
+        "title": "Stan stats metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "stan.subscriptions",
+        "title": "Stan subscriptions metrics"
+      }
+    ]
   },
   {
     "name": "snyk",
@@ -3733,7 +5164,19 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/snyk/snyk-1.1.2.zip.sig"
+    "signature_path": "/epr/snyk/snyk-1.1.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "snyk.audit",
+        "title": "Collect Snyk Audit Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "snyk.vulnerabilities",
+        "title": "Collect Snyk Vulnerability Data"
+      }
+    ]
   },
   {
     "name": "sophos",
@@ -3771,7 +5214,19 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/sophos/sophos-1.2.2.zip.sig"
+    "signature_path": "/epr/sophos/sophos-1.2.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "sophos.utm",
+        "title": "Sophos UTM logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "sophos.xg",
+        "title": "Sophos XG logs"
+      }
+    ]
   },
   {
     "name": "suricata",
@@ -3810,7 +5265,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/suricata/suricata-1.6.1.zip.sig"
+    "signature_path": "/epr/suricata/suricata-1.6.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "suricata.eve",
+        "title": "Suricata eve logs"
+      }
+    ]
   },
   {
     "name": "system",
@@ -3849,7 +5311,94 @@
       "os_system",
       "security"
     ],
-    "signature_path": "/epr/system/system-1.6.4.zip.sig"
+    "signature_path": "/epr/system/system-1.6.4.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "system.application",
+        "title": "Windows Application Events"
+      },
+      {
+        "type": "logs",
+        "dataset": "system.auth",
+        "title": "System auth logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.core",
+        "title": "System core metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.cpu",
+        "title": "System cpu metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.diskio",
+        "title": "System diskio metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.filesystem",
+        "title": "System filesystem metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.fsstat",
+        "title": "System fsstat metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.load",
+        "title": "System load metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.memory",
+        "title": "System memory metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.network",
+        "title": "System network metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.process",
+        "title": "System process metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.process.summary",
+        "title": "System process_summary metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "system.security",
+        "title": "Security logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.socket_summary",
+        "title": "System socket_summary metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "system.syslog",
+        "title": "System syslog logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "system.system",
+        "title": "Windows System Events"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.uptime",
+        "title": "System uptime metrics"
+      }
+    ]
   },
   {
     "name": "tenable_sc",
@@ -3887,7 +5436,24 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/tenable_sc/tenable_sc-1.0.0.zip.sig"
+    "signature_path": "/epr/tenable_sc/tenable_sc-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "tenable_sc.asset",
+        "title": "Tenable.sc asset logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "tenable_sc.plugin",
+        "title": "Tenable.sc plugin logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "tenable_sc.vulnerability",
+        "title": "Tenable.sc vulnerability logs"
+      }
+    ]
   },
   {
     "name": "ti_threatq",
@@ -3925,7 +5491,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/ti_threatq/ti_threatq-1.2.2.zip.sig"
+    "signature_path": "/epr/ti_threatq/ti_threatq-1.2.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_threatq.threat",
+        "title": "ThreatQ"
+      }
+    ]
   },
   {
     "name": "traefik",
@@ -3964,7 +5537,19 @@
       "web",
       "security"
     ],
-    "signature_path": "/epr/traefik/traefik-1.2.0.zip.sig"
+    "signature_path": "/epr/traefik/traefik-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "traefik.access",
+        "title": "Traefik access logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "traefik.health",
+        "title": "Traefik health metrics"
+      }
+    ]
   },
   {
     "name": "carbon_black_cloud",
@@ -4002,7 +5587,34 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/carbon_black_cloud/carbon_black_cloud-1.0.2.zip.sig"
+    "signature_path": "/epr/carbon_black_cloud/carbon_black_cloud-1.0.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.alert",
+        "title": "Alert"
+      },
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.asset_vulnerability_summary",
+        "title": "Asset Vulnerability Summary"
+      },
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.audit",
+        "title": "Audit"
+      },
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.endpoint_event",
+        "title": "Endpoint Event"
+      },
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.watchlist_hit",
+        "title": "Watchlist Hit"
+      }
+    ]
   },
   {
     "name": "carbonblack_edr",
@@ -4040,7 +5652,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/carbonblack_edr/carbonblack_edr-1.2.0.zip.sig"
+    "signature_path": "/epr/carbonblack_edr/carbonblack_edr-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "carbonblack_edr.log",
+        "title": "Carbon Black EDR logs"
+      }
+    ]
   },
   {
     "name": "windows",
@@ -4079,7 +5698,39 @@
       "os_system",
       "security"
     ],
-    "signature_path": "/epr/windows/windows-1.5.0.zip.sig"
+    "signature_path": "/epr/windows/windows-1.5.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "windows.forwarded",
+        "title": "Windows forwarded events"
+      },
+      {
+        "type": "metrics",
+        "dataset": "windows.perfmon",
+        "title": "Windows perfmon metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "windows.powershell",
+        "title": "Windows Powershell logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "windows.powershell_operational",
+        "title": "Windows Powershell/Operational logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "windows.service",
+        "title": "Windows service metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "windows.sysmon_operational",
+        "title": "Windows Sysmon/Operational events"
+      }
+    ]
   },
   {
     "name": "zeek",
@@ -4119,7 +5770,204 @@
       "monitoring",
       "security"
     ],
-    "signature_path": "/epr/zeek/zeek-1.6.1.zip.sig"
+    "signature_path": "/epr/zeek/zeek-1.6.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "zeek.capture_loss",
+        "title": "Zeek capture_loss logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.connection",
+        "title": "Zeek connection logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.dce_rpc",
+        "title": "Zeek dce_rpc logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.dhcp",
+        "title": "Zeek dhcp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.dnp3",
+        "title": "Zeek dnp3 logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.dns",
+        "title": "Zeek dns logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.dpd",
+        "title": "Zeek dpd logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.files",
+        "title": "Zeek files logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.ftp",
+        "title": "Zeek ftp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.http",
+        "title": "Zeek http logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.intel",
+        "title": "Zeek intel logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.irc",
+        "title": "Zeek irc logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.kerberos",
+        "title": "Zeek kerberos logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.modbus",
+        "title": "Zeek modbus logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.mysql",
+        "title": "Zeek mysql logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.notice",
+        "title": "Zeek notice logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.ntlm",
+        "title": "Zeek ntlm logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.ntp",
+        "title": "Zeek ntp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.ocsp",
+        "title": "Zeek ocsp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.pe",
+        "title": "Zeek pe logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.radius",
+        "title": "Zeek radius logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.rdp",
+        "title": "Zeek rdp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.rfb",
+        "title": "Zeek rfb logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.signature",
+        "title": "Zeek signature logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.sip",
+        "title": "Zeek sip logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.smb_cmd",
+        "title": "Zeek smb_cmd logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.smb_files",
+        "title": "Zeek smb_files logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.smb_mapping",
+        "title": "Zeek smb_mapping logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.smtp",
+        "title": "Zeek smtp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.snmp",
+        "title": "Zeek snmp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.socks",
+        "title": "Zeek socks logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.ssh",
+        "title": "Zeek ssh logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.ssl",
+        "title": "Zeek ssl logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.stats",
+        "title": "Zeek stats logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.syslog",
+        "title": "Zeek syslog logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.traceroute",
+        "title": "Zeek traceroute logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.tunnel",
+        "title": "Zeek tunnel logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.weird",
+        "title": "Zeek weird logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.x509",
+        "title": "Zeek x509 logs"
+      }
+    ]
   },
   {
     "name": "zerofox",
@@ -4158,7 +6006,14 @@
       "cloud",
       "security"
     ],
-    "signature_path": "/epr/zerofox/zerofox-1.2.1.zip.sig"
+    "signature_path": "/epr/zerofox/zerofox-1.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "zerofox.alerts",
+        "title": "Alerts"
+      }
+    ]
   },
   {
     "name": "zookeeper",
@@ -4197,7 +6052,24 @@
       "datastore",
       "config_management"
     ],
-    "signature_path": "/epr/zookeeper/zookeeper-1.2.0.zip.sig"
+    "signature_path": "/epr/zookeeper/zookeeper-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "zookeeper.connection",
+        "title": "ZooKeeper connection metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "zookeeper.mntr",
+        "title": "ZooKeeper mntr metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "zookeeper.server",
+        "title": "ZooKeeper server metrics"
+      }
+    ]
   },
   {
     "name": "zoom",
@@ -4236,6 +6108,13 @@
       "security",
       "productivity"
     ],
-    "signature_path": "/epr/zoom/zoom-1.2.1.zip.sig"
+    "signature_path": "/epr/zoom/zoom-1.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "zoom.webhook",
+        "title": "Zoom webhook logs"
+      }
+    ]
   }
 ]

--- a/testdata/generated/storage-indexer/search-package-experimental.json
+++ b/testdata/generated/storage-indexer/search-package-experimental.json
@@ -35,7 +35,19 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/1password/1password-1.4.0.zip.sig"
+    "signature_path": "/epr/1password/1password-1.4.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "1password.item_usages",
+        "title": "Collect 1Password item usages events"
+      },
+      {
+        "type": "logs",
+        "dataset": "1password.signin_attempts",
+        "title": "1Password sign-in attempt events"
+      }
+    ]
   },
   {
     "name": "aws",
@@ -410,7 +422,154 @@
       "aws",
       "cloud"
     ],
-    "signature_path": "/epr/aws/aws-1.16.4.zip.sig"
+    "signature_path": "/epr/aws/aws-1.16.4.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "aws.billing",
+        "title": "AWS Billing Metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.cloudfront_logs",
+        "title": "AWS CloudFront logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.cloudtrail",
+        "title": "AWS CloudTrail Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.cloudwatch_logs",
+        "title": "AWS CloudWatch logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.cloudwatch_metrics",
+        "title": "AWS CloudWatch metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.dynamodb",
+        "title": "AWS DynamoDB metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.ebs",
+        "title": "AWS EBS metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.ec2_logs",
+        "title": "AWS EC2 logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.ec2_metrics",
+        "title": "AWS EC2 metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.elb_logs",
+        "title": "AWS ELB logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.elb_metrics",
+        "title": "AWS ELB metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.firewall_logs",
+        "title": "AWS Network Firewall logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.firewall_metrics",
+        "title": "AWS Network Firewall metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.lambda",
+        "title": "AWS Lambda metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.natgateway",
+        "title": "AWS NAT gateway metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.rds",
+        "title": "AWS RDS metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.route53_public_logs",
+        "title": "AWS Route 53 Public Zone Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.route53_resolver_logs",
+        "title": "AWS Route 53 Resolver Query Logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.s3_daily_storage",
+        "title": "AWS S3 daily storage metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.s3_request",
+        "title": "AWS S3 request metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.s3_storage_lens",
+        "title": "AWS S3 Storage Lens metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.s3access",
+        "title": "AWS s3access logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.sns",
+        "title": "AWS SNS metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.sqs",
+        "title": "AWS SQS metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.transitgateway",
+        "title": "AWS Transit Gateway metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.usage",
+        "title": "AWS usage metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.vpcflow",
+        "title": "AWS vpcflow logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.vpn",
+        "title": "AWS VPN metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.waf",
+        "title": "AWS WAF logs"
+      }
+    ]
   },
   {
     "name": "awsfargate",
@@ -450,7 +609,14 @@
       "cloud",
       "containers"
     ],
-    "signature_path": "/epr/awsfargate/awsfargate-0.1.1.zip.sig"
+    "signature_path": "/epr/awsfargate/awsfargate-0.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "awsfargate.task_stats",
+        "title": "AWS Fargate task_stats metrics"
+      }
+    ]
   },
   {
     "name": "ti_abusech",
@@ -488,7 +654,24 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/ti_abusech/ti_abusech-1.2.3.zip.sig"
+    "signature_path": "/epr/ti_abusech/ti_abusech-1.2.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_abusech.malware",
+        "title": "AbuseCH Malware logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "ti_abusech.malwarebazaar",
+        "title": "AbuseCH MalwareBazaar logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "ti_abusech.url",
+        "title": "AbuseCH URL logs"
+      }
+    ]
   },
   {
     "name": "activemq",
@@ -526,7 +709,34 @@
     "categories": [
       "web"
     ],
-    "signature_path": "/epr/activemq/activemq-0.3.0.zip.sig"
+    "signature_path": "/epr/activemq/activemq-0.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "activemq.audit",
+        "title": "ActiveMQ audit logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "activemq.broker",
+        "title": "ActiveMQ broker metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "activemq.log",
+        "title": "ActiveMQ log logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "activemq.queue",
+        "title": "ActiveMQ queue metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "activemq.topic",
+        "title": "ActiveMQ topic metrics"
+      }
+    ]
   },
   {
     "name": "akamai",
@@ -567,7 +777,14 @@
       "web",
       "cloud"
     ],
-    "signature_path": "/epr/akamai/akamai-1.0.0.zip.sig"
+    "signature_path": "/epr/akamai/akamai-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "akamai.siem",
+        "title": "Akamai SIEM Logs"
+      }
+    ]
   },
   {
     "name": "ti_otx",
@@ -605,7 +822,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/ti_otx/ti_otx-1.2.2.zip.sig"
+    "signature_path": "/epr/ti_otx/ti_otx-1.2.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_otx.threat",
+        "title": "Alienvault OTX logs"
+      }
+    ]
   },
   {
     "name": "ti_anomali",
@@ -643,7 +867,19 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/ti_anomali/ti_anomali-1.2.3.zip.sig"
+    "signature_path": "/epr/ti_anomali/ti_anomali-1.2.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_anomali.limo",
+        "title": "Anomali Limo"
+      },
+      {
+        "type": "logs",
+        "dataset": "ti_anomali.threatstream",
+        "title": "Anomali Threatstream"
+      }
+    ]
   },
   {
     "name": "apache",
@@ -681,7 +917,24 @@
     "categories": [
       "web"
     ],
-    "signature_path": "/epr/apache/apache-1.3.5.zip.sig"
+    "signature_path": "/epr/apache/apache-1.3.5.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "apache.access",
+        "title": "Apache access logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "apache.error",
+        "title": "Apache error logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apache.status",
+        "title": "Apache status metrics"
+      }
+    ]
   },
   {
     "name": "tomcat",
@@ -720,7 +973,14 @@
       "web",
       "security"
     ],
-    "signature_path": "/epr/tomcat/tomcat-1.3.1.zip.sig"
+    "signature_path": "/epr/tomcat/tomcat-1.3.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "tomcat.log",
+        "title": "Apache Tomcat logs"
+      }
+    ]
   },
   {
     "name": "netscout",
@@ -758,7 +1018,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/netscout/netscout-0.7.0.zip.sig"
+    "signature_path": "/epr/netscout/netscout-0.7.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "netscout.sightline",
+        "title": "Arbor Peakflow SP logs"
+      }
+    ]
   },
   {
     "name": "atlassian_bitbucket",
@@ -797,7 +1064,14 @@
       "security",
       "web"
     ],
-    "signature_path": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.2.1.zip.sig"
+    "signature_path": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_bitbucket.audit",
+        "title": "Bitbucket Audit Logs"
+      }
+    ]
   },
   {
     "name": "atlassian_confluence",
@@ -836,7 +1110,14 @@
       "security",
       "web"
     ],
-    "signature_path": "/epr/atlassian_confluence/atlassian_confluence-1.3.0.zip.sig"
+    "signature_path": "/epr/atlassian_confluence/atlassian_confluence-1.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_confluence.audit",
+        "title": "Confluence Audit Logs"
+      }
+    ]
   },
   {
     "name": "atlassian_jira",
@@ -875,7 +1156,14 @@
       "security",
       "web"
     ],
-    "signature_path": "/epr/atlassian_jira/atlassian_jira-1.3.0.zip.sig"
+    "signature_path": "/epr/atlassian_jira/atlassian_jira-1.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_jira.audit",
+        "title": "Jira Audit Logs"
+      }
+    ]
   },
   {
     "name": "auditd",
@@ -913,7 +1201,14 @@
     "categories": [
       "os_system"
     ],
-    "signature_path": "/epr/auditd/auditd-3.1.0.zip.sig"
+    "signature_path": "/epr/auditd/auditd-3.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "auditd.log",
+        "title": "Auditd logs"
+      }
+    ]
   },
   {
     "name": "auditd_manager",
@@ -952,7 +1247,14 @@
       "os_system",
       "security"
     ],
-    "signature_path": "/epr/auditd_manager/auditd_manager-1.0.0.zip.sig"
+    "signature_path": "/epr/auditd_manager/auditd_manager-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "auditd_manager.auditd",
+        "title": "Auditd Manager"
+      }
+    ]
   },
   {
     "name": "auth0",
@@ -992,7 +1294,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/auth0/auth0-1.0.0.zip.sig"
+    "signature_path": "/epr/auth0/auth0-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "auth0.logs",
+        "title": "Auth0 logs via Webhooks"
+      }
+    ]
   },
   {
     "name": "azure_application_insights",
@@ -1054,7 +1363,19 @@
       "azure",
       "web"
     ],
-    "signature_path": "/epr/azure_application_insights/azure_application_insights-1.0.1.zip.sig"
+    "signature_path": "/epr/azure_application_insights/azure_application_insights-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "azure.app_insights",
+        "title": "Azure Application Insights"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.app_state",
+        "title": "Azure Application State"
+      }
+    ]
   },
   {
     "name": "azure_billing",
@@ -1101,7 +1422,14 @@
     "categories": [
       "azure"
     ],
-    "signature_path": "/epr/azure_billing/azure_billing-1.0.1.zip.sig"
+    "signature_path": "/epr/azure_billing/azure_billing-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "azure.billing",
+        "title": "Azure Billing Metrics"
+      }
+    ]
   },
   {
     "name": "azure",
@@ -1207,7 +1535,39 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/azure/azure-1.1.8.zip.sig"
+    "signature_path": "/epr/azure/azure-1.1.8.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "azure.activitylogs",
+        "title": "Azure Activity Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "azure.auditlogs",
+        "title": "Azure Audit Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "azure.eventhub",
+        "title": "Azure Event Hub Input"
+      },
+      {
+        "type": "logs",
+        "dataset": "azure.platformlogs",
+        "title": "Azure Platform Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "azure.signinlogs",
+        "title": "Azure Signin Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "azure.springcloudlogs",
+        "title": "Azure Spring Cloud Logs"
+      }
+    ]
   },
   {
     "name": "azure_metrics",
@@ -1353,7 +1713,49 @@
       "azure",
       "web"
     ],
-    "signature_path": "/epr/azure_metrics/azure_metrics-1.0.3.zip.sig"
+    "signature_path": "/epr/azure_metrics/azure_metrics-1.0.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "azure.compute_vm",
+        "title": "Compute VM"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.compute_vm_scaleset",
+        "title": "Compute VM Scaleset"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.container_instance",
+        "title": "Container Instance"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.container_registry",
+        "title": "Container Registry"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.container_service",
+        "title": "Container Service"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.database_account",
+        "title": "Database Account"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.monitor",
+        "title": "Monitor"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.storage_account",
+        "title": "Storage Account"
+      }
+    ]
   },
   {
     "name": "barracuda",
@@ -1392,7 +1794,19 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/barracuda/barracuda-0.9.0.zip.sig"
+    "signature_path": "/epr/barracuda/barracuda-0.9.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "barracuda.spamfirewall",
+        "title": "Barracuda Spam Firewall logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "barracuda.waf",
+        "title": "Barracuda Web Application Firewall logs"
+      }
+    ]
   },
   {
     "name": "bluecoat",
@@ -1422,7 +1836,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/bluecoat/bluecoat-0.8.0.zip.sig"
+    "signature_path": "/epr/bluecoat/bluecoat-0.8.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "bluecoat.director",
+        "title": "Blue Coat Director logs"
+      }
+    ]
   },
   {
     "name": "cef",
@@ -1452,7 +1873,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/cef/cef-2.0.0.zip.sig"
+    "signature_path": "/epr/cef/cef-2.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cef.log",
+        "title": "CEF log logs"
+      }
+    ]
   },
   {
     "name": "cloud_security_posture",
@@ -1491,7 +1919,14 @@
       "containers",
       "kubernetes"
     ],
-    "signature_path": "/epr/cloud_security_posture/cloud_security_posture-0.0.14.zip.sig"
+    "signature_path": "/epr/cloud_security_posture/cloud_security_posture-0.0.14.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cloud_security_posture.findings",
+        "title": "Findings"
+      }
+    ]
   },
   {
     "name": "cassandra",
@@ -1530,7 +1965,19 @@
       "datastore",
       "monitoring"
     ],
-    "signature_path": "/epr/cassandra/cassandra-1.1.0.zip.sig"
+    "signature_path": "/epr/cassandra/cassandra-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cassandra.log",
+        "title": "Cassandra System Logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "cassandra.metrics",
+        "title": "metrics"
+      }
+    ]
   },
   {
     "name": "checkpoint",
@@ -1568,7 +2015,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/checkpoint/checkpoint-1.5.0.zip.sig"
+    "signature_path": "/epr/checkpoint/checkpoint-1.5.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "checkpoint.firewall",
+        "title": "Check Point firewall logs"
+      }
+    ]
   },
   {
     "name": "cisco",
@@ -1607,7 +2061,34 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/cisco/cisco-0.12.5.zip.sig"
+    "signature_path": "/epr/cisco/cisco-0.12.5.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco.asa",
+        "title": "Cisco ASA logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "cisco.ftd",
+        "title": "Cisco FTD logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "cisco.ios",
+        "title": "Cisco IOS logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "cisco.meraki",
+        "title": "Cisco Meraki logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "cisco.nexus",
+        "title": "Cisco Nexus logs"
+      }
+    ]
   },
   {
     "name": "cisco_asa",
@@ -1646,7 +2127,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/cisco_asa/cisco_asa-2.4.1.zip.sig"
+    "signature_path": "/epr/cisco_asa/cisco_asa-2.4.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco_asa.log",
+        "title": "Cisco ASA logs"
+      }
+    ]
   },
   {
     "name": "cisco_duo",
@@ -1684,7 +2172,34 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/cisco_duo/cisco_duo-1.2.4.zip.sig"
+    "signature_path": "/epr/cisco_duo/cisco_duo-1.2.4.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco_duo.admin",
+        "title": "Cisco Duo administrator logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "cisco_duo.auth",
+        "title": "Cisco Duo authentication logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "cisco_duo.offline_enrollment",
+        "title": "Cisco Duo offline enrollment logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "cisco_duo.summary",
+        "title": "Cisco Duo summary logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "cisco_duo.telephony",
+        "title": "Cisco Duo telephony logs"
+      }
+    ]
   },
   {
     "name": "cisco_ftd",
@@ -1723,7 +2238,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/cisco_ftd/cisco_ftd-2.2.1.zip.sig"
+    "signature_path": "/epr/cisco_ftd/cisco_ftd-2.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco_ftd.log",
+        "title": "Cisco FTD logs"
+      }
+    ]
   },
   {
     "name": "cisco_ios",
@@ -1762,7 +2284,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/cisco_ios/cisco_ios-1.6.0.zip.sig"
+    "signature_path": "/epr/cisco_ios/cisco_ios-1.6.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco_ios.log",
+        "title": "Cisco IOS logs"
+      }
+    ]
   },
   {
     "name": "cisco_ise",
@@ -1800,7 +2329,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/cisco_ise/cisco_ise-0.1.0.zip.sig"
+    "signature_path": "/epr/cisco_ise/cisco_ise-0.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco_ise.log",
+        "title": "Cisco ISE logs"
+      }
+    ]
   },
   {
     "name": "cisco_meraki",
@@ -1839,7 +2375,19 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/cisco_meraki/cisco_meraki-0.5.0.zip.sig"
+    "signature_path": "/epr/cisco_meraki/cisco_meraki-0.5.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco_meraki.events",
+        "title": "Cisco Meraki webhook events"
+      },
+      {
+        "type": "logs",
+        "dataset": "cisco_meraki.log",
+        "title": "Cisco Meraki logs (via Syslog)"
+      }
+    ]
   },
   {
     "name": "cisco_nexus",
@@ -1878,7 +2426,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/cisco_nexus/cisco_nexus-0.5.1.zip.sig"
+    "signature_path": "/epr/cisco_nexus/cisco_nexus-0.5.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco_nexus.log",
+        "title": "Cisco Nexus logs"
+      }
+    ]
   },
   {
     "name": "cisco_secure_email_gateway",
@@ -1916,7 +2471,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/cisco_secure_email_gateway/cisco_secure_email_gateway-0.1.0.zip.sig"
+    "signature_path": "/epr/cisco_secure_email_gateway/cisco_secure_email_gateway-0.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco_secure_email_gateway.log",
+        "title": "Cisco Secure Email Gateway logs"
+      }
+    ]
   },
   {
     "name": "cisco_secure_endpoint",
@@ -1955,7 +2517,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/cisco_secure_endpoint/cisco_secure_endpoint-2.4.1.zip.sig"
+    "signature_path": "/epr/cisco_secure_endpoint/cisco_secure_endpoint-2.4.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco_secure_endpoint.event",
+        "title": "Cisco Secure Endpoint logs"
+      }
+    ]
   },
   {
     "name": "cisco_umbrella",
@@ -1994,7 +2563,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/cisco_umbrella/cisco_umbrella-1.0.0.zip.sig"
+    "signature_path": "/epr/cisco_umbrella/cisco_umbrella-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco_umbrella.log",
+        "title": "Cisco Umbrella logs"
+      }
+    ]
   },
   {
     "name": "cloudflare",
@@ -2035,7 +2611,19 @@
       "web",
       "cloud"
     ],
-    "signature_path": "/epr/cloudflare/cloudflare-2.0.0.zip.sig"
+    "signature_path": "/epr/cloudflare/cloudflare-2.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cloudflare.audit",
+        "title": "Cloudflare Audit Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "cloudflare.logpull",
+        "title": "Cloudflare Logpull"
+      }
+    ]
   },
   {
     "name": "cockroachdb",
@@ -2082,7 +2670,14 @@
     "categories": [
       "datastore"
     ],
-    "signature_path": "/epr/cockroachdb/cockroachdb-0.2.0.zip.sig"
+    "signature_path": "/epr/cockroachdb/cockroachdb-0.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "cockroachdb.status",
+        "title": "Status"
+      }
+    ]
   },
   {
     "name": "crowdstrike",
@@ -2120,7 +2715,19 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/crowdstrike/crowdstrike-1.3.3.zip.sig"
+    "signature_path": "/epr/crowdstrike/crowdstrike-1.3.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "crowdstrike.falcon",
+        "title": "Crowdstrike falcon logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "crowdstrike.fdr",
+        "title": "Falcon Data Replicator"
+      }
+    ]
   },
   {
     "name": "aws_logs",
@@ -2158,7 +2765,14 @@
       "cloud",
       "aws"
     ],
-    "signature_path": "/epr/aws_logs/aws_logs-0.2.1.zip.sig"
+    "signature_path": "/epr/aws_logs/aws_logs-0.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "aws_logs.generic",
+        "title": "Custom logs from AWS"
+      }
+    ]
   },
   {
     "name": "gcp_pubsub",
@@ -2198,7 +2812,14 @@
       "cloud",
       "custom"
     ],
-    "signature_path": "/epr/gcp_pubsub/gcp_pubsub-1.0.0.zip.sig"
+    "signature_path": "/epr/gcp_pubsub/gcp_pubsub-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "gcp_pubsub.generic",
+        "title": "Custom Google Pub/Sub Logs"
+      }
+    ]
   },
   {
     "name": "http_endpoint",
@@ -2234,7 +2855,14 @@
     "categories": [
       "custom"
     ],
-    "signature_path": "/epr/http_endpoint/http_endpoint-1.0.1.zip.sig"
+    "signature_path": "/epr/http_endpoint/http_endpoint-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "http_endpoint.generic",
+        "title": "Custom HTTP Endpoint Logs"
+      }
+    ]
   },
   {
     "name": "httpjson",
@@ -2263,7 +2891,14 @@
     "categories": [
       "custom"
     ],
-    "signature_path": "/epr/httpjson/httpjson-1.1.1.zip.sig"
+    "signature_path": "/epr/httpjson/httpjson-1.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "httpjson.generic",
+        "title": "Custom HTTPJSON Input"
+      }
+    ]
   },
   {
     "name": "journald",
@@ -2301,7 +2936,14 @@
     "categories": [
       "custom"
     ],
-    "signature_path": "/epr/journald/journald-0.0.2.zip.sig"
+    "signature_path": "/epr/journald/journald-0.0.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "journald.log",
+        "title": "Journald Log"
+      }
+    ]
   },
   {
     "name": "log",
@@ -2332,7 +2974,14 @@
     "categories": [
       "custom"
     ],
-    "signature_path": "/epr/log/log-1.0.0.zip.sig"
+    "signature_path": "/epr/log/log-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "log.log",
+        "title": "Log Dataset"
+      }
+    ]
   },
   {
     "name": "tcp",
@@ -2368,7 +3017,14 @@
     "categories": [
       "custom"
     ],
-    "signature_path": "/epr/tcp/tcp-1.0.0.zip.sig"
+    "signature_path": "/epr/tcp/tcp-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "tcp.generic",
+        "title": "Custom TCP Logs"
+      }
+    ]
   },
   {
     "name": "udp",
@@ -2404,7 +3060,14 @@
     "categories": [
       "custom"
     ],
-    "signature_path": "/epr/udp/udp-1.0.1.zip.sig"
+    "signature_path": "/epr/udp/udp-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "udp.generic",
+        "title": "Custom UDP Logs"
+      }
+    ]
   },
   {
     "name": "winlog",
@@ -2440,7 +3103,14 @@
     "categories": [
       "custom"
     ],
-    "signature_path": "/epr/winlog/winlog-1.4.0.zip.sig"
+    "signature_path": "/epr/winlog/winlog-1.4.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "winlog.winlog",
+        "title": "Custom Windows Event Log Dataset"
+      }
+    ]
   },
   {
     "name": "cyberark",
@@ -2478,7 +3148,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/cyberark/cyberark-0.4.4.zip.sig"
+    "signature_path": "/epr/cyberark/cyberark-0.4.4.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cyberark.corepas",
+        "title": "CyberArk logs"
+      }
+    ]
   },
   {
     "name": "cyberarkpas",
@@ -2516,7 +3193,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/cyberarkpas/cyberarkpas-2.4.2.zip.sig"
+    "signature_path": "/epr/cyberarkpas/cyberarkpas-2.4.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cyberarkpas.audit",
+        "title": "CyberArk PAS audit logs"
+      }
+    ]
   },
   {
     "name": "ti_cybersixgill",
@@ -2555,7 +3239,14 @@
       "security",
       "productivity"
     ],
-    "signature_path": "/epr/ti_cybersixgill/ti_cybersixgill-1.3.2.zip.sig"
+    "signature_path": "/epr/ti_cybersixgill/ti_cybersixgill-1.3.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_cybersixgill.threat",
+        "title": "Cybersixgill Darkfeed Logs"
+      }
+    ]
   },
   {
     "name": "cylance",
@@ -2593,7 +3284,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/cylance/cylance-0.8.1.zip.sig"
+    "signature_path": "/epr/cylance/cylance-0.8.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cylance.protect",
+        "title": "CylanceProtect logs"
+      }
+    ]
   },
   {
     "name": "dga",
@@ -2663,7 +3361,54 @@
       "containers",
       "os_system"
     ],
-    "signature_path": "/epr/docker/docker-1.2.0.zip.sig"
+    "signature_path": "/epr/docker/docker-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "docker.container",
+        "title": "Docker container metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "docker.cpu",
+        "title": "Docker cpu metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "docker.diskio",
+        "title": "Docker diskio metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "docker.event",
+        "title": "Docker event metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "docker.healthcheck",
+        "title": "Docker healthcheck metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "docker.image",
+        "title": "Docker image metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "docker.info",
+        "title": "Docker info metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "docker.memory",
+        "title": "Docker memory metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "docker.network",
+        "title": "Docker network metrics"
+      }
+    ]
   },
   {
     "name": "apm",
@@ -2702,7 +3447,49 @@
       "elastic_stack",
       "monitoring"
     ],
-    "signature_path": "/epr/apm/apm-8.2.0.zip.sig"
+    "signature_path": "/epr/apm/apm-8.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "apm.app",
+        "title": "APM application logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.app",
+        "title": "APM application metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "apm.error",
+        "title": "APM errors"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.internal",
+        "title": "APM internal metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.profiling",
+        "title": "APM profiles"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm.rum",
+        "title": "APM RUM traces"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm.sampled",
+        "title": "APM tail-sampled traces"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm",
+        "title": "APM traces"
+      }
+    ]
   },
   {
     "name": "elastic_agent",
@@ -2733,7 +3520,109 @@
     "categories": [
       "elastic_stack"
     ],
-    "signature_path": "/epr/elastic_agent/elastic_agent-1.3.1.zip.sig"
+    "signature_path": "/epr/elastic_agent/elastic_agent-1.3.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.apm_server",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.apm_server",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.auditbeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.auditbeat",
+        "title": "Elastic Agent Auditbeat Metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.elastic_agent",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.endpoint_security",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.endpoint_security",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.filebeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.filebeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.fleet_server",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.fleet_server",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.heartbeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.heartbeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.metricbeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.metricbeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.osquerybeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.osquerybeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.packetbeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.packetbeat",
+        "title": "Elastic Agent"
+      }
+    ]
   },
   {
     "name": "synthetics",
@@ -2772,7 +3661,39 @@
       "monitoring",
       "web"
     ],
-    "signature_path": "/epr/synthetics/synthetics-0.9.2.zip.sig"
+    "signature_path": "/epr/synthetics/synthetics-0.9.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "synthetics",
+        "dataset": "browser",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "browser.network",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "browser.screenshot",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "http",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "icmp",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "tcp",
+        "title": "synthetic monitor check"
+      }
+    ]
   },
   {
     "name": "elasticsearch",
@@ -2811,7 +3732,89 @@
       "elastic_stack",
       "datastore"
     ],
-    "signature_path": "/epr/elasticsearch/elasticsearch-0.2.0.zip.sig"
+    "signature_path": "/epr/elasticsearch/elasticsearch-0.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "elasticsearch.audit",
+        "title": "Elasticsearch audit logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elasticsearch.ccr",
+        "title": "Elasticsearch ccr metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elasticsearch.cluster_stats",
+        "title": "Elasticsearch cluster_stats metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "elasticsearch.deprecation",
+        "title": "Elasticsearch deprecation logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elasticsearch.enrich",
+        "title": "Elasticsearch enrich metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "elasticsearch.gc",
+        "title": "Elasticsearch gc logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elasticsearch.index",
+        "title": "Elasticsearch index metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elasticsearch.index_recovery",
+        "title": "Elasticsearch index_recovery metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elasticsearch.index_summary",
+        "title": "Elasticsearch index_summary metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elasticsearch.ml_job",
+        "title": "Elasticsearch ml_job metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elasticsearch.node",
+        "title": "Elasticsearch node metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elasticsearch.node_stats",
+        "title": "Elasticsearch node_stats metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elasticsearch.pending_tasks",
+        "title": "Elasticsearch pending_tasks metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "elasticsearch.server",
+        "title": "Elasticsearch server logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elasticsearch.shard",
+        "title": "Elasticsearch shard metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "elasticsearch.slowlog",
+        "title": "Elasticsearch slowlog logs"
+      }
+    ]
   },
   {
     "name": "endpoint",
@@ -2849,7 +3852,74 @@
       "security",
       "cloud"
     ],
-    "signature_path": "/epr/endpoint/endpoint-8.3.0.zip.sig"
+    "signature_path": "/epr/endpoint/endpoint-8.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "endpoint.action.responses",
+        "title": "Endpoint Action Responses"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.actions",
+        "title": "Endpoint Actions"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.alerts",
+        "title": "Endpoint Alerts"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.diagnostic.collection",
+        "title": "Endpoint Alert Collection"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.file",
+        "title": "Endpoint File Events"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.library",
+        "title": "Endpoint Library and Driver Events"
+      },
+      {
+        "type": "metrics",
+        "dataset": "endpoint.metadata",
+        "title": "Endpoint Metadata"
+      },
+      {
+        "type": "metrics",
+        "dataset": "endpoint.metrics",
+        "title": "Endpoint Metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.network",
+        "title": "Endpoint Network Events"
+      },
+      {
+        "type": "metrics",
+        "dataset": "endpoint.policy",
+        "title": "Endpoint Policy Response"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.process",
+        "title": "Endpoint Process Events"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.registry",
+        "title": "Endpoint Registry Events"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.security",
+        "title": "Endpoint Security Events"
+      }
+    ]
   },
   {
     "name": "f5",
@@ -2888,7 +3958,19 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/f5/f5-0.9.0.zip.sig"
+    "signature_path": "/epr/f5/f5-0.9.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "f5.bigipafm",
+        "title": "Big-IP Advanced Firewall Manager logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "f5.bigipapm",
+        "title": "Big-IP Access Policy Manager logs"
+      }
+    ]
   },
   {
     "name": "fim",
@@ -2928,7 +4010,14 @@
       "os_system",
       "security"
     ],
-    "signature_path": "/epr/fim/fim-1.0.0.zip.sig"
+    "signature_path": "/epr/fim/fim-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "fim.event",
+        "title": "Filesystem events"
+      }
+    ]
   },
   {
     "name": "fireeye",
@@ -2968,7 +4057,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/fireeye/fireeye-1.3.1.zip.sig"
+    "signature_path": "/epr/fireeye/fireeye-1.3.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "fireeye.nx",
+        "title": "Fireeye NX"
+      }
+    ]
   },
   {
     "name": "fleet_server",
@@ -3044,7 +4140,29 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/fortinet/fortinet-1.6.1.zip.sig"
+    "signature_path": "/epr/fortinet/fortinet-1.6.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "fortinet.clientendpoint",
+        "title": "Fortinet FortiClient Endpoint Security logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "fortinet.firewall",
+        "title": "Fortinet firewall logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "fortinet.fortimail",
+        "title": "Fortinet FortiMail logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "fortinet.fortimanager",
+        "title": "Fortinet Manager/Analyzer logs"
+      }
+    ]
   },
   {
     "name": "github",
@@ -3082,7 +4200,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/github/github-1.0.0.zip.sig"
+    "signature_path": "/epr/github/github-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "github.audit",
+        "title": "GitHub Audit Logs"
+      }
+    ]
   },
   {
     "name": "gcp",
@@ -3123,7 +4248,29 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/gcp/gcp-1.9.0.zip.sig"
+    "signature_path": "/epr/gcp/gcp-1.9.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "gcp.audit",
+        "title": "Google Cloud Platform (GCP) audit logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "gcp.dns",
+        "title": "Google Cloud Platform (GCP) DNS logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "gcp.firewall",
+        "title": "Google Cloud Platform (GCP) firewall logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "gcp.vpcflow",
+        "title": "Google Cloud Platform (GCP) vpcflow logs"
+      }
+    ]
   },
   {
     "name": "santa",
@@ -3161,7 +4308,14 @@
       "security",
       "os_system"
     ],
-    "signature_path": "/epr/santa/santa-2.0.1.zip.sig"
+    "signature_path": "/epr/santa/santa-2.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "santa.log",
+        "title": "Google Santa log logs"
+      }
+    ]
   },
   {
     "name": "google_workspace",
@@ -3199,7 +4353,39 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/google_workspace/google_workspace-1.5.0.zip.sig"
+    "signature_path": "/epr/google_workspace/google_workspace-1.5.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "google_workspace.admin",
+        "title": "Admin logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "google_workspace.drive",
+        "title": "Drive logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "google_workspace.groups",
+        "title": "Groups logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "google_workspace.login",
+        "title": "Login logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "google_workspace.saml",
+        "title": "SAML logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "google_workspace.user_accounts",
+        "title": "User accounts logs"
+      }
+    ]
   },
   {
     "name": "haproxy",
@@ -3238,7 +4424,24 @@
       "network",
       "web"
     ],
-    "signature_path": "/epr/haproxy/haproxy-0.7.0.zip.sig"
+    "signature_path": "/epr/haproxy/haproxy-0.7.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "haproxy.info",
+        "title": "HAProxy info metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "haproxy.log",
+        "title": "HAProxy logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "haproxy.stat",
+        "title": "HAProxy stat metrics"
+      }
+    ]
   },
   {
     "name": "hashicorp_vault",
@@ -3276,7 +4479,24 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/hashicorp_vault/hashicorp_vault-1.3.3.zip.sig"
+    "signature_path": "/epr/hashicorp_vault/hashicorp_vault-1.3.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "hashicorp_vault.audit",
+        "title": "Hashicorp Vault Audit Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "hashicorp_vault.log",
+        "title": "Hashicorp Vault Operational Logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "hashicorp_vault.metrics",
+        "title": "Hashicorp Vault Metrics"
+      }
+    ]
   },
   {
     "name": "hid_bravura_monitor",
@@ -3314,7 +4534,19 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/hid_bravura_monitor/hid_bravura_monitor-1.0.2.zip.sig"
+    "signature_path": "/epr/hid_bravura_monitor/hid_bravura_monitor-1.0.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "hid_bravura_monitor.log",
+        "title": "Hitachi ID Bravura Monitor"
+      },
+      {
+        "type": "logs",
+        "dataset": "hid_bravura_monitor.winlog",
+        "title": "Hitachi ID Security Fabric logs"
+      }
+    ]
   },
   {
     "name": "iis",
@@ -3352,7 +4584,34 @@
     "categories": [
       "web"
     ],
-    "signature_path": "/epr/iis/iis-0.8.0.zip.sig"
+    "signature_path": "/epr/iis/iis-0.8.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "iis.access",
+        "title": "IIS access logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "iis.application_pool",
+        "title": "IIS application_pool metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "iis.error",
+        "title": "IIS error logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "iis.webserver",
+        "title": "IIS web server metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "iis.website",
+        "title": "IIS website metrics"
+      }
+    ]
   },
   {
     "name": "imperva",
@@ -3382,7 +4641,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/imperva/imperva-0.7.0.zip.sig"
+    "signature_path": "/epr/imperva/imperva-0.7.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "imperva.securesphere",
+        "title": "Imperva SecureSphere logs"
+      }
+    ]
   },
   {
     "name": "infoblox",
@@ -3420,7 +4686,14 @@
     "categories": [
       "network"
     ],
-    "signature_path": "/epr/infoblox/infoblox-0.7.0.zip.sig"
+    "signature_path": "/epr/infoblox/infoblox-0.7.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "infoblox.nios",
+        "title": "Infoblox NIOS logs"
+      }
+    ]
   },
   {
     "name": "iptables",
@@ -3459,7 +4732,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/iptables/iptables-0.8.1.zip.sig"
+    "signature_path": "/epr/iptables/iptables-0.8.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "iptables.log",
+        "title": "Iptables log logs"
+      }
+    ]
   },
   {
     "name": "juniper_junos",
@@ -3498,7 +4778,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/juniper_junos/juniper_junos-0.1.1.zip.sig"
+    "signature_path": "/epr/juniper_junos/juniper_junos-0.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "juniper_junos.log",
+        "title": "Juniper JUNOS logs"
+      }
+    ]
   },
   {
     "name": "juniper",
@@ -3537,7 +4824,24 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/juniper/juniper-1.1.0.zip.sig"
+    "signature_path": "/epr/juniper/juniper-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "juniper.junos",
+        "title": "Juniper JUNOS logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "juniper.netscreen",
+        "title": "Netscreen logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "juniper.srx",
+        "title": "Juniper SRX logs"
+      }
+    ]
   },
   {
     "name": "juniper_netscreen",
@@ -3576,7 +4880,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/juniper_netscreen/juniper_netscreen-0.1.1.zip.sig"
+    "signature_path": "/epr/juniper_netscreen/juniper_netscreen-0.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "juniper_netscreen.log",
+        "title": "Netscreen logs"
+      }
+    ]
   },
   {
     "name": "juniper_srx",
@@ -3615,7 +4926,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/juniper_srx/juniper_srx-1.1.2.zip.sig"
+    "signature_path": "/epr/juniper_srx/juniper_srx-1.1.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "juniper_srx.log",
+        "title": "Juniper SRX logs"
+      }
+    ]
   },
   {
     "name": "kafka",
@@ -3653,7 +4971,29 @@
     "categories": [
       "message_queue"
     ],
-    "signature_path": "/epr/kafka/kafka-1.2.2.zip.sig"
+    "signature_path": "/epr/kafka/kafka-1.2.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "kafka.broker",
+        "title": "Kafka broker metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kafka.consumergroup",
+        "title": "Kafka consumergroup metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "kafka.log",
+        "title": "Kafka log logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kafka.partition",
+        "title": "Kafka partition metrics"
+      }
+    ]
   },
   {
     "name": "keycloak",
@@ -3693,7 +5033,14 @@
       "network",
       "web"
     ],
-    "signature_path": "/epr/keycloak/keycloak-1.2.1.zip.sig"
+    "signature_path": "/epr/keycloak/keycloak-1.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "keycloak.log",
+        "title": "Keycloak"
+      }
+    ]
   },
   {
     "name": "kibana",
@@ -3731,7 +5078,29 @@
     "categories": [
       "elastic_stack"
     ],
-    "signature_path": "/epr/kibana/kibana-1.0.2.zip.sig"
+    "signature_path": "/epr/kibana/kibana-1.0.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "kibana.audit",
+        "title": "kibana audit logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "kibana.log",
+        "title": "Kibana logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kibana.stats",
+        "title": "Kibana stats metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kibana.status",
+        "title": "Kibana status metrics"
+      }
+    ]
   },
   {
     "name": "kubernetes",
@@ -3891,7 +5260,139 @@
       "containers",
       "kubernetes"
     ],
-    "signature_path": "/epr/kubernetes/kubernetes-1.17.2.zip.sig"
+    "signature_path": "/epr/kubernetes/kubernetes-1.17.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.apiserver",
+        "title": "Kubernetes API Server metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "kubernetes.audit_logs",
+        "title": "Kubernetes audit logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.container",
+        "title": "Kubernetes Container metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "kubernetes.container_logs",
+        "title": "Kubernetes container logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.controllermanager",
+        "title": "Kubernetes Controller Manager metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.event",
+        "title": "Kubernetes Event metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.node",
+        "title": "Kubernetes Node metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.pod",
+        "title": "Kubernetes Pod metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.proxy",
+        "title": "Kubernetes Proxy metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.scheduler",
+        "title": "Kubernetes Scheduler metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_container",
+        "title": "Kubernetes Container metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_cronjob",
+        "title": "Kubernetes Cronjob metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_daemonset",
+        "title": "Kubernetes Deamonset metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_deployment",
+        "title": "Kubernetes Deployment metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_job",
+        "title": "Kubernetes Job metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_node",
+        "title": "Kubernetes Node metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_persistentvolume",
+        "title": "Kubernetes PersistentVolume metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_persistentvolumeclaim",
+        "title": "Kubernetes PersistentVolumeClaim metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_pod",
+        "title": "Kubernetes Pod metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_replicaset",
+        "title": "Kubernetes state_replicaset metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_resourcequota",
+        "title": "Kubernetes ResourceQuota metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_service",
+        "title": "Kubernetes Service metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_statefulset",
+        "title": "Kubernetes StatefulSet metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_storageclass",
+        "title": "Kubernetes StorageClass metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.system",
+        "title": "Kubernetes System metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.volume",
+        "title": "Kubernetes Volume metrics"
+      }
+    ]
   },
   {
     "name": "linux",
@@ -3920,7 +5421,64 @@
     "categories": [
       "os_system"
     ],
-    "signature_path": "/epr/linux/linux-0.6.2.zip.sig"
+    "signature_path": "/epr/linux/linux-0.6.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "linux.conntrack",
+        "title": "System conntrack metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "linux.entropy",
+        "title": "System entropy metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "linux.iostat",
+        "title": "Linux disk iostat metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "linux.ksm",
+        "title": "Kernel Samepage merging metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "linux.memory",
+        "title": "Linux-only memory metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "linux.network_summary",
+        "title": "System network_summary metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "linux.pageinfo",
+        "title": "System page info metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "linux.raid",
+        "title": "System raid metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "linux.service",
+        "title": "System service metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "linux.socket",
+        "title": "System socket metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "linux.users",
+        "title": "System users metrics"
+      }
+    ]
   },
   {
     "name": "logstash",
@@ -3958,7 +5516,29 @@
     "categories": [
       "elastic_stack"
     ],
-    "signature_path": "/epr/logstash/logstash-1.1.0.zip.sig"
+    "signature_path": "/epr/logstash/logstash-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "logstash.log",
+        "title": "Logstash logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "logstash.node",
+        "title": "Logstash node metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "logstash.node_stats",
+        "title": "Logstash node_stats metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "logstash.slowlog",
+        "title": "logstash slowlog logs"
+      }
+    ]
   },
   {
     "name": "problemchild",
@@ -4029,7 +5609,14 @@
       "security",
       "azure"
     ],
-    "signature_path": "/epr/m365_defender/m365_defender-1.0.3.zip.sig"
+    "signature_path": "/epr/m365_defender/m365_defender-1.0.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "m365_defender.log",
+        "title": "M365 Defender Logs"
+      }
+    ]
   },
   {
     "name": "ti_misp",
@@ -4067,7 +5654,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/ti_misp/ti_misp-1.2.2.zip.sig"
+    "signature_path": "/epr/ti_misp/ti_misp-1.2.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_misp.threat",
+        "title": "MISP"
+      }
+    ]
   },
   {
     "name": "mattermost",
@@ -4106,7 +5700,14 @@
       "security",
       "web"
     ],
-    "signature_path": "/epr/mattermost/mattermost-1.1.1.zip.sig"
+    "signature_path": "/epr/mattermost/mattermost-1.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "mattermost.audit",
+        "title": "Audit Logs"
+      }
+    ]
   },
   {
     "name": "microsoft",
@@ -4146,7 +5747,19 @@
       "security",
       "azure"
     ],
-    "signature_path": "/epr/microsoft/microsoft-1.1.0.zip.sig"
+    "signature_path": "/epr/microsoft/microsoft-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "microsoft.defender_atp",
+        "title": "Microsoft Defender ATP logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "microsoft.dhcp",
+        "title": "Microsoft DHCP logs"
+      }
+    ]
   },
   {
     "name": "microsoft_dhcp",
@@ -4184,7 +5797,14 @@
     "categories": [
       "network"
     ],
-    "signature_path": "/epr/microsoft_dhcp/microsoft_dhcp-1.3.1.zip.sig"
+    "signature_path": "/epr/microsoft_dhcp/microsoft_dhcp-1.3.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "microsoft_dhcp.log",
+        "title": "Microsoft DHCP Logs"
+      }
+    ]
   },
   {
     "name": "microsoft_defender_endpoint",
@@ -4224,7 +5844,14 @@
       "security",
       "azure"
     ],
-    "signature_path": "/epr/microsoft_defender_endpoint/microsoft_defender_endpoint-2.1.0.zip.sig"
+    "signature_path": "/epr/microsoft_defender_endpoint/microsoft_defender_endpoint-2.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "microsoft_defender_endpoint.log",
+        "title": "Microsoft Defender for Endpoint logs"
+      }
+    ]
   },
   {
     "name": "microsoft_sqlserver",
@@ -4263,7 +5890,14 @@
       "datastore",
       "security"
     ],
-    "signature_path": "/epr/microsoft_sqlserver/microsoft_sqlserver-0.4.5.zip.sig"
+    "signature_path": "/epr/microsoft_sqlserver/microsoft_sqlserver-0.4.5.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "microsoft_sqlserver.audit",
+        "title": "SQL Server audit events"
+      }
+    ]
   },
   {
     "name": "modsecurity",
@@ -4302,7 +5936,14 @@
       "security",
       "web"
     ],
-    "signature_path": "/epr/modsecurity/modsecurity-0.1.5.zip.sig"
+    "signature_path": "/epr/modsecurity/modsecurity-0.1.5.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "modsecurity.auditlog",
+        "title": "Modsecurity Audit Log"
+      }
+    ]
   },
   {
     "name": "mongodb",
@@ -4340,7 +5981,39 @@
     "categories": [
       "datastore"
     ],
-    "signature_path": "/epr/mongodb/mongodb-1.3.1.zip.sig"
+    "signature_path": "/epr/mongodb/mongodb-1.3.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "mongodb.collstats",
+        "title": "MongoDB collstats metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "mongodb.dbstats",
+        "title": "MongoDB dbstats metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "mongodb.log",
+        "title": "mongodb log logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "mongodb.metrics",
+        "title": "MongoDB metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "mongodb.replstatus",
+        "title": "MongoDB replstatus metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "mongodb.status",
+        "title": "MongoDB status metrics"
+      }
+    ]
   },
   {
     "name": "mysql",
@@ -4378,7 +6051,34 @@
     "categories": [
       "datastore"
     ],
-    "signature_path": "/epr/mysql/mysql-1.2.1.zip.sig"
+    "signature_path": "/epr/mysql/mysql-1.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "mysql.error",
+        "title": "MySQL error logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "mysql.galera_status",
+        "title": "MySQL galera_status metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "mysql.performance",
+        "title": "MySQL performance metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "mysql.slowlog",
+        "title": "MySQL slowlog logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "mysql.status",
+        "title": "MySQL status metrics"
+      }
+    ]
   },
   {
     "name": "mysql_enterprise",
@@ -4417,7 +6117,14 @@
       "security",
       "datastore"
     ],
-    "signature_path": "/epr/mysql_enterprise/mysql_enterprise-1.0.1.zip.sig"
+    "signature_path": "/epr/mysql_enterprise/mysql_enterprise-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "mysql_enterprise.audit",
+        "title": "MySQL Enterprise Audit Log"
+      }
+    ]
   },
   {
     "name": "nats",
@@ -4455,7 +6162,44 @@
     "categories": [
       "message_queue"
     ],
-    "signature_path": "/epr/nats/nats-1.2.0.zip.sig"
+    "signature_path": "/epr/nats/nats-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "nats.connection",
+        "title": "NATS connection metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "nats.connections",
+        "title": "NATS connections metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "nats.log",
+        "title": "NATS logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "nats.route",
+        "title": "NATS route metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "nats.routes",
+        "title": "NATS routes metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "nats.stats",
+        "title": "NATS stats metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "nats.subscriptions",
+        "title": "NATS subscriptions metrics"
+      }
+    ]
   },
   {
     "name": "netflow",
@@ -4485,7 +6229,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/netflow/netflow-1.4.2.zip.sig"
+    "signature_path": "/epr/netflow/netflow-1.4.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "netflow.log",
+        "title": "NetFlow logs"
+      }
+    ]
   },
   {
     "name": "netskope",
@@ -4523,7 +6274,19 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/netskope/netskope-0.1.2.zip.sig"
+    "signature_path": "/epr/netskope/netskope-0.1.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "netskope.alerts",
+        "title": "Alerts"
+      },
+      {
+        "type": "logs",
+        "dataset": "netskope.events",
+        "title": "Events"
+      }
+    ]
   },
   {
     "name": "network_traffic",
@@ -4552,7 +6315,89 @@
     "categories": [
       "web"
     ],
-    "signature_path": "/epr/network_traffic/network_traffic-0.8.1.zip.sig"
+    "signature_path": "/epr/network_traffic/network_traffic-0.8.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "network_traffic.amqp",
+        "title": "AMQP"
+      },
+      {
+        "type": "logs",
+        "dataset": "network_traffic.cassandra",
+        "title": "Cassandra"
+      },
+      {
+        "type": "logs",
+        "dataset": "network_traffic.dhcpv4",
+        "title": "DHCP"
+      },
+      {
+        "type": "logs",
+        "dataset": "network_traffic.dns",
+        "title": "DNS"
+      },
+      {
+        "type": "logs",
+        "dataset": "network_traffic.flow",
+        "title": "Flows"
+      },
+      {
+        "type": "logs",
+        "dataset": "network_traffic.http",
+        "title": "HTTP"
+      },
+      {
+        "type": "logs",
+        "dataset": "network_traffic.icmp",
+        "title": "ICMP"
+      },
+      {
+        "type": "logs",
+        "dataset": "network_traffic.memcached",
+        "title": "Memcached"
+      },
+      {
+        "type": "logs",
+        "dataset": "network_traffic.mongodb",
+        "title": "MongoDB"
+      },
+      {
+        "type": "logs",
+        "dataset": "network_traffic.mysql",
+        "title": "MySQL"
+      },
+      {
+        "type": "logs",
+        "dataset": "network_traffic.nfs",
+        "title": "NFS"
+      },
+      {
+        "type": "logs",
+        "dataset": "network_traffic.pgsql",
+        "title": "PostgreSQL"
+      },
+      {
+        "type": "logs",
+        "dataset": "network_traffic.redis",
+        "title": "Redis"
+      },
+      {
+        "type": "logs",
+        "dataset": "network_traffic.sip",
+        "title": "SIP"
+      },
+      {
+        "type": "logs",
+        "dataset": "network_traffic.thrift",
+        "title": "Thrift"
+      },
+      {
+        "type": "logs",
+        "dataset": "network_traffic.tls",
+        "title": "TLS"
+      }
+    ]
   },
   {
     "name": "nginx",
@@ -4591,7 +6436,24 @@
       "web",
       "security"
     ],
-    "signature_path": "/epr/nginx/nginx-1.3.1.zip.sig"
+    "signature_path": "/epr/nginx/nginx-1.3.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "nginx.access",
+        "title": "Nginx access logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "nginx.error",
+        "title": "Nginx error logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "nginx.stubstatus",
+        "title": "Nginx stubstatus metrics"
+      }
+    ]
   },
   {
     "name": "nginx_ingress_controller",
@@ -4630,7 +6492,19 @@
       "web",
       "security"
     ],
-    "signature_path": "/epr/nginx_ingress_controller/nginx_ingress_controller-1.2.0.zip.sig"
+    "signature_path": "/epr/nginx_ingress_controller/nginx_ingress_controller-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "nginx_ingress_controller.access",
+        "title": "Nginx Ingress Controller access logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "nginx_ingress_controller.error",
+        "title": "Nginx Ingress Controller error logs"
+      }
+    ]
   },
   {
     "name": "o365",
@@ -4668,7 +6542,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/o365/o365-1.4.3.zip.sig"
+    "signature_path": "/epr/o365/o365-1.4.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "o365.audit",
+        "title": "Office 365 audit logs"
+      }
+    ]
   },
   {
     "name": "okta",
@@ -4706,7 +6587,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/okta/okta-1.5.2.zip.sig"
+    "signature_path": "/epr/okta/okta-1.5.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "okta.system",
+        "title": "Okta system logs"
+      }
+    ]
   },
   {
     "name": "oracle",
@@ -4745,7 +6633,14 @@
       "security",
       "datastore"
     ],
-    "signature_path": "/epr/oracle/oracle-1.0.1.zip.sig"
+    "signature_path": "/epr/oracle/oracle-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "oracle.database_audit",
+        "title": "Oracle Audit Log"
+      }
+    ]
   },
   {
     "name": "osquery",
@@ -4784,7 +6679,14 @@
       "security",
       "os_system"
     ],
-    "signature_path": "/epr/osquery/osquery-1.2.1.zip.sig"
+    "signature_path": "/epr/osquery/osquery-1.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "osquery.result",
+        "title": "Osquery result logs"
+      }
+    ]
   },
   {
     "name": "osquery_manager",
@@ -4824,7 +6726,14 @@
       "os_system",
       "config_management"
     ],
-    "signature_path": "/epr/osquery_manager/osquery_manager-1.2.1.zip.sig"
+    "signature_path": "/epr/osquery_manager/osquery_manager-1.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "osquery_manager.result",
+        "title": "Osquery Manager queries"
+      }
+    ]
   },
   {
     "name": "panw_cortex_xdr",
@@ -4862,7 +6771,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/panw_cortex_xdr/panw_cortex_xdr-1.1.1.zip.sig"
+    "signature_path": "/epr/panw_cortex_xdr/panw_cortex_xdr-1.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "panw_cortex_xdr.alerts",
+        "title": "Palo Alto Cortex XDR API"
+      }
+    ]
   },
   {
     "name": "panw",
@@ -4900,7 +6816,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/panw/panw-1.5.3.zip.sig"
+    "signature_path": "/epr/panw/panw-1.5.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "panw.panos",
+        "title": "Palo Alto Networks PAN-OS firewall logs"
+      }
+    ]
   },
   {
     "name": "postgresql",
@@ -4938,7 +6861,34 @@
     "categories": [
       "datastore"
     ],
-    "signature_path": "/epr/postgresql/postgresql-1.2.0.zip.sig"
+    "signature_path": "/epr/postgresql/postgresql-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "postgresql.activity",
+        "title": "PostgreSQL activity metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "postgresql.bgwriter",
+        "title": "PostgreSQL bgwriter metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "postgresql.database",
+        "title": "PostgreSQL database metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "postgresql.log",
+        "title": "PostgreSQL logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "postgresql.statement",
+        "title": "PostgreSQL statement metrics"
+      }
+    ]
   },
   {
     "name": "security_detection_engine",
@@ -5007,7 +6957,24 @@
       "monitoring",
       "datastore"
     ],
-    "signature_path": "/epr/prometheus/prometheus-0.7.0.zip.sig"
+    "signature_path": "/epr/prometheus/prometheus-0.7.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "prometheus.collector",
+        "title": "Prometheus collector metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "prometheus.query",
+        "title": "Prometheus query metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "prometheus.remote_write",
+        "title": "Prometheus remote_write metrics"
+      }
+    ]
   },
   {
     "name": "proofpoint",
@@ -5045,7 +7012,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/proofpoint/proofpoint-0.6.0.zip.sig"
+    "signature_path": "/epr/proofpoint/proofpoint-0.6.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "proofpoint.emailsecurity",
+        "title": "Proofpoint Email Security logs"
+      }
+    ]
   },
   {
     "name": "pulse_connect_secure",
@@ -5084,7 +7058,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/pulse_connect_secure/pulse_connect_secure-0.2.1.zip.sig"
+    "signature_path": "/epr/pulse_connect_secure/pulse_connect_secure-0.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "pulse_connect_secure.log",
+        "title": "Pulse Connect Secure"
+      }
+    ]
   },
   {
     "name": "qnap_nas",
@@ -5122,7 +7103,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/qnap_nas/qnap_nas-1.1.1.zip.sig"
+    "signature_path": "/epr/qnap_nas/qnap_nas-1.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "qnap_nas.log",
+        "title": "QNAP NAS logs"
+      }
+    ]
   },
   {
     "name": "rabbitmq",
@@ -5160,7 +7148,34 @@
     "categories": [
       "message_queue"
     ],
-    "signature_path": "/epr/rabbitmq/rabbitmq-1.2.0.zip.sig"
+    "signature_path": "/epr/rabbitmq/rabbitmq-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "rabbitmq.connection",
+        "title": "RabbitMQ connection metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "rabbitmq.exchange",
+        "title": "RabbitMQ exchange metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "rabbitmq.log",
+        "title": "RabbitMQ application logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "rabbitmq.node",
+        "title": "RabbitMQ node metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "rabbitmq.queue",
+        "title": "RabbitMQ queue metrics"
+      }
+    ]
   },
   {
     "name": "radware",
@@ -5198,7 +7213,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/radware/radware-0.6.0.zip.sig"
+    "signature_path": "/epr/radware/radware-0.6.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "radware.defensepro",
+        "title": "Radware DefensePro logs"
+      }
+    ]
   },
   {
     "name": "ti_recordedfuture",
@@ -5236,7 +7258,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/ti_recordedfuture/ti_recordedfuture-0.1.2.zip.sig"
+    "signature_path": "/epr/ti_recordedfuture/ti_recordedfuture-0.1.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_recordedfuture.threat",
+        "title": "Recorded Future"
+      }
+    ]
   },
   {
     "name": "redis",
@@ -5275,7 +7304,34 @@
       "datastore",
       "message_queue"
     ],
-    "signature_path": "/epr/redis/redis-1.2.0.zip.sig"
+    "signature_path": "/epr/redis/redis-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "redis.info",
+        "title": "Redis info metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "redis.key",
+        "title": "Redis key metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "redis.keyspace",
+        "title": "Redis keyspace metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "redis.log",
+        "title": "Redis application logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "redis.slowlog",
+        "title": "Redis slow logs"
+      }
+    ]
   },
   {
     "name": "stan",
@@ -5314,7 +7370,29 @@
       "message_queue",
       "kubernetes"
     ],
-    "signature_path": "/epr/stan/stan-1.2.0.zip.sig"
+    "signature_path": "/epr/stan/stan-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "stan.channels",
+        "title": "Stan channels metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "stan.log",
+        "title": "STAN logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "stan.stats",
+        "title": "Stan stats metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "stan.subscriptions",
+        "title": "Stan subscriptions metrics"
+      }
+    ]
   },
   {
     "name": "snort",
@@ -5353,7 +7431,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/snort/snort-0.2.2.zip.sig"
+    "signature_path": "/epr/snort/snort-0.2.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "snort.log",
+        "title": "Snort"
+      }
+    ]
   },
   {
     "name": "snyk",
@@ -5391,7 +7476,19 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/snyk/snyk-1.1.2.zip.sig"
+    "signature_path": "/epr/snyk/snyk-1.1.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "snyk.audit",
+        "title": "Collect Snyk Audit Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "snyk.vulnerabilities",
+        "title": "Collect Snyk Vulnerability Data"
+      }
+    ]
   },
   {
     "name": "sonicwall",
@@ -5430,7 +7527,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/sonicwall/sonicwall-0.7.1.zip.sig"
+    "signature_path": "/epr/sonicwall/sonicwall-0.7.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "sonicwall.firewall",
+        "title": "Sonicwall-FW logs"
+      }
+    ]
   },
   {
     "name": "sophos",
@@ -5468,7 +7572,19 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/sophos/sophos-1.2.2.zip.sig"
+    "signature_path": "/epr/sophos/sophos-1.2.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "sophos.utm",
+        "title": "Sophos UTM logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "sophos.xg",
+        "title": "Sophos XG logs"
+      }
+    ]
   },
   {
     "name": "squid",
@@ -5497,7 +7613,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/squid/squid-0.7.0.zip.sig"
+    "signature_path": "/epr/squid/squid-0.7.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "squid.log",
+        "title": "Squid logs"
+      }
+    ]
   },
   {
     "name": "suricata",
@@ -5536,7 +7659,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/suricata/suricata-1.6.1.zip.sig"
+    "signature_path": "/epr/suricata/suricata-1.6.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "suricata.eve",
+        "title": "Suricata eve logs"
+      }
+    ]
   },
   {
     "name": "symantec",
@@ -5571,7 +7701,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/symantec/symantec-0.1.3.zip.sig"
+    "signature_path": "/epr/symantec/symantec-0.1.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "symantec.endpointprotection",
+        "title": "Symantec AntiVirus/Endpoint Protection logs"
+      }
+    ]
   },
   {
     "name": "symantec_endpoint",
@@ -5609,7 +7746,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/symantec_endpoint/symantec_endpoint-0.0.2.zip.sig"
+    "signature_path": "/epr/symantec_endpoint/symantec_endpoint-0.0.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "symantec_endpoint.log",
+        "title": "Symantec Endpoint Protection (SEP) Logs"
+      }
+    ]
   },
   {
     "name": "system",
@@ -5648,7 +7792,94 @@
       "os_system",
       "security"
     ],
-    "signature_path": "/epr/system/system-1.6.4.zip.sig"
+    "signature_path": "/epr/system/system-1.6.4.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "system.application",
+        "title": "Windows Application Events"
+      },
+      {
+        "type": "logs",
+        "dataset": "system.auth",
+        "title": "System auth logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.core",
+        "title": "System core metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.cpu",
+        "title": "System cpu metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.diskio",
+        "title": "System diskio metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.filesystem",
+        "title": "System filesystem metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.fsstat",
+        "title": "System fsstat metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.load",
+        "title": "System load metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.memory",
+        "title": "System memory metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.network",
+        "title": "System network metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.process",
+        "title": "System process metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.process.summary",
+        "title": "System process_summary metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "system.security",
+        "title": "Security logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.socket_summary",
+        "title": "System socket_summary metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "system.syslog",
+        "title": "System syslog logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "system.system",
+        "title": "Windows System Events"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.uptime",
+        "title": "System uptime metrics"
+      }
+    ]
   },
   {
     "name": "tenable_sc",
@@ -5686,7 +7917,24 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/tenable_sc/tenable_sc-1.1.1.zip.sig"
+    "signature_path": "/epr/tenable_sc/tenable_sc-1.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "tenable_sc.asset",
+        "title": "Tenable.sc asset logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "tenable_sc.plugin",
+        "title": "Tenable.sc plugin logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "tenable_sc.vulnerability",
+        "title": "Tenable.sc vulnerability logs"
+      }
+    ]
   },
   {
     "name": "ti_threatq",
@@ -5724,7 +7972,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/ti_threatq/ti_threatq-1.2.2.zip.sig"
+    "signature_path": "/epr/ti_threatq/ti_threatq-1.2.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_threatq.threat",
+        "title": "ThreatQ"
+      }
+    ]
   },
   {
     "name": "traefik",
@@ -5763,7 +8018,19 @@
       "web",
       "security"
     ],
-    "signature_path": "/epr/traefik/traefik-1.2.0.zip.sig"
+    "signature_path": "/epr/traefik/traefik-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "traefik.access",
+        "title": "Traefik access logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "traefik.health",
+        "title": "Traefik health metrics"
+      }
+    ]
   },
   {
     "name": "carbon_black_cloud",
@@ -5801,7 +8068,34 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/carbon_black_cloud/carbon_black_cloud-1.0.2.zip.sig"
+    "signature_path": "/epr/carbon_black_cloud/carbon_black_cloud-1.0.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.alert",
+        "title": "Alert"
+      },
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.asset_vulnerability_summary",
+        "title": "Asset Vulnerability Summary"
+      },
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.audit",
+        "title": "Audit"
+      },
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.endpoint_event",
+        "title": "Endpoint Event"
+      },
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.watchlist_hit",
+        "title": "Watchlist Hit"
+      }
+    ]
   },
   {
     "name": "carbonblack_edr",
@@ -5839,7 +8133,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/carbonblack_edr/carbonblack_edr-1.2.0.zip.sig"
+    "signature_path": "/epr/carbonblack_edr/carbonblack_edr-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "carbonblack_edr.log",
+        "title": "Carbon Black EDR logs"
+      }
+    ]
   },
   {
     "name": "vsphere",
@@ -5878,7 +8179,29 @@
       "monitoring",
       "os_system"
     ],
-    "signature_path": "/epr/vsphere/vsphere-0.1.0.zip.sig"
+    "signature_path": "/epr/vsphere/vsphere-0.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "vsphere.datastore",
+        "title": "vSphere datastore metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "vsphere.host",
+        "title": "vSphere host metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "vsphere.log",
+        "title": "vSphere Logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "vsphere.virtualmachine",
+        "title": "vSphere virtual machine metrics"
+      }
+    ]
   },
   {
     "name": "windows",
@@ -5917,7 +8240,39 @@
       "os_system",
       "security"
     ],
-    "signature_path": "/epr/windows/windows-1.5.0.zip.sig"
+    "signature_path": "/epr/windows/windows-1.5.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "windows.forwarded",
+        "title": "Windows forwarded events"
+      },
+      {
+        "type": "metrics",
+        "dataset": "windows.perfmon",
+        "title": "Windows perfmon metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "windows.powershell",
+        "title": "Windows Powershell logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "windows.powershell_operational",
+        "title": "Windows Powershell/Operational logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "windows.service",
+        "title": "Windows service metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "windows.sysmon_operational",
+        "title": "Windows Sysmon/Operational events"
+      }
+    ]
   },
   {
     "name": "zeek",
@@ -5957,7 +8312,204 @@
       "monitoring",
       "security"
     ],
-    "signature_path": "/epr/zeek/zeek-1.6.1.zip.sig"
+    "signature_path": "/epr/zeek/zeek-1.6.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "zeek.capture_loss",
+        "title": "Zeek capture_loss logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.connection",
+        "title": "Zeek connection logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.dce_rpc",
+        "title": "Zeek dce_rpc logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.dhcp",
+        "title": "Zeek dhcp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.dnp3",
+        "title": "Zeek dnp3 logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.dns",
+        "title": "Zeek dns logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.dpd",
+        "title": "Zeek dpd logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.files",
+        "title": "Zeek files logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.ftp",
+        "title": "Zeek ftp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.http",
+        "title": "Zeek http logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.intel",
+        "title": "Zeek intel logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.irc",
+        "title": "Zeek irc logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.kerberos",
+        "title": "Zeek kerberos logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.modbus",
+        "title": "Zeek modbus logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.mysql",
+        "title": "Zeek mysql logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.notice",
+        "title": "Zeek notice logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.ntlm",
+        "title": "Zeek ntlm logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.ntp",
+        "title": "Zeek ntp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.ocsp",
+        "title": "Zeek ocsp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.pe",
+        "title": "Zeek pe logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.radius",
+        "title": "Zeek radius logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.rdp",
+        "title": "Zeek rdp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.rfb",
+        "title": "Zeek rfb logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.signature",
+        "title": "Zeek signature logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.sip",
+        "title": "Zeek sip logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.smb_cmd",
+        "title": "Zeek smb_cmd logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.smb_files",
+        "title": "Zeek smb_files logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.smb_mapping",
+        "title": "Zeek smb_mapping logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.smtp",
+        "title": "Zeek smtp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.snmp",
+        "title": "Zeek snmp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.socks",
+        "title": "Zeek socks logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.ssh",
+        "title": "Zeek ssh logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.ssl",
+        "title": "Zeek ssl logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.stats",
+        "title": "Zeek stats logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.syslog",
+        "title": "Zeek syslog logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.traceroute",
+        "title": "Zeek traceroute logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.tunnel",
+        "title": "Zeek tunnel logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.weird",
+        "title": "Zeek weird logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.x509",
+        "title": "Zeek x509 logs"
+      }
+    ]
   },
   {
     "name": "zerofox",
@@ -5996,7 +8548,14 @@
       "cloud",
       "security"
     ],
-    "signature_path": "/epr/zerofox/zerofox-1.2.1.zip.sig"
+    "signature_path": "/epr/zerofox/zerofox-1.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "zerofox.alerts",
+        "title": "Alerts"
+      }
+    ]
   },
   {
     "name": "zookeeper",
@@ -6035,7 +8594,24 @@
       "datastore",
       "config_management"
     ],
-    "signature_path": "/epr/zookeeper/zookeeper-1.2.0.zip.sig"
+    "signature_path": "/epr/zookeeper/zookeeper-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "zookeeper.connection",
+        "title": "ZooKeeper connection metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "zookeeper.mntr",
+        "title": "ZooKeeper mntr metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "zookeeper.server",
+        "title": "ZooKeeper server metrics"
+      }
+    ]
   },
   {
     "name": "zoom",
@@ -6074,7 +8650,14 @@
       "security",
       "productivity"
     ],
-    "signature_path": "/epr/zoom/zoom-1.2.1.zip.sig"
+    "signature_path": "/epr/zoom/zoom-1.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "zoom.webhook",
+        "title": "Zoom webhook logs"
+      }
+    ]
   },
   {
     "name": "zscaler_zia",
@@ -6112,7 +8695,34 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/zscaler_zia/zscaler_zia-0.1.3.zip.sig"
+    "signature_path": "/epr/zscaler_zia/zscaler_zia-0.1.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "zscaler_zia.alerts",
+        "title": "Alerts"
+      },
+      {
+        "type": "logs",
+        "dataset": "zscaler_zia.dns",
+        "title": "DNS logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zscaler_zia.firewall",
+        "title": "Firewall Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zscaler_zia.tunnel",
+        "title": "Tunnel Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zscaler_zia.web",
+        "title": "Web Logs"
+      }
+    ]
   },
   {
     "name": "zscaler",
@@ -6151,7 +8761,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/zscaler/zscaler-0.5.1.zip.sig"
+    "signature_path": "/epr/zscaler/zscaler-0.5.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "zscaler.zia",
+        "title": "Zscaler NSS logs"
+      }
+    ]
   },
   {
     "name": "zscaler_zpa",
@@ -6189,7 +8806,34 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/zscaler_zpa/zscaler_zpa-0.1.2.zip.sig"
+    "signature_path": "/epr/zscaler_zpa/zscaler_zpa-0.1.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "zscaler_zpa.app_connector_status",
+        "title": "App Connector Status Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zscaler_zpa.audit",
+        "title": "Audit Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zscaler_zpa.browser_access",
+        "title": "Browser Access Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zscaler_zpa.user_activity",
+        "title": "User Activity Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zscaler_zpa.user_status",
+        "title": "User Status Logs"
+      }
+    ]
   },
   {
     "name": "pfsense",
@@ -6228,6 +8872,13 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/pfsense/pfsense-0.3.1.zip.sig"
+    "signature_path": "/epr/pfsense/pfsense-0.3.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "pfsense.log",
+        "title": "pfSense log logs"
+      }
+    ]
   }
 ]

--- a/testdata/generated/storage-indexer/search-package-internal.json
+++ b/testdata/generated/storage-indexer/search-package-internal.json
@@ -35,7 +35,19 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/1password/1password-1.4.0.zip.sig"
+    "signature_path": "/epr/1password/1password-1.4.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "1password.item_usages",
+        "title": "Collect 1Password item usages events"
+      },
+      {
+        "type": "logs",
+        "dataset": "1password.signin_attempts",
+        "title": "1Password sign-in attempt events"
+      }
+    ]
   },
   {
     "name": "aws",
@@ -410,7 +422,154 @@
       "aws",
       "cloud"
     ],
-    "signature_path": "/epr/aws/aws-1.16.4.zip.sig"
+    "signature_path": "/epr/aws/aws-1.16.4.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "aws.billing",
+        "title": "AWS Billing Metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.cloudfront_logs",
+        "title": "AWS CloudFront logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.cloudtrail",
+        "title": "AWS CloudTrail Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.cloudwatch_logs",
+        "title": "AWS CloudWatch logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.cloudwatch_metrics",
+        "title": "AWS CloudWatch metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.dynamodb",
+        "title": "AWS DynamoDB metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.ebs",
+        "title": "AWS EBS metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.ec2_logs",
+        "title": "AWS EC2 logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.ec2_metrics",
+        "title": "AWS EC2 metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.elb_logs",
+        "title": "AWS ELB logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.elb_metrics",
+        "title": "AWS ELB metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.firewall_logs",
+        "title": "AWS Network Firewall logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.firewall_metrics",
+        "title": "AWS Network Firewall metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.lambda",
+        "title": "AWS Lambda metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.natgateway",
+        "title": "AWS NAT gateway metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.rds",
+        "title": "AWS RDS metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.route53_public_logs",
+        "title": "AWS Route 53 Public Zone Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.route53_resolver_logs",
+        "title": "AWS Route 53 Resolver Query Logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.s3_daily_storage",
+        "title": "AWS S3 daily storage metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.s3_request",
+        "title": "AWS S3 request metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.s3_storage_lens",
+        "title": "AWS S3 Storage Lens metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.s3access",
+        "title": "AWS s3access logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.sns",
+        "title": "AWS SNS metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.sqs",
+        "title": "AWS SQS metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.transitgateway",
+        "title": "AWS Transit Gateway metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.usage",
+        "title": "AWS usage metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.vpcflow",
+        "title": "AWS vpcflow logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.vpn",
+        "title": "AWS VPN metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.waf",
+        "title": "AWS WAF logs"
+      }
+    ]
   },
   {
     "name": "ti_abusech",
@@ -448,7 +607,24 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/ti_abusech/ti_abusech-1.2.3.zip.sig"
+    "signature_path": "/epr/ti_abusech/ti_abusech-1.2.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_abusech.malware",
+        "title": "AbuseCH Malware logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "ti_abusech.malwarebazaar",
+        "title": "AbuseCH MalwareBazaar logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "ti_abusech.url",
+        "title": "AbuseCH URL logs"
+      }
+    ]
   },
   {
     "name": "akamai",
@@ -489,7 +665,14 @@
       "web",
       "cloud"
     ],
-    "signature_path": "/epr/akamai/akamai-1.0.0.zip.sig"
+    "signature_path": "/epr/akamai/akamai-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "akamai.siem",
+        "title": "Akamai SIEM Logs"
+      }
+    ]
   },
   {
     "name": "ti_otx",
@@ -527,7 +710,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/ti_otx/ti_otx-1.2.2.zip.sig"
+    "signature_path": "/epr/ti_otx/ti_otx-1.2.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_otx.threat",
+        "title": "Alienvault OTX logs"
+      }
+    ]
   },
   {
     "name": "ti_anomali",
@@ -565,7 +755,19 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/ti_anomali/ti_anomali-1.2.3.zip.sig"
+    "signature_path": "/epr/ti_anomali/ti_anomali-1.2.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_anomali.limo",
+        "title": "Anomali Limo"
+      },
+      {
+        "type": "logs",
+        "dataset": "ti_anomali.threatstream",
+        "title": "Anomali Threatstream"
+      }
+    ]
   },
   {
     "name": "apache",
@@ -603,7 +805,24 @@
     "categories": [
       "web"
     ],
-    "signature_path": "/epr/apache/apache-1.3.5.zip.sig"
+    "signature_path": "/epr/apache/apache-1.3.5.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "apache.access",
+        "title": "Apache access logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "apache.error",
+        "title": "Apache error logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apache.status",
+        "title": "Apache status metrics"
+      }
+    ]
   },
   {
     "name": "tomcat",
@@ -642,7 +861,14 @@
       "web",
       "security"
     ],
-    "signature_path": "/epr/tomcat/tomcat-1.3.1.zip.sig"
+    "signature_path": "/epr/tomcat/tomcat-1.3.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "tomcat.log",
+        "title": "Apache Tomcat logs"
+      }
+    ]
   },
   {
     "name": "atlassian_bitbucket",
@@ -681,7 +907,14 @@
       "security",
       "web"
     ],
-    "signature_path": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.2.1.zip.sig"
+    "signature_path": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_bitbucket.audit",
+        "title": "Bitbucket Audit Logs"
+      }
+    ]
   },
   {
     "name": "atlassian_confluence",
@@ -720,7 +953,14 @@
       "security",
       "web"
     ],
-    "signature_path": "/epr/atlassian_confluence/atlassian_confluence-1.3.0.zip.sig"
+    "signature_path": "/epr/atlassian_confluence/atlassian_confluence-1.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_confluence.audit",
+        "title": "Confluence Audit Logs"
+      }
+    ]
   },
   {
     "name": "atlassian_jira",
@@ -759,7 +999,14 @@
       "security",
       "web"
     ],
-    "signature_path": "/epr/atlassian_jira/atlassian_jira-1.3.0.zip.sig"
+    "signature_path": "/epr/atlassian_jira/atlassian_jira-1.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_jira.audit",
+        "title": "Jira Audit Logs"
+      }
+    ]
   },
   {
     "name": "auditd",
@@ -797,7 +1044,14 @@
     "categories": [
       "os_system"
     ],
-    "signature_path": "/epr/auditd/auditd-3.1.0.zip.sig"
+    "signature_path": "/epr/auditd/auditd-3.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "auditd.log",
+        "title": "Auditd logs"
+      }
+    ]
   },
   {
     "name": "auditd_manager",
@@ -836,7 +1090,14 @@
       "os_system",
       "security"
     ],
-    "signature_path": "/epr/auditd_manager/auditd_manager-1.0.0.zip.sig"
+    "signature_path": "/epr/auditd_manager/auditd_manager-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "auditd_manager.auditd",
+        "title": "Auditd Manager"
+      }
+    ]
   },
   {
     "name": "auth0",
@@ -876,7 +1137,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/auth0/auth0-1.0.0.zip.sig"
+    "signature_path": "/epr/auth0/auth0-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "auth0.logs",
+        "title": "Auth0 logs via Webhooks"
+      }
+    ]
   },
   {
     "name": "azure_application_insights",
@@ -938,7 +1206,19 @@
       "azure",
       "web"
     ],
-    "signature_path": "/epr/azure_application_insights/azure_application_insights-1.0.1.zip.sig"
+    "signature_path": "/epr/azure_application_insights/azure_application_insights-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "azure.app_insights",
+        "title": "Azure Application Insights"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.app_state",
+        "title": "Azure Application State"
+      }
+    ]
   },
   {
     "name": "azure_billing",
@@ -985,7 +1265,14 @@
     "categories": [
       "azure"
     ],
-    "signature_path": "/epr/azure_billing/azure_billing-1.0.1.zip.sig"
+    "signature_path": "/epr/azure_billing/azure_billing-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "azure.billing",
+        "title": "Azure Billing Metrics"
+      }
+    ]
   },
   {
     "name": "azure",
@@ -1091,7 +1378,39 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/azure/azure-1.1.8.zip.sig"
+    "signature_path": "/epr/azure/azure-1.1.8.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "azure.activitylogs",
+        "title": "Azure Activity Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "azure.auditlogs",
+        "title": "Azure Audit Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "azure.eventhub",
+        "title": "Azure Event Hub Input"
+      },
+      {
+        "type": "logs",
+        "dataset": "azure.platformlogs",
+        "title": "Azure Platform Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "azure.signinlogs",
+        "title": "Azure Signin Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "azure.springcloudlogs",
+        "title": "Azure Spring Cloud Logs"
+      }
+    ]
   },
   {
     "name": "azure_metrics",
@@ -1237,7 +1556,49 @@
       "azure",
       "web"
     ],
-    "signature_path": "/epr/azure_metrics/azure_metrics-1.0.3.zip.sig"
+    "signature_path": "/epr/azure_metrics/azure_metrics-1.0.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "azure.compute_vm",
+        "title": "Compute VM"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.compute_vm_scaleset",
+        "title": "Compute VM Scaleset"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.container_instance",
+        "title": "Container Instance"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.container_registry",
+        "title": "Container Registry"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.container_service",
+        "title": "Container Service"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.database_account",
+        "title": "Database Account"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.monitor",
+        "title": "Monitor"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.storage_account",
+        "title": "Storage Account"
+      }
+    ]
   },
   {
     "name": "cef",
@@ -1267,7 +1628,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/cef/cef-2.0.0.zip.sig"
+    "signature_path": "/epr/cef/cef-2.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cef.log",
+        "title": "CEF log logs"
+      }
+    ]
   },
   {
     "name": "cassandra",
@@ -1306,7 +1674,19 @@
       "datastore",
       "monitoring"
     ],
-    "signature_path": "/epr/cassandra/cassandra-1.1.0.zip.sig"
+    "signature_path": "/epr/cassandra/cassandra-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cassandra.log",
+        "title": "Cassandra System Logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "cassandra.metrics",
+        "title": "metrics"
+      }
+    ]
   },
   {
     "name": "checkpoint",
@@ -1344,7 +1724,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/checkpoint/checkpoint-1.5.0.zip.sig"
+    "signature_path": "/epr/checkpoint/checkpoint-1.5.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "checkpoint.firewall",
+        "title": "Check Point firewall logs"
+      }
+    ]
   },
   {
     "name": "cisco_asa",
@@ -1383,7 +1770,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/cisco_asa/cisco_asa-2.4.1.zip.sig"
+    "signature_path": "/epr/cisco_asa/cisco_asa-2.4.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco_asa.log",
+        "title": "Cisco ASA logs"
+      }
+    ]
   },
   {
     "name": "cisco_duo",
@@ -1421,7 +1815,34 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/cisco_duo/cisco_duo-1.2.4.zip.sig"
+    "signature_path": "/epr/cisco_duo/cisco_duo-1.2.4.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco_duo.admin",
+        "title": "Cisco Duo administrator logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "cisco_duo.auth",
+        "title": "Cisco Duo authentication logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "cisco_duo.offline_enrollment",
+        "title": "Cisco Duo offline enrollment logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "cisco_duo.summary",
+        "title": "Cisco Duo summary logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "cisco_duo.telephony",
+        "title": "Cisco Duo telephony logs"
+      }
+    ]
   },
   {
     "name": "cisco_ftd",
@@ -1460,7 +1881,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/cisco_ftd/cisco_ftd-2.2.1.zip.sig"
+    "signature_path": "/epr/cisco_ftd/cisco_ftd-2.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco_ftd.log",
+        "title": "Cisco FTD logs"
+      }
+    ]
   },
   {
     "name": "cisco_ios",
@@ -1499,7 +1927,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/cisco_ios/cisco_ios-1.6.0.zip.sig"
+    "signature_path": "/epr/cisco_ios/cisco_ios-1.6.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco_ios.log",
+        "title": "Cisco IOS logs"
+      }
+    ]
   },
   {
     "name": "cisco_secure_endpoint",
@@ -1538,7 +1973,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/cisco_secure_endpoint/cisco_secure_endpoint-2.4.1.zip.sig"
+    "signature_path": "/epr/cisco_secure_endpoint/cisco_secure_endpoint-2.4.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco_secure_endpoint.event",
+        "title": "Cisco Secure Endpoint logs"
+      }
+    ]
   },
   {
     "name": "cisco_umbrella",
@@ -1577,7 +2019,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/cisco_umbrella/cisco_umbrella-1.0.0.zip.sig"
+    "signature_path": "/epr/cisco_umbrella/cisco_umbrella-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco_umbrella.log",
+        "title": "Cisco Umbrella logs"
+      }
+    ]
   },
   {
     "name": "cloudflare",
@@ -1618,7 +2067,19 @@
       "web",
       "cloud"
     ],
-    "signature_path": "/epr/cloudflare/cloudflare-2.0.0.zip.sig"
+    "signature_path": "/epr/cloudflare/cloudflare-2.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cloudflare.audit",
+        "title": "Cloudflare Audit Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "cloudflare.logpull",
+        "title": "Cloudflare Logpull"
+      }
+    ]
   },
   {
     "name": "crowdstrike",
@@ -1656,7 +2117,19 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/crowdstrike/crowdstrike-1.3.3.zip.sig"
+    "signature_path": "/epr/crowdstrike/crowdstrike-1.3.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "crowdstrike.falcon",
+        "title": "Crowdstrike falcon logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "crowdstrike.fdr",
+        "title": "Falcon Data Replicator"
+      }
+    ]
   },
   {
     "name": "gcp_pubsub",
@@ -1696,7 +2169,14 @@
       "cloud",
       "custom"
     ],
-    "signature_path": "/epr/gcp_pubsub/gcp_pubsub-1.0.0.zip.sig"
+    "signature_path": "/epr/gcp_pubsub/gcp_pubsub-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "gcp_pubsub.generic",
+        "title": "Custom Google Pub/Sub Logs"
+      }
+    ]
   },
   {
     "name": "http_endpoint",
@@ -1732,7 +2212,14 @@
     "categories": [
       "custom"
     ],
-    "signature_path": "/epr/http_endpoint/http_endpoint-1.0.1.zip.sig"
+    "signature_path": "/epr/http_endpoint/http_endpoint-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "http_endpoint.generic",
+        "title": "Custom HTTP Endpoint Logs"
+      }
+    ]
   },
   {
     "name": "httpjson",
@@ -1761,7 +2248,14 @@
     "categories": [
       "custom"
     ],
-    "signature_path": "/epr/httpjson/httpjson-1.1.1.zip.sig"
+    "signature_path": "/epr/httpjson/httpjson-1.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "httpjson.generic",
+        "title": "Custom HTTPJSON Input"
+      }
+    ]
   },
   {
     "name": "log",
@@ -1792,7 +2286,14 @@
     "categories": [
       "custom"
     ],
-    "signature_path": "/epr/log/log-1.0.0.zip.sig"
+    "signature_path": "/epr/log/log-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "log.log",
+        "title": "Log Dataset"
+      }
+    ]
   },
   {
     "name": "tcp",
@@ -1828,7 +2329,14 @@
     "categories": [
       "custom"
     ],
-    "signature_path": "/epr/tcp/tcp-1.0.0.zip.sig"
+    "signature_path": "/epr/tcp/tcp-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "tcp.generic",
+        "title": "Custom TCP Logs"
+      }
+    ]
   },
   {
     "name": "udp",
@@ -1864,7 +2372,14 @@
     "categories": [
       "custom"
     ],
-    "signature_path": "/epr/udp/udp-1.0.1.zip.sig"
+    "signature_path": "/epr/udp/udp-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "udp.generic",
+        "title": "Custom UDP Logs"
+      }
+    ]
   },
   {
     "name": "winlog",
@@ -1900,7 +2415,14 @@
     "categories": [
       "custom"
     ],
-    "signature_path": "/epr/winlog/winlog-1.4.0.zip.sig"
+    "signature_path": "/epr/winlog/winlog-1.4.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "winlog.winlog",
+        "title": "Custom Windows Event Log Dataset"
+      }
+    ]
   },
   {
     "name": "cyberarkpas",
@@ -1938,7 +2460,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/cyberarkpas/cyberarkpas-2.4.2.zip.sig"
+    "signature_path": "/epr/cyberarkpas/cyberarkpas-2.4.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cyberarkpas.audit",
+        "title": "CyberArk PAS audit logs"
+      }
+    ]
   },
   {
     "name": "ti_cybersixgill",
@@ -1977,7 +2506,14 @@
       "security",
       "productivity"
     ],
-    "signature_path": "/epr/ti_cybersixgill/ti_cybersixgill-1.3.2.zip.sig"
+    "signature_path": "/epr/ti_cybersixgill/ti_cybersixgill-1.3.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_cybersixgill.threat",
+        "title": "Cybersixgill Darkfeed Logs"
+      }
+    ]
   },
   {
     "name": "docker",
@@ -2016,7 +2552,54 @@
       "containers",
       "os_system"
     ],
-    "signature_path": "/epr/docker/docker-1.2.0.zip.sig"
+    "signature_path": "/epr/docker/docker-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "docker.container",
+        "title": "Docker container metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "docker.cpu",
+        "title": "Docker cpu metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "docker.diskio",
+        "title": "Docker diskio metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "docker.event",
+        "title": "Docker event metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "docker.healthcheck",
+        "title": "Docker healthcheck metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "docker.image",
+        "title": "Docker image metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "docker.info",
+        "title": "Docker info metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "docker.memory",
+        "title": "Docker memory metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "docker.network",
+        "title": "Docker network metrics"
+      }
+    ]
   },
   {
     "name": "apm",
@@ -2055,7 +2638,49 @@
       "elastic_stack",
       "monitoring"
     ],
-    "signature_path": "/epr/apm/apm-8.2.0.zip.sig"
+    "signature_path": "/epr/apm/apm-8.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "apm.app",
+        "title": "APM application logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.app",
+        "title": "APM application metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "apm.error",
+        "title": "APM errors"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.internal",
+        "title": "APM internal metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.profiling",
+        "title": "APM profiles"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm.rum",
+        "title": "APM RUM traces"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm.sampled",
+        "title": "APM tail-sampled traces"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm",
+        "title": "APM traces"
+      }
+    ]
   },
   {
     "name": "elastic_agent",
@@ -2086,7 +2711,109 @@
     "categories": [
       "elastic_stack"
     ],
-    "signature_path": "/epr/elastic_agent/elastic_agent-1.3.1.zip.sig"
+    "signature_path": "/epr/elastic_agent/elastic_agent-1.3.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.apm_server",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.apm_server",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.auditbeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.auditbeat",
+        "title": "Elastic Agent Auditbeat Metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.elastic_agent",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.endpoint_security",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.endpoint_security",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.filebeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.filebeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.fleet_server",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.fleet_server",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.heartbeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.heartbeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.metricbeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.metricbeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.osquerybeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.osquerybeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.packetbeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.packetbeat",
+        "title": "Elastic Agent"
+      }
+    ]
   },
   {
     "name": "endpoint",
@@ -2124,7 +2851,74 @@
       "security",
       "cloud"
     ],
-    "signature_path": "/epr/endpoint/endpoint-8.3.0.zip.sig"
+    "signature_path": "/epr/endpoint/endpoint-8.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "endpoint.action.responses",
+        "title": "Endpoint Action Responses"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.actions",
+        "title": "Endpoint Actions"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.alerts",
+        "title": "Endpoint Alerts"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.diagnostic.collection",
+        "title": "Endpoint Alert Collection"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.file",
+        "title": "Endpoint File Events"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.library",
+        "title": "Endpoint Library and Driver Events"
+      },
+      {
+        "type": "metrics",
+        "dataset": "endpoint.metadata",
+        "title": "Endpoint Metadata"
+      },
+      {
+        "type": "metrics",
+        "dataset": "endpoint.metrics",
+        "title": "Endpoint Metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.network",
+        "title": "Endpoint Network Events"
+      },
+      {
+        "type": "metrics",
+        "dataset": "endpoint.policy",
+        "title": "Endpoint Policy Response"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.process",
+        "title": "Endpoint Process Events"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.registry",
+        "title": "Endpoint Registry Events"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.security",
+        "title": "Endpoint Security Events"
+      }
+    ]
   },
   {
     "name": "fim",
@@ -2164,7 +2958,14 @@
       "os_system",
       "security"
     ],
-    "signature_path": "/epr/fim/fim-1.0.0.zip.sig"
+    "signature_path": "/epr/fim/fim-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "fim.event",
+        "title": "Filesystem events"
+      }
+    ]
   },
   {
     "name": "fireeye",
@@ -2204,7 +3005,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/fireeye/fireeye-1.3.1.zip.sig"
+    "signature_path": "/epr/fireeye/fireeye-1.3.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "fireeye.nx",
+        "title": "Fireeye NX"
+      }
+    ]
   },
   {
     "name": "fleet_server",
@@ -2280,7 +3088,29 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/fortinet/fortinet-1.6.1.zip.sig"
+    "signature_path": "/epr/fortinet/fortinet-1.6.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "fortinet.clientendpoint",
+        "title": "Fortinet FortiClient Endpoint Security logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "fortinet.firewall",
+        "title": "Fortinet firewall logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "fortinet.fortimail",
+        "title": "Fortinet FortiMail logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "fortinet.fortimanager",
+        "title": "Fortinet Manager/Analyzer logs"
+      }
+    ]
   },
   {
     "name": "github",
@@ -2318,7 +3148,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/github/github-1.0.0.zip.sig"
+    "signature_path": "/epr/github/github-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "github.audit",
+        "title": "GitHub Audit Logs"
+      }
+    ]
   },
   {
     "name": "gcp",
@@ -2359,7 +3196,29 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/gcp/gcp-1.9.0.zip.sig"
+    "signature_path": "/epr/gcp/gcp-1.9.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "gcp.audit",
+        "title": "Google Cloud Platform (GCP) audit logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "gcp.dns",
+        "title": "Google Cloud Platform (GCP) DNS logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "gcp.firewall",
+        "title": "Google Cloud Platform (GCP) firewall logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "gcp.vpcflow",
+        "title": "Google Cloud Platform (GCP) vpcflow logs"
+      }
+    ]
   },
   {
     "name": "santa",
@@ -2397,7 +3256,14 @@
       "security",
       "os_system"
     ],
-    "signature_path": "/epr/santa/santa-2.0.1.zip.sig"
+    "signature_path": "/epr/santa/santa-2.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "santa.log",
+        "title": "Google Santa log logs"
+      }
+    ]
   },
   {
     "name": "google_workspace",
@@ -2435,7 +3301,39 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/google_workspace/google_workspace-1.5.0.zip.sig"
+    "signature_path": "/epr/google_workspace/google_workspace-1.5.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "google_workspace.admin",
+        "title": "Admin logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "google_workspace.drive",
+        "title": "Drive logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "google_workspace.groups",
+        "title": "Groups logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "google_workspace.login",
+        "title": "Login logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "google_workspace.saml",
+        "title": "SAML logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "google_workspace.user_accounts",
+        "title": "User accounts logs"
+      }
+    ]
   },
   {
     "name": "hashicorp_vault",
@@ -2473,7 +3371,24 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/hashicorp_vault/hashicorp_vault-1.3.3.zip.sig"
+    "signature_path": "/epr/hashicorp_vault/hashicorp_vault-1.3.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "hashicorp_vault.audit",
+        "title": "Hashicorp Vault Audit Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "hashicorp_vault.log",
+        "title": "Hashicorp Vault Operational Logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "hashicorp_vault.metrics",
+        "title": "Hashicorp Vault Metrics"
+      }
+    ]
   },
   {
     "name": "hid_bravura_monitor",
@@ -2511,7 +3426,19 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/hid_bravura_monitor/hid_bravura_monitor-1.0.2.zip.sig"
+    "signature_path": "/epr/hid_bravura_monitor/hid_bravura_monitor-1.0.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "hid_bravura_monitor.log",
+        "title": "Hitachi ID Bravura Monitor"
+      },
+      {
+        "type": "logs",
+        "dataset": "hid_bravura_monitor.winlog",
+        "title": "Hitachi ID Security Fabric logs"
+      }
+    ]
   },
   {
     "name": "juniper",
@@ -2550,7 +3477,24 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/juniper/juniper-1.1.0.zip.sig"
+    "signature_path": "/epr/juniper/juniper-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "juniper.junos",
+        "title": "Juniper JUNOS logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "juniper.netscreen",
+        "title": "Netscreen logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "juniper.srx",
+        "title": "Juniper SRX logs"
+      }
+    ]
   },
   {
     "name": "juniper_srx",
@@ -2589,7 +3533,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/juniper_srx/juniper_srx-1.1.2.zip.sig"
+    "signature_path": "/epr/juniper_srx/juniper_srx-1.1.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "juniper_srx.log",
+        "title": "Juniper SRX logs"
+      }
+    ]
   },
   {
     "name": "kafka",
@@ -2627,7 +3578,29 @@
     "categories": [
       "message_queue"
     ],
-    "signature_path": "/epr/kafka/kafka-1.2.2.zip.sig"
+    "signature_path": "/epr/kafka/kafka-1.2.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "kafka.broker",
+        "title": "Kafka broker metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kafka.consumergroup",
+        "title": "Kafka consumergroup metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "kafka.log",
+        "title": "Kafka log logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kafka.partition",
+        "title": "Kafka partition metrics"
+      }
+    ]
   },
   {
     "name": "keycloak",
@@ -2667,7 +3640,14 @@
       "network",
       "web"
     ],
-    "signature_path": "/epr/keycloak/keycloak-1.2.1.zip.sig"
+    "signature_path": "/epr/keycloak/keycloak-1.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "keycloak.log",
+        "title": "Keycloak"
+      }
+    ]
   },
   {
     "name": "kibana",
@@ -2705,7 +3685,29 @@
     "categories": [
       "elastic_stack"
     ],
-    "signature_path": "/epr/kibana/kibana-1.0.0.zip.sig"
+    "signature_path": "/epr/kibana/kibana-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "kibana.audit",
+        "title": "kibana audit logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "kibana.log",
+        "title": "Kibana logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kibana.stats",
+        "title": "Kibana stats metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kibana.status",
+        "title": "Kibana status metrics"
+      }
+    ]
   },
   {
     "name": "kubernetes",
@@ -2865,7 +3867,139 @@
       "containers",
       "kubernetes"
     ],
-    "signature_path": "/epr/kubernetes/kubernetes-1.17.2.zip.sig"
+    "signature_path": "/epr/kubernetes/kubernetes-1.17.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.apiserver",
+        "title": "Kubernetes API Server metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "kubernetes.audit_logs",
+        "title": "Kubernetes audit logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.container",
+        "title": "Kubernetes Container metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "kubernetes.container_logs",
+        "title": "Kubernetes container logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.controllermanager",
+        "title": "Kubernetes Controller Manager metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.event",
+        "title": "Kubernetes Event metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.node",
+        "title": "Kubernetes Node metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.pod",
+        "title": "Kubernetes Pod metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.proxy",
+        "title": "Kubernetes Proxy metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.scheduler",
+        "title": "Kubernetes Scheduler metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_container",
+        "title": "Kubernetes Container metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_cronjob",
+        "title": "Kubernetes Cronjob metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_daemonset",
+        "title": "Kubernetes Deamonset metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_deployment",
+        "title": "Kubernetes Deployment metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_job",
+        "title": "Kubernetes Job metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_node",
+        "title": "Kubernetes Node metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_persistentvolume",
+        "title": "Kubernetes PersistentVolume metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_persistentvolumeclaim",
+        "title": "Kubernetes PersistentVolumeClaim metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_pod",
+        "title": "Kubernetes Pod metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_replicaset",
+        "title": "Kubernetes state_replicaset metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_resourcequota",
+        "title": "Kubernetes ResourceQuota metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_service",
+        "title": "Kubernetes Service metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_statefulset",
+        "title": "Kubernetes StatefulSet metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_storageclass",
+        "title": "Kubernetes StorageClass metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.system",
+        "title": "Kubernetes System metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.volume",
+        "title": "Kubernetes Volume metrics"
+      }
+    ]
   },
   {
     "name": "logstash",
@@ -2903,7 +4037,29 @@
     "categories": [
       "elastic_stack"
     ],
-    "signature_path": "/epr/logstash/logstash-1.0.0.zip.sig"
+    "signature_path": "/epr/logstash/logstash-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "logstash.log",
+        "title": "Logstash logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "logstash.node",
+        "title": "Logstash node metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "logstash.node_stats",
+        "title": "Logstash node_stats metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "logstash.slowlog",
+        "title": "logstash slowlog logs"
+      }
+    ]
   },
   {
     "name": "m365_defender",
@@ -2943,7 +4099,14 @@
       "security",
       "azure"
     ],
-    "signature_path": "/epr/m365_defender/m365_defender-1.0.3.zip.sig"
+    "signature_path": "/epr/m365_defender/m365_defender-1.0.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "m365_defender.log",
+        "title": "M365 Defender Logs"
+      }
+    ]
   },
   {
     "name": "ti_misp",
@@ -2981,7 +4144,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/ti_misp/ti_misp-1.2.2.zip.sig"
+    "signature_path": "/epr/ti_misp/ti_misp-1.2.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_misp.threat",
+        "title": "MISP"
+      }
+    ]
   },
   {
     "name": "mattermost",
@@ -3020,7 +4190,14 @@
       "security",
       "web"
     ],
-    "signature_path": "/epr/mattermost/mattermost-1.1.1.zip.sig"
+    "signature_path": "/epr/mattermost/mattermost-1.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "mattermost.audit",
+        "title": "Audit Logs"
+      }
+    ]
   },
   {
     "name": "microsoft",
@@ -3060,7 +4237,19 @@
       "security",
       "azure"
     ],
-    "signature_path": "/epr/microsoft/microsoft-1.0.0.zip.sig"
+    "signature_path": "/epr/microsoft/microsoft-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "microsoft.defender_atp",
+        "title": "Microsoft Defender for Endpoint"
+      },
+      {
+        "type": "logs",
+        "dataset": "microsoft.dhcp",
+        "title": "Microsoft DHCP logs"
+      }
+    ]
   },
   {
     "name": "microsoft_dhcp",
@@ -3098,7 +4287,14 @@
     "categories": [
       "network"
     ],
-    "signature_path": "/epr/microsoft_dhcp/microsoft_dhcp-1.3.1.zip.sig"
+    "signature_path": "/epr/microsoft_dhcp/microsoft_dhcp-1.3.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "microsoft_dhcp.log",
+        "title": "Microsoft DHCP Logs"
+      }
+    ]
   },
   {
     "name": "microsoft_defender_endpoint",
@@ -3138,7 +4334,14 @@
       "security",
       "azure"
     ],
-    "signature_path": "/epr/microsoft_defender_endpoint/microsoft_defender_endpoint-2.1.0.zip.sig"
+    "signature_path": "/epr/microsoft_defender_endpoint/microsoft_defender_endpoint-2.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "microsoft_defender_endpoint.log",
+        "title": "Microsoft Defender for Endpoint logs"
+      }
+    ]
   },
   {
     "name": "mongodb",
@@ -3176,7 +4379,39 @@
     "categories": [
       "datastore"
     ],
-    "signature_path": "/epr/mongodb/mongodb-1.3.1.zip.sig"
+    "signature_path": "/epr/mongodb/mongodb-1.3.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "mongodb.collstats",
+        "title": "MongoDB collstats metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "mongodb.dbstats",
+        "title": "MongoDB dbstats metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "mongodb.log",
+        "title": "mongodb log logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "mongodb.metrics",
+        "title": "MongoDB metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "mongodb.replstatus",
+        "title": "MongoDB replstatus metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "mongodb.status",
+        "title": "MongoDB status metrics"
+      }
+    ]
   },
   {
     "name": "mysql",
@@ -3214,7 +4449,34 @@
     "categories": [
       "datastore"
     ],
-    "signature_path": "/epr/mysql/mysql-1.2.1.zip.sig"
+    "signature_path": "/epr/mysql/mysql-1.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "mysql.error",
+        "title": "MySQL error logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "mysql.galera_status",
+        "title": "MySQL galera_status metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "mysql.performance",
+        "title": "MySQL performance metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "mysql.slowlog",
+        "title": "MySQL slowlog logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "mysql.status",
+        "title": "MySQL status metrics"
+      }
+    ]
   },
   {
     "name": "mysql_enterprise",
@@ -3253,7 +4515,14 @@
       "security",
       "datastore"
     ],
-    "signature_path": "/epr/mysql_enterprise/mysql_enterprise-1.0.1.zip.sig"
+    "signature_path": "/epr/mysql_enterprise/mysql_enterprise-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "mysql_enterprise.audit",
+        "title": "MySQL Enterprise Audit Log"
+      }
+    ]
   },
   {
     "name": "nats",
@@ -3291,7 +4560,44 @@
     "categories": [
       "message_queue"
     ],
-    "signature_path": "/epr/nats/nats-1.2.0.zip.sig"
+    "signature_path": "/epr/nats/nats-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "nats.connection",
+        "title": "NATS connection metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "nats.connections",
+        "title": "NATS connections metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "nats.log",
+        "title": "NATS logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "nats.route",
+        "title": "NATS route metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "nats.routes",
+        "title": "NATS routes metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "nats.stats",
+        "title": "NATS stats metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "nats.subscriptions",
+        "title": "NATS subscriptions metrics"
+      }
+    ]
   },
   {
     "name": "netflow",
@@ -3321,7 +4627,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/netflow/netflow-1.4.2.zip.sig"
+    "signature_path": "/epr/netflow/netflow-1.4.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "netflow.log",
+        "title": "NetFlow logs"
+      }
+    ]
   },
   {
     "name": "nginx",
@@ -3360,7 +4673,24 @@
       "web",
       "security"
     ],
-    "signature_path": "/epr/nginx/nginx-1.3.1.zip.sig"
+    "signature_path": "/epr/nginx/nginx-1.3.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "nginx.access",
+        "title": "Nginx access logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "nginx.error",
+        "title": "Nginx error logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "nginx.stubstatus",
+        "title": "Nginx stubstatus metrics"
+      }
+    ]
   },
   {
     "name": "nginx_ingress_controller",
@@ -3399,7 +4729,19 @@
       "web",
       "security"
     ],
-    "signature_path": "/epr/nginx_ingress_controller/nginx_ingress_controller-1.2.0.zip.sig"
+    "signature_path": "/epr/nginx_ingress_controller/nginx_ingress_controller-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "nginx_ingress_controller.access",
+        "title": "Nginx Ingress Controller access logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "nginx_ingress_controller.error",
+        "title": "Nginx Ingress Controller error logs"
+      }
+    ]
   },
   {
     "name": "o365",
@@ -3437,7 +4779,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/o365/o365-1.4.3.zip.sig"
+    "signature_path": "/epr/o365/o365-1.4.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "o365.audit",
+        "title": "Office 365 audit logs"
+      }
+    ]
   },
   {
     "name": "okta",
@@ -3475,7 +4824,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/okta/okta-1.5.2.zip.sig"
+    "signature_path": "/epr/okta/okta-1.5.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "okta.system",
+        "title": "Okta system logs"
+      }
+    ]
   },
   {
     "name": "oracle",
@@ -3514,7 +4870,14 @@
       "security",
       "datastore"
     ],
-    "signature_path": "/epr/oracle/oracle-1.0.1.zip.sig"
+    "signature_path": "/epr/oracle/oracle-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "oracle.database_audit",
+        "title": "Oracle Audit Log"
+      }
+    ]
   },
   {
     "name": "osquery",
@@ -3553,7 +4916,14 @@
       "security",
       "os_system"
     ],
-    "signature_path": "/epr/osquery/osquery-1.2.1.zip.sig"
+    "signature_path": "/epr/osquery/osquery-1.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "osquery.result",
+        "title": "Osquery result logs"
+      }
+    ]
   },
   {
     "name": "osquery_manager",
@@ -3593,7 +4963,14 @@
       "os_system",
       "config_management"
     ],
-    "signature_path": "/epr/osquery_manager/osquery_manager-1.2.1.zip.sig"
+    "signature_path": "/epr/osquery_manager/osquery_manager-1.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "osquery_manager.result",
+        "title": "Osquery Manager queries"
+      }
+    ]
   },
   {
     "name": "panw_cortex_xdr",
@@ -3631,7 +5008,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/panw_cortex_xdr/panw_cortex_xdr-1.1.1.zip.sig"
+    "signature_path": "/epr/panw_cortex_xdr/panw_cortex_xdr-1.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "panw_cortex_xdr.alerts",
+        "title": "Palo Alto Cortex XDR API"
+      }
+    ]
   },
   {
     "name": "panw",
@@ -3669,7 +5053,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/panw/panw-1.5.3.zip.sig"
+    "signature_path": "/epr/panw/panw-1.5.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "panw.panos",
+        "title": "Palo Alto Networks PAN-OS firewall logs"
+      }
+    ]
   },
   {
     "name": "postgresql",
@@ -3707,7 +5098,34 @@
     "categories": [
       "datastore"
     ],
-    "signature_path": "/epr/postgresql/postgresql-1.2.0.zip.sig"
+    "signature_path": "/epr/postgresql/postgresql-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "postgresql.activity",
+        "title": "PostgreSQL activity metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "postgresql.bgwriter",
+        "title": "PostgreSQL bgwriter metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "postgresql.database",
+        "title": "PostgreSQL database metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "postgresql.log",
+        "title": "PostgreSQL logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "postgresql.statement",
+        "title": "PostgreSQL statement metrics"
+      }
+    ]
   },
   {
     "name": "security_detection_engine",
@@ -3775,7 +5193,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/qnap_nas/qnap_nas-1.1.1.zip.sig"
+    "signature_path": "/epr/qnap_nas/qnap_nas-1.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "qnap_nas.log",
+        "title": "QNAP NAS logs"
+      }
+    ]
   },
   {
     "name": "rabbitmq",
@@ -3813,7 +5238,34 @@
     "categories": [
       "message_queue"
     ],
-    "signature_path": "/epr/rabbitmq/rabbitmq-1.2.0.zip.sig"
+    "signature_path": "/epr/rabbitmq/rabbitmq-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "rabbitmq.connection",
+        "title": "RabbitMQ connection metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "rabbitmq.exchange",
+        "title": "RabbitMQ exchange metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "rabbitmq.log",
+        "title": "RabbitMQ application logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "rabbitmq.node",
+        "title": "RabbitMQ node metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "rabbitmq.queue",
+        "title": "RabbitMQ queue metrics"
+      }
+    ]
   },
   {
     "name": "redis",
@@ -3852,7 +5304,34 @@
       "datastore",
       "message_queue"
     ],
-    "signature_path": "/epr/redis/redis-1.2.0.zip.sig"
+    "signature_path": "/epr/redis/redis-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "redis.info",
+        "title": "Redis info metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "redis.key",
+        "title": "Redis key metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "redis.keyspace",
+        "title": "Redis keyspace metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "redis.log",
+        "title": "Redis application logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "redis.slowlog",
+        "title": "Redis slow logs"
+      }
+    ]
   },
   {
     "name": "stan",
@@ -3891,7 +5370,29 @@
       "message_queue",
       "kubernetes"
     ],
-    "signature_path": "/epr/stan/stan-1.2.0.zip.sig"
+    "signature_path": "/epr/stan/stan-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "stan.channels",
+        "title": "Stan channels metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "stan.log",
+        "title": "STAN logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "stan.stats",
+        "title": "Stan stats metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "stan.subscriptions",
+        "title": "Stan subscriptions metrics"
+      }
+    ]
   },
   {
     "name": "snyk",
@@ -3929,7 +5430,19 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/snyk/snyk-1.1.2.zip.sig"
+    "signature_path": "/epr/snyk/snyk-1.1.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "snyk.audit",
+        "title": "Collect Snyk Audit Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "snyk.vulnerabilities",
+        "title": "Collect Snyk Vulnerability Data"
+      }
+    ]
   },
   {
     "name": "sophos",
@@ -3967,7 +5480,19 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/sophos/sophos-1.2.2.zip.sig"
+    "signature_path": "/epr/sophos/sophos-1.2.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "sophos.utm",
+        "title": "Sophos UTM logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "sophos.xg",
+        "title": "Sophos XG logs"
+      }
+    ]
   },
   {
     "name": "suricata",
@@ -4006,7 +5531,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/suricata/suricata-1.6.1.zip.sig"
+    "signature_path": "/epr/suricata/suricata-1.6.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "suricata.eve",
+        "title": "Suricata eve logs"
+      }
+    ]
   },
   {
     "name": "system",
@@ -4045,7 +5577,94 @@
       "os_system",
       "security"
     ],
-    "signature_path": "/epr/system/system-1.6.4.zip.sig"
+    "signature_path": "/epr/system/system-1.6.4.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "system.application",
+        "title": "Windows Application Events"
+      },
+      {
+        "type": "logs",
+        "dataset": "system.auth",
+        "title": "System auth logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.core",
+        "title": "System core metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.cpu",
+        "title": "System cpu metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.diskio",
+        "title": "System diskio metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.filesystem",
+        "title": "System filesystem metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.fsstat",
+        "title": "System fsstat metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.load",
+        "title": "System load metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.memory",
+        "title": "System memory metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.network",
+        "title": "System network metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.process",
+        "title": "System process metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.process.summary",
+        "title": "System process_summary metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "system.security",
+        "title": "Security logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.socket_summary",
+        "title": "System socket_summary metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "system.syslog",
+        "title": "System syslog logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "system.system",
+        "title": "Windows System Events"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.uptime",
+        "title": "System uptime metrics"
+      }
+    ]
   },
   {
     "name": "tenable_sc",
@@ -4083,7 +5702,24 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/tenable_sc/tenable_sc-1.1.1.zip.sig"
+    "signature_path": "/epr/tenable_sc/tenable_sc-1.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "tenable_sc.asset",
+        "title": "Tenable.sc asset logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "tenable_sc.plugin",
+        "title": "Tenable.sc plugin logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "tenable_sc.vulnerability",
+        "title": "Tenable.sc vulnerability logs"
+      }
+    ]
   },
   {
     "name": "ti_threatq",
@@ -4121,7 +5757,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/ti_threatq/ti_threatq-1.2.2.zip.sig"
+    "signature_path": "/epr/ti_threatq/ti_threatq-1.2.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_threatq.threat",
+        "title": "ThreatQ"
+      }
+    ]
   },
   {
     "name": "traefik",
@@ -4160,7 +5803,19 @@
       "web",
       "security"
     ],
-    "signature_path": "/epr/traefik/traefik-1.2.0.zip.sig"
+    "signature_path": "/epr/traefik/traefik-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "traefik.access",
+        "title": "Traefik access logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "traefik.health",
+        "title": "Traefik health metrics"
+      }
+    ]
   },
   {
     "name": "carbon_black_cloud",
@@ -4198,7 +5853,34 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/carbon_black_cloud/carbon_black_cloud-1.0.2.zip.sig"
+    "signature_path": "/epr/carbon_black_cloud/carbon_black_cloud-1.0.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.alert",
+        "title": "Alert"
+      },
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.asset_vulnerability_summary",
+        "title": "Asset Vulnerability Summary"
+      },
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.audit",
+        "title": "Audit"
+      },
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.endpoint_event",
+        "title": "Endpoint Event"
+      },
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.watchlist_hit",
+        "title": "Watchlist Hit"
+      }
+    ]
   },
   {
     "name": "carbonblack_edr",
@@ -4236,7 +5918,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/carbonblack_edr/carbonblack_edr-1.2.0.zip.sig"
+    "signature_path": "/epr/carbonblack_edr/carbonblack_edr-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "carbonblack_edr.log",
+        "title": "Carbon Black EDR logs"
+      }
+    ]
   },
   {
     "name": "windows",
@@ -4275,7 +5964,39 @@
       "os_system",
       "security"
     ],
-    "signature_path": "/epr/windows/windows-1.5.0.zip.sig"
+    "signature_path": "/epr/windows/windows-1.5.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "windows.forwarded",
+        "title": "Windows forwarded events"
+      },
+      {
+        "type": "metrics",
+        "dataset": "windows.perfmon",
+        "title": "Windows perfmon metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "windows.powershell",
+        "title": "Windows Powershell logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "windows.powershell_operational",
+        "title": "Windows Powershell/Operational logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "windows.service",
+        "title": "Windows service metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "windows.sysmon_operational",
+        "title": "Windows Sysmon/Operational events"
+      }
+    ]
   },
   {
     "name": "zeek",
@@ -4315,7 +6036,204 @@
       "monitoring",
       "security"
     ],
-    "signature_path": "/epr/zeek/zeek-1.6.1.zip.sig"
+    "signature_path": "/epr/zeek/zeek-1.6.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "zeek.capture_loss",
+        "title": "Zeek capture_loss logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.connection",
+        "title": "Zeek connection logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.dce_rpc",
+        "title": "Zeek dce_rpc logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.dhcp",
+        "title": "Zeek dhcp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.dnp3",
+        "title": "Zeek dnp3 logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.dns",
+        "title": "Zeek dns logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.dpd",
+        "title": "Zeek dpd logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.files",
+        "title": "Zeek files logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.ftp",
+        "title": "Zeek ftp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.http",
+        "title": "Zeek http logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.intel",
+        "title": "Zeek intel logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.irc",
+        "title": "Zeek irc logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.kerberos",
+        "title": "Zeek kerberos logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.modbus",
+        "title": "Zeek modbus logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.mysql",
+        "title": "Zeek mysql logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.notice",
+        "title": "Zeek notice logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.ntlm",
+        "title": "Zeek ntlm logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.ntp",
+        "title": "Zeek ntp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.ocsp",
+        "title": "Zeek ocsp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.pe",
+        "title": "Zeek pe logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.radius",
+        "title": "Zeek radius logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.rdp",
+        "title": "Zeek rdp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.rfb",
+        "title": "Zeek rfb logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.signature",
+        "title": "Zeek signature logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.sip",
+        "title": "Zeek sip logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.smb_cmd",
+        "title": "Zeek smb_cmd logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.smb_files",
+        "title": "Zeek smb_files logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.smb_mapping",
+        "title": "Zeek smb_mapping logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.smtp",
+        "title": "Zeek smtp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.snmp",
+        "title": "Zeek snmp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.socks",
+        "title": "Zeek socks logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.ssh",
+        "title": "Zeek ssh logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.ssl",
+        "title": "Zeek ssl logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.stats",
+        "title": "Zeek stats logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.syslog",
+        "title": "Zeek syslog logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.traceroute",
+        "title": "Zeek traceroute logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.tunnel",
+        "title": "Zeek tunnel logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.weird",
+        "title": "Zeek weird logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.x509",
+        "title": "Zeek x509 logs"
+      }
+    ]
   },
   {
     "name": "zerofox",
@@ -4354,7 +6272,14 @@
       "cloud",
       "security"
     ],
-    "signature_path": "/epr/zerofox/zerofox-1.2.1.zip.sig"
+    "signature_path": "/epr/zerofox/zerofox-1.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "zerofox.alerts",
+        "title": "Alerts"
+      }
+    ]
   },
   {
     "name": "zookeeper",
@@ -4393,7 +6318,24 @@
       "datastore",
       "config_management"
     ],
-    "signature_path": "/epr/zookeeper/zookeeper-1.2.0.zip.sig"
+    "signature_path": "/epr/zookeeper/zookeeper-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "zookeeper.connection",
+        "title": "ZooKeeper connection metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "zookeeper.mntr",
+        "title": "ZooKeeper mntr metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "zookeeper.server",
+        "title": "ZooKeeper server metrics"
+      }
+    ]
   },
   {
     "name": "zoom",
@@ -4432,6 +6374,13 @@
       "security",
       "productivity"
     ],
-    "signature_path": "/epr/zoom/zoom-1.2.1.zip.sig"
+    "signature_path": "/epr/zoom/zoom-1.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "zoom.webhook",
+        "title": "Zoom webhook logs"
+      }
+    ]
   }
 ]

--- a/testdata/generated/storage-indexer/search-package-prerelease.json
+++ b/testdata/generated/storage-indexer/search-package-prerelease.json
@@ -35,7 +35,19 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/1password/1password-1.4.0.zip.sig"
+    "signature_path": "/epr/1password/1password-1.4.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "1password.item_usages",
+        "title": "Collect 1Password item usages events"
+      },
+      {
+        "type": "logs",
+        "dataset": "1password.signin_attempts",
+        "title": "1Password sign-in attempt events"
+      }
+    ]
   },
   {
     "name": "aws",
@@ -410,7 +422,154 @@
       "aws",
       "cloud"
     ],
-    "signature_path": "/epr/aws/aws-1.16.4.zip.sig"
+    "signature_path": "/epr/aws/aws-1.16.4.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "aws.billing",
+        "title": "AWS Billing Metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.cloudfront_logs",
+        "title": "AWS CloudFront logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.cloudtrail",
+        "title": "AWS CloudTrail Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.cloudwatch_logs",
+        "title": "AWS CloudWatch logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.cloudwatch_metrics",
+        "title": "AWS CloudWatch metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.dynamodb",
+        "title": "AWS DynamoDB metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.ebs",
+        "title": "AWS EBS metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.ec2_logs",
+        "title": "AWS EC2 logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.ec2_metrics",
+        "title": "AWS EC2 metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.elb_logs",
+        "title": "AWS ELB logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.elb_metrics",
+        "title": "AWS ELB metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.firewall_logs",
+        "title": "AWS Network Firewall logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.firewall_metrics",
+        "title": "AWS Network Firewall metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.lambda",
+        "title": "AWS Lambda metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.natgateway",
+        "title": "AWS NAT gateway metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.rds",
+        "title": "AWS RDS metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.route53_public_logs",
+        "title": "AWS Route 53 Public Zone Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.route53_resolver_logs",
+        "title": "AWS Route 53 Resolver Query Logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.s3_daily_storage",
+        "title": "AWS S3 daily storage metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.s3_request",
+        "title": "AWS S3 request metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.s3_storage_lens",
+        "title": "AWS S3 Storage Lens metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.s3access",
+        "title": "AWS s3access logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.sns",
+        "title": "AWS SNS metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.sqs",
+        "title": "AWS SQS metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.transitgateway",
+        "title": "AWS Transit Gateway metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.usage",
+        "title": "AWS usage metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.vpcflow",
+        "title": "AWS vpcflow logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.vpn",
+        "title": "AWS VPN metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.waf",
+        "title": "AWS WAF logs"
+      }
+    ]
   },
   {
     "name": "awsfargate",
@@ -450,7 +609,14 @@
       "cloud",
       "containers"
     ],
-    "signature_path": "/epr/awsfargate/awsfargate-0.1.1.zip.sig"
+    "signature_path": "/epr/awsfargate/awsfargate-0.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "awsfargate.task_stats",
+        "title": "AWS Fargate task_stats metrics"
+      }
+    ]
   },
   {
     "name": "ti_abusech",
@@ -488,7 +654,24 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/ti_abusech/ti_abusech-1.2.3.zip.sig"
+    "signature_path": "/epr/ti_abusech/ti_abusech-1.2.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_abusech.malware",
+        "title": "AbuseCH Malware logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "ti_abusech.malwarebazaar",
+        "title": "AbuseCH MalwareBazaar logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "ti_abusech.url",
+        "title": "AbuseCH URL logs"
+      }
+    ]
   },
   {
     "name": "activemq",
@@ -526,7 +709,34 @@
     "categories": [
       "web"
     ],
-    "signature_path": "/epr/activemq/activemq-0.3.0.zip.sig"
+    "signature_path": "/epr/activemq/activemq-0.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "activemq.audit",
+        "title": "ActiveMQ audit logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "activemq.broker",
+        "title": "ActiveMQ broker metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "activemq.log",
+        "title": "ActiveMQ log logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "activemq.queue",
+        "title": "ActiveMQ queue metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "activemq.topic",
+        "title": "ActiveMQ topic metrics"
+      }
+    ]
   },
   {
     "name": "akamai",
@@ -567,7 +777,14 @@
       "web",
       "cloud"
     ],
-    "signature_path": "/epr/akamai/akamai-1.0.0.zip.sig"
+    "signature_path": "/epr/akamai/akamai-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "akamai.siem",
+        "title": "Akamai SIEM Logs"
+      }
+    ]
   },
   {
     "name": "ti_otx",
@@ -605,7 +822,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/ti_otx/ti_otx-1.2.2.zip.sig"
+    "signature_path": "/epr/ti_otx/ti_otx-1.2.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_otx.threat",
+        "title": "Alienvault OTX logs"
+      }
+    ]
   },
   {
     "name": "ti_anomali",
@@ -643,7 +867,19 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/ti_anomali/ti_anomali-1.2.3.zip.sig"
+    "signature_path": "/epr/ti_anomali/ti_anomali-1.2.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_anomali.limo",
+        "title": "Anomali Limo"
+      },
+      {
+        "type": "logs",
+        "dataset": "ti_anomali.threatstream",
+        "title": "Anomali Threatstream"
+      }
+    ]
   },
   {
     "name": "apache",
@@ -681,7 +917,24 @@
     "categories": [
       "web"
     ],
-    "signature_path": "/epr/apache/apache-1.3.5.zip.sig"
+    "signature_path": "/epr/apache/apache-1.3.5.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "apache.access",
+        "title": "Apache access logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "apache.error",
+        "title": "Apache error logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apache.status",
+        "title": "Apache status metrics"
+      }
+    ]
   },
   {
     "name": "tomcat",
@@ -720,7 +973,14 @@
       "web",
       "security"
     ],
-    "signature_path": "/epr/tomcat/tomcat-1.3.1.zip.sig"
+    "signature_path": "/epr/tomcat/tomcat-1.3.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "tomcat.log",
+        "title": "Apache Tomcat logs"
+      }
+    ]
   },
   {
     "name": "netscout",
@@ -758,7 +1018,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/netscout/netscout-0.7.0.zip.sig"
+    "signature_path": "/epr/netscout/netscout-0.7.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "netscout.sightline",
+        "title": "Arbor Peakflow SP logs"
+      }
+    ]
   },
   {
     "name": "atlassian_bitbucket",
@@ -797,7 +1064,14 @@
       "security",
       "web"
     ],
-    "signature_path": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.2.1.zip.sig"
+    "signature_path": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_bitbucket.audit",
+        "title": "Bitbucket Audit Logs"
+      }
+    ]
   },
   {
     "name": "atlassian_confluence",
@@ -836,7 +1110,14 @@
       "security",
       "web"
     ],
-    "signature_path": "/epr/atlassian_confluence/atlassian_confluence-1.3.0.zip.sig"
+    "signature_path": "/epr/atlassian_confluence/atlassian_confluence-1.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_confluence.audit",
+        "title": "Confluence Audit Logs"
+      }
+    ]
   },
   {
     "name": "atlassian_jira",
@@ -875,7 +1156,14 @@
       "security",
       "web"
     ],
-    "signature_path": "/epr/atlassian_jira/atlassian_jira-1.3.0.zip.sig"
+    "signature_path": "/epr/atlassian_jira/atlassian_jira-1.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_jira.audit",
+        "title": "Jira Audit Logs"
+      }
+    ]
   },
   {
     "name": "auditd",
@@ -913,7 +1201,14 @@
     "categories": [
       "os_system"
     ],
-    "signature_path": "/epr/auditd/auditd-3.1.0.zip.sig"
+    "signature_path": "/epr/auditd/auditd-3.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "auditd.log",
+        "title": "Auditd logs"
+      }
+    ]
   },
   {
     "name": "auditd_manager",
@@ -952,7 +1247,14 @@
       "os_system",
       "security"
     ],
-    "signature_path": "/epr/auditd_manager/auditd_manager-1.0.0.zip.sig"
+    "signature_path": "/epr/auditd_manager/auditd_manager-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "auditd_manager.auditd",
+        "title": "Auditd Manager"
+      }
+    ]
   },
   {
     "name": "auth0",
@@ -992,7 +1294,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/auth0/auth0-1.0.0.zip.sig"
+    "signature_path": "/epr/auth0/auth0-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "auth0.logs",
+        "title": "Auth0 logs via Webhooks"
+      }
+    ]
   },
   {
     "name": "azure_application_insights",
@@ -1054,7 +1363,19 @@
       "azure",
       "web"
     ],
-    "signature_path": "/epr/azure_application_insights/azure_application_insights-1.0.1.zip.sig"
+    "signature_path": "/epr/azure_application_insights/azure_application_insights-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "azure.app_insights",
+        "title": "Azure Application Insights"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.app_state",
+        "title": "Azure Application State"
+      }
+    ]
   },
   {
     "name": "azure_billing",
@@ -1101,7 +1422,14 @@
     "categories": [
       "azure"
     ],
-    "signature_path": "/epr/azure_billing/azure_billing-1.0.1.zip.sig"
+    "signature_path": "/epr/azure_billing/azure_billing-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "azure.billing",
+        "title": "Azure Billing Metrics"
+      }
+    ]
   },
   {
     "name": "azure",
@@ -1207,7 +1535,39 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/azure/azure-1.1.8.zip.sig"
+    "signature_path": "/epr/azure/azure-1.1.8.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "azure.activitylogs",
+        "title": "Azure Activity Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "azure.auditlogs",
+        "title": "Azure Audit Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "azure.eventhub",
+        "title": "Azure Event Hub Input"
+      },
+      {
+        "type": "logs",
+        "dataset": "azure.platformlogs",
+        "title": "Azure Platform Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "azure.signinlogs",
+        "title": "Azure Signin Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "azure.springcloudlogs",
+        "title": "Azure Spring Cloud Logs"
+      }
+    ]
   },
   {
     "name": "azure_metrics",
@@ -1353,7 +1713,49 @@
       "azure",
       "web"
     ],
-    "signature_path": "/epr/azure_metrics/azure_metrics-1.0.3.zip.sig"
+    "signature_path": "/epr/azure_metrics/azure_metrics-1.0.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "azure.compute_vm",
+        "title": "Compute VM"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.compute_vm_scaleset",
+        "title": "Compute VM Scaleset"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.container_instance",
+        "title": "Container Instance"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.container_registry",
+        "title": "Container Registry"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.container_service",
+        "title": "Container Service"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.database_account",
+        "title": "Database Account"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.monitor",
+        "title": "Monitor"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.storage_account",
+        "title": "Storage Account"
+      }
+    ]
   },
   {
     "name": "barracuda",
@@ -1392,7 +1794,19 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/barracuda/barracuda-0.9.0.zip.sig"
+    "signature_path": "/epr/barracuda/barracuda-0.9.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "barracuda.spamfirewall",
+        "title": "Barracuda Spam Firewall logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "barracuda.waf",
+        "title": "Barracuda Web Application Firewall logs"
+      }
+    ]
   },
   {
     "name": "bluecoat",
@@ -1422,7 +1836,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/bluecoat/bluecoat-0.8.0.zip.sig"
+    "signature_path": "/epr/bluecoat/bluecoat-0.8.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "bluecoat.director",
+        "title": "Blue Coat Director logs"
+      }
+    ]
   },
   {
     "name": "cef",
@@ -1452,7 +1873,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/cef/cef-2.0.0.zip.sig"
+    "signature_path": "/epr/cef/cef-2.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cef.log",
+        "title": "CEF log logs"
+      }
+    ]
   },
   {
     "name": "cloud_security_posture",
@@ -1491,7 +1919,14 @@
       "containers",
       "kubernetes"
     ],
-    "signature_path": "/epr/cloud_security_posture/cloud_security_posture-0.0.14.zip.sig"
+    "signature_path": "/epr/cloud_security_posture/cloud_security_posture-0.0.14.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cloud_security_posture.findings",
+        "title": "Findings"
+      }
+    ]
   },
   {
     "name": "cassandra",
@@ -1530,7 +1965,19 @@
       "datastore",
       "monitoring"
     ],
-    "signature_path": "/epr/cassandra/cassandra-1.1.0.zip.sig"
+    "signature_path": "/epr/cassandra/cassandra-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cassandra.log",
+        "title": "Cassandra System Logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "cassandra.metrics",
+        "title": "metrics"
+      }
+    ]
   },
   {
     "name": "checkpoint",
@@ -1568,7 +2015,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/checkpoint/checkpoint-1.5.0.zip.sig"
+    "signature_path": "/epr/checkpoint/checkpoint-1.5.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "checkpoint.firewall",
+        "title": "Check Point firewall logs"
+      }
+    ]
   },
   {
     "name": "cisco",
@@ -1607,7 +2061,34 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/cisco/cisco-0.12.5.zip.sig"
+    "signature_path": "/epr/cisco/cisco-0.12.5.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco.asa",
+        "title": "Cisco ASA logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "cisco.ftd",
+        "title": "Cisco FTD logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "cisco.ios",
+        "title": "Cisco IOS logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "cisco.meraki",
+        "title": "Cisco Meraki logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "cisco.nexus",
+        "title": "Cisco Nexus logs"
+      }
+    ]
   },
   {
     "name": "cisco_asa",
@@ -1646,7 +2127,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/cisco_asa/cisco_asa-2.4.1.zip.sig"
+    "signature_path": "/epr/cisco_asa/cisco_asa-2.4.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco_asa.log",
+        "title": "Cisco ASA logs"
+      }
+    ]
   },
   {
     "name": "cisco_duo",
@@ -1684,7 +2172,34 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/cisco_duo/cisco_duo-1.2.4.zip.sig"
+    "signature_path": "/epr/cisco_duo/cisco_duo-1.2.4.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco_duo.admin",
+        "title": "Cisco Duo administrator logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "cisco_duo.auth",
+        "title": "Cisco Duo authentication logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "cisco_duo.offline_enrollment",
+        "title": "Cisco Duo offline enrollment logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "cisco_duo.summary",
+        "title": "Cisco Duo summary logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "cisco_duo.telephony",
+        "title": "Cisco Duo telephony logs"
+      }
+    ]
   },
   {
     "name": "cisco_ftd",
@@ -1723,7 +2238,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/cisco_ftd/cisco_ftd-2.2.1.zip.sig"
+    "signature_path": "/epr/cisco_ftd/cisco_ftd-2.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco_ftd.log",
+        "title": "Cisco FTD logs"
+      }
+    ]
   },
   {
     "name": "cisco_ios",
@@ -1762,7 +2284,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/cisco_ios/cisco_ios-1.6.0.zip.sig"
+    "signature_path": "/epr/cisco_ios/cisco_ios-1.6.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco_ios.log",
+        "title": "Cisco IOS logs"
+      }
+    ]
   },
   {
     "name": "cisco_ise",
@@ -1800,7 +2329,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/cisco_ise/cisco_ise-0.1.0.zip.sig"
+    "signature_path": "/epr/cisco_ise/cisco_ise-0.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco_ise.log",
+        "title": "Cisco ISE logs"
+      }
+    ]
   },
   {
     "name": "cisco_meraki",
@@ -1839,7 +2375,19 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/cisco_meraki/cisco_meraki-0.5.0.zip.sig"
+    "signature_path": "/epr/cisco_meraki/cisco_meraki-0.5.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco_meraki.events",
+        "title": "Cisco Meraki webhook events"
+      },
+      {
+        "type": "logs",
+        "dataset": "cisco_meraki.log",
+        "title": "Cisco Meraki logs (via Syslog)"
+      }
+    ]
   },
   {
     "name": "cisco_nexus",
@@ -1878,7 +2426,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/cisco_nexus/cisco_nexus-0.5.1.zip.sig"
+    "signature_path": "/epr/cisco_nexus/cisco_nexus-0.5.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco_nexus.log",
+        "title": "Cisco Nexus logs"
+      }
+    ]
   },
   {
     "name": "cisco_secure_email_gateway",
@@ -1916,7 +2471,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/cisco_secure_email_gateway/cisco_secure_email_gateway-0.1.0.zip.sig"
+    "signature_path": "/epr/cisco_secure_email_gateway/cisco_secure_email_gateway-0.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco_secure_email_gateway.log",
+        "title": "Cisco Secure Email Gateway logs"
+      }
+    ]
   },
   {
     "name": "cisco_secure_endpoint",
@@ -1955,7 +2517,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/cisco_secure_endpoint/cisco_secure_endpoint-2.4.1.zip.sig"
+    "signature_path": "/epr/cisco_secure_endpoint/cisco_secure_endpoint-2.4.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco_secure_endpoint.event",
+        "title": "Cisco Secure Endpoint logs"
+      }
+    ]
   },
   {
     "name": "cisco_umbrella",
@@ -1994,7 +2563,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/cisco_umbrella/cisco_umbrella-1.0.0.zip.sig"
+    "signature_path": "/epr/cisco_umbrella/cisco_umbrella-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco_umbrella.log",
+        "title": "Cisco Umbrella logs"
+      }
+    ]
   },
   {
     "name": "cloudflare",
@@ -2035,7 +2611,19 @@
       "web",
       "cloud"
     ],
-    "signature_path": "/epr/cloudflare/cloudflare-2.0.0.zip.sig"
+    "signature_path": "/epr/cloudflare/cloudflare-2.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cloudflare.audit",
+        "title": "Cloudflare Audit Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "cloudflare.logpull",
+        "title": "Cloudflare Logpull"
+      }
+    ]
   },
   {
     "name": "cockroachdb",
@@ -2082,7 +2670,14 @@
     "categories": [
       "datastore"
     ],
-    "signature_path": "/epr/cockroachdb/cockroachdb-0.2.0.zip.sig"
+    "signature_path": "/epr/cockroachdb/cockroachdb-0.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "cockroachdb.status",
+        "title": "Status"
+      }
+    ]
   },
   {
     "name": "crowdstrike",
@@ -2120,7 +2715,19 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/crowdstrike/crowdstrike-1.3.3.zip.sig"
+    "signature_path": "/epr/crowdstrike/crowdstrike-1.3.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "crowdstrike.falcon",
+        "title": "Crowdstrike falcon logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "crowdstrike.fdr",
+        "title": "Falcon Data Replicator"
+      }
+    ]
   },
   {
     "name": "aws_logs",
@@ -2158,7 +2765,14 @@
       "cloud",
       "aws"
     ],
-    "signature_path": "/epr/aws_logs/aws_logs-0.2.1.zip.sig"
+    "signature_path": "/epr/aws_logs/aws_logs-0.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "aws_logs.generic",
+        "title": "Custom logs from AWS"
+      }
+    ]
   },
   {
     "name": "gcp_pubsub",
@@ -2198,7 +2812,14 @@
       "cloud",
       "custom"
     ],
-    "signature_path": "/epr/gcp_pubsub/gcp_pubsub-1.0.0.zip.sig"
+    "signature_path": "/epr/gcp_pubsub/gcp_pubsub-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "gcp_pubsub.generic",
+        "title": "Custom Google Pub/Sub Logs"
+      }
+    ]
   },
   {
     "name": "http_endpoint",
@@ -2234,7 +2855,14 @@
     "categories": [
       "custom"
     ],
-    "signature_path": "/epr/http_endpoint/http_endpoint-1.0.1.zip.sig"
+    "signature_path": "/epr/http_endpoint/http_endpoint-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "http_endpoint.generic",
+        "title": "Custom HTTP Endpoint Logs"
+      }
+    ]
   },
   {
     "name": "httpjson",
@@ -2263,7 +2891,14 @@
     "categories": [
       "custom"
     ],
-    "signature_path": "/epr/httpjson/httpjson-1.1.1.zip.sig"
+    "signature_path": "/epr/httpjson/httpjson-1.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "httpjson.generic",
+        "title": "Custom HTTPJSON Input"
+      }
+    ]
   },
   {
     "name": "journald",
@@ -2301,7 +2936,14 @@
     "categories": [
       "custom"
     ],
-    "signature_path": "/epr/journald/journald-0.0.2.zip.sig"
+    "signature_path": "/epr/journald/journald-0.0.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "journald.log",
+        "title": "Journald Log"
+      }
+    ]
   },
   {
     "name": "log",
@@ -2332,7 +2974,14 @@
     "categories": [
       "custom"
     ],
-    "signature_path": "/epr/log/log-1.0.0.zip.sig"
+    "signature_path": "/epr/log/log-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "log.log",
+        "title": "Log Dataset"
+      }
+    ]
   },
   {
     "name": "tcp",
@@ -2368,7 +3017,14 @@
     "categories": [
       "custom"
     ],
-    "signature_path": "/epr/tcp/tcp-1.0.0.zip.sig"
+    "signature_path": "/epr/tcp/tcp-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "tcp.generic",
+        "title": "Custom TCP Logs"
+      }
+    ]
   },
   {
     "name": "udp",
@@ -2404,7 +3060,14 @@
     "categories": [
       "custom"
     ],
-    "signature_path": "/epr/udp/udp-1.0.1.zip.sig"
+    "signature_path": "/epr/udp/udp-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "udp.generic",
+        "title": "Custom UDP Logs"
+      }
+    ]
   },
   {
     "name": "winlog",
@@ -2440,7 +3103,14 @@
     "categories": [
       "custom"
     ],
-    "signature_path": "/epr/winlog/winlog-1.4.0.zip.sig"
+    "signature_path": "/epr/winlog/winlog-1.4.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "winlog.winlog",
+        "title": "Custom Windows Event Log Dataset"
+      }
+    ]
   },
   {
     "name": "cyberark",
@@ -2478,7 +3148,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/cyberark/cyberark-0.4.4.zip.sig"
+    "signature_path": "/epr/cyberark/cyberark-0.4.4.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cyberark.corepas",
+        "title": "CyberArk logs"
+      }
+    ]
   },
   {
     "name": "cyberarkpas",
@@ -2516,7 +3193,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/cyberarkpas/cyberarkpas-2.4.2.zip.sig"
+    "signature_path": "/epr/cyberarkpas/cyberarkpas-2.4.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cyberarkpas.audit",
+        "title": "CyberArk PAS audit logs"
+      }
+    ]
   },
   {
     "name": "ti_cybersixgill",
@@ -2555,7 +3239,14 @@
       "security",
       "productivity"
     ],
-    "signature_path": "/epr/ti_cybersixgill/ti_cybersixgill-1.3.2.zip.sig"
+    "signature_path": "/epr/ti_cybersixgill/ti_cybersixgill-1.3.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_cybersixgill.threat",
+        "title": "Cybersixgill Darkfeed Logs"
+      }
+    ]
   },
   {
     "name": "cylance",
@@ -2593,7 +3284,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/cylance/cylance-0.8.1.zip.sig"
+    "signature_path": "/epr/cylance/cylance-0.8.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cylance.protect",
+        "title": "CylanceProtect logs"
+      }
+    ]
   },
   {
     "name": "dga",
@@ -2663,7 +3361,54 @@
       "containers",
       "os_system"
     ],
-    "signature_path": "/epr/docker/docker-1.2.0.zip.sig"
+    "signature_path": "/epr/docker/docker-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "docker.container",
+        "title": "Docker container metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "docker.cpu",
+        "title": "Docker cpu metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "docker.diskio",
+        "title": "Docker diskio metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "docker.event",
+        "title": "Docker event metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "docker.healthcheck",
+        "title": "Docker healthcheck metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "docker.image",
+        "title": "Docker image metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "docker.info",
+        "title": "Docker info metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "docker.memory",
+        "title": "Docker memory metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "docker.network",
+        "title": "Docker network metrics"
+      }
+    ]
   },
   {
     "name": "apm",
@@ -2702,7 +3447,49 @@
       "elastic_stack",
       "monitoring"
     ],
-    "signature_path": "/epr/apm/apm-8.2.0.zip.sig"
+    "signature_path": "/epr/apm/apm-8.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "apm.app",
+        "title": "APM application logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.app",
+        "title": "APM application metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "apm.error",
+        "title": "APM errors"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.internal",
+        "title": "APM internal metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.profiling",
+        "title": "APM profiles"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm.rum",
+        "title": "APM RUM traces"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm.sampled",
+        "title": "APM tail-sampled traces"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm",
+        "title": "APM traces"
+      }
+    ]
   },
   {
     "name": "elastic_agent",
@@ -2733,7 +3520,109 @@
     "categories": [
       "elastic_stack"
     ],
-    "signature_path": "/epr/elastic_agent/elastic_agent-1.3.1.zip.sig"
+    "signature_path": "/epr/elastic_agent/elastic_agent-1.3.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.apm_server",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.apm_server",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.auditbeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.auditbeat",
+        "title": "Elastic Agent Auditbeat Metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.elastic_agent",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.endpoint_security",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.endpoint_security",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.filebeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.filebeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.fleet_server",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.fleet_server",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.heartbeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.heartbeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.metricbeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.metricbeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.osquerybeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.osquerybeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.packetbeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.packetbeat",
+        "title": "Elastic Agent"
+      }
+    ]
   },
   {
     "name": "synthetics",
@@ -2772,7 +3661,39 @@
       "monitoring",
       "web"
     ],
-    "signature_path": "/epr/synthetics/synthetics-0.9.2.zip.sig"
+    "signature_path": "/epr/synthetics/synthetics-0.9.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "synthetics",
+        "dataset": "browser",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "browser.network",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "browser.screenshot",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "http",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "icmp",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "tcp",
+        "title": "synthetic monitor check"
+      }
+    ]
   },
   {
     "name": "elasticsearch",
@@ -2811,7 +3732,89 @@
       "elastic_stack",
       "datastore"
     ],
-    "signature_path": "/epr/elasticsearch/elasticsearch-0.2.0.zip.sig"
+    "signature_path": "/epr/elasticsearch/elasticsearch-0.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "elasticsearch.audit",
+        "title": "Elasticsearch audit logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elasticsearch.ccr",
+        "title": "Elasticsearch ccr metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elasticsearch.cluster_stats",
+        "title": "Elasticsearch cluster_stats metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "elasticsearch.deprecation",
+        "title": "Elasticsearch deprecation logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elasticsearch.enrich",
+        "title": "Elasticsearch enrich metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "elasticsearch.gc",
+        "title": "Elasticsearch gc logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elasticsearch.index",
+        "title": "Elasticsearch index metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elasticsearch.index_recovery",
+        "title": "Elasticsearch index_recovery metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elasticsearch.index_summary",
+        "title": "Elasticsearch index_summary metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elasticsearch.ml_job",
+        "title": "Elasticsearch ml_job metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elasticsearch.node",
+        "title": "Elasticsearch node metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elasticsearch.node_stats",
+        "title": "Elasticsearch node_stats metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elasticsearch.pending_tasks",
+        "title": "Elasticsearch pending_tasks metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "elasticsearch.server",
+        "title": "Elasticsearch server logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elasticsearch.shard",
+        "title": "Elasticsearch shard metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "elasticsearch.slowlog",
+        "title": "Elasticsearch slowlog logs"
+      }
+    ]
   },
   {
     "name": "endpoint",
@@ -2849,7 +3852,74 @@
       "security",
       "cloud"
     ],
-    "signature_path": "/epr/endpoint/endpoint-8.3.0.zip.sig"
+    "signature_path": "/epr/endpoint/endpoint-8.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "endpoint.action.responses",
+        "title": "Endpoint Action Responses"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.actions",
+        "title": "Endpoint Actions"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.alerts",
+        "title": "Endpoint Alerts"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.diagnostic.collection",
+        "title": "Endpoint Alert Collection"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.file",
+        "title": "Endpoint File Events"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.library",
+        "title": "Endpoint Library and Driver Events"
+      },
+      {
+        "type": "metrics",
+        "dataset": "endpoint.metadata",
+        "title": "Endpoint Metadata"
+      },
+      {
+        "type": "metrics",
+        "dataset": "endpoint.metrics",
+        "title": "Endpoint Metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.network",
+        "title": "Endpoint Network Events"
+      },
+      {
+        "type": "metrics",
+        "dataset": "endpoint.policy",
+        "title": "Endpoint Policy Response"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.process",
+        "title": "Endpoint Process Events"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.registry",
+        "title": "Endpoint Registry Events"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.security",
+        "title": "Endpoint Security Events"
+      }
+    ]
   },
   {
     "name": "f5",
@@ -2888,7 +3958,19 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/f5/f5-0.9.0.zip.sig"
+    "signature_path": "/epr/f5/f5-0.9.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "f5.bigipafm",
+        "title": "Big-IP Advanced Firewall Manager logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "f5.bigipapm",
+        "title": "Big-IP Access Policy Manager logs"
+      }
+    ]
   },
   {
     "name": "fim",
@@ -2928,7 +4010,14 @@
       "os_system",
       "security"
     ],
-    "signature_path": "/epr/fim/fim-1.0.0.zip.sig"
+    "signature_path": "/epr/fim/fim-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "fim.event",
+        "title": "Filesystem events"
+      }
+    ]
   },
   {
     "name": "fireeye",
@@ -2968,7 +4057,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/fireeye/fireeye-1.3.1.zip.sig"
+    "signature_path": "/epr/fireeye/fireeye-1.3.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "fireeye.nx",
+        "title": "Fireeye NX"
+      }
+    ]
   },
   {
     "name": "fleet_server",
@@ -3044,7 +4140,29 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/fortinet/fortinet-1.6.1.zip.sig"
+    "signature_path": "/epr/fortinet/fortinet-1.6.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "fortinet.clientendpoint",
+        "title": "Fortinet FortiClient Endpoint Security logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "fortinet.firewall",
+        "title": "Fortinet firewall logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "fortinet.fortimail",
+        "title": "Fortinet FortiMail logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "fortinet.fortimanager",
+        "title": "Fortinet Manager/Analyzer logs"
+      }
+    ]
   },
   {
     "name": "github",
@@ -3082,7 +4200,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/github/github-1.0.0.zip.sig"
+    "signature_path": "/epr/github/github-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "github.audit",
+        "title": "GitHub Audit Logs"
+      }
+    ]
   },
   {
     "name": "gcp",
@@ -3123,7 +4248,29 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/gcp/gcp-1.9.0.zip.sig"
+    "signature_path": "/epr/gcp/gcp-1.9.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "gcp.audit",
+        "title": "Google Cloud Platform (GCP) audit logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "gcp.dns",
+        "title": "Google Cloud Platform (GCP) DNS logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "gcp.firewall",
+        "title": "Google Cloud Platform (GCP) firewall logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "gcp.vpcflow",
+        "title": "Google Cloud Platform (GCP) vpcflow logs"
+      }
+    ]
   },
   {
     "name": "santa",
@@ -3161,7 +4308,14 @@
       "security",
       "os_system"
     ],
-    "signature_path": "/epr/santa/santa-2.0.1.zip.sig"
+    "signature_path": "/epr/santa/santa-2.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "santa.log",
+        "title": "Google Santa log logs"
+      }
+    ]
   },
   {
     "name": "google_workspace",
@@ -3199,7 +4353,39 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/google_workspace/google_workspace-1.5.0.zip.sig"
+    "signature_path": "/epr/google_workspace/google_workspace-1.5.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "google_workspace.admin",
+        "title": "Admin logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "google_workspace.drive",
+        "title": "Drive logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "google_workspace.groups",
+        "title": "Groups logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "google_workspace.login",
+        "title": "Login logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "google_workspace.saml",
+        "title": "SAML logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "google_workspace.user_accounts",
+        "title": "User accounts logs"
+      }
+    ]
   },
   {
     "name": "haproxy",
@@ -3238,7 +4424,24 @@
       "network",
       "web"
     ],
-    "signature_path": "/epr/haproxy/haproxy-0.7.0.zip.sig"
+    "signature_path": "/epr/haproxy/haproxy-0.7.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "haproxy.info",
+        "title": "HAProxy info metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "haproxy.log",
+        "title": "HAProxy logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "haproxy.stat",
+        "title": "HAProxy stat metrics"
+      }
+    ]
   },
   {
     "name": "hashicorp_vault",
@@ -3276,7 +4479,24 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/hashicorp_vault/hashicorp_vault-1.3.3.zip.sig"
+    "signature_path": "/epr/hashicorp_vault/hashicorp_vault-1.3.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "hashicorp_vault.audit",
+        "title": "Hashicorp Vault Audit Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "hashicorp_vault.log",
+        "title": "Hashicorp Vault Operational Logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "hashicorp_vault.metrics",
+        "title": "Hashicorp Vault Metrics"
+      }
+    ]
   },
   {
     "name": "hid_bravura_monitor",
@@ -3314,7 +4534,19 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/hid_bravura_monitor/hid_bravura_monitor-1.0.2.zip.sig"
+    "signature_path": "/epr/hid_bravura_monitor/hid_bravura_monitor-1.0.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "hid_bravura_monitor.log",
+        "title": "Hitachi ID Bravura Monitor"
+      },
+      {
+        "type": "logs",
+        "dataset": "hid_bravura_monitor.winlog",
+        "title": "Hitachi ID Security Fabric logs"
+      }
+    ]
   },
   {
     "name": "iis",
@@ -3352,7 +4584,34 @@
     "categories": [
       "web"
     ],
-    "signature_path": "/epr/iis/iis-0.8.0.zip.sig"
+    "signature_path": "/epr/iis/iis-0.8.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "iis.access",
+        "title": "IIS access logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "iis.application_pool",
+        "title": "IIS application_pool metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "iis.error",
+        "title": "IIS error logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "iis.webserver",
+        "title": "IIS web server metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "iis.website",
+        "title": "IIS website metrics"
+      }
+    ]
   },
   {
     "name": "imperva",
@@ -3382,7 +4641,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/imperva/imperva-0.7.0.zip.sig"
+    "signature_path": "/epr/imperva/imperva-0.7.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "imperva.securesphere",
+        "title": "Imperva SecureSphere logs"
+      }
+    ]
   },
   {
     "name": "infoblox",
@@ -3420,7 +4686,14 @@
     "categories": [
       "network"
     ],
-    "signature_path": "/epr/infoblox/infoblox-0.7.0.zip.sig"
+    "signature_path": "/epr/infoblox/infoblox-0.7.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "infoblox.nios",
+        "title": "Infoblox NIOS logs"
+      }
+    ]
   },
   {
     "name": "iptables",
@@ -3459,7 +4732,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/iptables/iptables-0.8.1.zip.sig"
+    "signature_path": "/epr/iptables/iptables-0.8.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "iptables.log",
+        "title": "Iptables log logs"
+      }
+    ]
   },
   {
     "name": "juniper_junos",
@@ -3498,7 +4778,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/juniper_junos/juniper_junos-0.1.1.zip.sig"
+    "signature_path": "/epr/juniper_junos/juniper_junos-0.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "juniper_junos.log",
+        "title": "Juniper JUNOS logs"
+      }
+    ]
   },
   {
     "name": "juniper",
@@ -3537,7 +4824,24 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/juniper/juniper-1.1.0.zip.sig"
+    "signature_path": "/epr/juniper/juniper-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "juniper.junos",
+        "title": "Juniper JUNOS logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "juniper.netscreen",
+        "title": "Netscreen logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "juniper.srx",
+        "title": "Juniper SRX logs"
+      }
+    ]
   },
   {
     "name": "juniper_netscreen",
@@ -3576,7 +4880,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/juniper_netscreen/juniper_netscreen-0.1.1.zip.sig"
+    "signature_path": "/epr/juniper_netscreen/juniper_netscreen-0.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "juniper_netscreen.log",
+        "title": "Netscreen logs"
+      }
+    ]
   },
   {
     "name": "juniper_srx",
@@ -3615,7 +4926,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/juniper_srx/juniper_srx-1.1.2.zip.sig"
+    "signature_path": "/epr/juniper_srx/juniper_srx-1.1.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "juniper_srx.log",
+        "title": "Juniper SRX logs"
+      }
+    ]
   },
   {
     "name": "kafka",
@@ -3653,7 +4971,29 @@
     "categories": [
       "message_queue"
     ],
-    "signature_path": "/epr/kafka/kafka-1.2.2.zip.sig"
+    "signature_path": "/epr/kafka/kafka-1.2.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "kafka.broker",
+        "title": "Kafka broker metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kafka.consumergroup",
+        "title": "Kafka consumergroup metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "kafka.log",
+        "title": "Kafka log logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kafka.partition",
+        "title": "Kafka partition metrics"
+      }
+    ]
   },
   {
     "name": "keycloak",
@@ -3693,7 +5033,14 @@
       "network",
       "web"
     ],
-    "signature_path": "/epr/keycloak/keycloak-1.2.1.zip.sig"
+    "signature_path": "/epr/keycloak/keycloak-1.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "keycloak.log",
+        "title": "Keycloak"
+      }
+    ]
   },
   {
     "name": "kibana",
@@ -3731,7 +5078,29 @@
     "categories": [
       "elastic_stack"
     ],
-    "signature_path": "/epr/kibana/kibana-1.0.2.zip.sig"
+    "signature_path": "/epr/kibana/kibana-1.0.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "kibana.audit",
+        "title": "kibana audit logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "kibana.log",
+        "title": "Kibana logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kibana.stats",
+        "title": "Kibana stats metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kibana.status",
+        "title": "Kibana status metrics"
+      }
+    ]
   },
   {
     "name": "kubernetes",
@@ -3891,7 +5260,139 @@
       "containers",
       "kubernetes"
     ],
-    "signature_path": "/epr/kubernetes/kubernetes-1.17.2.zip.sig"
+    "signature_path": "/epr/kubernetes/kubernetes-1.17.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.apiserver",
+        "title": "Kubernetes API Server metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "kubernetes.audit_logs",
+        "title": "Kubernetes audit logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.container",
+        "title": "Kubernetes Container metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "kubernetes.container_logs",
+        "title": "Kubernetes container logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.controllermanager",
+        "title": "Kubernetes Controller Manager metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.event",
+        "title": "Kubernetes Event metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.node",
+        "title": "Kubernetes Node metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.pod",
+        "title": "Kubernetes Pod metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.proxy",
+        "title": "Kubernetes Proxy metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.scheduler",
+        "title": "Kubernetes Scheduler metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_container",
+        "title": "Kubernetes Container metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_cronjob",
+        "title": "Kubernetes Cronjob metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_daemonset",
+        "title": "Kubernetes Deamonset metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_deployment",
+        "title": "Kubernetes Deployment metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_job",
+        "title": "Kubernetes Job metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_node",
+        "title": "Kubernetes Node metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_persistentvolume",
+        "title": "Kubernetes PersistentVolume metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_persistentvolumeclaim",
+        "title": "Kubernetes PersistentVolumeClaim metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_pod",
+        "title": "Kubernetes Pod metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_replicaset",
+        "title": "Kubernetes state_replicaset metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_resourcequota",
+        "title": "Kubernetes ResourceQuota metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_service",
+        "title": "Kubernetes Service metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_statefulset",
+        "title": "Kubernetes StatefulSet metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_storageclass",
+        "title": "Kubernetes StorageClass metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.system",
+        "title": "Kubernetes System metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.volume",
+        "title": "Kubernetes Volume metrics"
+      }
+    ]
   },
   {
     "name": "linux",
@@ -3920,7 +5421,64 @@
     "categories": [
       "os_system"
     ],
-    "signature_path": "/epr/linux/linux-0.6.2.zip.sig"
+    "signature_path": "/epr/linux/linux-0.6.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "linux.conntrack",
+        "title": "System conntrack metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "linux.entropy",
+        "title": "System entropy metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "linux.iostat",
+        "title": "Linux disk iostat metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "linux.ksm",
+        "title": "Kernel Samepage merging metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "linux.memory",
+        "title": "Linux-only memory metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "linux.network_summary",
+        "title": "System network_summary metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "linux.pageinfo",
+        "title": "System page info metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "linux.raid",
+        "title": "System raid metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "linux.service",
+        "title": "System service metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "linux.socket",
+        "title": "System socket metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "linux.users",
+        "title": "System users metrics"
+      }
+    ]
   },
   {
     "name": "logstash",
@@ -3958,7 +5516,29 @@
     "categories": [
       "elastic_stack"
     ],
-    "signature_path": "/epr/logstash/logstash-1.1.0.zip.sig"
+    "signature_path": "/epr/logstash/logstash-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "logstash.log",
+        "title": "Logstash logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "logstash.node",
+        "title": "Logstash node metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "logstash.node_stats",
+        "title": "Logstash node_stats metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "logstash.slowlog",
+        "title": "logstash slowlog logs"
+      }
+    ]
   },
   {
     "name": "problemchild",
@@ -4029,7 +5609,14 @@
       "security",
       "azure"
     ],
-    "signature_path": "/epr/m365_defender/m365_defender-1.0.3.zip.sig"
+    "signature_path": "/epr/m365_defender/m365_defender-1.0.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "m365_defender.log",
+        "title": "M365 Defender Logs"
+      }
+    ]
   },
   {
     "name": "ti_misp",
@@ -4067,7 +5654,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/ti_misp/ti_misp-1.2.2.zip.sig"
+    "signature_path": "/epr/ti_misp/ti_misp-1.2.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_misp.threat",
+        "title": "MISP"
+      }
+    ]
   },
   {
     "name": "mattermost",
@@ -4106,7 +5700,14 @@
       "security",
       "web"
     ],
-    "signature_path": "/epr/mattermost/mattermost-1.1.1.zip.sig"
+    "signature_path": "/epr/mattermost/mattermost-1.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "mattermost.audit",
+        "title": "Audit Logs"
+      }
+    ]
   },
   {
     "name": "microsoft",
@@ -4146,7 +5747,19 @@
       "security",
       "azure"
     ],
-    "signature_path": "/epr/microsoft/microsoft-1.1.0.zip.sig"
+    "signature_path": "/epr/microsoft/microsoft-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "microsoft.defender_atp",
+        "title": "Microsoft Defender ATP logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "microsoft.dhcp",
+        "title": "Microsoft DHCP logs"
+      }
+    ]
   },
   {
     "name": "microsoft_dhcp",
@@ -4184,7 +5797,14 @@
     "categories": [
       "network"
     ],
-    "signature_path": "/epr/microsoft_dhcp/microsoft_dhcp-1.3.1.zip.sig"
+    "signature_path": "/epr/microsoft_dhcp/microsoft_dhcp-1.3.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "microsoft_dhcp.log",
+        "title": "Microsoft DHCP Logs"
+      }
+    ]
   },
   {
     "name": "microsoft_defender_endpoint",
@@ -4224,7 +5844,14 @@
       "security",
       "azure"
     ],
-    "signature_path": "/epr/microsoft_defender_endpoint/microsoft_defender_endpoint-2.1.0.zip.sig"
+    "signature_path": "/epr/microsoft_defender_endpoint/microsoft_defender_endpoint-2.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "microsoft_defender_endpoint.log",
+        "title": "Microsoft Defender for Endpoint logs"
+      }
+    ]
   },
   {
     "name": "microsoft_sqlserver",
@@ -4263,7 +5890,14 @@
       "datastore",
       "security"
     ],
-    "signature_path": "/epr/microsoft_sqlserver/microsoft_sqlserver-0.4.5.zip.sig"
+    "signature_path": "/epr/microsoft_sqlserver/microsoft_sqlserver-0.4.5.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "microsoft_sqlserver.audit",
+        "title": "SQL Server audit events"
+      }
+    ]
   },
   {
     "name": "modsecurity",
@@ -4302,7 +5936,14 @@
       "security",
       "web"
     ],
-    "signature_path": "/epr/modsecurity/modsecurity-0.1.5.zip.sig"
+    "signature_path": "/epr/modsecurity/modsecurity-0.1.5.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "modsecurity.auditlog",
+        "title": "Modsecurity Audit Log"
+      }
+    ]
   },
   {
     "name": "mongodb",
@@ -4340,7 +5981,39 @@
     "categories": [
       "datastore"
     ],
-    "signature_path": "/epr/mongodb/mongodb-1.3.1.zip.sig"
+    "signature_path": "/epr/mongodb/mongodb-1.3.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "mongodb.collstats",
+        "title": "MongoDB collstats metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "mongodb.dbstats",
+        "title": "MongoDB dbstats metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "mongodb.log",
+        "title": "mongodb log logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "mongodb.metrics",
+        "title": "MongoDB metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "mongodb.replstatus",
+        "title": "MongoDB replstatus metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "mongodb.status",
+        "title": "MongoDB status metrics"
+      }
+    ]
   },
   {
     "name": "mysql",
@@ -4378,7 +6051,34 @@
     "categories": [
       "datastore"
     ],
-    "signature_path": "/epr/mysql/mysql-1.2.1.zip.sig"
+    "signature_path": "/epr/mysql/mysql-1.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "mysql.error",
+        "title": "MySQL error logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "mysql.galera_status",
+        "title": "MySQL galera_status metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "mysql.performance",
+        "title": "MySQL performance metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "mysql.slowlog",
+        "title": "MySQL slowlog logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "mysql.status",
+        "title": "MySQL status metrics"
+      }
+    ]
   },
   {
     "name": "mysql_enterprise",
@@ -4417,7 +6117,14 @@
       "security",
       "datastore"
     ],
-    "signature_path": "/epr/mysql_enterprise/mysql_enterprise-1.0.1.zip.sig"
+    "signature_path": "/epr/mysql_enterprise/mysql_enterprise-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "mysql_enterprise.audit",
+        "title": "MySQL Enterprise Audit Log"
+      }
+    ]
   },
   {
     "name": "nats",
@@ -4455,7 +6162,44 @@
     "categories": [
       "message_queue"
     ],
-    "signature_path": "/epr/nats/nats-1.2.0.zip.sig"
+    "signature_path": "/epr/nats/nats-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "nats.connection",
+        "title": "NATS connection metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "nats.connections",
+        "title": "NATS connections metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "nats.log",
+        "title": "NATS logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "nats.route",
+        "title": "NATS route metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "nats.routes",
+        "title": "NATS routes metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "nats.stats",
+        "title": "NATS stats metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "nats.subscriptions",
+        "title": "NATS subscriptions metrics"
+      }
+    ]
   },
   {
     "name": "netflow",
@@ -4485,7 +6229,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/netflow/netflow-1.4.2.zip.sig"
+    "signature_path": "/epr/netflow/netflow-1.4.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "netflow.log",
+        "title": "NetFlow logs"
+      }
+    ]
   },
   {
     "name": "netskope",
@@ -4523,7 +6274,19 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/netskope/netskope-0.1.2.zip.sig"
+    "signature_path": "/epr/netskope/netskope-0.1.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "netskope.alerts",
+        "title": "Alerts"
+      },
+      {
+        "type": "logs",
+        "dataset": "netskope.events",
+        "title": "Events"
+      }
+    ]
   },
   {
     "name": "network_traffic",
@@ -4552,7 +6315,89 @@
     "categories": [
       "web"
     ],
-    "signature_path": "/epr/network_traffic/network_traffic-0.8.1.zip.sig"
+    "signature_path": "/epr/network_traffic/network_traffic-0.8.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "network_traffic.amqp",
+        "title": "AMQP"
+      },
+      {
+        "type": "logs",
+        "dataset": "network_traffic.cassandra",
+        "title": "Cassandra"
+      },
+      {
+        "type": "logs",
+        "dataset": "network_traffic.dhcpv4",
+        "title": "DHCP"
+      },
+      {
+        "type": "logs",
+        "dataset": "network_traffic.dns",
+        "title": "DNS"
+      },
+      {
+        "type": "logs",
+        "dataset": "network_traffic.flow",
+        "title": "Flows"
+      },
+      {
+        "type": "logs",
+        "dataset": "network_traffic.http",
+        "title": "HTTP"
+      },
+      {
+        "type": "logs",
+        "dataset": "network_traffic.icmp",
+        "title": "ICMP"
+      },
+      {
+        "type": "logs",
+        "dataset": "network_traffic.memcached",
+        "title": "Memcached"
+      },
+      {
+        "type": "logs",
+        "dataset": "network_traffic.mongodb",
+        "title": "MongoDB"
+      },
+      {
+        "type": "logs",
+        "dataset": "network_traffic.mysql",
+        "title": "MySQL"
+      },
+      {
+        "type": "logs",
+        "dataset": "network_traffic.nfs",
+        "title": "NFS"
+      },
+      {
+        "type": "logs",
+        "dataset": "network_traffic.pgsql",
+        "title": "PostgreSQL"
+      },
+      {
+        "type": "logs",
+        "dataset": "network_traffic.redis",
+        "title": "Redis"
+      },
+      {
+        "type": "logs",
+        "dataset": "network_traffic.sip",
+        "title": "SIP"
+      },
+      {
+        "type": "logs",
+        "dataset": "network_traffic.thrift",
+        "title": "Thrift"
+      },
+      {
+        "type": "logs",
+        "dataset": "network_traffic.tls",
+        "title": "TLS"
+      }
+    ]
   },
   {
     "name": "nginx",
@@ -4591,7 +6436,24 @@
       "web",
       "security"
     ],
-    "signature_path": "/epr/nginx/nginx-1.3.1.zip.sig"
+    "signature_path": "/epr/nginx/nginx-1.3.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "nginx.access",
+        "title": "Nginx access logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "nginx.error",
+        "title": "Nginx error logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "nginx.stubstatus",
+        "title": "Nginx stubstatus metrics"
+      }
+    ]
   },
   {
     "name": "nginx_ingress_controller",
@@ -4630,7 +6492,19 @@
       "web",
       "security"
     ],
-    "signature_path": "/epr/nginx_ingress_controller/nginx_ingress_controller-1.2.0.zip.sig"
+    "signature_path": "/epr/nginx_ingress_controller/nginx_ingress_controller-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "nginx_ingress_controller.access",
+        "title": "Nginx Ingress Controller access logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "nginx_ingress_controller.error",
+        "title": "Nginx Ingress Controller error logs"
+      }
+    ]
   },
   {
     "name": "o365",
@@ -4668,7 +6542,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/o365/o365-1.4.3.zip.sig"
+    "signature_path": "/epr/o365/o365-1.4.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "o365.audit",
+        "title": "Office 365 audit logs"
+      }
+    ]
   },
   {
     "name": "okta",
@@ -4706,7 +6587,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/okta/okta-1.5.2.zip.sig"
+    "signature_path": "/epr/okta/okta-1.5.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "okta.system",
+        "title": "Okta system logs"
+      }
+    ]
   },
   {
     "name": "oracle",
@@ -4745,7 +6633,14 @@
       "security",
       "datastore"
     ],
-    "signature_path": "/epr/oracle/oracle-1.0.1.zip.sig"
+    "signature_path": "/epr/oracle/oracle-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "oracle.database_audit",
+        "title": "Oracle Audit Log"
+      }
+    ]
   },
   {
     "name": "osquery",
@@ -4784,7 +6679,14 @@
       "security",
       "os_system"
     ],
-    "signature_path": "/epr/osquery/osquery-1.2.1.zip.sig"
+    "signature_path": "/epr/osquery/osquery-1.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "osquery.result",
+        "title": "Osquery result logs"
+      }
+    ]
   },
   {
     "name": "osquery_manager",
@@ -4824,7 +6726,14 @@
       "os_system",
       "config_management"
     ],
-    "signature_path": "/epr/osquery_manager/osquery_manager-1.2.1.zip.sig"
+    "signature_path": "/epr/osquery_manager/osquery_manager-1.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "osquery_manager.result",
+        "title": "Osquery Manager queries"
+      }
+    ]
   },
   {
     "name": "panw_cortex_xdr",
@@ -4862,7 +6771,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/panw_cortex_xdr/panw_cortex_xdr-1.1.1.zip.sig"
+    "signature_path": "/epr/panw_cortex_xdr/panw_cortex_xdr-1.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "panw_cortex_xdr.alerts",
+        "title": "Palo Alto Cortex XDR API"
+      }
+    ]
   },
   {
     "name": "panw",
@@ -4900,7 +6816,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/panw/panw-1.5.3.zip.sig"
+    "signature_path": "/epr/panw/panw-1.5.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "panw.panos",
+        "title": "Palo Alto Networks PAN-OS firewall logs"
+      }
+    ]
   },
   {
     "name": "postgresql",
@@ -4938,7 +6861,34 @@
     "categories": [
       "datastore"
     ],
-    "signature_path": "/epr/postgresql/postgresql-1.2.0.zip.sig"
+    "signature_path": "/epr/postgresql/postgresql-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "postgresql.activity",
+        "title": "PostgreSQL activity metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "postgresql.bgwriter",
+        "title": "PostgreSQL bgwriter metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "postgresql.database",
+        "title": "PostgreSQL database metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "postgresql.log",
+        "title": "PostgreSQL logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "postgresql.statement",
+        "title": "PostgreSQL statement metrics"
+      }
+    ]
   },
   {
     "name": "security_detection_engine",
@@ -5007,7 +6957,24 @@
       "monitoring",
       "datastore"
     ],
-    "signature_path": "/epr/prometheus/prometheus-0.7.0.zip.sig"
+    "signature_path": "/epr/prometheus/prometheus-0.7.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "prometheus.collector",
+        "title": "Prometheus collector metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "prometheus.query",
+        "title": "Prometheus query metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "prometheus.remote_write",
+        "title": "Prometheus remote_write metrics"
+      }
+    ]
   },
   {
     "name": "proofpoint",
@@ -5045,7 +7012,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/proofpoint/proofpoint-0.6.0.zip.sig"
+    "signature_path": "/epr/proofpoint/proofpoint-0.6.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "proofpoint.emailsecurity",
+        "title": "Proofpoint Email Security logs"
+      }
+    ]
   },
   {
     "name": "pulse_connect_secure",
@@ -5084,7 +7058,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/pulse_connect_secure/pulse_connect_secure-0.2.1.zip.sig"
+    "signature_path": "/epr/pulse_connect_secure/pulse_connect_secure-0.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "pulse_connect_secure.log",
+        "title": "Pulse Connect Secure"
+      }
+    ]
   },
   {
     "name": "qnap_nas",
@@ -5122,7 +7103,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/qnap_nas/qnap_nas-1.1.1.zip.sig"
+    "signature_path": "/epr/qnap_nas/qnap_nas-1.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "qnap_nas.log",
+        "title": "QNAP NAS logs"
+      }
+    ]
   },
   {
     "name": "rabbitmq",
@@ -5160,7 +7148,34 @@
     "categories": [
       "message_queue"
     ],
-    "signature_path": "/epr/rabbitmq/rabbitmq-1.2.0.zip.sig"
+    "signature_path": "/epr/rabbitmq/rabbitmq-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "rabbitmq.connection",
+        "title": "RabbitMQ connection metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "rabbitmq.exchange",
+        "title": "RabbitMQ exchange metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "rabbitmq.log",
+        "title": "RabbitMQ application logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "rabbitmq.node",
+        "title": "RabbitMQ node metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "rabbitmq.queue",
+        "title": "RabbitMQ queue metrics"
+      }
+    ]
   },
   {
     "name": "radware",
@@ -5198,7 +7213,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/radware/radware-0.6.0.zip.sig"
+    "signature_path": "/epr/radware/radware-0.6.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "radware.defensepro",
+        "title": "Radware DefensePro logs"
+      }
+    ]
   },
   {
     "name": "ti_recordedfuture",
@@ -5236,7 +7258,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/ti_recordedfuture/ti_recordedfuture-0.1.2.zip.sig"
+    "signature_path": "/epr/ti_recordedfuture/ti_recordedfuture-0.1.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_recordedfuture.threat",
+        "title": "Recorded Future"
+      }
+    ]
   },
   {
     "name": "redis",
@@ -5275,7 +7304,34 @@
       "datastore",
       "message_queue"
     ],
-    "signature_path": "/epr/redis/redis-1.2.0.zip.sig"
+    "signature_path": "/epr/redis/redis-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "redis.info",
+        "title": "Redis info metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "redis.key",
+        "title": "Redis key metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "redis.keyspace",
+        "title": "Redis keyspace metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "redis.log",
+        "title": "Redis application logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "redis.slowlog",
+        "title": "Redis slow logs"
+      }
+    ]
   },
   {
     "name": "stan",
@@ -5314,7 +7370,29 @@
       "message_queue",
       "kubernetes"
     ],
-    "signature_path": "/epr/stan/stan-1.2.0.zip.sig"
+    "signature_path": "/epr/stan/stan-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "stan.channels",
+        "title": "Stan channels metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "stan.log",
+        "title": "STAN logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "stan.stats",
+        "title": "Stan stats metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "stan.subscriptions",
+        "title": "Stan subscriptions metrics"
+      }
+    ]
   },
   {
     "name": "snort",
@@ -5353,7 +7431,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/snort/snort-0.2.2.zip.sig"
+    "signature_path": "/epr/snort/snort-0.2.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "snort.log",
+        "title": "Snort"
+      }
+    ]
   },
   {
     "name": "snyk",
@@ -5391,7 +7476,19 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/snyk/snyk-1.1.2.zip.sig"
+    "signature_path": "/epr/snyk/snyk-1.1.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "snyk.audit",
+        "title": "Collect Snyk Audit Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "snyk.vulnerabilities",
+        "title": "Collect Snyk Vulnerability Data"
+      }
+    ]
   },
   {
     "name": "sonicwall",
@@ -5430,7 +7527,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/sonicwall/sonicwall-0.7.1.zip.sig"
+    "signature_path": "/epr/sonicwall/sonicwall-0.7.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "sonicwall.firewall",
+        "title": "Sonicwall-FW logs"
+      }
+    ]
   },
   {
     "name": "sophos",
@@ -5468,7 +7572,19 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/sophos/sophos-1.2.2.zip.sig"
+    "signature_path": "/epr/sophos/sophos-1.2.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "sophos.utm",
+        "title": "Sophos UTM logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "sophos.xg",
+        "title": "Sophos XG logs"
+      }
+    ]
   },
   {
     "name": "squid",
@@ -5497,7 +7613,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/squid/squid-0.7.0.zip.sig"
+    "signature_path": "/epr/squid/squid-0.7.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "squid.log",
+        "title": "Squid logs"
+      }
+    ]
   },
   {
     "name": "suricata",
@@ -5536,7 +7659,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/suricata/suricata-1.6.1.zip.sig"
+    "signature_path": "/epr/suricata/suricata-1.6.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "suricata.eve",
+        "title": "Suricata eve logs"
+      }
+    ]
   },
   {
     "name": "symantec",
@@ -5571,7 +7701,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/symantec/symantec-0.1.3.zip.sig"
+    "signature_path": "/epr/symantec/symantec-0.1.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "symantec.endpointprotection",
+        "title": "Symantec AntiVirus/Endpoint Protection logs"
+      }
+    ]
   },
   {
     "name": "symantec_endpoint",
@@ -5609,7 +7746,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/symantec_endpoint/symantec_endpoint-0.0.2.zip.sig"
+    "signature_path": "/epr/symantec_endpoint/symantec_endpoint-0.0.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "symantec_endpoint.log",
+        "title": "Symantec Endpoint Protection (SEP) Logs"
+      }
+    ]
   },
   {
     "name": "system",
@@ -5648,7 +7792,94 @@
       "os_system",
       "security"
     ],
-    "signature_path": "/epr/system/system-1.6.4.zip.sig"
+    "signature_path": "/epr/system/system-1.6.4.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "system.application",
+        "title": "Windows Application Events"
+      },
+      {
+        "type": "logs",
+        "dataset": "system.auth",
+        "title": "System auth logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.core",
+        "title": "System core metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.cpu",
+        "title": "System cpu metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.diskio",
+        "title": "System diskio metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.filesystem",
+        "title": "System filesystem metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.fsstat",
+        "title": "System fsstat metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.load",
+        "title": "System load metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.memory",
+        "title": "System memory metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.network",
+        "title": "System network metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.process",
+        "title": "System process metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.process.summary",
+        "title": "System process_summary metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "system.security",
+        "title": "Security logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.socket_summary",
+        "title": "System socket_summary metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "system.syslog",
+        "title": "System syslog logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "system.system",
+        "title": "Windows System Events"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.uptime",
+        "title": "System uptime metrics"
+      }
+    ]
   },
   {
     "name": "tenable_sc",
@@ -5686,7 +7917,24 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/tenable_sc/tenable_sc-1.1.1.zip.sig"
+    "signature_path": "/epr/tenable_sc/tenable_sc-1.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "tenable_sc.asset",
+        "title": "Tenable.sc asset logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "tenable_sc.plugin",
+        "title": "Tenable.sc plugin logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "tenable_sc.vulnerability",
+        "title": "Tenable.sc vulnerability logs"
+      }
+    ]
   },
   {
     "name": "ti_threatq",
@@ -5724,7 +7972,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/ti_threatq/ti_threatq-1.2.2.zip.sig"
+    "signature_path": "/epr/ti_threatq/ti_threatq-1.2.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_threatq.threat",
+        "title": "ThreatQ"
+      }
+    ]
   },
   {
     "name": "traefik",
@@ -5763,7 +8018,19 @@
       "web",
       "security"
     ],
-    "signature_path": "/epr/traefik/traefik-1.2.0.zip.sig"
+    "signature_path": "/epr/traefik/traefik-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "traefik.access",
+        "title": "Traefik access logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "traefik.health",
+        "title": "Traefik health metrics"
+      }
+    ]
   },
   {
     "name": "carbon_black_cloud",
@@ -5801,7 +8068,34 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/carbon_black_cloud/carbon_black_cloud-1.0.2.zip.sig"
+    "signature_path": "/epr/carbon_black_cloud/carbon_black_cloud-1.0.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.alert",
+        "title": "Alert"
+      },
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.asset_vulnerability_summary",
+        "title": "Asset Vulnerability Summary"
+      },
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.audit",
+        "title": "Audit"
+      },
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.endpoint_event",
+        "title": "Endpoint Event"
+      },
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.watchlist_hit",
+        "title": "Watchlist Hit"
+      }
+    ]
   },
   {
     "name": "carbonblack_edr",
@@ -5839,7 +8133,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/carbonblack_edr/carbonblack_edr-1.2.0.zip.sig"
+    "signature_path": "/epr/carbonblack_edr/carbonblack_edr-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "carbonblack_edr.log",
+        "title": "Carbon Black EDR logs"
+      }
+    ]
   },
   {
     "name": "vsphere",
@@ -5878,7 +8179,29 @@
       "monitoring",
       "os_system"
     ],
-    "signature_path": "/epr/vsphere/vsphere-0.1.0.zip.sig"
+    "signature_path": "/epr/vsphere/vsphere-0.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "vsphere.datastore",
+        "title": "vSphere datastore metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "vsphere.host",
+        "title": "vSphere host metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "vsphere.log",
+        "title": "vSphere Logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "vsphere.virtualmachine",
+        "title": "vSphere virtual machine metrics"
+      }
+    ]
   },
   {
     "name": "windows",
@@ -5917,7 +8240,39 @@
       "os_system",
       "security"
     ],
-    "signature_path": "/epr/windows/windows-1.5.0.zip.sig"
+    "signature_path": "/epr/windows/windows-1.5.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "windows.forwarded",
+        "title": "Windows forwarded events"
+      },
+      {
+        "type": "metrics",
+        "dataset": "windows.perfmon",
+        "title": "Windows perfmon metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "windows.powershell",
+        "title": "Windows Powershell logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "windows.powershell_operational",
+        "title": "Windows Powershell/Operational logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "windows.service",
+        "title": "Windows service metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "windows.sysmon_operational",
+        "title": "Windows Sysmon/Operational events"
+      }
+    ]
   },
   {
     "name": "zeek",
@@ -5957,7 +8312,204 @@
       "monitoring",
       "security"
     ],
-    "signature_path": "/epr/zeek/zeek-1.6.1.zip.sig"
+    "signature_path": "/epr/zeek/zeek-1.6.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "zeek.capture_loss",
+        "title": "Zeek capture_loss logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.connection",
+        "title": "Zeek connection logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.dce_rpc",
+        "title": "Zeek dce_rpc logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.dhcp",
+        "title": "Zeek dhcp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.dnp3",
+        "title": "Zeek dnp3 logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.dns",
+        "title": "Zeek dns logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.dpd",
+        "title": "Zeek dpd logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.files",
+        "title": "Zeek files logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.ftp",
+        "title": "Zeek ftp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.http",
+        "title": "Zeek http logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.intel",
+        "title": "Zeek intel logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.irc",
+        "title": "Zeek irc logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.kerberos",
+        "title": "Zeek kerberos logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.modbus",
+        "title": "Zeek modbus logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.mysql",
+        "title": "Zeek mysql logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.notice",
+        "title": "Zeek notice logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.ntlm",
+        "title": "Zeek ntlm logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.ntp",
+        "title": "Zeek ntp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.ocsp",
+        "title": "Zeek ocsp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.pe",
+        "title": "Zeek pe logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.radius",
+        "title": "Zeek radius logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.rdp",
+        "title": "Zeek rdp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.rfb",
+        "title": "Zeek rfb logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.signature",
+        "title": "Zeek signature logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.sip",
+        "title": "Zeek sip logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.smb_cmd",
+        "title": "Zeek smb_cmd logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.smb_files",
+        "title": "Zeek smb_files logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.smb_mapping",
+        "title": "Zeek smb_mapping logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.smtp",
+        "title": "Zeek smtp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.snmp",
+        "title": "Zeek snmp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.socks",
+        "title": "Zeek socks logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.ssh",
+        "title": "Zeek ssh logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.ssl",
+        "title": "Zeek ssl logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.stats",
+        "title": "Zeek stats logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.syslog",
+        "title": "Zeek syslog logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.traceroute",
+        "title": "Zeek traceroute logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.tunnel",
+        "title": "Zeek tunnel logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.weird",
+        "title": "Zeek weird logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.x509",
+        "title": "Zeek x509 logs"
+      }
+    ]
   },
   {
     "name": "zerofox",
@@ -5996,7 +8548,14 @@
       "cloud",
       "security"
     ],
-    "signature_path": "/epr/zerofox/zerofox-1.2.1.zip.sig"
+    "signature_path": "/epr/zerofox/zerofox-1.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "zerofox.alerts",
+        "title": "Alerts"
+      }
+    ]
   },
   {
     "name": "zookeeper",
@@ -6035,7 +8594,24 @@
       "datastore",
       "config_management"
     ],
-    "signature_path": "/epr/zookeeper/zookeeper-1.2.0.zip.sig"
+    "signature_path": "/epr/zookeeper/zookeeper-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "zookeeper.connection",
+        "title": "ZooKeeper connection metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "zookeeper.mntr",
+        "title": "ZooKeeper mntr metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "zookeeper.server",
+        "title": "ZooKeeper server metrics"
+      }
+    ]
   },
   {
     "name": "zoom",
@@ -6074,7 +8650,14 @@
       "security",
       "productivity"
     ],
-    "signature_path": "/epr/zoom/zoom-1.2.1.zip.sig"
+    "signature_path": "/epr/zoom/zoom-1.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "zoom.webhook",
+        "title": "Zoom webhook logs"
+      }
+    ]
   },
   {
     "name": "zscaler_zia",
@@ -6112,7 +8695,34 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/zscaler_zia/zscaler_zia-0.1.3.zip.sig"
+    "signature_path": "/epr/zscaler_zia/zscaler_zia-0.1.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "zscaler_zia.alerts",
+        "title": "Alerts"
+      },
+      {
+        "type": "logs",
+        "dataset": "zscaler_zia.dns",
+        "title": "DNS logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zscaler_zia.firewall",
+        "title": "Firewall Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zscaler_zia.tunnel",
+        "title": "Tunnel Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zscaler_zia.web",
+        "title": "Web Logs"
+      }
+    ]
   },
   {
     "name": "zscaler",
@@ -6151,7 +8761,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/zscaler/zscaler-0.5.1.zip.sig"
+    "signature_path": "/epr/zscaler/zscaler-0.5.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "zscaler.zia",
+        "title": "Zscaler NSS logs"
+      }
+    ]
   },
   {
     "name": "zscaler_zpa",
@@ -6189,7 +8806,34 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/zscaler_zpa/zscaler_zpa-0.1.2.zip.sig"
+    "signature_path": "/epr/zscaler_zpa/zscaler_zpa-0.1.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "zscaler_zpa.app_connector_status",
+        "title": "App Connector Status Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zscaler_zpa.audit",
+        "title": "Audit Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zscaler_zpa.browser_access",
+        "title": "Browser Access Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zscaler_zpa.user_activity",
+        "title": "User Activity Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zscaler_zpa.user_status",
+        "title": "User Status Logs"
+      }
+    ]
   },
   {
     "name": "pfsense",
@@ -6228,6 +8872,13 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/pfsense/pfsense-0.3.1.zip.sig"
+    "signature_path": "/epr/pfsense/pfsense-0.3.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "pfsense.log",
+        "title": "pfSense log logs"
+      }
+    ]
   }
 ]

--- a/testdata/generated/storage-indexer/search.json
+++ b/testdata/generated/storage-indexer/search.json
@@ -35,7 +35,19 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/1password/1password-1.4.0.zip.sig"
+    "signature_path": "/epr/1password/1password-1.4.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "1password.item_usages",
+        "title": "Collect 1Password item usages events"
+      },
+      {
+        "type": "logs",
+        "dataset": "1password.signin_attempts",
+        "title": "1Password sign-in attempt events"
+      }
+    ]
   },
   {
     "name": "aws",
@@ -410,7 +422,154 @@
       "aws",
       "cloud"
     ],
-    "signature_path": "/epr/aws/aws-1.16.4.zip.sig"
+    "signature_path": "/epr/aws/aws-1.16.4.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "aws.billing",
+        "title": "AWS Billing Metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.cloudfront_logs",
+        "title": "AWS CloudFront logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.cloudtrail",
+        "title": "AWS CloudTrail Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.cloudwatch_logs",
+        "title": "AWS CloudWatch logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.cloudwatch_metrics",
+        "title": "AWS CloudWatch metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.dynamodb",
+        "title": "AWS DynamoDB metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.ebs",
+        "title": "AWS EBS metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.ec2_logs",
+        "title": "AWS EC2 logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.ec2_metrics",
+        "title": "AWS EC2 metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.elb_logs",
+        "title": "AWS ELB logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.elb_metrics",
+        "title": "AWS ELB metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.firewall_logs",
+        "title": "AWS Network Firewall logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.firewall_metrics",
+        "title": "AWS Network Firewall metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.lambda",
+        "title": "AWS Lambda metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.natgateway",
+        "title": "AWS NAT gateway metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.rds",
+        "title": "AWS RDS metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.route53_public_logs",
+        "title": "AWS Route 53 Public Zone Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.route53_resolver_logs",
+        "title": "AWS Route 53 Resolver Query Logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.s3_daily_storage",
+        "title": "AWS S3 daily storage metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.s3_request",
+        "title": "AWS S3 request metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.s3_storage_lens",
+        "title": "AWS S3 Storage Lens metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.s3access",
+        "title": "AWS s3access logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.sns",
+        "title": "AWS SNS metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.sqs",
+        "title": "AWS SQS metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.transitgateway",
+        "title": "AWS Transit Gateway metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.usage",
+        "title": "AWS usage metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.vpcflow",
+        "title": "AWS vpcflow logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "aws.vpn",
+        "title": "AWS VPN metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "aws.waf",
+        "title": "AWS WAF logs"
+      }
+    ]
   },
   {
     "name": "ti_abusech",
@@ -448,7 +607,24 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/ti_abusech/ti_abusech-1.2.3.zip.sig"
+    "signature_path": "/epr/ti_abusech/ti_abusech-1.2.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_abusech.malware",
+        "title": "AbuseCH Malware logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "ti_abusech.malwarebazaar",
+        "title": "AbuseCH MalwareBazaar logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "ti_abusech.url",
+        "title": "AbuseCH URL logs"
+      }
+    ]
   },
   {
     "name": "akamai",
@@ -489,7 +665,14 @@
       "web",
       "cloud"
     ],
-    "signature_path": "/epr/akamai/akamai-1.0.0.zip.sig"
+    "signature_path": "/epr/akamai/akamai-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "akamai.siem",
+        "title": "Akamai SIEM Logs"
+      }
+    ]
   },
   {
     "name": "ti_otx",
@@ -527,7 +710,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/ti_otx/ti_otx-1.2.2.zip.sig"
+    "signature_path": "/epr/ti_otx/ti_otx-1.2.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_otx.threat",
+        "title": "Alienvault OTX logs"
+      }
+    ]
   },
   {
     "name": "ti_anomali",
@@ -565,7 +755,19 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/ti_anomali/ti_anomali-1.2.3.zip.sig"
+    "signature_path": "/epr/ti_anomali/ti_anomali-1.2.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_anomali.limo",
+        "title": "Anomali Limo"
+      },
+      {
+        "type": "logs",
+        "dataset": "ti_anomali.threatstream",
+        "title": "Anomali Threatstream"
+      }
+    ]
   },
   {
     "name": "apache",
@@ -603,7 +805,24 @@
     "categories": [
       "web"
     ],
-    "signature_path": "/epr/apache/apache-1.3.5.zip.sig"
+    "signature_path": "/epr/apache/apache-1.3.5.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "apache.access",
+        "title": "Apache access logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "apache.error",
+        "title": "Apache error logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apache.status",
+        "title": "Apache status metrics"
+      }
+    ]
   },
   {
     "name": "tomcat",
@@ -642,7 +861,14 @@
       "web",
       "security"
     ],
-    "signature_path": "/epr/tomcat/tomcat-1.3.1.zip.sig"
+    "signature_path": "/epr/tomcat/tomcat-1.3.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "tomcat.log",
+        "title": "Apache Tomcat logs"
+      }
+    ]
   },
   {
     "name": "atlassian_bitbucket",
@@ -681,7 +907,14 @@
       "security",
       "web"
     ],
-    "signature_path": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.2.1.zip.sig"
+    "signature_path": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_bitbucket.audit",
+        "title": "Bitbucket Audit Logs"
+      }
+    ]
   },
   {
     "name": "atlassian_confluence",
@@ -720,7 +953,14 @@
       "security",
       "web"
     ],
-    "signature_path": "/epr/atlassian_confluence/atlassian_confluence-1.3.0.zip.sig"
+    "signature_path": "/epr/atlassian_confluence/atlassian_confluence-1.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_confluence.audit",
+        "title": "Confluence Audit Logs"
+      }
+    ]
   },
   {
     "name": "atlassian_jira",
@@ -759,7 +999,14 @@
       "security",
       "web"
     ],
-    "signature_path": "/epr/atlassian_jira/atlassian_jira-1.3.0.zip.sig"
+    "signature_path": "/epr/atlassian_jira/atlassian_jira-1.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_jira.audit",
+        "title": "Jira Audit Logs"
+      }
+    ]
   },
   {
     "name": "auditd",
@@ -797,7 +1044,14 @@
     "categories": [
       "os_system"
     ],
-    "signature_path": "/epr/auditd/auditd-3.1.0.zip.sig"
+    "signature_path": "/epr/auditd/auditd-3.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "auditd.log",
+        "title": "Auditd logs"
+      }
+    ]
   },
   {
     "name": "auditd_manager",
@@ -836,7 +1090,14 @@
       "os_system",
       "security"
     ],
-    "signature_path": "/epr/auditd_manager/auditd_manager-1.0.0.zip.sig"
+    "signature_path": "/epr/auditd_manager/auditd_manager-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "auditd_manager.auditd",
+        "title": "Auditd Manager"
+      }
+    ]
   },
   {
     "name": "auth0",
@@ -876,7 +1137,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/auth0/auth0-1.0.0.zip.sig"
+    "signature_path": "/epr/auth0/auth0-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "auth0.logs",
+        "title": "Auth0 logs via Webhooks"
+      }
+    ]
   },
   {
     "name": "azure_application_insights",
@@ -938,7 +1206,19 @@
       "azure",
       "web"
     ],
-    "signature_path": "/epr/azure_application_insights/azure_application_insights-1.0.1.zip.sig"
+    "signature_path": "/epr/azure_application_insights/azure_application_insights-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "azure.app_insights",
+        "title": "Azure Application Insights"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.app_state",
+        "title": "Azure Application State"
+      }
+    ]
   },
   {
     "name": "azure_billing",
@@ -985,7 +1265,14 @@
     "categories": [
       "azure"
     ],
-    "signature_path": "/epr/azure_billing/azure_billing-1.0.1.zip.sig"
+    "signature_path": "/epr/azure_billing/azure_billing-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "azure.billing",
+        "title": "Azure Billing Metrics"
+      }
+    ]
   },
   {
     "name": "azure",
@@ -1091,7 +1378,39 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/azure/azure-1.1.8.zip.sig"
+    "signature_path": "/epr/azure/azure-1.1.8.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "azure.activitylogs",
+        "title": "Azure Activity Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "azure.auditlogs",
+        "title": "Azure Audit Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "azure.eventhub",
+        "title": "Azure Event Hub Input"
+      },
+      {
+        "type": "logs",
+        "dataset": "azure.platformlogs",
+        "title": "Azure Platform Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "azure.signinlogs",
+        "title": "Azure Signin Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "azure.springcloudlogs",
+        "title": "Azure Spring Cloud Logs"
+      }
+    ]
   },
   {
     "name": "azure_metrics",
@@ -1237,7 +1556,49 @@
       "azure",
       "web"
     ],
-    "signature_path": "/epr/azure_metrics/azure_metrics-1.0.3.zip.sig"
+    "signature_path": "/epr/azure_metrics/azure_metrics-1.0.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "azure.compute_vm",
+        "title": "Compute VM"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.compute_vm_scaleset",
+        "title": "Compute VM Scaleset"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.container_instance",
+        "title": "Container Instance"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.container_registry",
+        "title": "Container Registry"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.container_service",
+        "title": "Container Service"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.database_account",
+        "title": "Database Account"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.monitor",
+        "title": "Monitor"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.storage_account",
+        "title": "Storage Account"
+      }
+    ]
   },
   {
     "name": "cef",
@@ -1267,7 +1628,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/cef/cef-2.0.0.zip.sig"
+    "signature_path": "/epr/cef/cef-2.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cef.log",
+        "title": "CEF log logs"
+      }
+    ]
   },
   {
     "name": "cassandra",
@@ -1306,7 +1674,19 @@
       "datastore",
       "monitoring"
     ],
-    "signature_path": "/epr/cassandra/cassandra-1.1.0.zip.sig"
+    "signature_path": "/epr/cassandra/cassandra-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cassandra.log",
+        "title": "Cassandra System Logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "cassandra.metrics",
+        "title": "metrics"
+      }
+    ]
   },
   {
     "name": "checkpoint",
@@ -1344,7 +1724,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/checkpoint/checkpoint-1.5.0.zip.sig"
+    "signature_path": "/epr/checkpoint/checkpoint-1.5.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "checkpoint.firewall",
+        "title": "Check Point firewall logs"
+      }
+    ]
   },
   {
     "name": "cisco_asa",
@@ -1383,7 +1770,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/cisco_asa/cisco_asa-2.4.1.zip.sig"
+    "signature_path": "/epr/cisco_asa/cisco_asa-2.4.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco_asa.log",
+        "title": "Cisco ASA logs"
+      }
+    ]
   },
   {
     "name": "cisco_duo",
@@ -1421,7 +1815,34 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/cisco_duo/cisco_duo-1.2.4.zip.sig"
+    "signature_path": "/epr/cisco_duo/cisco_duo-1.2.4.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco_duo.admin",
+        "title": "Cisco Duo administrator logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "cisco_duo.auth",
+        "title": "Cisco Duo authentication logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "cisco_duo.offline_enrollment",
+        "title": "Cisco Duo offline enrollment logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "cisco_duo.summary",
+        "title": "Cisco Duo summary logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "cisco_duo.telephony",
+        "title": "Cisco Duo telephony logs"
+      }
+    ]
   },
   {
     "name": "cisco_ftd",
@@ -1460,7 +1881,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/cisco_ftd/cisco_ftd-2.2.1.zip.sig"
+    "signature_path": "/epr/cisco_ftd/cisco_ftd-2.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco_ftd.log",
+        "title": "Cisco FTD logs"
+      }
+    ]
   },
   {
     "name": "cisco_ios",
@@ -1499,7 +1927,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/cisco_ios/cisco_ios-1.6.0.zip.sig"
+    "signature_path": "/epr/cisco_ios/cisco_ios-1.6.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco_ios.log",
+        "title": "Cisco IOS logs"
+      }
+    ]
   },
   {
     "name": "cisco_secure_endpoint",
@@ -1538,7 +1973,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/cisco_secure_endpoint/cisco_secure_endpoint-2.4.1.zip.sig"
+    "signature_path": "/epr/cisco_secure_endpoint/cisco_secure_endpoint-2.4.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco_secure_endpoint.event",
+        "title": "Cisco Secure Endpoint logs"
+      }
+    ]
   },
   {
     "name": "cisco_umbrella",
@@ -1577,7 +2019,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/cisco_umbrella/cisco_umbrella-1.0.0.zip.sig"
+    "signature_path": "/epr/cisco_umbrella/cisco_umbrella-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cisco_umbrella.log",
+        "title": "Cisco Umbrella logs"
+      }
+    ]
   },
   {
     "name": "cloudflare",
@@ -1618,7 +2067,19 @@
       "web",
       "cloud"
     ],
-    "signature_path": "/epr/cloudflare/cloudflare-2.0.0.zip.sig"
+    "signature_path": "/epr/cloudflare/cloudflare-2.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cloudflare.audit",
+        "title": "Cloudflare Audit Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "cloudflare.logpull",
+        "title": "Cloudflare Logpull"
+      }
+    ]
   },
   {
     "name": "crowdstrike",
@@ -1656,7 +2117,19 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/crowdstrike/crowdstrike-1.3.3.zip.sig"
+    "signature_path": "/epr/crowdstrike/crowdstrike-1.3.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "crowdstrike.falcon",
+        "title": "Crowdstrike falcon logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "crowdstrike.fdr",
+        "title": "Falcon Data Replicator"
+      }
+    ]
   },
   {
     "name": "gcp_pubsub",
@@ -1696,7 +2169,14 @@
       "cloud",
       "custom"
     ],
-    "signature_path": "/epr/gcp_pubsub/gcp_pubsub-1.0.0.zip.sig"
+    "signature_path": "/epr/gcp_pubsub/gcp_pubsub-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "gcp_pubsub.generic",
+        "title": "Custom Google Pub/Sub Logs"
+      }
+    ]
   },
   {
     "name": "http_endpoint",
@@ -1732,7 +2212,14 @@
     "categories": [
       "custom"
     ],
-    "signature_path": "/epr/http_endpoint/http_endpoint-1.0.1.zip.sig"
+    "signature_path": "/epr/http_endpoint/http_endpoint-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "http_endpoint.generic",
+        "title": "Custom HTTP Endpoint Logs"
+      }
+    ]
   },
   {
     "name": "httpjson",
@@ -1761,7 +2248,14 @@
     "categories": [
       "custom"
     ],
-    "signature_path": "/epr/httpjson/httpjson-1.1.1.zip.sig"
+    "signature_path": "/epr/httpjson/httpjson-1.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "httpjson.generic",
+        "title": "Custom HTTPJSON Input"
+      }
+    ]
   },
   {
     "name": "log",
@@ -1792,7 +2286,14 @@
     "categories": [
       "custom"
     ],
-    "signature_path": "/epr/log/log-1.0.0.zip.sig"
+    "signature_path": "/epr/log/log-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "log.log",
+        "title": "Log Dataset"
+      }
+    ]
   },
   {
     "name": "tcp",
@@ -1828,7 +2329,14 @@
     "categories": [
       "custom"
     ],
-    "signature_path": "/epr/tcp/tcp-1.0.0.zip.sig"
+    "signature_path": "/epr/tcp/tcp-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "tcp.generic",
+        "title": "Custom TCP Logs"
+      }
+    ]
   },
   {
     "name": "udp",
@@ -1864,7 +2372,14 @@
     "categories": [
       "custom"
     ],
-    "signature_path": "/epr/udp/udp-1.0.1.zip.sig"
+    "signature_path": "/epr/udp/udp-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "udp.generic",
+        "title": "Custom UDP Logs"
+      }
+    ]
   },
   {
     "name": "winlog",
@@ -1900,7 +2415,14 @@
     "categories": [
       "custom"
     ],
-    "signature_path": "/epr/winlog/winlog-1.4.0.zip.sig"
+    "signature_path": "/epr/winlog/winlog-1.4.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "winlog.winlog",
+        "title": "Custom Windows Event Log Dataset"
+      }
+    ]
   },
   {
     "name": "cyberarkpas",
@@ -1938,7 +2460,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/cyberarkpas/cyberarkpas-2.4.2.zip.sig"
+    "signature_path": "/epr/cyberarkpas/cyberarkpas-2.4.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cyberarkpas.audit",
+        "title": "CyberArk PAS audit logs"
+      }
+    ]
   },
   {
     "name": "ti_cybersixgill",
@@ -1977,7 +2506,14 @@
       "security",
       "productivity"
     ],
-    "signature_path": "/epr/ti_cybersixgill/ti_cybersixgill-1.3.2.zip.sig"
+    "signature_path": "/epr/ti_cybersixgill/ti_cybersixgill-1.3.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_cybersixgill.threat",
+        "title": "Cybersixgill Darkfeed Logs"
+      }
+    ]
   },
   {
     "name": "docker",
@@ -2016,7 +2552,54 @@
       "containers",
       "os_system"
     ],
-    "signature_path": "/epr/docker/docker-1.2.0.zip.sig"
+    "signature_path": "/epr/docker/docker-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "docker.container",
+        "title": "Docker container metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "docker.cpu",
+        "title": "Docker cpu metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "docker.diskio",
+        "title": "Docker diskio metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "docker.event",
+        "title": "Docker event metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "docker.healthcheck",
+        "title": "Docker healthcheck metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "docker.image",
+        "title": "Docker image metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "docker.info",
+        "title": "Docker info metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "docker.memory",
+        "title": "Docker memory metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "docker.network",
+        "title": "Docker network metrics"
+      }
+    ]
   },
   {
     "name": "apm",
@@ -2055,7 +2638,49 @@
       "elastic_stack",
       "monitoring"
     ],
-    "signature_path": "/epr/apm/apm-8.2.0.zip.sig"
+    "signature_path": "/epr/apm/apm-8.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "apm.app",
+        "title": "APM application logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.app",
+        "title": "APM application metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "apm.error",
+        "title": "APM errors"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.internal",
+        "title": "APM internal metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.profiling",
+        "title": "APM profiles"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm.rum",
+        "title": "APM RUM traces"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm.sampled",
+        "title": "APM tail-sampled traces"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm",
+        "title": "APM traces"
+      }
+    ]
   },
   {
     "name": "elastic_agent",
@@ -2086,7 +2711,109 @@
     "categories": [
       "elastic_stack"
     ],
-    "signature_path": "/epr/elastic_agent/elastic_agent-1.3.1.zip.sig"
+    "signature_path": "/epr/elastic_agent/elastic_agent-1.3.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.apm_server",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.apm_server",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.auditbeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.auditbeat",
+        "title": "Elastic Agent Auditbeat Metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.elastic_agent",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.endpoint_security",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.endpoint_security",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.filebeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.filebeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.fleet_server",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.fleet_server",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.heartbeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.heartbeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.metricbeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.metricbeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.osquerybeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.osquerybeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "logs",
+        "dataset": "elastic_agent.packetbeat",
+        "title": "Elastic Agent"
+      },
+      {
+        "type": "metrics",
+        "dataset": "elastic_agent.packetbeat",
+        "title": "Elastic Agent"
+      }
+    ]
   },
   {
     "name": "endpoint",
@@ -2124,7 +2851,74 @@
       "security",
       "cloud"
     ],
-    "signature_path": "/epr/endpoint/endpoint-8.3.0.zip.sig"
+    "signature_path": "/epr/endpoint/endpoint-8.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "endpoint.action.responses",
+        "title": "Endpoint Action Responses"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.actions",
+        "title": "Endpoint Actions"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.alerts",
+        "title": "Endpoint Alerts"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.diagnostic.collection",
+        "title": "Endpoint Alert Collection"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.file",
+        "title": "Endpoint File Events"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.library",
+        "title": "Endpoint Library and Driver Events"
+      },
+      {
+        "type": "metrics",
+        "dataset": "endpoint.metadata",
+        "title": "Endpoint Metadata"
+      },
+      {
+        "type": "metrics",
+        "dataset": "endpoint.metrics",
+        "title": "Endpoint Metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.network",
+        "title": "Endpoint Network Events"
+      },
+      {
+        "type": "metrics",
+        "dataset": "endpoint.policy",
+        "title": "Endpoint Policy Response"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.process",
+        "title": "Endpoint Process Events"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.registry",
+        "title": "Endpoint Registry Events"
+      },
+      {
+        "type": "logs",
+        "dataset": "endpoint.events.security",
+        "title": "Endpoint Security Events"
+      }
+    ]
   },
   {
     "name": "fim",
@@ -2164,7 +2958,14 @@
       "os_system",
       "security"
     ],
-    "signature_path": "/epr/fim/fim-1.0.0.zip.sig"
+    "signature_path": "/epr/fim/fim-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "fim.event",
+        "title": "Filesystem events"
+      }
+    ]
   },
   {
     "name": "fireeye",
@@ -2204,7 +3005,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/fireeye/fireeye-1.3.1.zip.sig"
+    "signature_path": "/epr/fireeye/fireeye-1.3.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "fireeye.nx",
+        "title": "Fireeye NX"
+      }
+    ]
   },
   {
     "name": "fleet_server",
@@ -2280,7 +3088,29 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/fortinet/fortinet-1.6.1.zip.sig"
+    "signature_path": "/epr/fortinet/fortinet-1.6.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "fortinet.clientendpoint",
+        "title": "Fortinet FortiClient Endpoint Security logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "fortinet.firewall",
+        "title": "Fortinet firewall logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "fortinet.fortimail",
+        "title": "Fortinet FortiMail logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "fortinet.fortimanager",
+        "title": "Fortinet Manager/Analyzer logs"
+      }
+    ]
   },
   {
     "name": "github",
@@ -2318,7 +3148,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/github/github-1.0.0.zip.sig"
+    "signature_path": "/epr/github/github-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "github.audit",
+        "title": "GitHub Audit Logs"
+      }
+    ]
   },
   {
     "name": "gcp",
@@ -2359,7 +3196,29 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/gcp/gcp-1.9.0.zip.sig"
+    "signature_path": "/epr/gcp/gcp-1.9.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "gcp.audit",
+        "title": "Google Cloud Platform (GCP) audit logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "gcp.dns",
+        "title": "Google Cloud Platform (GCP) DNS logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "gcp.firewall",
+        "title": "Google Cloud Platform (GCP) firewall logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "gcp.vpcflow",
+        "title": "Google Cloud Platform (GCP) vpcflow logs"
+      }
+    ]
   },
   {
     "name": "santa",
@@ -2397,7 +3256,14 @@
       "security",
       "os_system"
     ],
-    "signature_path": "/epr/santa/santa-2.0.1.zip.sig"
+    "signature_path": "/epr/santa/santa-2.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "santa.log",
+        "title": "Google Santa log logs"
+      }
+    ]
   },
   {
     "name": "google_workspace",
@@ -2435,7 +3301,39 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/google_workspace/google_workspace-1.5.0.zip.sig"
+    "signature_path": "/epr/google_workspace/google_workspace-1.5.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "google_workspace.admin",
+        "title": "Admin logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "google_workspace.drive",
+        "title": "Drive logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "google_workspace.groups",
+        "title": "Groups logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "google_workspace.login",
+        "title": "Login logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "google_workspace.saml",
+        "title": "SAML logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "google_workspace.user_accounts",
+        "title": "User accounts logs"
+      }
+    ]
   },
   {
     "name": "hashicorp_vault",
@@ -2473,7 +3371,24 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/hashicorp_vault/hashicorp_vault-1.3.3.zip.sig"
+    "signature_path": "/epr/hashicorp_vault/hashicorp_vault-1.3.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "hashicorp_vault.audit",
+        "title": "Hashicorp Vault Audit Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "hashicorp_vault.log",
+        "title": "Hashicorp Vault Operational Logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "hashicorp_vault.metrics",
+        "title": "Hashicorp Vault Metrics"
+      }
+    ]
   },
   {
     "name": "hid_bravura_monitor",
@@ -2511,7 +3426,19 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/hid_bravura_monitor/hid_bravura_monitor-1.0.2.zip.sig"
+    "signature_path": "/epr/hid_bravura_monitor/hid_bravura_monitor-1.0.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "hid_bravura_monitor.log",
+        "title": "Hitachi ID Bravura Monitor"
+      },
+      {
+        "type": "logs",
+        "dataset": "hid_bravura_monitor.winlog",
+        "title": "Hitachi ID Security Fabric logs"
+      }
+    ]
   },
   {
     "name": "juniper",
@@ -2550,7 +3477,24 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/juniper/juniper-1.1.0.zip.sig"
+    "signature_path": "/epr/juniper/juniper-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "juniper.junos",
+        "title": "Juniper JUNOS logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "juniper.netscreen",
+        "title": "Netscreen logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "juniper.srx",
+        "title": "Juniper SRX logs"
+      }
+    ]
   },
   {
     "name": "juniper_srx",
@@ -2589,7 +3533,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/juniper_srx/juniper_srx-1.1.2.zip.sig"
+    "signature_path": "/epr/juniper_srx/juniper_srx-1.1.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "juniper_srx.log",
+        "title": "Juniper SRX logs"
+      }
+    ]
   },
   {
     "name": "kafka",
@@ -2627,7 +3578,29 @@
     "categories": [
       "message_queue"
     ],
-    "signature_path": "/epr/kafka/kafka-1.2.2.zip.sig"
+    "signature_path": "/epr/kafka/kafka-1.2.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "kafka.broker",
+        "title": "Kafka broker metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kafka.consumergroup",
+        "title": "Kafka consumergroup metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "kafka.log",
+        "title": "Kafka log logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kafka.partition",
+        "title": "Kafka partition metrics"
+      }
+    ]
   },
   {
     "name": "keycloak",
@@ -2667,7 +3640,14 @@
       "network",
       "web"
     ],
-    "signature_path": "/epr/keycloak/keycloak-1.2.1.zip.sig"
+    "signature_path": "/epr/keycloak/keycloak-1.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "keycloak.log",
+        "title": "Keycloak"
+      }
+    ]
   },
   {
     "name": "kibana",
@@ -2705,7 +3685,29 @@
     "categories": [
       "elastic_stack"
     ],
-    "signature_path": "/epr/kibana/kibana-1.0.0.zip.sig"
+    "signature_path": "/epr/kibana/kibana-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "kibana.audit",
+        "title": "kibana audit logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "kibana.log",
+        "title": "Kibana logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kibana.stats",
+        "title": "Kibana stats metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kibana.status",
+        "title": "Kibana status metrics"
+      }
+    ]
   },
   {
     "name": "kubernetes",
@@ -2865,7 +3867,139 @@
       "containers",
       "kubernetes"
     ],
-    "signature_path": "/epr/kubernetes/kubernetes-1.17.2.zip.sig"
+    "signature_path": "/epr/kubernetes/kubernetes-1.17.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.apiserver",
+        "title": "Kubernetes API Server metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "kubernetes.audit_logs",
+        "title": "Kubernetes audit logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.container",
+        "title": "Kubernetes Container metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "kubernetes.container_logs",
+        "title": "Kubernetes container logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.controllermanager",
+        "title": "Kubernetes Controller Manager metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.event",
+        "title": "Kubernetes Event metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.node",
+        "title": "Kubernetes Node metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.pod",
+        "title": "Kubernetes Pod metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.proxy",
+        "title": "Kubernetes Proxy metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.scheduler",
+        "title": "Kubernetes Scheduler metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_container",
+        "title": "Kubernetes Container metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_cronjob",
+        "title": "Kubernetes Cronjob metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_daemonset",
+        "title": "Kubernetes Deamonset metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_deployment",
+        "title": "Kubernetes Deployment metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_job",
+        "title": "Kubernetes Job metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_node",
+        "title": "Kubernetes Node metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_persistentvolume",
+        "title": "Kubernetes PersistentVolume metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_persistentvolumeclaim",
+        "title": "Kubernetes PersistentVolumeClaim metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_pod",
+        "title": "Kubernetes Pod metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_replicaset",
+        "title": "Kubernetes state_replicaset metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_resourcequota",
+        "title": "Kubernetes ResourceQuota metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_service",
+        "title": "Kubernetes Service metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_statefulset",
+        "title": "Kubernetes StatefulSet metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.state_storageclass",
+        "title": "Kubernetes StorageClass metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.system",
+        "title": "Kubernetes System metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "kubernetes.volume",
+        "title": "Kubernetes Volume metrics"
+      }
+    ]
   },
   {
     "name": "logstash",
@@ -2903,7 +4037,29 @@
     "categories": [
       "elastic_stack"
     ],
-    "signature_path": "/epr/logstash/logstash-1.0.0.zip.sig"
+    "signature_path": "/epr/logstash/logstash-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "logstash.log",
+        "title": "Logstash logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "logstash.node",
+        "title": "Logstash node metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "logstash.node_stats",
+        "title": "Logstash node_stats metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "logstash.slowlog",
+        "title": "logstash slowlog logs"
+      }
+    ]
   },
   {
     "name": "m365_defender",
@@ -2943,7 +4099,14 @@
       "security",
       "azure"
     ],
-    "signature_path": "/epr/m365_defender/m365_defender-1.0.3.zip.sig"
+    "signature_path": "/epr/m365_defender/m365_defender-1.0.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "m365_defender.log",
+        "title": "M365 Defender Logs"
+      }
+    ]
   },
   {
     "name": "ti_misp",
@@ -2981,7 +4144,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/ti_misp/ti_misp-1.2.2.zip.sig"
+    "signature_path": "/epr/ti_misp/ti_misp-1.2.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_misp.threat",
+        "title": "MISP"
+      }
+    ]
   },
   {
     "name": "mattermost",
@@ -3020,7 +4190,14 @@
       "security",
       "web"
     ],
-    "signature_path": "/epr/mattermost/mattermost-1.1.1.zip.sig"
+    "signature_path": "/epr/mattermost/mattermost-1.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "mattermost.audit",
+        "title": "Audit Logs"
+      }
+    ]
   },
   {
     "name": "microsoft",
@@ -3060,7 +4237,19 @@
       "security",
       "azure"
     ],
-    "signature_path": "/epr/microsoft/microsoft-1.0.0.zip.sig"
+    "signature_path": "/epr/microsoft/microsoft-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "microsoft.defender_atp",
+        "title": "Microsoft Defender for Endpoint"
+      },
+      {
+        "type": "logs",
+        "dataset": "microsoft.dhcp",
+        "title": "Microsoft DHCP logs"
+      }
+    ]
   },
   {
     "name": "microsoft_dhcp",
@@ -3098,7 +4287,14 @@
     "categories": [
       "network"
     ],
-    "signature_path": "/epr/microsoft_dhcp/microsoft_dhcp-1.3.1.zip.sig"
+    "signature_path": "/epr/microsoft_dhcp/microsoft_dhcp-1.3.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "microsoft_dhcp.log",
+        "title": "Microsoft DHCP Logs"
+      }
+    ]
   },
   {
     "name": "microsoft_defender_endpoint",
@@ -3138,7 +4334,14 @@
       "security",
       "azure"
     ],
-    "signature_path": "/epr/microsoft_defender_endpoint/microsoft_defender_endpoint-2.1.0.zip.sig"
+    "signature_path": "/epr/microsoft_defender_endpoint/microsoft_defender_endpoint-2.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "microsoft_defender_endpoint.log",
+        "title": "Microsoft Defender for Endpoint logs"
+      }
+    ]
   },
   {
     "name": "mongodb",
@@ -3176,7 +4379,39 @@
     "categories": [
       "datastore"
     ],
-    "signature_path": "/epr/mongodb/mongodb-1.3.1.zip.sig"
+    "signature_path": "/epr/mongodb/mongodb-1.3.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "mongodb.collstats",
+        "title": "MongoDB collstats metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "mongodb.dbstats",
+        "title": "MongoDB dbstats metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "mongodb.log",
+        "title": "mongodb log logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "mongodb.metrics",
+        "title": "MongoDB metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "mongodb.replstatus",
+        "title": "MongoDB replstatus metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "mongodb.status",
+        "title": "MongoDB status metrics"
+      }
+    ]
   },
   {
     "name": "mysql",
@@ -3214,7 +4449,34 @@
     "categories": [
       "datastore"
     ],
-    "signature_path": "/epr/mysql/mysql-1.2.1.zip.sig"
+    "signature_path": "/epr/mysql/mysql-1.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "mysql.error",
+        "title": "MySQL error logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "mysql.galera_status",
+        "title": "MySQL galera_status metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "mysql.performance",
+        "title": "MySQL performance metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "mysql.slowlog",
+        "title": "MySQL slowlog logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "mysql.status",
+        "title": "MySQL status metrics"
+      }
+    ]
   },
   {
     "name": "mysql_enterprise",
@@ -3253,7 +4515,14 @@
       "security",
       "datastore"
     ],
-    "signature_path": "/epr/mysql_enterprise/mysql_enterprise-1.0.1.zip.sig"
+    "signature_path": "/epr/mysql_enterprise/mysql_enterprise-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "mysql_enterprise.audit",
+        "title": "MySQL Enterprise Audit Log"
+      }
+    ]
   },
   {
     "name": "nats",
@@ -3291,7 +4560,44 @@
     "categories": [
       "message_queue"
     ],
-    "signature_path": "/epr/nats/nats-1.2.0.zip.sig"
+    "signature_path": "/epr/nats/nats-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "nats.connection",
+        "title": "NATS connection metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "nats.connections",
+        "title": "NATS connections metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "nats.log",
+        "title": "NATS logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "nats.route",
+        "title": "NATS route metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "nats.routes",
+        "title": "NATS routes metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "nats.stats",
+        "title": "NATS stats metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "nats.subscriptions",
+        "title": "NATS subscriptions metrics"
+      }
+    ]
   },
   {
     "name": "netflow",
@@ -3321,7 +4627,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/netflow/netflow-1.4.2.zip.sig"
+    "signature_path": "/epr/netflow/netflow-1.4.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "netflow.log",
+        "title": "NetFlow logs"
+      }
+    ]
   },
   {
     "name": "nginx",
@@ -3360,7 +4673,24 @@
       "web",
       "security"
     ],
-    "signature_path": "/epr/nginx/nginx-1.3.1.zip.sig"
+    "signature_path": "/epr/nginx/nginx-1.3.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "nginx.access",
+        "title": "Nginx access logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "nginx.error",
+        "title": "Nginx error logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "nginx.stubstatus",
+        "title": "Nginx stubstatus metrics"
+      }
+    ]
   },
   {
     "name": "nginx_ingress_controller",
@@ -3399,7 +4729,19 @@
       "web",
       "security"
     ],
-    "signature_path": "/epr/nginx_ingress_controller/nginx_ingress_controller-1.2.0.zip.sig"
+    "signature_path": "/epr/nginx_ingress_controller/nginx_ingress_controller-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "nginx_ingress_controller.access",
+        "title": "Nginx Ingress Controller access logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "nginx_ingress_controller.error",
+        "title": "Nginx Ingress Controller error logs"
+      }
+    ]
   },
   {
     "name": "o365",
@@ -3437,7 +4779,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/o365/o365-1.4.3.zip.sig"
+    "signature_path": "/epr/o365/o365-1.4.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "o365.audit",
+        "title": "Office 365 audit logs"
+      }
+    ]
   },
   {
     "name": "okta",
@@ -3475,7 +4824,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/okta/okta-1.5.2.zip.sig"
+    "signature_path": "/epr/okta/okta-1.5.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "okta.system",
+        "title": "Okta system logs"
+      }
+    ]
   },
   {
     "name": "oracle",
@@ -3514,7 +4870,14 @@
       "security",
       "datastore"
     ],
-    "signature_path": "/epr/oracle/oracle-1.0.1.zip.sig"
+    "signature_path": "/epr/oracle/oracle-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "oracle.database_audit",
+        "title": "Oracle Audit Log"
+      }
+    ]
   },
   {
     "name": "osquery",
@@ -3553,7 +4916,14 @@
       "security",
       "os_system"
     ],
-    "signature_path": "/epr/osquery/osquery-1.2.1.zip.sig"
+    "signature_path": "/epr/osquery/osquery-1.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "osquery.result",
+        "title": "Osquery result logs"
+      }
+    ]
   },
   {
     "name": "osquery_manager",
@@ -3593,7 +4963,14 @@
       "os_system",
       "config_management"
     ],
-    "signature_path": "/epr/osquery_manager/osquery_manager-1.2.1.zip.sig"
+    "signature_path": "/epr/osquery_manager/osquery_manager-1.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "osquery_manager.result",
+        "title": "Osquery Manager queries"
+      }
+    ]
   },
   {
     "name": "panw_cortex_xdr",
@@ -3631,7 +5008,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/panw_cortex_xdr/panw_cortex_xdr-1.1.1.zip.sig"
+    "signature_path": "/epr/panw_cortex_xdr/panw_cortex_xdr-1.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "panw_cortex_xdr.alerts",
+        "title": "Palo Alto Cortex XDR API"
+      }
+    ]
   },
   {
     "name": "panw",
@@ -3669,7 +5053,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/panw/panw-1.5.3.zip.sig"
+    "signature_path": "/epr/panw/panw-1.5.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "panw.panos",
+        "title": "Palo Alto Networks PAN-OS firewall logs"
+      }
+    ]
   },
   {
     "name": "postgresql",
@@ -3707,7 +5098,34 @@
     "categories": [
       "datastore"
     ],
-    "signature_path": "/epr/postgresql/postgresql-1.2.0.zip.sig"
+    "signature_path": "/epr/postgresql/postgresql-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "postgresql.activity",
+        "title": "PostgreSQL activity metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "postgresql.bgwriter",
+        "title": "PostgreSQL bgwriter metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "postgresql.database",
+        "title": "PostgreSQL database metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "postgresql.log",
+        "title": "PostgreSQL logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "postgresql.statement",
+        "title": "PostgreSQL statement metrics"
+      }
+    ]
   },
   {
     "name": "security_detection_engine",
@@ -3775,7 +5193,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/qnap_nas/qnap_nas-1.1.1.zip.sig"
+    "signature_path": "/epr/qnap_nas/qnap_nas-1.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "qnap_nas.log",
+        "title": "QNAP NAS logs"
+      }
+    ]
   },
   {
     "name": "rabbitmq",
@@ -3813,7 +5238,34 @@
     "categories": [
       "message_queue"
     ],
-    "signature_path": "/epr/rabbitmq/rabbitmq-1.2.0.zip.sig"
+    "signature_path": "/epr/rabbitmq/rabbitmq-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "rabbitmq.connection",
+        "title": "RabbitMQ connection metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "rabbitmq.exchange",
+        "title": "RabbitMQ exchange metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "rabbitmq.log",
+        "title": "RabbitMQ application logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "rabbitmq.node",
+        "title": "RabbitMQ node metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "rabbitmq.queue",
+        "title": "RabbitMQ queue metrics"
+      }
+    ]
   },
   {
     "name": "redis",
@@ -3852,7 +5304,34 @@
       "datastore",
       "message_queue"
     ],
-    "signature_path": "/epr/redis/redis-1.2.0.zip.sig"
+    "signature_path": "/epr/redis/redis-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "redis.info",
+        "title": "Redis info metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "redis.key",
+        "title": "Redis key metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "redis.keyspace",
+        "title": "Redis keyspace metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "redis.log",
+        "title": "Redis application logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "redis.slowlog",
+        "title": "Redis slow logs"
+      }
+    ]
   },
   {
     "name": "stan",
@@ -3891,7 +5370,29 @@
       "message_queue",
       "kubernetes"
     ],
-    "signature_path": "/epr/stan/stan-1.2.0.zip.sig"
+    "signature_path": "/epr/stan/stan-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "stan.channels",
+        "title": "Stan channels metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "stan.log",
+        "title": "STAN logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "stan.stats",
+        "title": "Stan stats metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "stan.subscriptions",
+        "title": "Stan subscriptions metrics"
+      }
+    ]
   },
   {
     "name": "snyk",
@@ -3929,7 +5430,19 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/snyk/snyk-1.1.2.zip.sig"
+    "signature_path": "/epr/snyk/snyk-1.1.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "snyk.audit",
+        "title": "Collect Snyk Audit Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "snyk.vulnerabilities",
+        "title": "Collect Snyk Vulnerability Data"
+      }
+    ]
   },
   {
     "name": "sophos",
@@ -3967,7 +5480,19 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/sophos/sophos-1.2.2.zip.sig"
+    "signature_path": "/epr/sophos/sophos-1.2.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "sophos.utm",
+        "title": "Sophos UTM logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "sophos.xg",
+        "title": "Sophos XG logs"
+      }
+    ]
   },
   {
     "name": "suricata",
@@ -4006,7 +5531,14 @@
       "network",
       "security"
     ],
-    "signature_path": "/epr/suricata/suricata-1.6.1.zip.sig"
+    "signature_path": "/epr/suricata/suricata-1.6.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "suricata.eve",
+        "title": "Suricata eve logs"
+      }
+    ]
   },
   {
     "name": "system",
@@ -4045,7 +5577,94 @@
       "os_system",
       "security"
     ],
-    "signature_path": "/epr/system/system-1.6.4.zip.sig"
+    "signature_path": "/epr/system/system-1.6.4.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "system.application",
+        "title": "Windows Application Events"
+      },
+      {
+        "type": "logs",
+        "dataset": "system.auth",
+        "title": "System auth logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.core",
+        "title": "System core metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.cpu",
+        "title": "System cpu metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.diskio",
+        "title": "System diskio metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.filesystem",
+        "title": "System filesystem metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.fsstat",
+        "title": "System fsstat metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.load",
+        "title": "System load metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.memory",
+        "title": "System memory metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.network",
+        "title": "System network metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.process",
+        "title": "System process metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.process.summary",
+        "title": "System process_summary metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "system.security",
+        "title": "Security logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.socket_summary",
+        "title": "System socket_summary metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "system.syslog",
+        "title": "System syslog logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "system.system",
+        "title": "Windows System Events"
+      },
+      {
+        "type": "metrics",
+        "dataset": "system.uptime",
+        "title": "System uptime metrics"
+      }
+    ]
   },
   {
     "name": "tenable_sc",
@@ -4083,7 +5702,24 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/tenable_sc/tenable_sc-1.1.1.zip.sig"
+    "signature_path": "/epr/tenable_sc/tenable_sc-1.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "tenable_sc.asset",
+        "title": "Tenable.sc asset logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "tenable_sc.plugin",
+        "title": "Tenable.sc plugin logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "tenable_sc.vulnerability",
+        "title": "Tenable.sc vulnerability logs"
+      }
+    ]
   },
   {
     "name": "ti_threatq",
@@ -4121,7 +5757,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/ti_threatq/ti_threatq-1.2.2.zip.sig"
+    "signature_path": "/epr/ti_threatq/ti_threatq-1.2.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_threatq.threat",
+        "title": "ThreatQ"
+      }
+    ]
   },
   {
     "name": "traefik",
@@ -4160,7 +5803,19 @@
       "web",
       "security"
     ],
-    "signature_path": "/epr/traefik/traefik-1.2.0.zip.sig"
+    "signature_path": "/epr/traefik/traefik-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "traefik.access",
+        "title": "Traefik access logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "traefik.health",
+        "title": "Traefik health metrics"
+      }
+    ]
   },
   {
     "name": "carbon_black_cloud",
@@ -4198,7 +5853,34 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/carbon_black_cloud/carbon_black_cloud-1.0.2.zip.sig"
+    "signature_path": "/epr/carbon_black_cloud/carbon_black_cloud-1.0.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.alert",
+        "title": "Alert"
+      },
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.asset_vulnerability_summary",
+        "title": "Asset Vulnerability Summary"
+      },
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.audit",
+        "title": "Audit"
+      },
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.endpoint_event",
+        "title": "Endpoint Event"
+      },
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.watchlist_hit",
+        "title": "Watchlist Hit"
+      }
+    ]
   },
   {
     "name": "carbonblack_edr",
@@ -4236,7 +5918,14 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/carbonblack_edr/carbonblack_edr-1.2.0.zip.sig"
+    "signature_path": "/epr/carbonblack_edr/carbonblack_edr-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "carbonblack_edr.log",
+        "title": "Carbon Black EDR logs"
+      }
+    ]
   },
   {
     "name": "windows",
@@ -4275,7 +5964,39 @@
       "os_system",
       "security"
     ],
-    "signature_path": "/epr/windows/windows-1.5.0.zip.sig"
+    "signature_path": "/epr/windows/windows-1.5.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "windows.forwarded",
+        "title": "Windows forwarded events"
+      },
+      {
+        "type": "metrics",
+        "dataset": "windows.perfmon",
+        "title": "Windows perfmon metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "windows.powershell",
+        "title": "Windows Powershell logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "windows.powershell_operational",
+        "title": "Windows Powershell/Operational logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "windows.service",
+        "title": "Windows service metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "windows.sysmon_operational",
+        "title": "Windows Sysmon/Operational events"
+      }
+    ]
   },
   {
     "name": "zeek",
@@ -4315,7 +6036,204 @@
       "monitoring",
       "security"
     ],
-    "signature_path": "/epr/zeek/zeek-1.6.1.zip.sig"
+    "signature_path": "/epr/zeek/zeek-1.6.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "zeek.capture_loss",
+        "title": "Zeek capture_loss logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.connection",
+        "title": "Zeek connection logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.dce_rpc",
+        "title": "Zeek dce_rpc logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.dhcp",
+        "title": "Zeek dhcp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.dnp3",
+        "title": "Zeek dnp3 logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.dns",
+        "title": "Zeek dns logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.dpd",
+        "title": "Zeek dpd logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.files",
+        "title": "Zeek files logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.ftp",
+        "title": "Zeek ftp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.http",
+        "title": "Zeek http logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.intel",
+        "title": "Zeek intel logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.irc",
+        "title": "Zeek irc logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.kerberos",
+        "title": "Zeek kerberos logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.modbus",
+        "title": "Zeek modbus logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.mysql",
+        "title": "Zeek mysql logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.notice",
+        "title": "Zeek notice logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.ntlm",
+        "title": "Zeek ntlm logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.ntp",
+        "title": "Zeek ntp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.ocsp",
+        "title": "Zeek ocsp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.pe",
+        "title": "Zeek pe logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.radius",
+        "title": "Zeek radius logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.rdp",
+        "title": "Zeek rdp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.rfb",
+        "title": "Zeek rfb logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.signature",
+        "title": "Zeek signature logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.sip",
+        "title": "Zeek sip logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.smb_cmd",
+        "title": "Zeek smb_cmd logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.smb_files",
+        "title": "Zeek smb_files logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.smb_mapping",
+        "title": "Zeek smb_mapping logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.smtp",
+        "title": "Zeek smtp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.snmp",
+        "title": "Zeek snmp logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.socks",
+        "title": "Zeek socks logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.ssh",
+        "title": "Zeek ssh logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.ssl",
+        "title": "Zeek ssl logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.stats",
+        "title": "Zeek stats logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.syslog",
+        "title": "Zeek syslog logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.traceroute",
+        "title": "Zeek traceroute logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.tunnel",
+        "title": "Zeek tunnel logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.weird",
+        "title": "Zeek weird logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "zeek.x509",
+        "title": "Zeek x509 logs"
+      }
+    ]
   },
   {
     "name": "zerofox",
@@ -4354,7 +6272,14 @@
       "cloud",
       "security"
     ],
-    "signature_path": "/epr/zerofox/zerofox-1.2.1.zip.sig"
+    "signature_path": "/epr/zerofox/zerofox-1.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "zerofox.alerts",
+        "title": "Alerts"
+      }
+    ]
   },
   {
     "name": "zookeeper",
@@ -4393,7 +6318,24 @@
       "datastore",
       "config_management"
     ],
-    "signature_path": "/epr/zookeeper/zookeeper-1.2.0.zip.sig"
+    "signature_path": "/epr/zookeeper/zookeeper-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "zookeeper.connection",
+        "title": "ZooKeeper connection metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "zookeeper.mntr",
+        "title": "ZooKeeper mntr metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "zookeeper.server",
+        "title": "ZooKeeper server metrics"
+      }
+    ]
   },
   {
     "name": "zoom",
@@ -4432,6 +6374,13 @@
       "security",
       "productivity"
     ],
-    "signature_path": "/epr/zoom/zoom-1.2.1.zip.sig"
+    "signature_path": "/epr/zoom/zoom-1.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "zoom.webhook",
+        "title": "Zoom webhook logs"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
This information is already included in responses to the `/package` output. Add it to `/search` responses so it can be also used for discovery purposes, without having to request all packages individually.

Closes https://github.com/elastic/package-registry/issues/1252