### PR TITLE
Add CORS headers to package registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * Include summary of data streams in search responses. [#1264](https://github.com/elastic/package-registry/pull/1264)
+* Add Access-Control-Allow-Origin header for all origins. [#1266](https://github.com/elastic/package-registry/pull/1266)
 
 ### Deprecated
 

--- a/internal/util/cors.go
+++ b/internal/util/cors.go
@@ -1,0 +1,21 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package util
+
+import (
+	"net/http"
+
+	"github.com/gorilla/mux"
+)
+
+// CORSMiddleware is a middleware used to add CORS related headers.
+func CORSMiddleware() mux.MiddlewareFunc {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Access-Control-Allow-Origin", "*")
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/internal/util/cors_test.go
+++ b/internal/util/cors_test.go
@@ -1,0 +1,28 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package util
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCORSHeaders(t *testing.T) {
+	router := mux.NewRouter()
+	router.HandleFunc("/", func(http.ResponseWriter, *http.Request) {})
+	router.Use(CORSMiddleware())
+
+	recorder := httptest.NewRecorder()
+	request, _ := http.NewRequest(http.MethodGet, "/", nil)
+
+	router.ServeHTTP(recorder, request)
+
+	allowOrigin := recorder.Header().Values("Access-Control-Allow-Origin")
+	assert.Equal(t, []string{"*"}, allowOrigin)
+}

--- a/main.go
+++ b/main.go
@@ -394,6 +394,7 @@ func getRouter(logger *zap.Logger, config *Config, indexer Indexer) (*mux.Router
 	router.HandleFunc(packageIndexRouterPath, packageIndexHandler)
 	router.HandleFunc(staticRouterPath, staticHandler)
 	router.Use(util.LoggingMiddleware(logger))
+	router.Use(util.CORSMiddleware())
 	if metricsAddress != "" {
 		router.Use(metrics.MetricsMiddleware())
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -37,6 +37,23 @@ var (
 	testLogger         = util.NewTestLogger()
 )
 
+func TestRouter(t *testing.T) {
+	logger := util.NewTestLogger()
+	config := defaultConfig
+	indexer := NewCombinedIndexer()
+
+	router, err := getRouter(logger, &config, indexer)
+	require.NoError(t, err)
+
+	recorder := httptest.NewRecorder()
+	request, _ := http.NewRequest(http.MethodGet, "/", nil)
+
+	router.ServeHTTP(recorder, request)
+
+	allowOrigin := recorder.Header().Values("Access-Control-Allow-Origin")
+	assert.Equal(t, []string{"*"}, allowOrigin)
+}
+
 func TestEndpoints(t *testing.T) {
 	packagesBasePaths := []string{"./testdata/second_package_path", "./testdata/package"}
 	indexer := NewCombinedIndexer(


### PR DESCRIPTION
Add `Access-Control-Allow-Origin: *` header to all responses.

Fixes https://github.com/elastic/package-registry/issues/1265.