### PR TITLE
Expose is_default setting of agentless deployment mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Include summary of data streams in search responses. [#1264](https://github.com/elastic/package-registry/pull/1264)
 * Add Access-Control-Allow-Origin header for all origins. [#1266](https://github.com/elastic/package-registry/pull/1266)
-* Expose `is_default` flag in agentless deployment modes. [#1269](https://github.com/elastic/package-spec/pull/1269)
+* Expose `is_default` flag in agentless deployment modes. [#1269](https://github.com/elastic/package-registry/pull/1269)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Include summary of data streams in search responses. [#1264](https://github.com/elastic/package-registry/pull/1264)
 * Add Access-Control-Allow-Origin header for all origins. [#1266](https://github.com/elastic/package-registry/pull/1266)
+* Expose `is_default` flag in agentless deployment modes. [#1269](https://github.com/elastic/package-spec/pull/1269)
 
 ### Deprecated
 

--- a/packages/package.go
+++ b/packages/package.go
@@ -193,7 +193,8 @@ type DeploymentModes struct {
 }
 
 type DeploymentMode struct {
-	Enabled bool `config:"enabled" json:"enabled" yaml:"enabled" validate:"required"`
+	Enabled   bool  `config:"enabled" json:"enabled" yaml:"enabled" validate:"required"`
+	IsDefault *bool `config:"is_default" json:"is_default,omitempty" yaml:"is_default,omitempty"`
 }
 
 func NewDownload(p Package, t string) Download {

--- a/packages/testdata/marshaler/packages.json
+++ b/packages/testdata/marshaler/packages.json
@@ -596,7 +596,8 @@
        "enabled": false
       },
       "agentless": {
-       "enabled": true
+       "enabled": true,
+       "is_default": true
       }
      }
     },

--- a/testdata/generated/package/deployment_modes/0.0.1/index.json
+++ b/testdata/generated/package/deployment_modes/0.0.1/index.json
@@ -89,7 +89,8 @@
           "enabled": false
         },
         "agentless": {
-          "enabled": true
+          "enabled": true,
+          "is_default": true
         }
       }
     },

--- a/testdata/generated/search-package-experimental.json
+++ b/testdata/generated/search-package-experimental.json
@@ -226,7 +226,8 @@
             "enabled": false
           },
           "agentless": {
-            "enabled": true
+            "enabled": true,
+            "is_default": true
           }
         }
       },

--- a/testdata/generated/search-package-prerelease.json
+++ b/testdata/generated/search-package-prerelease.json
@@ -226,7 +226,8 @@
             "enabled": false
           },
           "agentless": {
-            "enabled": true
+            "enabled": true,
+            "is_default": true
           }
         }
       },

--- a/testdata/generated/search-prerelease-capabilities-none.json
+++ b/testdata/generated/search-prerelease-capabilities-none.json
@@ -226,7 +226,8 @@
             "enabled": false
           },
           "agentless": {
-            "enabled": true
+            "enabled": true,
+            "is_default": true
           }
         }
       },

--- a/testdata/generated/search-prerelease-capabilities-observability-security.json
+++ b/testdata/generated/search-prerelease-capabilities-observability-security.json
@@ -226,7 +226,8 @@
             "enabled": false
           },
           "agentless": {
-            "enabled": true
+            "enabled": true,
+            "is_default": true
           }
         }
       },

--- a/testdata/package/deployment_modes/0.0.1/manifest.yml
+++ b/testdata/package/deployment_modes/0.0.1/manifest.yml
@@ -47,6 +47,7 @@ policy_templates:
         enabled: false
       agentless:
         enabled: true
+        is_default: true
         organization: elastic
         division: observability
         team: integration


### PR DESCRIPTION
Expose `is_default` property of agentless deployment mode, added in https://github.com/elastic/package-spec/pull/854.

Closes https://github.com/elastic/package-registry/issues/1263