### PR TITLE
Fix types of test packages

### DIFF
--- a/packages/testdata/marshaler/packages.json
+++ b/packages/testdata/marshaler/packages.json
@@ -40,7 +40,7 @@
    "version": "1.0.0",
    "release": "beta",
    "description": "Test package-specified agent privileges",
-   "type": "solution",
+   "type": "integration",
    "download": "/epr/agent_privileges/agent_privileges-1.0.0.zip",
    "path": "/package/agent_privileges/1.0.0",
    "conditions": {
@@ -491,7 +491,7 @@
    "version": "0.0.1",
    "release": "beta",
    "description": "Package without release, should be set to default",
-   "type": "solution",
+   "type": "integration",
    "download": "/epr/defaultrelease/defaultrelease-0.0.1.zip",
    "path": "/package/defaultrelease/0.0.1",
    "categories": [
@@ -675,7 +675,7 @@
    "version": "1.0.0",
    "release": "beta",
    "description": "Test package-specified Elasticsearch index privileges and cluster privileges",
-   "type": "solution",
+   "type": "integration",
    "download": "/epr/elasticsearch_privileges/elasticsearch_privileges-1.0.0.zip",
    "path": "/package/elasticsearch_privileges/1.0.0",
    "conditions": {
@@ -1175,7 +1175,7 @@
    "version": "1.0.0",
    "release": "beta",
    "description": "This is the foo integration",
-   "type": "solution",
+   "type": "integration",
    "download": "/epr/foo/foo-1.0.0.zip",
    "path": "/package/foo/1.0.0",
    "conditions": {
@@ -1272,7 +1272,7 @@
    "version": "1.0.0",
    "release": "beta",
    "description": "This is the hidden integration",
-   "type": "solution",
+   "type": "integration",
    "download": "/epr/hidden/hidden-1.0.0.zip",
    "path": "/package/hidden/1.0.0",
    "conditions": {
@@ -1316,7 +1316,7 @@
    "version": "1.0.0",
    "release": "beta",
    "description": "Test form ILM Policy in Package",
-   "type": "solution",
+   "type": "integration",
    "download": "/epr/ilm_policy/ilm_policy-1.0.0.zip",
    "path": "/package/ilm_policy/1.0.0",
    "conditions": {
@@ -1655,7 +1655,7 @@
    "version": "1.0.0",
    "release": "beta",
    "description": "This is a test package showing input-level agent yaml templates",
-   "type": "solution",
+   "type": "integration",
    "download": "/epr/input_level_templates/input_level_templates-1.0.0.zip",
    "path": "/package/input_level_templates/1.0.0",
    "conditions": {

--- a/testdata/generated/package/agent_privileges/1.0.0/index.json
+++ b/testdata/generated/package/agent_privileges/1.0.0/index.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "release": "beta",
   "description": "Test package-specified agent privileges",
-  "type": "solution",
+  "type": "integration",
   "download": "/epr/agent_privileges/agent_privileges-1.0.0.zip",
   "path": "/package/agent_privileges/1.0.0",
   "conditions": {

--- a/testdata/generated/package/defaultrelease/0.0.1/index.json
+++ b/testdata/generated/package/defaultrelease/0.0.1/index.json
@@ -4,7 +4,7 @@
   "version": "0.0.1",
   "release": "beta",
   "description": "Package without release, should be set to default",
-  "type": "solution",
+  "type": "integration",
   "download": "/epr/defaultrelease/defaultrelease-0.0.1.zip",
   "path": "/package/defaultrelease/0.0.1",
   "categories": [

--- a/testdata/generated/package/elasticsearch_privileges/1.0.0/index.json
+++ b/testdata/generated/package/elasticsearch_privileges/1.0.0/index.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "release": "beta",
   "description": "Test package-specified Elasticsearch index privileges and cluster privileges",
-  "type": "solution",
+  "type": "integration",
   "download": "/epr/elasticsearch_privileges/elasticsearch_privileges-1.0.0.zip",
   "path": "/package/elasticsearch_privileges/1.0.0",
   "conditions": {

--- a/testdata/generated/package/foo/1.0.0/index.json
+++ b/testdata/generated/package/foo/1.0.0/index.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "release": "beta",
   "description": "This is the foo integration",
-  "type": "solution",
+  "type": "integration",
   "download": "/epr/foo/foo-1.0.0.zip",
   "path": "/package/foo/1.0.0",
   "conditions": {

--- a/testdata/generated/package/hidden/1.0.0/index.json
+++ b/testdata/generated/package/hidden/1.0.0/index.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "release": "beta",
   "description": "This is the hidden integration",
-  "type": "solution",
+  "type": "integration",
   "download": "/epr/hidden/hidden-1.0.0.zip",
   "path": "/package/hidden/1.0.0",
   "conditions": {

--- a/testdata/generated/package/ilm_policy/1.0.0/index.json
+++ b/testdata/generated/package/ilm_policy/1.0.0/index.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "release": "beta",
   "description": "Test form ILM Policy in Package",
-  "type": "solution",
+  "type": "integration",
   "download": "/epr/ilm_policy/ilm_policy-1.0.0.zip",
   "path": "/package/ilm_policy/1.0.0",
   "conditions": {

--- a/testdata/generated/package/input_level_templates/1.0.0/index.json
+++ b/testdata/generated/package/input_level_templates/1.0.0/index.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "release": "beta",
   "description": "This is a test package showing input-level agent yaml templates",
-  "type": "solution",
+  "type": "integration",
   "download": "/epr/input_level_templates/input_level_templates-1.0.0.zip",
   "path": "/package/input_level_templates/1.0.0",
   "conditions": {

--- a/testdata/generated/search-all-proxy.json
+++ b/testdata/generated/search-all-proxy.json
@@ -5,7 +5,7 @@
     "version": "1.0.0",
     "release": "beta",
     "description": "Test package-specified agent privileges",
-    "type": "solution",
+    "type": "integration",
     "download": "/epr/agent_privileges/agent_privileges-1.0.0.zip",
     "path": "/package/agent_privileges/1.0.0",
     "conditions": {
@@ -67,7 +67,7 @@
     "version": "1.0.0",
     "release": "beta",
     "description": "Test package-specified Elasticsearch index privileges and cluster privileges",
-    "type": "solution",
+    "type": "integration",
     "download": "/epr/elasticsearch_privileges/elasticsearch_privileges-1.0.0.zip",
     "path": "/package/elasticsearch_privileges/1.0.0",
     "conditions": {
@@ -246,7 +246,7 @@
     "version": "1.0.0",
     "release": "beta",
     "description": "This is the foo integration",
-    "type": "solution",
+    "type": "integration",
     "download": "/epr/foo/foo-1.0.0.zip",
     "path": "/package/foo/1.0.0",
     "conditions": {
@@ -271,7 +271,7 @@
     "version": "1.0.0",
     "release": "beta",
     "description": "This is the hidden integration",
-    "type": "solution",
+    "type": "integration",
     "download": "/epr/hidden/hidden-1.0.0.zip",
     "path": "/package/hidden/1.0.0",
     "conditions": {
@@ -296,7 +296,7 @@
     "version": "1.0.0",
     "release": "beta",
     "description": "Test form ILM Policy in Package",
-    "type": "solution",
+    "type": "integration",
     "download": "/epr/ilm_policy/ilm_policy-1.0.0.zip",
     "path": "/package/ilm_policy/1.0.0",
     "conditions": {
@@ -321,7 +321,7 @@
     "version": "1.0.0",
     "release": "beta",
     "description": "This is a test package showing input-level agent yaml templates",
-    "type": "solution",
+    "type": "integration",
     "download": "/epr/input_level_templates/input_level_templates-1.0.0.zip",
     "path": "/package/input_level_templates/1.0.0",
     "policy_templates": [

--- a/testdata/generated/search-all.json
+++ b/testdata/generated/search-all.json
@@ -5,7 +5,7 @@
     "version": "1.0.0",
     "release": "beta",
     "description": "Test package-specified agent privileges",
-    "type": "solution",
+    "type": "integration",
     "download": "/epr/agent_privileges/agent_privileges-1.0.0.zip",
     "path": "/package/agent_privileges/1.0.0",
     "conditions": {
@@ -67,7 +67,7 @@
     "version": "1.0.0",
     "release": "beta",
     "description": "Test package-specified Elasticsearch index privileges and cluster privileges",
-    "type": "solution",
+    "type": "integration",
     "download": "/epr/elasticsearch_privileges/elasticsearch_privileges-1.0.0.zip",
     "path": "/package/elasticsearch_privileges/1.0.0",
     "conditions": {
@@ -246,7 +246,7 @@
     "version": "1.0.0",
     "release": "beta",
     "description": "This is the foo integration",
-    "type": "solution",
+    "type": "integration",
     "download": "/epr/foo/foo-1.0.0.zip",
     "path": "/package/foo/1.0.0",
     "conditions": {
@@ -271,7 +271,7 @@
     "version": "1.0.0",
     "release": "beta",
     "description": "This is the hidden integration",
-    "type": "solution",
+    "type": "integration",
     "download": "/epr/hidden/hidden-1.0.0.zip",
     "path": "/package/hidden/1.0.0",
     "conditions": {
@@ -296,7 +296,7 @@
     "version": "1.0.0",
     "release": "beta",
     "description": "Test form ILM Policy in Package",
-    "type": "solution",
+    "type": "integration",
     "download": "/epr/ilm_policy/ilm_policy-1.0.0.zip",
     "path": "/package/ilm_policy/1.0.0",
     "conditions": {
@@ -321,7 +321,7 @@
     "version": "1.0.0",
     "release": "beta",
     "description": "This is a test package showing input-level agent yaml templates",
-    "type": "solution",
+    "type": "integration",
     "download": "/epr/input_level_templates/input_level_templates-1.0.0.zip",
     "path": "/package/input_level_templates/1.0.0",
     "policy_templates": [

--- a/testdata/generated/search-category-custom.json
+++ b/testdata/generated/search-category-custom.json
@@ -5,7 +5,7 @@
     "version": "1.0.0",
     "release": "beta",
     "description": "Test package-specified agent privileges",
-    "type": "solution",
+    "type": "integration",
     "download": "/epr/agent_privileges/agent_privileges-1.0.0.zip",
     "path": "/package/agent_privileges/1.0.0",
     "conditions": {
@@ -67,7 +67,7 @@
     "version": "1.0.0",
     "release": "beta",
     "description": "Test package-specified Elasticsearch index privileges and cluster privileges",
-    "type": "solution",
+    "type": "integration",
     "download": "/epr/elasticsearch_privileges/elasticsearch_privileges-1.0.0.zip",
     "path": "/package/elasticsearch_privileges/1.0.0",
     "conditions": {
@@ -92,7 +92,7 @@
     "version": "1.0.0",
     "release": "beta",
     "description": "This is the foo integration",
-    "type": "solution",
+    "type": "integration",
     "download": "/epr/foo/foo-1.0.0.zip",
     "path": "/package/foo/1.0.0",
     "conditions": {
@@ -117,7 +117,7 @@
     "version": "1.0.0",
     "release": "beta",
     "description": "This is the hidden integration",
-    "type": "solution",
+    "type": "integration",
     "download": "/epr/hidden/hidden-1.0.0.zip",
     "path": "/package/hidden/1.0.0",
     "conditions": {
@@ -142,7 +142,7 @@
     "version": "1.0.0",
     "release": "beta",
     "description": "Test form ILM Policy in Package",
-    "type": "solution",
+    "type": "integration",
     "download": "/epr/ilm_policy/ilm_policy-1.0.0.zip",
     "path": "/package/ilm_policy/1.0.0",
     "conditions": {
@@ -167,7 +167,7 @@
     "version": "1.0.0",
     "release": "beta",
     "description": "This is a test package showing input-level agent yaml templates",
-    "type": "solution",
+    "type": "integration",
     "download": "/epr/input_level_templates/input_level_templates-1.0.0.zip",
     "path": "/package/input_level_templates/1.0.0",
     "policy_templates": [

--- a/testdata/generated/search-just-latest-proxy.json
+++ b/testdata/generated/search-just-latest-proxy.json
@@ -5,7 +5,7 @@
     "version": "1.0.0",
     "release": "beta",
     "description": "Test package-specified agent privileges",
-    "type": "solution",
+    "type": "integration",
     "download": "/epr/agent_privileges/agent_privileges-1.0.0.zip",
     "path": "/package/agent_privileges/1.0.0",
     "conditions": {
@@ -67,7 +67,7 @@
     "version": "1.0.0",
     "release": "beta",
     "description": "Test package-specified Elasticsearch index privileges and cluster privileges",
-    "type": "solution",
+    "type": "integration",
     "download": "/epr/elasticsearch_privileges/elasticsearch_privileges-1.0.0.zip",
     "path": "/package/elasticsearch_privileges/1.0.0",
     "conditions": {
@@ -170,7 +170,7 @@
     "version": "1.0.0",
     "release": "beta",
     "description": "This is the foo integration",
-    "type": "solution",
+    "type": "integration",
     "download": "/epr/foo/foo-1.0.0.zip",
     "path": "/package/foo/1.0.0",
     "conditions": {
@@ -195,7 +195,7 @@
     "version": "1.0.0",
     "release": "beta",
     "description": "This is the hidden integration",
-    "type": "solution",
+    "type": "integration",
     "download": "/epr/hidden/hidden-1.0.0.zip",
     "path": "/package/hidden/1.0.0",
     "conditions": {
@@ -220,7 +220,7 @@
     "version": "1.0.0",
     "release": "beta",
     "description": "Test form ILM Policy in Package",
-    "type": "solution",
+    "type": "integration",
     "download": "/epr/ilm_policy/ilm_policy-1.0.0.zip",
     "path": "/package/ilm_policy/1.0.0",
     "conditions": {
@@ -245,7 +245,7 @@
     "version": "1.0.0",
     "release": "beta",
     "description": "This is a test package showing input-level agent yaml templates",
-    "type": "solution",
+    "type": "integration",
     "download": "/epr/input_level_templates/input_level_templates-1.0.0.zip",
     "path": "/package/input_level_templates/1.0.0",
     "policy_templates": [

--- a/testdata/generated/search-kibana721.json
+++ b/testdata/generated/search-kibana721.json
@@ -115,7 +115,7 @@
     "version": "1.0.0",
     "release": "beta",
     "description": "This is the foo integration",
-    "type": "solution",
+    "type": "integration",
     "download": "/epr/foo/foo-1.0.0.zip",
     "path": "/package/foo/1.0.0",
     "conditions": {
@@ -140,7 +140,7 @@
     "version": "1.0.0",
     "release": "beta",
     "description": "This is the hidden integration",
-    "type": "solution",
+    "type": "integration",
     "download": "/epr/hidden/hidden-1.0.0.zip",
     "path": "/package/hidden/1.0.0",
     "conditions": {
@@ -165,7 +165,7 @@
     "version": "1.0.0",
     "release": "beta",
     "description": "Test form ILM Policy in Package",
-    "type": "solution",
+    "type": "integration",
     "download": "/epr/ilm_policy/ilm_policy-1.0.0.zip",
     "path": "/package/ilm_policy/1.0.0",
     "conditions": {

--- a/testdata/generated/search-kibana800.json
+++ b/testdata/generated/search-kibana800.json
@@ -5,7 +5,7 @@
     "version": "1.0.0",
     "release": "beta",
     "description": "Test package-specified agent privileges",
-    "type": "solution",
+    "type": "integration",
     "download": "/epr/agent_privileges/agent_privileges-1.0.0.zip",
     "path": "/package/agent_privileges/1.0.0",
     "conditions": {
@@ -67,7 +67,7 @@
     "version": "1.0.0",
     "release": "beta",
     "description": "Test package-specified Elasticsearch index privileges and cluster privileges",
-    "type": "solution",
+    "type": "integration",
     "download": "/epr/elasticsearch_privileges/elasticsearch_privileges-1.0.0.zip",
     "path": "/package/elasticsearch_privileges/1.0.0",
     "conditions": {
@@ -134,7 +134,7 @@
     "version": "1.0.0",
     "release": "beta",
     "description": "This is the foo integration",
-    "type": "solution",
+    "type": "integration",
     "download": "/epr/foo/foo-1.0.0.zip",
     "path": "/package/foo/1.0.0",
     "conditions": {
@@ -159,7 +159,7 @@
     "version": "1.0.0",
     "release": "beta",
     "description": "This is the hidden integration",
-    "type": "solution",
+    "type": "integration",
     "download": "/epr/hidden/hidden-1.0.0.zip",
     "path": "/package/hidden/1.0.0",
     "conditions": {
@@ -184,7 +184,7 @@
     "version": "1.0.0",
     "release": "beta",
     "description": "Test form ILM Policy in Package",
-    "type": "solution",
+    "type": "integration",
     "download": "/epr/ilm_policy/ilm_policy-1.0.0.zip",
     "path": "/package/ilm_policy/1.0.0",
     "conditions": {
@@ -209,7 +209,7 @@
     "version": "1.0.0",
     "release": "beta",
     "description": "This is a test package showing input-level agent yaml templates",
-    "type": "solution",
+    "type": "integration",
     "download": "/epr/input_level_templates/input_level_templates-1.0.0.zip",
     "path": "/package/input_level_templates/1.0.0",
     "policy_templates": [

--- a/testdata/generated/search-package-experimental.json
+++ b/testdata/generated/search-package-experimental.json
@@ -5,7 +5,7 @@
     "version": "1.0.0",
     "release": "beta",
     "description": "Test package-specified agent privileges",
-    "type": "solution",
+    "type": "integration",
     "download": "/epr/agent_privileges/agent_privileges-1.0.0.zip",
     "path": "/package/agent_privileges/1.0.0",
     "conditions": {
@@ -95,7 +95,7 @@
     "version": "0.0.1",
     "release": "beta",
     "description": "Package without release, should be set to default",
-    "type": "solution",
+    "type": "integration",
     "download": "/epr/defaultrelease/defaultrelease-0.0.1.zip",
     "path": "/package/defaultrelease/0.0.1",
     "categories": [
@@ -267,7 +267,7 @@
     "version": "1.0.0",
     "release": "beta",
     "description": "Test package-specified Elasticsearch index privileges and cluster privileges",
-    "type": "solution",
+    "type": "integration",
     "download": "/epr/elasticsearch_privileges/elasticsearch_privileges-1.0.0.zip",
     "path": "/package/elasticsearch_privileges/1.0.0",
     "conditions": {
@@ -370,7 +370,7 @@
     "version": "1.0.0",
     "release": "beta",
     "description": "This is the foo integration",
-    "type": "solution",
+    "type": "integration",
     "download": "/epr/foo/foo-1.0.0.zip",
     "path": "/package/foo/1.0.0",
     "conditions": {
@@ -439,7 +439,7 @@
     "version": "1.0.0",
     "release": "beta",
     "description": "This is the hidden integration",
-    "type": "solution",
+    "type": "integration",
     "download": "/epr/hidden/hidden-1.0.0.zip",
     "path": "/package/hidden/1.0.0",
     "conditions": {
@@ -464,7 +464,7 @@
     "version": "1.0.0",
     "release": "beta",
     "description": "Test form ILM Policy in Package",
-    "type": "solution",
+    "type": "integration",
     "download": "/epr/ilm_policy/ilm_policy-1.0.0.zip",
     "path": "/package/ilm_policy/1.0.0",
     "conditions": {
@@ -548,7 +548,7 @@
     "version": "1.0.0",
     "release": "beta",
     "description": "This is a test package showing input-level agent yaml templates",
-    "type": "solution",
+    "type": "integration",
     "download": "/epr/input_level_templates/input_level_templates-1.0.0.zip",
     "path": "/package/input_level_templates/1.0.0",
     "policy_templates": [

--- a/testdata/generated/search-package-internal.json
+++ b/testdata/generated/search-package-internal.json
@@ -5,7 +5,7 @@
     "version": "1.0.0",
     "release": "beta",
     "description": "Test package-specified agent privileges",
-    "type": "solution",
+    "type": "integration",
     "download": "/epr/agent_privileges/agent_privileges-1.0.0.zip",
     "path": "/package/agent_privileges/1.0.0",
     "conditions": {
@@ -67,7 +67,7 @@
     "version": "1.0.0",
     "release": "beta",
     "description": "Test package-specified Elasticsearch index privileges and cluster privileges",
-    "type": "solution",
+    "type": "integration",
     "download": "/epr/elasticsearch_privileges/elasticsearch_privileges-1.0.0.zip",
     "path": "/package/elasticsearch_privileges/1.0.0",
     "conditions": {
@@ -170,7 +170,7 @@
     "version": "1.0.0",
     "release": "beta",
     "description": "This is the foo integration",
-    "type": "solution",
+    "type": "integration",
     "download": "/epr/foo/foo-1.0.0.zip",
     "path": "/package/foo/1.0.0",
     "conditions": {
@@ -195,7 +195,7 @@
     "version": "1.0.0",
     "release": "beta",
     "description": "This is the hidden integration",
-    "type": "solution",
+    "type": "integration",
     "download": "/epr/hidden/hidden-1.0.0.zip",
     "path": "/package/hidden/1.0.0",
     "conditions": {
@@ -220,7 +220,7 @@
     "version": "1.0.0",
     "release": "beta",
     "description": "Test form ILM Policy in Package",
-    "type": "solution",
+    "type": "integration",
     "download": "/epr/ilm_policy/ilm_policy-1.0.0.zip",
     "path": "/package/ilm_policy/1.0.0",
     "conditions": {
@@ -245,7 +245,7 @@
     "version": "1.0.0",
     "release": "beta",
     "description": "This is a test package showing input-level agent yaml templates",
-    "type": "solution",
+    "type": "integration",
     "download": "/epr/input_level_templates/input_level_templates-1.0.0.zip",
     "path": "/package/input_level_templates/1.0.0",
     "policy_templates": [

--- a/testdata/generated/search-package-prerelease.json
+++ b/testdata/generated/search-package-prerelease.json
@@ -5,7 +5,7 @@
     "version": "1.0.0",
     "release": "beta",
     "description": "Test package-specified agent privileges",
-    "type": "solution",
+    "type": "integration",
     "download": "/epr/agent_privileges/agent_privileges-1.0.0.zip",
     "path": "/package/agent_privileges/1.0.0",
     "conditions": {
@@ -95,7 +95,7 @@
     "version": "0.0.1",
     "release": "beta",
     "description": "Package without release, should be set to default",
-    "type": "solution",
+    "type": "integration",
     "download": "/epr/defaultrelease/defaultrelease-0.0.1.zip",
     "path": "/package/defaultrelease/0.0.1",
     "categories": [
@@ -267,7 +267,7 @@
     "version": "1.0.0",
     "release": "beta",
     "description": "Test package-specified Elasticsearch index privileges and cluster privileges",
-    "type": "solution",
+    "type": "integration",
     "download": "/epr/elasticsearch_privileges/elasticsearch_privileges-1.0.0.zip",
     "path": "/package/elasticsearch_privileges/1.0.0",
     "conditions": {
@@ -378,7 +378,7 @@
     "version": "1.0.0",
     "release": "beta",
     "description": "This is the foo integration",
-    "type": "solution",
+    "type": "integration",
     "download": "/epr/foo/foo-1.0.0.zip",
     "path": "/package/foo/1.0.0",
     "conditions": {
@@ -447,7 +447,7 @@
     "version": "1.0.0",
     "release": "beta",
     "description": "This is the hidden integration",
-    "type": "solution",
+    "type": "integration",
     "download": "/epr/hidden/hidden-1.0.0.zip",
     "path": "/package/hidden/1.0.0",
     "conditions": {
@@ -472,7 +472,7 @@
     "version": "1.0.0",
     "release": "beta",
     "description": "Test form ILM Policy in Package",
-    "type": "solution",
+    "type": "integration",
     "download": "/epr/ilm_policy/ilm_policy-1.0.0.zip",
     "path": "/package/ilm_policy/1.0.0",
     "conditions": {
@@ -556,7 +556,7 @@
     "version": "1.0.0",
     "release": "beta",
     "description": "This is a test package showing input-level agent yaml templates",
-    "type": "solution",
+    "type": "integration",
     "download": "/epr/input_level_templates/input_level_templates-1.0.0.zip",
     "path": "/package/input_level_templates/1.0.0",
     "policy_templates": [

--- a/testdata/generated/search-prerelease-capabilities-none.json
+++ b/testdata/generated/search-prerelease-capabilities-none.json
@@ -5,7 +5,7 @@
     "version": "1.0.0",
     "release": "beta",
     "description": "Test package-specified agent privileges",
-    "type": "solution",
+    "type": "integration",
     "download": "/epr/agent_privileges/agent_privileges-1.0.0.zip",
     "path": "/package/agent_privileges/1.0.0",
     "conditions": {
@@ -95,7 +95,7 @@
     "version": "0.0.1",
     "release": "beta",
     "description": "Package without release, should be set to default",
-    "type": "solution",
+    "type": "integration",
     "download": "/epr/defaultrelease/defaultrelease-0.0.1.zip",
     "path": "/package/defaultrelease/0.0.1",
     "categories": [
@@ -267,7 +267,7 @@
     "version": "1.0.0",
     "release": "beta",
     "description": "Test package-specified Elasticsearch index privileges and cluster privileges",
-    "type": "solution",
+    "type": "integration",
     "download": "/epr/elasticsearch_privileges/elasticsearch_privileges-1.0.0.zip",
     "path": "/package/elasticsearch_privileges/1.0.0",
     "conditions": {
@@ -414,7 +414,7 @@
     "version": "1.0.0",
     "release": "beta",
     "description": "This is the hidden integration",
-    "type": "solution",
+    "type": "integration",
     "download": "/epr/hidden/hidden-1.0.0.zip",
     "path": "/package/hidden/1.0.0",
     "conditions": {
@@ -439,7 +439,7 @@
     "version": "1.0.0",
     "release": "beta",
     "description": "Test form ILM Policy in Package",
-    "type": "solution",
+    "type": "integration",
     "download": "/epr/ilm_policy/ilm_policy-1.0.0.zip",
     "path": "/package/ilm_policy/1.0.0",
     "conditions": {
@@ -523,7 +523,7 @@
     "version": "1.0.0",
     "release": "beta",
     "description": "This is a test package showing input-level agent yaml templates",
-    "type": "solution",
+    "type": "integration",
     "download": "/epr/input_level_templates/input_level_templates-1.0.0.zip",
     "path": "/package/input_level_templates/1.0.0",
     "policy_templates": [

--- a/testdata/generated/search-prerelease-capabilities-observability-security.json
+++ b/testdata/generated/search-prerelease-capabilities-observability-security.json
@@ -5,7 +5,7 @@
     "version": "1.0.0",
     "release": "beta",
     "description": "Test package-specified agent privileges",
-    "type": "solution",
+    "type": "integration",
     "download": "/epr/agent_privileges/agent_privileges-1.0.0.zip",
     "path": "/package/agent_privileges/1.0.0",
     "conditions": {
@@ -95,7 +95,7 @@
     "version": "0.0.1",
     "release": "beta",
     "description": "Package without release, should be set to default",
-    "type": "solution",
+    "type": "integration",
     "download": "/epr/defaultrelease/defaultrelease-0.0.1.zip",
     "path": "/package/defaultrelease/0.0.1",
     "categories": [
@@ -267,7 +267,7 @@
     "version": "1.0.0",
     "release": "beta",
     "description": "Test package-specified Elasticsearch index privileges and cluster privileges",
-    "type": "solution",
+    "type": "integration",
     "download": "/epr/elasticsearch_privileges/elasticsearch_privileges-1.0.0.zip",
     "path": "/package/elasticsearch_privileges/1.0.0",
     "conditions": {
@@ -422,7 +422,7 @@
     "version": "1.0.0",
     "release": "beta",
     "description": "This is the hidden integration",
-    "type": "solution",
+    "type": "integration",
     "download": "/epr/hidden/hidden-1.0.0.zip",
     "path": "/package/hidden/1.0.0",
     "conditions": {
@@ -447,7 +447,7 @@
     "version": "1.0.0",
     "release": "beta",
     "description": "Test form ILM Policy in Package",
-    "type": "solution",
+    "type": "integration",
     "download": "/epr/ilm_policy/ilm_policy-1.0.0.zip",
     "path": "/package/ilm_policy/1.0.0",
     "conditions": {
@@ -531,7 +531,7 @@
     "version": "1.0.0",
     "release": "beta",
     "description": "This is a test package showing input-level agent yaml templates",
-    "type": "solution",
+    "type": "integration",
     "download": "/epr/input_level_templates/input_level_templates-1.0.0.zip",
     "path": "/package/input_level_templates/1.0.0",
     "policy_templates": [

--- a/testdata/generated/search-spec-max-2.10.0.json
+++ b/testdata/generated/search-spec-max-2.10.0.json
@@ -5,7 +5,7 @@
     "version": "1.0.0",
     "release": "beta",
     "description": "Test package-specified agent privileges",
-    "type": "solution",
+    "type": "integration",
     "download": "/epr/agent_privileges/agent_privileges-1.0.0.zip",
     "path": "/package/agent_privileges/1.0.0",
     "conditions": {
@@ -95,7 +95,7 @@
     "version": "0.0.1",
     "release": "beta",
     "description": "Package without release, should be set to default",
-    "type": "solution",
+    "type": "integration",
     "download": "/epr/defaultrelease/defaultrelease-0.0.1.zip",
     "path": "/package/defaultrelease/0.0.1",
     "categories": [
@@ -200,7 +200,7 @@
     "version": "1.0.0",
     "release": "beta",
     "description": "Test package-specified Elasticsearch index privileges and cluster privileges",
-    "type": "solution",
+    "type": "integration",
     "download": "/epr/elasticsearch_privileges/elasticsearch_privileges-1.0.0.zip",
     "path": "/package/elasticsearch_privileges/1.0.0",
     "conditions": {
@@ -303,7 +303,7 @@
     "version": "1.0.0",
     "release": "beta",
     "description": "This is the foo integration",
-    "type": "solution",
+    "type": "integration",
     "download": "/epr/foo/foo-1.0.0.zip",
     "path": "/package/foo/1.0.0",
     "conditions": {
@@ -328,7 +328,7 @@
     "version": "1.0.0",
     "release": "beta",
     "description": "This is the hidden integration",
-    "type": "solution",
+    "type": "integration",
     "download": "/epr/hidden/hidden-1.0.0.zip",
     "path": "/package/hidden/1.0.0",
     "conditions": {
@@ -353,7 +353,7 @@
     "version": "1.0.0",
     "release": "beta",
     "description": "Test form ILM Policy in Package",
-    "type": "solution",
+    "type": "integration",
     "download": "/epr/ilm_policy/ilm_policy-1.0.0.zip",
     "path": "/package/ilm_policy/1.0.0",
     "conditions": {
@@ -437,7 +437,7 @@
     "version": "1.0.0",
     "release": "beta",
     "description": "This is a test package showing input-level agent yaml templates",
-    "type": "solution",
+    "type": "integration",
     "download": "/epr/input_level_templates/input_level_templates-1.0.0.zip",
     "path": "/package/input_level_templates/1.0.0",
     "policy_templates": [

--- a/testdata/generated/search-spec-min-1.1.0-max-2.10.0.json
+++ b/testdata/generated/search-spec-min-1.1.0-max-2.10.0.json
@@ -47,7 +47,7 @@
     "version": "1.0.0",
     "release": "beta",
     "description": "This is the foo integration",
-    "type": "solution",
+    "type": "integration",
     "download": "/epr/foo/foo-1.0.0.zip",
     "path": "/package/foo/1.0.0",
     "conditions": {

--- a/testdata/generated/search.json
+++ b/testdata/generated/search.json
@@ -5,7 +5,7 @@
     "version": "1.0.0",
     "release": "beta",
     "description": "Test package-specified agent privileges",
-    "type": "solution",
+    "type": "integration",
     "download": "/epr/agent_privileges/agent_privileges-1.0.0.zip",
     "path": "/package/agent_privileges/1.0.0",
     "conditions": {
@@ -67,7 +67,7 @@
     "version": "1.0.0",
     "release": "beta",
     "description": "Test package-specified Elasticsearch index privileges and cluster privileges",
-    "type": "solution",
+    "type": "integration",
     "download": "/epr/elasticsearch_privileges/elasticsearch_privileges-1.0.0.zip",
     "path": "/package/elasticsearch_privileges/1.0.0",
     "conditions": {
@@ -170,7 +170,7 @@
     "version": "1.0.0",
     "release": "beta",
     "description": "This is the foo integration",
-    "type": "solution",
+    "type": "integration",
     "download": "/epr/foo/foo-1.0.0.zip",
     "path": "/package/foo/1.0.0",
     "conditions": {
@@ -195,7 +195,7 @@
     "version": "1.0.0",
     "release": "beta",
     "description": "This is the hidden integration",
-    "type": "solution",
+    "type": "integration",
     "download": "/epr/hidden/hidden-1.0.0.zip",
     "path": "/package/hidden/1.0.0",
     "conditions": {
@@ -220,7 +220,7 @@
     "version": "1.0.0",
     "release": "beta",
     "description": "Test form ILM Policy in Package",
-    "type": "solution",
+    "type": "integration",
     "download": "/epr/ilm_policy/ilm_policy-1.0.0.zip",
     "path": "/package/ilm_policy/1.0.0",
     "conditions": {
@@ -245,7 +245,7 @@
     "version": "1.0.0",
     "release": "beta",
     "description": "This is a test package showing input-level agent yaml templates",
-    "type": "solution",
+    "type": "integration",
     "download": "/epr/input_level_templates/input_level_templates-1.0.0.zip",
     "path": "/package/input_level_templates/1.0.0",
     "policy_templates": [

--- a/testdata/package/agent_privileges/1.0.0/manifest.yml
+++ b/testdata/package/agent_privileges/1.0.0/manifest.yml
@@ -5,7 +5,7 @@ description: Test package-specified agent privileges
 version: 1.0.0
 title: Agent Privileges
 categories: ["custom"]
-type: solution
+type: integration
 release: beta
 
 agent:

--- a/testdata/package/defaultrelease/0.0.1/manifest.yml
+++ b/testdata/package/defaultrelease/0.0.1/manifest.yml
@@ -5,6 +5,6 @@ description: Package without release, should be set to default
 version: 0.0.1
 title: Default Release
 categories: ["aws"]
-type: solution
+type: integration
 
 

--- a/testdata/package/elasticsearch_privileges/1.0.0/manifest.yml
+++ b/testdata/package/elasticsearch_privileges/1.0.0/manifest.yml
@@ -5,7 +5,7 @@ description: Test package-specified Elasticsearch index privileges and cluster p
 version: 1.0.0
 title: Elasticsearch Privileges
 categories: ["custom"]
-type: solution
+type: integration
 release: beta
 
 elasticsearch:

--- a/testdata/package/foo/1.0.0/manifest.yml
+++ b/testdata/package/foo/1.0.0/manifest.yml
@@ -5,7 +5,7 @@ description: This is the foo integration
 version: 1.0.0
 title: Foo
 categories: ["custom"]
-type: solution
+type: integration
 release: beta
 
 conditions:

--- a/testdata/package/hidden/1.0.0/manifest.yml
+++ b/testdata/package/hidden/1.0.0/manifest.yml
@@ -5,7 +5,7 @@ description: This is the hidden integration
 version: 1.0.0
 title: Hidden
 categories: ["custom"]
-type: solution
+type: integration
 release: beta
 
 conditions:

--- a/testdata/package/ilm_policy/1.0.0/manifest.yml
+++ b/testdata/package/ilm_policy/1.0.0/manifest.yml
@@ -5,7 +5,7 @@ description: Test form ILM Policy in Package
 version: 1.0.0
 title: ILM Policy
 categories: ["custom"]
-type: solution
+type: integration
 release: beta
 
 conditions:

--- a/testdata/package/input_level_templates/1.0.0/manifest.yml
+++ b/testdata/package/input_level_templates/1.0.0/manifest.yml
@@ -5,7 +5,7 @@ description: This is a test package showing input-level agent yaml templates
 version: 1.0.0
 title: Input level templates
 categories: ["custom"]
-type: solution
+type: integration
 release: beta
 
 conditions:


### PR DESCRIPTION
Related to https://github.com/elastic/package-registry/issues/1277

Use valid types in test packages to reduce problems when developing with Kibana.

Packages with wrong types also cause issues with `elastic-package`, that expects the manifest at the root of the package to have a valid type.

Most test packages here are actually invalid. This is in part intentional, as Package Registry is expected to be resilient to invalid or legacy packages.