### PR TITLE
Adding new security subcategory for `siem`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Added new security subcategory `siem` [#1234](https://github.com/elastic/package-registry/pull/1234)
+
 ### Deprecated
 
 ### Known Issues

--- a/categories/categories.yml
+++ b/categories/categories.yml
@@ -129,6 +129,8 @@ categories:
         title: "Productivity"
       proxy_security:
         title: "Proxy"
+      siem:
+        title: "SIEM"
       threat_intel:
         title: "Threat Intelligence"
       vpn_security:


### PR DESCRIPTION
Adding a new Security sub-category for `siem` to support the AI4DSOC initiate

Relates https://github.com/elastic/security-team/issues/12103