### PR TITLE
Add new benchmarks for storage indexer

### DIFF
--- a/internal/util/logging.go
+++ b/internal/util/logging.go
@@ -60,7 +60,10 @@ func NewLogger(options LoggerOptions) (*zap.Logger, error) {
 }
 
 func NewTestLogger() *zap.Logger {
-	level := zap.DebugLevel
+	return NewTestLoggerLevel(zap.DebugLevel)
+}
+
+func NewTestLoggerLevel(level zapcore.Level) *zap.Logger {
 	logger, err := NewLogger(LoggerOptions{
 		Type:  DevLogger,
 		Level: &level,

--- a/storage/fakestorage.go
+++ b/storage/fakestorage.go
@@ -29,11 +29,11 @@ func PrepareFakeServer(tb testing.TB, indexPath string) *fakestorage.Server {
 	return fakestorage.NewServer(serverObjects)
 }
 
-func updateFakeServer(t *testing.T, server *fakestorage.Server, revision, indexPath string) {
+func updateFakeServer(tb testing.TB, server *fakestorage.Server, revision, indexPath string) {
 	indexContent, err := os.ReadFile(indexPath)
-	require.NoError(t, err, "index file must be populated")
+	require.NoError(tb, err, "index file must be populated")
 
-	serverObjects := prepareServerObjects(t, revision, indexContent)
+	serverObjects := prepareServerObjects(tb, revision, indexContent)
 
 	for _, so := range serverObjects {
 		server.CreateObject(so)

--- a/storage/indexer_test.go
+++ b/storage/indexer_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
 
 	"github.com/elastic/package-registry/internal/util"
 	"github.com/elastic/package-registry/packages"
@@ -35,7 +36,7 @@ func BenchmarkInit(b *testing.B) {
 	defer fs.Stop()
 	storageClient := fs.Client()
 
-	logger := util.NewTestLogger()
+	logger := util.NewTestLoggerLevel(zapcore.FatalLevel)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		indexer := NewIndexer(logger, storageClient, FakeIndexerOptions)
@@ -50,7 +51,7 @@ func BenchmarkIndexerUpdateIndex(b *testing.B) {
 	defer fs.Stop()
 	storageClient := fs.Client()
 
-	logger := util.NewTestLogger()
+	logger := util.NewTestLoggerLevel(zapcore.FatalLevel)
 	indexer := NewIndexer(logger, storageClient, FakeIndexerOptions)
 	err := indexer.Init(context.Background())
 	require.NoError(b, err)
@@ -72,7 +73,7 @@ func BenchmarkIndexerGet(b *testing.B) {
 	defer fs.Stop()
 	storageClient := fs.Client()
 
-	logger := util.NewTestLogger()
+	logger := util.NewTestLoggerLevel(zapcore.FatalLevel)
 	indexer := NewIndexer(logger, storageClient, FakeIndexerOptions)
 	err := indexer.Init(context.Background())
 	require.NoError(b, err)


### PR DESCRIPTION
This PR adds new benchmarks to help get data about how the storage indexer works.

It adds two different benchmarks:
- Related to updating indexer
    - It could show the data (e.g. memory) required to replace the current list of packages used by the indexer.
- Related to query the indexer all the packages
    - It could show the data (e.g. memory) required to build the answer for the search API request.
