### PR TITLE
Change license to Elastic License 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Change license from Elastic v1 to Elastic v2.
+
 ### Deprecated
 
 ### Known Issues

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* Change license from Elastic v1 to Elastic v2.
+* Change license from Elastic License to Elastic License 2.0 [#1298](https://github.com/elastic/package-registry/pull/1298).
 
 ### Deprecated
 

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,223 +1,93 @@
-ELASTIC LICENSE AGREEMENT
+Elastic License 2.0
 
-PLEASE READ CAREFULLY THIS ELASTIC LICENSE AGREEMENT (THIS "AGREEMENT"), WHICH
-CONSTITUTES A LEGALLY BINDING AGREEMENT AND GOVERNS ALL OF YOUR USE OF ALL OF
-THE ELASTIC SOFTWARE WITH WHICH THIS AGREEMENT IS INCLUDED ("ELASTIC SOFTWARE")
-THAT IS PROVIDED IN OBJECT CODE FORMAT, AND, IN ACCORDANCE WITH SECTION 2 BELOW,
-CERTAIN OF THE ELASTIC SOFTWARE THAT IS PROVIDED IN SOURCE CODE FORMAT. BY
-INSTALLING OR USING ANY OF THE ELASTIC SOFTWARE GOVERNED BY THIS AGREEMENT, YOU
-ARE ASSENTING TO THE TERMS AND CONDITIONS OF THIS AGREEMENT. IF YOU DO NOT AGREE
-WITH SUCH TERMS AND CONDITIONS, YOU MAY NOT INSTALL OR USE THE ELASTIC SOFTWARE
-GOVERNED BY THIS AGREEMENT. IF YOU ARE INSTALLING OR USING THE SOFTWARE ON
-BEHALF OF A LEGAL ENTITY, YOU REPRESENT AND WARRANT THAT YOU HAVE THE ACTUAL
-AUTHORITY TO AGREE TO THE TERMS AND CONDITIONS OF THIS AGREEMENT ON BEHALF OF
-SUCH ENTITY.
+URL: https://www.elastic.co/licensing/elastic-license
 
-Posted Date: April 20, 2018
+## Acceptance
 
-This Agreement is entered into by and between Elasticsearch BV ("Elastic") and
-You, or the legal entity on behalf of whom You are acting (as applicable,
-"You").
+By using the software, you agree to all of the terms and conditions below.
 
-1. OBJECT CODE END USER LICENSES, RESTRICTIONS AND THIRD PARTY OPEN SOURCE
-SOFTWARE
+## Copyright License
 
-  1.1 Object Code End User License. Subject to the terms and conditions of
-  Section 1.2 of this Agreement, Elastic hereby grants to You, AT NO CHARGE and
-  for so long as you are not in breach of any provision of this Agreement, a
-  License to the Basic Features and Functions of the Elastic Software.
+The licensor grants you a non-exclusive, royalty-free, worldwide,
+non-sublicensable, non-transferable license to use, copy, distribute, make
+available, and prepare derivative works of the software, in each case subject to
+the limitations and conditions below.
 
-  1.2 Reservation of Rights; Restrictions. As between Elastic and You, Elastic
-  and its licensors own all right, title and interest in and to the Elastic
-  Software, and except as expressly set forth in Sections 1.1, and 2.1 of this
-  Agreement, no other license to the Elastic Software is granted to You under
-  this Agreement, by implication, estoppel or otherwise. You agree not to: (i)
-  reverse engineer or decompile, decrypt, disassemble or otherwise reduce any
-  Elastic Software provided to You in Object Code, or any portion thereof, to
-  Source Code, except and only to the extent any such restriction is prohibited
-  by applicable law, (ii) except as expressly permitted in this Agreement,
-  prepare derivative works from, modify, copy or use the Elastic Software Object
-  Code or the Commercial Software Source Code in any manner; (iii) except as
-  expressly permitted in Section 1.1 above, transfer, sell, rent, lease,
-  distribute, sublicense, loan or otherwise transfer, Elastic Software Object
-  Code, in whole or in part, to any third party; (iv) use Elastic Software
-  Object Code for providing time-sharing services, any software-as-a-service,
-  service bureau services or as part of an application services provider or
-  other service offering (collectively, "SaaS Offering") where obtaining access
-  to the Elastic Software or the features and functions of the Elastic Software
-  is a primary reason or substantial motivation for users of the SaaS Offering
-  to access and/or use the SaaS Offering ("Prohibited SaaS Offering"); (v)
-  circumvent the limitations on use of Elastic Software provided to You in
-  Object Code format that are imposed or preserved by any License Key, or (vi)
-  alter or remove any Marks and Notices in the Elastic Software. If You have any
-  question as to whether a specific SaaS Offering constitutes a Prohibited SaaS
-  Offering, or are interested in obtaining Elastic's permission to engage in
-  commercial or non-commercial distribution of the Elastic Software, please
-  contact elastic_license@elastic.co.
+## Limitations
 
-  1.3 Third Party Open Source Software. The Commercial Software may contain or
-  be provided with third party open source libraries, components, utilities and
-  other open source software (collectively, "Open Source Software"), which Open
-  Source Software may have applicable license terms as identified on a website
-  designated by Elastic. Notwithstanding anything to the contrary herein, use of
-  the Open Source Software shall be subject to the license terms and conditions
-  applicable to such Open Source Software, to the extent required by the
-  applicable licensor (which terms shall not restrict the license rights granted
-  to You hereunder, but may contain additional rights). To the extent any
-  condition of this Agreement conflicts with any license to the Open Source
-  Software, the Open Source Software license will govern with respect to such
-  Open Source Software only. Elastic may also separately provide you with
-  certain open source software that is licensed by Elastic. Your use of such
-  Elastic open source software will not be governed by this Agreement, but by
-  the applicable open source license terms.
+You may not provide the software to third parties as a hosted or managed
+service, where the service provides users with access to any substantial set of
+the features or functionality of the software.
 
-2. COMMERCIAL SOFTWARE SOURCE CODE
+You may not move, change, disable, or circumvent the license key functionality
+in the software, and you may not remove or obscure any functionality in the
+software that is protected by the license key.
 
-  2.1 Limited License. Subject to the terms and conditions of Section 2.2 of
-  this Agreement, Elastic hereby grants to You, AT NO CHARGE and for so long as
-  you are not in breach of any provision of this Agreement, a limited,
-  non-exclusive, non-transferable, fully paid up royalty free right and license
-  to the Commercial Software in Source Code format, without the right to grant
-  or authorize sublicenses, to prepare Derivative Works of the Commercial
-  Software, provided You (i) do not hack the licensing mechanism, or otherwise
-  circumvent the intended limitations on the use of Elastic Software to enable
-  features other than Basic Features and Functions or those features You are
-  entitled to as part of a Subscription, and (ii) use the resulting object code
-  only for reasonable testing purposes.
+You may not alter, remove, or obscure any licensing, copyright, or other notices
+of the licensor in the software. Any use of the licensor’s trademarks is subject
+to applicable law.
 
-  2.2 Restrictions. Nothing in Section 2.1 grants You the right to (i) use the
-  Commercial Software Source Code other than in accordance with Section 2.1
-  above, (ii) use a Derivative Work of the Commercial Software outside of a
-  Non-production Environment, in any production capacity, on a temporary or
-  permanent basis, or (iii) transfer, sell, rent, lease, distribute, sublicense,
-  loan or otherwise make available the Commercial Software Source Code, in whole
-  or in part, to any third party. Notwithstanding the foregoing, You may
-  maintain a copy of the repository in which the Source Code of the Commercial
-  Software resides and that copy may be publicly accessible, provided that you
-  include this Agreement with Your copy of the repository.
+## Patents
 
-3. TERMINATION
+The licensor grants you a license, under any patent claims the licensor can
+license, or becomes able to license, to make, have made, use, sell, offer for
+sale, import and have imported the software, in each case subject to the
+limitations and conditions in this license. This license does not cover any
+patent claims that you cause to be infringed by modifications or additions to
+the software. If you or your company make any written claim that the software
+infringes or contributes to infringement of any patent, your patent license for
+the software granted under these terms ends immediately. If your company makes
+such a claim, your patent license ends immediately for work on behalf of your
+company.
 
-  3.1 Termination. This Agreement will automatically terminate, whether or not
-  You receive notice of such Termination from Elastic, if You breach any of its
-  provisions.
+## Notices
 
-  3.2 Post Termination. Upon any termination of this Agreement, for any reason,
-  You shall promptly cease the use of the Elastic Software in Object Code format
-  and cease use of the Commercial Software in Source Code format. For the
-  avoidance of doubt, termination of this Agreement will not affect Your right
-  to use Elastic Software, in either Object Code or Source Code formats, made
-  available under the Apache License Version 2.0.
+You must ensure that anyone who gets a copy of any part of the software from you
+also gets a copy of these terms.
 
-  3.3 Survival. Sections 1.2, 2.2. 3.3, 4 and 5 shall survive any termination or
-  expiration of this Agreement.
+If you modify the software, you must include in any modified copies of the
+software prominent notices stating that you have modified the software.
 
-4. DISCLAIMER OF WARRANTIES AND LIMITATION OF LIABILITY
+## No Other Rights
 
-  4.1 Disclaimer of Warranties. TO THE MAXIMUM EXTENT PERMITTED UNDER APPLICABLE
-  LAW, THE ELASTIC SOFTWARE IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
-  AND ELASTIC AND ITS LICENSORS MAKE NO WARRANTIES WHETHER EXPRESSED, IMPLIED OR
-  STATUTORY REGARDING OR RELATING TO THE ELASTIC SOFTWARE. TO THE MAXIMUM EXTENT
-  PERMITTED UNDER APPLICABLE LAW, ELASTIC AND ITS LICENSORS SPECIFICALLY
-  DISCLAIM ALL IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
-  PURPOSE AND NON-INFRINGEMENT WITH RESPECT TO THE ELASTIC SOFTWARE, AND WITH
-  RESPECT TO THE USE OF THE FOREGOING. FURTHER, ELASTIC DOES NOT WARRANT RESULTS
-  OF USE OR THAT THE ELASTIC SOFTWARE WILL BE ERROR FREE OR THAT THE USE OF THE
-  ELASTIC SOFTWARE WILL BE UNINTERRUPTED.
+These terms do not imply any licenses other than those expressly granted in
+these terms.
 
-  4.2 Limitation of Liability. IN NO EVENT SHALL ELASTIC OR ITS LICENSORS BE
-  LIABLE TO YOU OR ANY THIRD PARTY FOR ANY DIRECT OR INDIRECT DAMAGES,
-  INCLUDING, WITHOUT LIMITATION, FOR ANY LOSS OF PROFITS, LOSS OF USE, BUSINESS
-  INTERRUPTION, LOSS OF DATA, COST OF SUBSTITUTE GOODS OR SERVICES, OR FOR ANY
-  SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES OF ANY KIND, IN CONNECTION WITH
-  OR ARISING OUT OF THE USE OR INABILITY TO USE THE ELASTIC SOFTWARE, OR THE
-  PERFORMANCE OF OR FAILURE TO PERFORM THIS AGREEMENT, WHETHER ALLEGED AS A
-  BREACH OF CONTRACT OR TORTIOUS CONDUCT, INCLUDING NEGLIGENCE, EVEN IF ELASTIC
-  HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+## Termination
 
-5. MISCELLANEOUS
+If you use the software in violation of these terms, such use is not licensed,
+and your licenses will automatically terminate. If the licensor provides you
+with a notice of your violation, and you cease all violation of this license no
+later than 30 days after you receive that notice, your licenses will be
+reinstated retroactively. However, if you violate these terms after such
+reinstatement, any additional violation of these terms will cause your licenses
+to terminate automatically and permanently.
 
-  This Agreement completely and exclusively states the entire agreement of the
-  parties regarding the subject matter herein, and it supersedes, and its terms
-  govern, all prior proposals, agreements, or other communications between the
-  parties, oral or written, regarding such subject matter. This Agreement may be
-  modified by Elastic from time to time, and any such modifications will be
-  effective upon the "Posted Date" set forth at the top of the modified
-  Agreement. If any provision hereof is held unenforceable, this Agreement will
-  continue without said provision and be interpreted to reflect the original
-  intent of the parties. This Agreement and any non-contractual obligation
-  arising out of or in connection with it, is governed exclusively by Dutch law.
-  This Agreement shall not be governed by the 1980 UN Convention on Contracts
-  for the International Sale of Goods. All disputes arising out of or in
-  connection with this Agreement, including its existence and validity, shall be
-  resolved by the courts with jurisdiction in Amsterdam, The Netherlands, except
-  where mandatory law provides for the courts at another location in The
-  Netherlands to have jurisdiction. The parties hereby irrevocably waive any and
-  all claims and defenses either might otherwise have in any such action or
-  proceeding in any of such courts based upon any alleged lack of personal
-  jurisdiction, improper venue, forum non conveniens or any similar claim or
-  defense. A breach or threatened breach, by You of Section 2 may cause
-  irreparable harm for which damages at law may not provide adequate relief, and
-  therefore Elastic shall be entitled to seek injunctive relief without being
-  required to post a bond. You may not assign this Agreement (including by
-  operation of law in connection with a merger or acquisition), in whole or in
-  part to any third party without the prior written consent of Elastic, which
-  may be withheld or granted by Elastic in its sole and absolute discretion.
-  Any assignment in violation of the preceding sentence is void. Notices to
-  Elastic may also be sent to legal@elastic.co.
+## No Liability
 
-6. DEFINITIONS
+*As far as the law allows, the software comes as is, without any warranty or
+condition, and the licensor will not be liable to you for any damages arising
+out of these terms or the use or nature of the software, under any kind of
+legal claim.*
 
-  The following terms have the meanings ascribed:
+## Definitions
 
-  6.1 "Affiliate" means, with respect to a party, any entity that controls, is
-  controlled by, or which is under common control with, such party, where
-  "control" means ownership of at least fifty percent (50%) of the outstanding
-  voting shares of the entity, or the contractual right to establish policy for,
-  and manage the operations of, the entity.
+The **licensor** is the entity offering these terms, and the **software** is the
+software the licensor makes available under these terms, including any portion
+of it.
 
-  6.2 "Basic Features and Functions" means those features and functions of the
-  Elastic Software that are eligible for use under a Basic license, as set forth
-  at https://www.elastic.co/subscriptions, as may be modified by Elastic from
-  time to time.
+**you** refers to the individual or entity agreeing to these terms.
 
-  6.3 "Commercial Software" means the Elastic Software Source Code in any file
-  containing a header stating the contents are subject to the Elastic License or
-  which is contained in the repository folder labeled "x-pack", unless a LICENSE
-  file present in the directory subtree declares a different license.
+**your company** is any legal entity, sole proprietorship, or other kind of
+organization that you work for, plus all organizations that have control over,
+are under the control of, or are under common control with that
+organization. **control** means ownership of substantially all the assets of an
+entity, or the power to direct its management and policies by vote, contract, or
+otherwise. Control can be direct or indirect.
 
-  6.4 "Derivative Work of the Commercial Software" means, for purposes of this
-  Agreement, any modification(s) or enhancement(s) to the Commercial Software,
-  which represent, as a whole, an original work of authorship.
+**your licenses** are all the licenses granted to you for the software under
+these terms.
 
-  6.5 "License" means a limited, non-exclusive, non-transferable, fully paid up,
-  royalty free, right and license, without the right to grant or authorize
-  sublicenses, solely for Your internal business operations to (i) install and
-  use the applicable Features and Functions of the Elastic Software in Object
-  Code, and (ii) permit Contractors and Your Affiliates to use the Elastic
-  software as set forth in (i) above, provided that such use by Contractors must
-  be solely for Your benefit and/or the benefit of Your Affiliates, and You
-  shall be responsible for all acts and omissions of such Contractors and
-  Affiliates in connection with their use of the Elastic software that are
-  contrary to the terms and conditions of this Agreement.
+**use** means anything you do with the software requiring one of your licenses.
 
-  6.6 "License Key" means a sequence of bytes, including but not limited to a
-  JSON blob, that is used to enable certain features and functions of the
-  Elastic Software.
-
-  6.7 "Marks and Notices" means all Elastic trademarks, trade names, logos and
-  notices present on the Documentation as originally provided by Elastic.
-
-  6.8 "Non-production Environment" means an environment for development, testing
-  or quality assurance, where software is not used for production purposes.
-
-  6.9 "Object Code" means any form resulting from mechanical transformation or
-  translation of Source Code form, including but not limited to compiled object
-  code, generated documentation, and conversions to other media types.
-
-  6.10 "Source Code" means the preferred form of computer software for making
-  modifications, including but not limited to software source code,
-  documentation source, and configuration files.
-
-  6.11 "Subscription" means the right to receive Support Services and a License
-  to the Commercial Software.
+**trademark** means trademarks, service marks, and similar rights.

--- a/archiver/archive.go
+++ b/archiver/archive.go
@@ -1,6 +1,6 @@
 // Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-// or more contributor license agreements. Licensed under the Elastic License;
-// you may not use this file except in compliance with the Elastic License.
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
 
 package archiver
 

--- a/artifacts.go
+++ b/artifacts.go
@@ -1,6 +1,6 @@
 // Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-// or more contributor license agreements. Licensed under the Elastic License;
-// you may not use this file except in compliance with the Elastic License.
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
 
 package main
 

--- a/categories.go
+++ b/categories.go
@@ -1,6 +1,6 @@
 // Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-// or more contributor license agreements. Licensed under the Elastic License;
-// you may not use this file except in compliance with the Elastic License.
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
 
 package main
 

--- a/categories/categories.go
+++ b/categories/categories.go
@@ -1,6 +1,6 @@
 // Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-// or more contributor license agreements. Licensed under the Elastic License;
-// you may not use this file except in compliance with the Elastic License.
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
 
 package categories
 

--- a/categories/categories_test.go
+++ b/categories/categories_test.go
@@ -1,6 +1,6 @@
 // Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-// or more contributor license agreements. Licensed under the Elastic License;
-// you may not use this file except in compliance with the Elastic License.
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
 
 package categories
 

--- a/categories/default.go
+++ b/categories/default.go
@@ -1,6 +1,6 @@
 // Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-// or more contributor license agreements. Licensed under the Elastic License;
-// you may not use this file except in compliance with the Elastic License.
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
 
 package categories
 

--- a/categories_test.go
+++ b/categories_test.go
@@ -1,6 +1,6 @@
 // Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-// or more contributor license agreements. Licensed under the Elastic License;
-// you may not use this file except in compliance with the Elastic License.
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
 
 package main
 

--- a/favicon.go
+++ b/favicon.go
@@ -1,6 +1,6 @@
 // Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-// or more contributor license agreements. Licensed under the Elastic License;
-// you may not use this file except in compliance with the Elastic License.
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
 
 package main
 

--- a/flags.go
+++ b/flags.go
@@ -1,6 +1,6 @@
 // Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-// or more contributor license agreements. Licensed under the Elastic License;
-// you may not use this file except in compliance with the Elastic License.
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
 
 package main
 

--- a/flags_test.go
+++ b/flags_test.go
@@ -1,6 +1,6 @@
 // Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-// or more contributor license agreements. Licensed under the Elastic License;
-// you may not use this file except in compliance with the Elastic License.
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
 
 package main
 

--- a/handler.go
+++ b/handler.go
@@ -1,6 +1,6 @@
 // Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-// or more contributor license agreements. Licensed under the Elastic License;
-// you may not use this file except in compliance with the Elastic License.
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
 
 package main
 

--- a/index.go
+++ b/index.go
@@ -1,6 +1,6 @@
 // Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-// or more contributor license agreements. Licensed under the Elastic License;
-// you may not use this file except in compliance with the Elastic License.
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
 
 package main
 

--- a/indexer.go
+++ b/indexer.go
@@ -1,6 +1,6 @@
 // Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-// or more contributor license agreements. Licensed under the Elastic License;
-// you may not use this file except in compliance with the Elastic License.
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
 
 package main
 

--- a/indexer_test.go
+++ b/indexer_test.go
@@ -1,6 +1,6 @@
 // Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-// or more contributor license agreements. Licensed under the Elastic License;
-// you may not use this file except in compliance with the Elastic License.
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
 
 package main
 

--- a/internal/util/cors.go
+++ b/internal/util/cors.go
@@ -1,6 +1,6 @@
 // Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-// or more contributor license agreements. Licensed under the Elastic License;
-// you may not use this file except in compliance with the Elastic License.
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
 
 package util
 

--- a/internal/util/cors_test.go
+++ b/internal/util/cors_test.go
@@ -1,6 +1,6 @@
 // Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-// or more contributor license agreements. Licensed under the Elastic License;
-// you may not use this file except in compliance with the Elastic License.
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
 
 package util
 

--- a/internal/util/json.go
+++ b/internal/util/json.go
@@ -1,6 +1,6 @@
 // Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-// or more contributor license agreements. Licensed under the Elastic License;
-// you may not use this file except in compliance with the Elastic License.
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
 
 package util
 

--- a/internal/util/logging.go
+++ b/internal/util/logging.go
@@ -1,6 +1,6 @@
 // Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-// or more contributor license agreements. Licensed under the Elastic License;
-// you may not use this file except in compliance with the Elastic License.
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
 
 package util
 

--- a/internal/util/logging_test.go
+++ b/internal/util/logging_test.go
@@ -1,6 +1,6 @@
 // Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-// or more contributor license agreements. Licensed under the Elastic License;
-// you may not use this file except in compliance with the Elastic License.
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
 
 package util
 

--- a/internal/util/mapstr.go
+++ b/internal/util/mapstr.go
@@ -1,6 +1,6 @@
 // Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-// or more contributor license agreements. Licensed under the Elastic License;
-// you may not use this file except in compliance with the Elastic License.
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
 
 package util
 

--- a/magefile.go
+++ b/magefile.go
@@ -1,6 +1,6 @@
 // Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-// or more contributor license agreements. Licensed under the Elastic License;
-// you may not use this file except in compliance with the Elastic License.
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
 
 //go:build mage
 
@@ -94,7 +94,7 @@ func GoImports() error {
 // appropriate license header based on the value of mage.BeatLicense.
 func AddLicenseHeaders() error {
 	fmt.Println(">> fmt - go-licenser: Adding missing headers")
-	return sh.RunV("go", "run", GoLicenserImportPath, "-license", "Elastic")
+	return sh.RunV("go", "run", GoLicenserImportPath, "-license", "Elasticv2")
 }
 
 // FindFilesRecursive recursively traverses from the CWD and invokes the given

--- a/main.go
+++ b/main.go
@@ -1,6 +1,6 @@
 // Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-// or more contributor license agreements. Licensed under the Elastic License;
-// you may not use this file except in compliance with the Elastic License.
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
 
 package main
 

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,6 @@
 // Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-// or more contributor license agreements. Licensed under the Elastic License;
-// you may not use this file except in compliance with the Elastic License.
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
 
 package main
 

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -1,6 +1,6 @@
 // Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-// or more contributor license agreements. Licensed under the Elastic License;
-// you may not use this file except in compliance with the Elastic License.
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
 
 package metrics
 

--- a/metrics/middleware.go
+++ b/metrics/middleware.go
@@ -1,6 +1,6 @@
 // Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-// or more contributor license agreements. Licensed under the Elastic License;
-// you may not use this file except in compliance with the Elastic License.
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
 
 package metrics
 

--- a/mime_types.go
+++ b/mime_types.go
@@ -1,6 +1,6 @@
 // Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-// or more contributor license agreements. Licensed under the Elastic License;
-// you may not use this file except in compliance with the Elastic License.
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
 
 package main
 

--- a/package_index.go
+++ b/package_index.go
@@ -1,6 +1,6 @@
 // Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-// or more contributor license agreements. Licensed under the Elastic License;
-// you may not use this file except in compliance with the Elastic License.
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
 
 package main
 

--- a/package_storage_test.go
+++ b/package_storage_test.go
@@ -1,6 +1,6 @@
 // Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-// or more contributor license agreements. Licensed under the Elastic License;
-// you may not use this file except in compliance with the Elastic License.
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
 
 package main
 

--- a/packages/category.go
+++ b/packages/category.go
@@ -1,6 +1,6 @@
 // Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-// or more contributor license agreements. Licensed under the Elastic License;
-// you may not use this file except in compliance with the Elastic License.
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
 
 package packages
 

--- a/packages/datastream.go
+++ b/packages/datastream.go
@@ -1,6 +1,6 @@
 // Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-// or more contributor license agreements. Licensed under the Elastic License;
-// you may not use this file except in compliance with the Elastic License.
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
 
 package packages
 

--- a/packages/fs.go
+++ b/packages/fs.go
@@ -1,6 +1,6 @@
 // Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-// or more contributor license agreements. Licensed under the Elastic License;
-// you may not use this file except in compliance with the Elastic License.
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
 
 package packages
 

--- a/packages/http.go
+++ b/packages/http.go
@@ -1,6 +1,6 @@
 // Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-// or more contributor license agreements. Licensed under the Elastic License;
-// you may not use this file except in compliance with the Elastic License.
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
 
 package packages
 

--- a/packages/marshaler.go
+++ b/packages/marshaler.go
@@ -1,6 +1,6 @@
 // Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-// or more contributor license agreements. Licensed under the Elastic License;
-// you may not use this file except in compliance with the Elastic License.
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
 
 package packages
 

--- a/packages/marshaler_test.go
+++ b/packages/marshaler_test.go
@@ -1,6 +1,6 @@
 // Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-// or more contributor license agreements. Licensed under the Elastic License;
-// you may not use this file except in compliance with the Elastic License.
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
 
 package packages
 

--- a/packages/package.go
+++ b/packages/package.go
@@ -1,6 +1,6 @@
 // Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-// or more contributor license agreements. Licensed under the Elastic License;
-// you may not use this file except in compliance with the Elastic License.
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
 
 package packages
 

--- a/packages/package_test.go
+++ b/packages/package_test.go
@@ -1,6 +1,6 @@
 // Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-// or more contributor license agreements. Licensed under the Elastic License;
-// you may not use this file except in compliance with the Elastic License.
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
 
 package packages
 

--- a/packages/packages.go
+++ b/packages/packages.go
@@ -1,6 +1,6 @@
 // Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-// or more contributor license agreements. Licensed under the Elastic License;
-// you may not use this file except in compliance with the Elastic License.
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
 
 package packages
 

--- a/packages/packages_test.go
+++ b/packages/packages_test.go
@@ -1,6 +1,6 @@
 // Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-// or more contributor license agreements. Licensed under the Elastic License;
-// you may not use this file except in compliance with the Elastic License.
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
 
 package packages
 

--- a/packages/releases.go
+++ b/packages/releases.go
@@ -1,6 +1,6 @@
 // Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-// or more contributor license agreements. Licensed under the Elastic License;
-// you may not use this file except in compliance with the Elastic License.
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
 
 package packages
 

--- a/packages/releases_test.go
+++ b/packages/releases_test.go
@@ -1,6 +1,6 @@
 // Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-// or more contributor license agreements. Licensed under the Elastic License;
-// you may not use this file except in compliance with the Elastic License.
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
 
 package packages
 

--- a/packages/resolver.go
+++ b/packages/resolver.go
@@ -1,6 +1,6 @@
 // Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-// or more contributor license agreements. Licensed under the Elastic License;
-// you may not use this file except in compliance with the Elastic License.
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
 
 package packages
 

--- a/proxymode/logger.go
+++ b/proxymode/logger.go
@@ -1,6 +1,6 @@
 // Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-// or more contributor license agreements. Licensed under the Elastic License;
-// you may not use this file except in compliance with the Elastic License.
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
 
 package proxymode
 

--- a/proxymode/proxymode.go
+++ b/proxymode/proxymode.go
@@ -1,6 +1,6 @@
 // Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-// or more contributor license agreements. Licensed under the Elastic License;
-// you may not use this file except in compliance with the Elastic License.
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
 
 package proxymode
 

--- a/proxymode/resolver.go
+++ b/proxymode/resolver.go
@@ -1,6 +1,6 @@
 // Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-// or more contributor license agreements. Licensed under the Elastic License;
-// you may not use this file except in compliance with the Elastic License.
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
 
 package proxymode
 

--- a/search.go
+++ b/search.go
@@ -1,6 +1,6 @@
 // Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-// or more contributor license agreements. Licensed under the Elastic License;
-// you may not use this file except in compliance with the Elastic License.
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
 
 package main
 

--- a/search_test.go
+++ b/search_test.go
@@ -1,6 +1,6 @@
 // Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-// or more contributor license agreements. Licensed under the Elastic License;
-// you may not use this file except in compliance with the Elastic License.
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
 
 package main
 

--- a/signatures.go
+++ b/signatures.go
@@ -1,6 +1,6 @@
 // Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-// or more contributor license agreements. Licensed under the Elastic License;
-// you may not use this file except in compliance with the Elastic License.
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
 
 package main
 

--- a/static.go
+++ b/static.go
@@ -1,6 +1,6 @@
 // Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-// or more contributor license agreements. Licensed under the Elastic License;
-// you may not use this file except in compliance with the Elastic License.
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
 
 package main
 

--- a/storage/cursor.go
+++ b/storage/cursor.go
@@ -1,6 +1,6 @@
 // Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-// or more contributor license agreements. Licensed under the Elastic License;
-// you may not use this file except in compliance with the Elastic License.
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
 
 package storage
 

--- a/storage/fakestorage.go
+++ b/storage/fakestorage.go
@@ -1,6 +1,6 @@
 // Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-// or more contributor license agreements. Licensed under the Elastic License;
-// you may not use this file except in compliance with the Elastic License.
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
 
 package storage
 

--- a/storage/fakestorage_test.go
+++ b/storage/fakestorage_test.go
@@ -1,6 +1,6 @@
 // Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-// or more contributor license agreements. Licensed under the Elastic License;
-// you may not use this file except in compliance with the Elastic License.
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
 
 package storage
 

--- a/storage/index.go
+++ b/storage/index.go
@@ -1,6 +1,6 @@
 // Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-// or more contributor license agreements. Licensed under the Elastic License;
-// you may not use this file except in compliance with the Elastic License.
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
 
 package storage
 

--- a/storage/indexer.go
+++ b/storage/indexer.go
@@ -1,6 +1,6 @@
 // Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-// or more contributor license agreements. Licensed under the Elastic License;
-// you may not use this file except in compliance with the Elastic License.
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
 
 package storage
 

--- a/storage/indexer_test.go
+++ b/storage/indexer_test.go
@@ -1,6 +1,6 @@
 // Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-// or more contributor license agreements. Licensed under the Elastic License;
-// you may not use this file except in compliance with the Elastic License.
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
 
 package storage
 

--- a/storage/paths.go
+++ b/storage/paths.go
@@ -1,6 +1,6 @@
 // Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-// or more contributor license agreements. Licensed under the Elastic License;
-// you may not use this file except in compliance with the Elastic License.
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
 
 package storage
 

--- a/storage/resolver.go
+++ b/storage/resolver.go
@@ -1,6 +1,6 @@
 // Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-// or more contributor license agreements. Licensed under the Elastic License;
-// you may not use this file except in compliance with the Elastic License.
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
 
 package storage
 

--- a/testdata/package/main.go
+++ b/testdata/package/main.go
@@ -1,6 +1,6 @@
 // Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-// or more contributor license agreements. Licensed under the Elastic License;
-// you may not use this file except in compliance with the Elastic License.
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
 
 package main
 

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -1,6 +1,6 @@
 // Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-// or more contributor license agreements. Licensed under the Elastic License;
-// you may not use this file except in compliance with the Elastic License.
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
 
 //go:build tools
 


### PR DESCRIPTION
Update to the preferred version of the Elastic License.

From https://www.elastic.co/licensing/elastic-license/faq:

> How is Elastic License 2.0 different from Elastic License 1.0?
> 
> With Elastic License 2.0, we listened to the [feedback](https://www.elastic.co/blog/license-change-clarification) from our community, combined with our experience over the last few years and what we’ve seen from companies like [MongoDB](https://www.mongodb.com/blog/post/mongodb-now-released-under-the-server-side-public-license), [CockroachDB](https://www.cockroachlabs.com/docs/v24.2/licensing-faqs.html), [RedisLabs](https://redislabs.com/blog/redis-labs-modules-license-changes/), [TimescaleDB](https://blog.timescale.com/blog/building-open-source-business-in-cloud-era-v2/), [Graylog](https://www.graylog.org/post/graylog-v4-0-licensing-sspl). As a result, we started by saying “let’s allow everything, and focus on adding the smallest number of protections against abuse,” and created the license with that in mind.
> The Elastic License 2.0 allows free use, modification, and redistribution, with only 3 simple limitations to protect our products and brand from abuse, as outlined [above](https://www.elastic.co/licensing/elastic-license/faq#can-you-summarize-what-is-allowed-with-the-elastic-license-2-0).