### PR TITLE
Fix usages of time.Since in defer statement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Update Go runtime to 1.24.2. [#1299](https://github.com/elastic/package-registry/pull/1299)
 * Ignore unknown categories instead of producing fatal errors. [#1297](https://github.com/elastic/package-registry/pull/1297)
+* Fix usages of time.Since in defer statements used to obtain duration Prometheus metrics in the indexer. [#1304](https://github.com/elastic/package-registry/pull/1304)
 
 ### Added
 

--- a/packages/packages.go
+++ b/packages/packages.go
@@ -195,7 +195,9 @@ func (i *FileSystemIndexer) Init(ctx context.Context) (err error) {
 // Caching the packages request many file reads every time this method is called.
 func (i *FileSystemIndexer) Get(ctx context.Context, opts *GetOptions) (Packages, error) {
 	start := time.Now()
-	defer metrics.IndexerGetDurationSeconds.With(prometheus.Labels{"indexer": i.label}).Observe(time.Since(start).Seconds())
+	defer func() {
+		metrics.IndexerGetDurationSeconds.With(prometheus.Labels{"indexer": i.label}).Observe(time.Since(start).Seconds())
+	}()
 	if opts == nil {
 		return i.packageList, nil
 	}

--- a/storage/indexer.go
+++ b/storage/indexer.go
@@ -158,7 +158,9 @@ func (i *Indexer) updateIndex(ctx context.Context) error {
 
 	i.logger.Debug("Update indices")
 	start := time.Now()
-	defer metrics.StorageIndexerUpdateIndexDurationSeconds.Observe(time.Since(start).Seconds())
+	defer func() {
+		metrics.StorageIndexerUpdateIndexDurationSeconds.Observe(time.Since(start).Seconds())
+	}()
 
 	bucketName, rootStoragePath, err := extractBucketNameFromURL(i.options.PackageStorageBucketInternal)
 	if err != nil {
@@ -202,7 +204,9 @@ func (i *Indexer) updateIndex(ctx context.Context) error {
 
 func (i *Indexer) Get(ctx context.Context, opts *packages.GetOptions) (packages.Packages, error) {
 	start := time.Now()
-	defer metrics.IndexerGetDurationSeconds.With(prometheus.Labels{"indexer": indexerGetDurationPrometheusLabel}).Observe(time.Since(start).Seconds())
+	defer func() {
+		metrics.IndexerGetDurationSeconds.With(prometheus.Labels{"indexer": indexerGetDurationPrometheusLabel}).Observe(time.Since(start).Seconds())
+	}()
 
 	i.m.RLock()
 	defer i.m.RUnlock()


### PR DESCRIPTION
This PR fixes the warning found when using `time.Since` as part of a defer statement:

> call to time.Since is not deferred 

Related docs: https://pkg.go.dev/golang.org/x/tools/go/analysis/passes/defers

These usages are mainly related to duration Prometheus metrics from the indexer.
