### PR TITLE
Revisited APM spans/transactions set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Update Go runtime to 1.24.2. [#1299](https://github.com/elastic/package-registry/pull/1299)
 * Ignore unknown categories instead of producing fatal errors. [#1297](https://github.com/elastic/package-registry/pull/1297)
 * Fix usages of time.Since in defer statements used to obtain duration Prometheus metrics in the indexer. [#1304](https://github.com/elastic/package-registry/pull/1304)
+* Rename some spans to avoid conflicts. [#1306](https://github.com/elastic/package-registry/pull/1306)
 
 ### Added
 
 * Change license from Elastic License to Elastic License 2.0. [#1298](https://github.com/elastic/package-registry/pull/1298)
-* Revisited spans and transactions shown in APM. [#1306](https://github.com/elastic/package-registry/pull/1306)
+* Add APM spans for proxy requests. [#1306](https://github.com/elastic/package-registry/pull/1306)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * Change license from Elastic License to Elastic License 2.0. [#1298](https://github.com/elastic/package-registry/pull/1298)
+* Revisited spans and transactions shown in APM. [#1306](https://github.com/elastic/package-registry/pull/1306)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * Change license from Elastic License to Elastic License 2.0. [#1298](https://github.com/elastic/package-registry/pull/1298)
-* Add APM spans for proxy requests. [#1306](https://github.com/elastic/package-registry/pull/1306)
+* Add APM spans for proxy requests and storage indexer Get calls. [#1306](https://github.com/elastic/package-registry/pull/1306)
 
 ### Deprecated
 

--- a/packages/http.go
+++ b/packages/http.go
@@ -63,7 +63,7 @@ func ServePackageSignature(logger *zap.Logger, w http.ResponseWriter, r *http.Re
 }
 
 func serveLocalPackage(logger *zap.Logger, w http.ResponseWriter, r *http.Request, p *Package, packagePath string) {
-	span, _ := apm.StartSpan(r.Context(), "ServePackage", "app")
+	span, _ := apm.StartSpan(r.Context(), "ServeLocalPackage", "app")
 	defer span.End()
 
 	logger = logger.With(zap.String("file.name", packagePath))
@@ -93,7 +93,7 @@ func serveLocalPackage(logger *zap.Logger, w http.ResponseWriter, r *http.Reques
 
 // ServePackageResource is used by staticHandler.
 func ServePackageResource(logger *zap.Logger, w http.ResponseWriter, r *http.Request, p *Package, packageFilePath string) {
-	span, _ := apm.StartSpan(r.Context(), "ServePackage", "app")
+	span, _ := apm.StartSpan(r.Context(), "ServePackageResource", "app")
 	defer span.End()
 
 	if p.RemoteResolver() != nil {

--- a/packages/http.go
+++ b/packages/http.go
@@ -64,6 +64,7 @@ func ServePackageSignature(logger *zap.Logger, w http.ResponseWriter, r *http.Re
 
 func serveLocalPackage(logger *zap.Logger, w http.ResponseWriter, r *http.Request, p *Package, packagePath string) {
 	span, _ := apm.StartSpan(r.Context(), "ServeLocalPackage", "app")
+	span.Context.SetLabel("file.name", packagePath)
 	defer span.End()
 
 	logger = logger.With(zap.String("file.name", packagePath))
@@ -94,6 +95,7 @@ func serveLocalPackage(logger *zap.Logger, w http.ResponseWriter, r *http.Reques
 // ServePackageResource is used by staticHandler.
 func ServePackageResource(logger *zap.Logger, w http.ResponseWriter, r *http.Request, p *Package, packageFilePath string) {
 	span, _ := apm.StartSpan(r.Context(), "ServePackageResource", "app")
+	span.Context.SetLabel("file.name", packageFilePath)
 	defer span.End()
 
 	if p.RemoteResolver() != nil {

--- a/packages/packages.go
+++ b/packages/packages.go
@@ -214,7 +214,7 @@ func (i *FileSystemIndexer) Get(ctx context.Context, opts *GetOptions) (Packages
 }
 
 func (i *FileSystemIndexer) getPackagesFromFileSystem(ctx context.Context) (Packages, error) {
-	span, _ := apm.StartSpan(ctx, "GetPackagesFromFileSystem", "app")
+	span, _ := apm.StartSpan(ctx, "GetFromFileSystem", "app")
 	span.Context.SetLabel("indexer", i.label)
 	defer span.End()
 

--- a/packages/packages.go
+++ b/packages/packages.go
@@ -198,6 +198,10 @@ func (i *FileSystemIndexer) Get(ctx context.Context, opts *GetOptions) (Packages
 	defer func() {
 		metrics.IndexerGetDurationSeconds.With(prometheus.Labels{"indexer": i.label}).Observe(time.Since(start).Seconds())
 	}()
+	span, ctx := apm.StartSpan(ctx, "GetFileSystemIndexer", "app")
+	span.Context.SetLabel("indexer", i.label)
+	defer span.End()
+
 	if opts == nil {
 		return i.packageList, nil
 	}
@@ -210,7 +214,7 @@ func (i *FileSystemIndexer) Get(ctx context.Context, opts *GetOptions) (Packages
 }
 
 func (i *FileSystemIndexer) getPackagesFromFileSystem(ctx context.Context) (Packages, error) {
-	span, _ := apm.StartSpan(ctx, "GetFromFileSystem", "app")
+	span, _ := apm.StartSpan(ctx, "GetPackagesFromFileSystem", "app")
 	span.Context.SetLabel("indexer", i.label)
 	defer span.End()
 

--- a/proxymode/proxymode.go
+++ b/proxymode/proxymode.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/hashicorp/go-retryablehttp"
+	"go.elastic.co/apm/v2"
 
 	"go.uber.org/zap"
 
@@ -112,6 +113,9 @@ func (pm *ProxyMode) Enabled() bool {
 }
 
 func (pm *ProxyMode) Search(r *http.Request) (packages.Packages, error) {
+	span, _ := apm.StartSpan(r.Context(), "Proxy Search", "app")
+	defer span.End()
+
 	proxyURL := *r.URL
 	proxyURL.Host = pm.destinationURL.Host
 	proxyURL.Scheme = pm.destinationURL.Scheme
@@ -140,6 +144,9 @@ func (pm *ProxyMode) Search(r *http.Request) (packages.Packages, error) {
 }
 
 func (pm *ProxyMode) Categories(r *http.Request) ([]packages.Category, error) {
+	span, _ := apm.StartSpan(r.Context(), "Proxy Categories", "app")
+	defer span.End()
+
 	proxyURL := *r.URL
 	proxyURL.Host = pm.destinationURL.Host
 	proxyURL.Scheme = pm.destinationURL.Scheme
@@ -165,6 +172,9 @@ func (pm *ProxyMode) Categories(r *http.Request) ([]packages.Category, error) {
 }
 
 func (pm *ProxyMode) Package(r *http.Request) (*packages.Package, error) {
+	span, _ := apm.StartSpan(r.Context(), "Proxy Package", "app")
+	defer span.End()
+
 	vars := mux.Vars(r)
 	packageName, ok := vars["packageName"]
 	if !ok {

--- a/search.go
+++ b/search.go
@@ -33,7 +33,7 @@ func searchHandlerWithProxyMode(logger *zap.Logger, indexer Indexer, proxyMode *
 	return func(w http.ResponseWriter, r *http.Request) {
 		logger := logger.With(apmzap.TraceContext(r.Context())...)
 
-		filter, err := newSearchFilterFromQuery(r.Context(), r.URL.Query())
+		filter, err := newSearchFilterFromQuery(r.URL.Query())
 		if err != nil {
 			badRequest(w, err.Error())
 			return
@@ -73,10 +73,7 @@ func searchHandlerWithProxyMode(logger *zap.Logger, indexer Indexer, proxyMode *
 	}
 }
 
-func newSearchFilterFromQuery(ctx context.Context, query url.Values) (*packages.Filter, error) {
-	span, _ := apm.StartSpan(ctx, "NewSearchFilterFromQuery", "app")
-	defer span.End()
-
+func newSearchFilterFromQuery(query url.Values) (*packages.Filter, error) {
 	var filter packages.Filter
 
 	if len(query) == 0 {

--- a/search.go
+++ b/search.go
@@ -33,7 +33,7 @@ func searchHandlerWithProxyMode(logger *zap.Logger, indexer Indexer, proxyMode *
 	return func(w http.ResponseWriter, r *http.Request) {
 		logger := logger.With(apmzap.TraceContext(r.Context())...)
 
-		filter, err := newSearchFilterFromQuery(r.URL.Query())
+		filter, err := newSearchFilterFromQuery(r.Context(), r.URL.Query())
 		if err != nil {
 			badRequest(w, err.Error())
 			return
@@ -73,7 +73,10 @@ func searchHandlerWithProxyMode(logger *zap.Logger, indexer Indexer, proxyMode *
 	}
 }
 
-func newSearchFilterFromQuery(query url.Values) (*packages.Filter, error) {
+func newSearchFilterFromQuery(ctx context.Context, query url.Values) (*packages.Filter, error) {
+	span, _ := apm.StartSpan(ctx, "NewSearchFilterFromQuery", "app")
+	defer span.End()
+
 	var filter packages.Filter
 
 	if len(query) == 0 {

--- a/storage/indexer.go
+++ b/storage/indexer.go
@@ -208,6 +208,9 @@ func (i *Indexer) Get(ctx context.Context, opts *packages.GetOptions) (packages.
 		metrics.IndexerGetDurationSeconds.With(prometheus.Labels{"indexer": indexerGetDurationPrometheusLabel}).Observe(time.Since(start).Seconds())
 	}()
 
+	span, ctx := apm.StartSpan(ctx, "GetStorageIndexer", "app")
+	defer span.End()
+
 	i.m.RLock()
 	defer i.m.RUnlock()
 


### PR DESCRIPTION
This PR reviews the APM spans that are set in Elastic Package Registry. Mainly it add news spans to allow us to have a better knowledge of the requests.

Additionally, more tests have been added to the list packages test (storage indexer).

Some examples:
- `GET /package/{packageName}/{packageVersion}`
![Package endpoint](https://github.com/user-attachments/assets/b2433359-0252-4d96-9f64-39feb830532f)
- `GET /package/{packageName}/{packageVersion}/{name}`
![Package artifact endpoint](https://github.com/user-attachments/assets/330421c0-7401-4826-be56-6e6d91ea369a)
- `GET /search`
![Search endpoint](https://github.com/user-attachments/assets/5a539011-5daa-46f9-9435-67f2a5629fbd)
