### PR TITLE
Add helper to build a docker image for the Package Registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,14 +103,14 @@ Additionally, the following **frozen** endpoints exist and are **no longer updat
 
 **General**
 ```bash
-docker build --build-arg GO_VERSION="$(cat .go-version)" .
-docker run --rm -p 8080:8080 {image id from prior step}
+mage dockerBuild
+docker run --rm -p 8080:8080 docker.elastic.co/package-registry/package-registry:main
 ```
 
 **Commands ready to cut-and-paste**
 ```bash
-docker build --build-arg GO_VERSION="$(cat .go-version)" --rm -t docker.elastic.co/package-registry/package-registry:main .
-docker run --rm -it -p 8080:8080 $(docker images -q docker.elastic.co/package-registry/package-registry:main)
+mage dockerBuild main
+docker run --rm -it -p 8080:8080 docker.elastic.co/package-registry/package-registry:main
 ```
 
 **Testing service with local packages**
@@ -159,9 +159,7 @@ For that, you need to build a new Package Registry docker image from your requir
 0. Make sure you've built the Docker image for Package Registry (let's consider in this example `main`):
 
    ```bash
-   docker build --rm \
-     --build-arg GO_VERSION="$(cat .go-version)" \
-     -t docker.elastic.co/package-registry/package-registry:main .
+   mage dockerBuild main
    ```
 
 1. Build `elastic-package` changing the base image used for the Package Registry docker image (use `main` instead of `v1.24.0`):

--- a/magefile.go
+++ b/magefile.go
@@ -37,6 +37,27 @@ func Build() error {
 	return sh.Run("go", "build", ".")
 }
 
+// DockerBuild builds the Docker image for the package registry. It must be specified
+// the docker tag to be used as an argument (e.g. main, latest).
+func DockerBuild(tag string) error {
+	contents, err := os.ReadFile(".go-version")
+	if err != nil {
+		return fmt.Errorf("failed to read .go-version: %w", err)
+	}
+	goVersion := strings.TrimSpace(string(contents))
+	if goVersion == "" {
+		return fmt.Errorf("empty go version in .go-version")
+	}
+	dockerImage := fmt.Sprintf("docker.elastic.co/package-registry/package-registry:%s", tag)
+
+	fmt.Println(">> Building Docker image:", dockerImage)
+	err = sh.Run("docker", "build", "--build-arg", fmt.Sprintf("GO_VERSION=%s", goVersion), "-t", dockerImage, ".")
+	if err != nil {
+		return fmt.Errorf("failed to build docker image: %w", err)
+	}
+	return nil
+}
+
 func Check() error {
 	mg.SerialDeps(
 		Format,


### PR DESCRIPTION
Added a new mage target `dockerBuild` to help developers to create their on package registry docker images.

```
 $ mage -l
Targets:
  addLicenseHeaders    adds license headers to .go files.
  build                
  check                
  clean                
  dockerBuild          builds the Docker image for the package registry.
  format               adds license headers, formats .go files with goimports, and formats .py files with autopep8.
  goImports            executes goimports against all .go files in and below the CWD.
  modTidy              cleans unused dependencies.
  staticcheck          runs a static code analyzer.
  test      
```

```
 $ mage -h dockerBuild
DockerBuild builds the Docker image for the package registry. It must be specified the docker tag to be used as an argument (e.g. main, latest).

Usage:

	mage dockerbuild <tag>

```

### Author's Checklist
- [x] Update references in README.


Relates https://github.com/elastic/package-registry/pull/1294