### PR TITLE
Show message with number packages and objects in fake server

### DIFF
--- a/main.go
+++ b/main.go
@@ -223,14 +223,14 @@ func initFakeGCSServer(logger *zap.Logger, indexPath string) (*fakestorage.Serve
 		if err != nil {
 			return nil, fmt.Errorf("failed to convert port to integer from STORAGE_EMULATOR_HOST: %w", err)
 		}
-		fakeServer, err = storage.RunFakeServerOnHostPort(indexPath, host, uint16(portInt))
+		fakeServer, err = storage.RunFakeServerOnHostPort(logger, indexPath, host, uint16(portInt))
 		if err != nil {
 			return nil, fmt.Errorf("failed to prepare fake storage server: %w", err)
 		}
 	} else {
 		logger.Info("Create fake GCS server on random port")
 		// let the fake server choose a random port
-		fakeServer, err = storage.RunFakeServerOnHostPort(indexPath, "localhost", 0)
+		fakeServer, err = storage.RunFakeServerOnHostPort(logger, indexPath, "localhost", 0)
 		if err != nil {
 			return nil, fmt.Errorf("failed to prepare fake storage server: %w", err)
 		}

--- a/storage/fakestorage.go
+++ b/storage/fakestorage.go
@@ -28,7 +28,7 @@ func RunFakeServerOnHostPort(indexPath, host string, port uint16) (*fakestorage.
 	}
 
 	const firstRevision = "1"
-	serverObjects, err := prepareServerObjects(firstRevision, indexContent)
+	serverObjects, _, err := prepareServerObjects(firstRevision, indexContent)
 	if err != nil {
 		return nil, fmt.Errorf("failed to prepare server objects: %w", err)
 	}
@@ -45,8 +45,10 @@ func PrepareFakeServer(tb testing.TB, indexPath string) *fakestorage.Server {
 	require.NoError(tb, err, "index file must be populated")
 
 	const firstRevision = "1"
-	serverObjects, err := prepareServerObjects(firstRevision, indexContent)
+	serverObjects, numPackages, err := prepareServerObjects(firstRevision, indexContent)
 	require.NoError(tb, err, "failed to prepare server objects")
+	tb.Logf("Prepared %d packages with total %d server objects.", numPackages, len(serverObjects))
+
 	return fakestorage.NewServer(serverObjects)
 }
 
@@ -54,8 +56,9 @@ func updateFakeServer(tb testing.TB, server *fakestorage.Server, revision, index
 	indexContent, err := os.ReadFile(indexPath)
 	require.NoError(tb, err, "index file must be populated")
 
-	serverObjects, err := prepareServerObjects(revision, indexContent)
+	serverObjects, numPackages, err := prepareServerObjects(revision, indexContent)
 	require.NoError(tb, err, "failed to prepare server objects")
+	tb.Logf("Prepared %d packages with total %d server objects.", numPackages, len(serverObjects))
 
 	for _, so := range serverObjects {
 		server.CreateObject(so)
@@ -66,14 +69,14 @@ type searchIndexAll struct {
 	Packages []packageIndex `json:"packages"`
 }
 
-func prepareServerObjects(revision string, indexContent []byte) ([]fakestorage.Object, error) {
+func prepareServerObjects(revision string, indexContent []byte) ([]fakestorage.Object, int, error) {
 	var index searchIndexAll
 	err := json.Unmarshal(indexContent, &index)
 	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal index content: %w", err)
+		return nil, 0, fmt.Errorf("failed to unmarshal index content: %w", err)
 	}
 	if len(index.Packages) == 0 {
-		return nil, fmt.Errorf("index file must contain some package entries")
+		return nil, 0, fmt.Errorf("index file must contain some package entries")
 	}
 
 	var serverObjects []fakestorage.Object
@@ -90,5 +93,5 @@ func prepareServerObjects(revision string, indexContent []byte) ([]fakestorage.O
 		},
 		Content: indexContent,
 	})
-	return serverObjects, nil
+	return serverObjects, len(index.Packages), nil
 }


### PR DESCRIPTION
Restore the number of packages and number of objects created in `prepareServerObjects`.

This function was updated in https://github.com/elastic/package-registry/pull/1309/ and that message was removed.