### PR TITLE
Add helper to update indices in fake GCS server

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,39 +281,11 @@ in the Elastic Package Registry service locally. For that you need to follow the
    ```json
    {"log.level":"info","@timestamp":"2025-06-11T10:02:17.680+0200","log.origin":{"function":"github.com/elastic/package-registry/storage.(*Indexer).updateIndex","file.name":"storage/indexer.go","file.line":178},"message":"cursor is up-to-date","cursor.current":"1","ecs.version":"1.6.0"}
    ```
-2. Update the new index JSON file to the new path `v2/metadata/<cursor>/search-index-all.json`:
-   ```
-   curl -X POST \
-     --data-binary @<path_to_index_json> \
-     -H "Content-Type: application/json" \
-     "http://localhost:4443/upload/storage/v1/b/fake-package-storage-internal/o?uploadType=media&name=v2%2Fmetadata%2F<cursor>%2Fsearch-index-all.json"
-   ```
-   - Example uploading JSON file to path for cursor `2` (v2/metadata/2/cursor.json)
-   ```
-   curl -X POST \
-     --data-binary @../storage/testdata/search-index-all.json \
-     -H "Content-Type: application/json" \
-     "http://localhost:4443/upload/storage/v1/b/fake-package-storage-internal/o?uploadType=media&name=v2%2Fmetadata%2F2%2Fsearch-index-all.json"
-   ```
-3. Create the new cursor file `cursor.json` with the next cursor as string value. In this example `2`:
-   ```
-   {
-     "current": "2"
-   }
-   ```
-4. Update the new contents of the cursor file to the path `v2/metadata/cursor.json`:
-   ```
-   curl -X POST \
-     --data-binary @<path_to_cursor_json> \
-     -H "Content-Type: application/json" \
-     "http://localhost:4443/upload/storage/v1/b/fake-package-storage-internal/o?uploadType=media&name=v2%2Fmetadata%2Fcursor.json"
-   ```
-   - Example uploading JSON file to path for cursor `2` (v2/metadata/2/cursor.json)
-   ```
-   curl -X POST \
-     --data-binary @cursor-new.json \
-     -H "Content-Type: application/json" \
-     "http://localhost:4443/upload/storage/v1/b/fake-package-storage-internal/o?uploadType=media&name=v2%2Fmetadata%2Fcursor.json"
+2. Update the new index JSON file to the new path `v2/metadata/<cursor>/search-index-all.json` and also update `cursor.json` file in the fake GCS server using the script helper:
+   ```shell
+   # bash dev/updateIndexDatabase.sh -i <path_to_index> -c <cursor_string> -b <bucket>
+   # Example adding a new index using as cursor "2":
+   bash dev/updateIndexDatabase.sh -i ./search-index-all.json -c 2 -b fake-package-storage-internal
    ```
 
 After following these steps, the next log messages must appear in the EPR service:

--- a/dev/updateIndexDatabase.sh
+++ b/dev/updateIndexDatabase.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 set -euo pipefail
-set -x
+
+cleanup() {
+    local exit_code=$?
+    rm -rf cursor-new.json
+    exit "$exit_code"
+}
+trap cleanup EXIT
 
 usage() {
     echo "$0 -c <cursor> -i <index_path> [-b <bucket_name>] [-e <emulator_address>] [-h]"

--- a/dev/updateIndexDatabase.sh
+++ b/dev/updateIndexDatabase.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+set -euo pipefail
+set -x
+
+usage() {
+    echo "$0 -c <cursor> -i <index_path> [-b <bucket_name>] [-e <emulator_address>] [-h]"
+    echo -e "\t-c <cursor>: Cursor to set the new index."
+    echo -e "\t-i <index_path>: Path to the search index JSON."
+    echo -e "\t-b <bucket_name>: Bucket name. Default: example"
+    echo -e "\t-e <emulator_address>: Address of the emulator host (fake GCS server). Default: http://localhost:4443"
+    echo -e "\t-h: Show this message"
+}
+
+BUCKET_NAME="example"
+INDEX_PATH=""
+EMULATOR_HOST="http://localhost:4443"
+CURSOR=""
+
+while getopts ":b:i:e:c:h" o; do
+  case "${o}" in
+    b)
+      BUCKET_NAME="${OPTARG}"
+      ;;
+    i)
+      INDEX_PATH="${OPTARG}"
+      ;;
+    e)
+      EMULATOR_HOST="${OPTARG}"
+      ;;
+    c)
+      CURSOR="${OPTARG}"
+      ;;
+    h)
+      usage
+      exit 0
+      ;;
+    \?)
+      echo "Invalid option ${OPTARG}"
+      usage
+      exit 1
+      ;;
+    :)
+      echo "Missing argument for -${OPTARG}"
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [[ "${CURSOR}" == "" ]]; then
+    echo "Missing cursor"
+    usage
+    exit 1
+fi
+
+BASE_URL="${EMULATOR_HOST}/upload/storage/v1/b/${BUCKET_NAME}/o"
+curl -X POST \
+    --data-binary "@${INDEX_PATH}" \
+    -H "Content-Type: application/json" \
+    "${BASE_URL}?uploadType=media&name=v2%2Fmetadata%2F${CURSOR}%2Fsearch-index-all.json"
+
+cat << EOF > cursor-new.json
+{
+  "current": "${CURSOR}"
+}
+EOF
+
+echo "Setting cursor as:"
+cat cursor-new.json
+
+curl -X POST \
+    --data-binary @cursor-new.json \
+    -H "Content-Type: application/json" \
+    "${BASE_URL}?uploadType=media&name=v2%2Fmetadata%2Fcursor.json"


### PR DESCRIPTION
Relates https://github.com/elastic/package-registry/pull/1313

This PR adds a helper to update the index in the fake GCS server.
Updated the documentation accordingly.

Example:
```shell
bash dev/updateIndexDatabase.sh -i storage/testdata/search-index-all-full.json -c 4 -b fake-package-storage-internal
```
