### PR TITLE
[SQL storage indexer] Use bytes (blob) to store data in database instead of string

### DIFF
--- a/internal/database/model.go
+++ b/internal/database/model.go
@@ -17,6 +17,6 @@ type Package struct {
 	DiscoveryFields string
 	Type            string
 	Path            string
-	Data            string
-	BaseData        string
+	Data            []byte
+	BaseData        []byte
 }

--- a/internal/database/sqliterepository.go
+++ b/internal/database/sqliterepository.go
@@ -41,8 +41,8 @@ var keys = []keyDefinition{
 	{"discoveryFields", "TEXT NOT NULL"},
 	{"type", "TEXT NOT NULL"},
 	{"path", "TEXT NOT NULL"},
-	{"data", "TEXT NOT NULL"},
-	{"baseData", "TEXT NOT NULL"},
+	{"data", "BLOB NOT NULL"},
+	{"baseData", "BLOB NOT NULL"},
 }
 
 const defaultMaxBulkAddBatch = 2000
@@ -355,9 +355,9 @@ func (r *SQLiteRepository) AllFunc(ctx context.Context, database string, whereOp
 		}
 		if useBaseData {
 			pkg.BaseData = pkg.Data
-			pkg.Data = ""
+			pkg.Data = []byte{}
 		} else {
-			pkg.BaseData = ""
+			pkg.BaseData = []byte{}
 		}
 		err = process(ctx, &pkg)
 		if err != nil {

--- a/internal/storage/sqlindexer.go
+++ b/internal/storage/sqlindexer.go
@@ -362,8 +362,8 @@ func createDatabasePackage(pkg *packages.Package, cursor string) (*database.Pack
 		Capabilities:    capabilities,
 		DiscoveryFields: discoveryFields.String(),
 		Prerelease:      pkg.IsPrerelease(),
-		Data:            string(fullContents),
-		BaseData:        string(baseContents),
+		Data:            fullContents,
+		BaseData:        baseContents,
 	}
 
 	return &newPackage, nil
@@ -430,12 +430,12 @@ func (i *SQLIndexer) Get(ctx context.Context, opts *packages.GetOptions) (packag
 			var pkg packages.Package
 			var err error
 			if opts != nil && opts.FullData {
-				err = json.Unmarshal([]byte(p.Data), &pkg)
+				err = json.Unmarshal(p.Data, &pkg)
 			} else {
 				// BaseData is used for performance reasons, it contains only the fields that are needed for the search index.
 				// FormatVersion needs to be set from database to ensure compatibility with the package structure.
 				pkg.FormatVersion = p.FormatVersion
-				err = json.Unmarshal([]byte(p.BaseData), &pkg)
+				err = json.Unmarshal(p.BaseData, &pkg)
 			}
 			if err != nil {
 				return fmt.Errorf("failed to parse package %s-%s: %w", p.Name, p.Version, err)

--- a/search.go
+++ b/search.go
@@ -80,7 +80,7 @@ func searchHandlerWithProxyMode(logger *zap.Logger, indexer Indexer, proxyMode *
 
 		if cache != nil {
 			val := cache.Add(r.URL.String(), data)
-			logger.Debug("added to cache request", zap.String("cache.url", r.URL.String()), zap.Int("cache.size", cache.Len()), zap.Bool("cache.added", val))
+			logger.Debug("added to cache request", zap.String("cache.url", r.URL.String()), zap.Int("cache.size", cache.Len()), zap.Bool("cache.eviction", val))
 		}
 	}
 }


### PR DESCRIPTION
This PR updates the type for `Data` and `BaseData` fields to be `[]byte` instead of `string`.
This change requires to use `BLOB` as a SQLite type.

As it is shown in the following benchmarks, it results in an improvement on `bytes/operation` and `allocations/operation`

- Get operation benchmark:
```
goos: linux
goarch: amd64
pkg: github.com/elastic/package-registry/internal/storage
cpu: 11th Gen Intel(R) Core(TM) i7-11800H @ 2.30GHz
                 │ ../package-registry-main/sql_prod_indexer_main_get.txt │ sql_prod_indexer_main_get_bytes.txt │
                 │                         sec/op                         │      sec/op        vs base          │
SQLIndexerGet-16                                               2.364 ± 8%         2.461 ± 15%  ~ (p=0.123 n=10)

                 │ ../package-registry-main/sql_prod_indexer_main_get.txt │ sql_prod_indexer_main_get_bytes.txt  │
                 │                          B/op                          │     B/op      vs base                │
SQLIndexerGet-16                                             476.8Mi ± 0%   418.9Mi ± 0%  -12.14% (p=0.000 n=10)

                 │ ../package-registry-main/sql_prod_indexer_main_get.txt │ sql_prod_indexer_main_get_bytes.txt │
                 │                       allocs/op                        │  allocs/op    vs base               │
SQLIndexerGet-16                                              6.020M ± 0%    5.945M ± 0%  -1.25% (p=0.000 n=10)
```
- Updating index operatoin benchmark:
```
goos: linux
goarch: amd64
pkg: github.com/elastic/package-registry/internal/storage
cpu: 11th Gen Intel(R) Core(TM) i7-11800H @ 2.30GHz
                         │ ../package-registry-main/sql_prod_indexer_main_update.txt │ sql_prod_indexer_main_update_bytes.txt │
                         │                          sec/op                           │        sec/op         vs base          │
SQLIndexerUpdateIndex-16                                                  19.80 ± 7%             19.49 ± 4%  ~ (p=0.143 n=10)

                         │ ../package-registry-main/sql_prod_indexer_main_update.txt │ sql_prod_indexer_main_update_bytes.txt │
                         │                           B/op                            │      B/op        vs base               │
SQLIndexerUpdateIndex-16                                                5.415Gi ± 0%      5.037Gi ± 0%  -6.99% (p=0.000 n=10)

                         │ ../package-registry-main/sql_prod_indexer_main_update.txt │ sql_prod_indexer_main_update_bytes.txt │
                         │                         allocs/op                         │    allocs/op     vs base               │
SQLIndexerUpdateIndex-16                                                 13.52M ± 0%       13.49M ± 0%  -0.16% (p=0.000 n=10)
```
