### PR TITLE
[SQL storage indexer] Reorder primary key to keep same ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Breaking changes
 
 ### Bugfixes
+* Reorder fields in primary key to keep same ordering as before (technical preview). [#1348](https://github.com/elastic/package-registry/pull/1348)
 
 ### Added
 
@@ -28,7 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 * Add new method `MustParsePackage` to create new packages, running more validations. [#1333](https://github.com/elastic/package-registry/pull/1333)
 * Allow to customize settings related to SQL storage indexer (technical preview). [#1334](https://github.com/elastic/package-registry/pull/1334) [#1337](https://github.com/elastic/package-registry/pull/1337)
-* Cleanup SQL storage indexer backup database only when a new index version is downloaded (technical preview). [#1337](https://github.com/elastic/package-registry/pull/1337)
+* Cleanup SQL storage indexer backup database only when a new index version is downloaded (technical preview). [#1334](https://github.com/elastic/package-registry/pull/1334)
 * Add support to discover content packages based on the datasets defined in the discovery parameter. [#1338](https://github.com/elastic/package-registry/pull/1338)
 * Include deployment modes in responses when they are defined at inputs of the policy templates. [#1345](https://github.com/elastic/package-registry/pull/1345)
 

--- a/internal/database/sqliterepository.go
+++ b/internal/database/sqliterepository.go
@@ -158,7 +158,7 @@ func (r *SQLiteRepository) Initialize(ctx context.Context) error {
 	for _, i := range keys {
 		createQuery.WriteString(fmt.Sprintf("%s %s, ", i.Name, i.SQLType))
 	}
-	createQuery.WriteString("PRIMARY KEY (cursor, name, version));")
+	createQuery.WriteString("PRIMARY KEY (name, version, cursor));")
 	if _, err := r.db.ExecContext(ctx, createQuery.String()); err != nil {
 		return err
 	}


### PR DESCRIPTION
Update the fields used in the primary key set for the SQL database to keep the same ordering as in the storage indexer (`storage/indexer.go`).

Follows #1334 