### PR TITLE
Use buildkite plugin to manage docker login

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -8,11 +8,3 @@ echo "Golang version:"
 version=$(cat .go-version)
 export SETUP_GOLANG_VERSION="${version}"
 echo "${SETUP_GOLANG_VERSION}"
-
-DOCKER_REGISTRY_SECRET_PATH="kv/ci-shared/platform-ingest/docker_registry_prod"
-if [[ "$BUILDKITE_PIPELINE_SLUG" == "package-registry" && "$BUILDKITE_STEP_KEY" == "publish" ]] || \
-    [[ "$BUILDKITE_PIPELINE_SLUG" == "package-registry-release-package-registry-distribution" && "$BUILDKITE_STEP_KEY" == "release-distribution" ]]; then
-    DOCKER_USERNAME_SECRET=$(retry 5 vault kv get -field user "${DOCKER_REGISTRY_SECRET_PATH}")
-    DOCKER_PASSWORD_SECRET=$(retry 5 vault kv get -field password "${DOCKER_REGISTRY_SECRET_PATH}")
-    docker login -u "${DOCKER_USERNAME_SECRET}" -p "${DOCKER_PASSWORD_SECRET}" "${DOCKER_REGISTRY}" 2>/dev/null
-fi

--- a/.buildkite/hooks/pre-exit
+++ b/.buildkite/hooks/pre-exit
@@ -4,9 +4,4 @@ source .buildkite/scripts/tooling.sh
 
 set -euo pipefail
 
-if [[ "$BUILDKITE_PIPELINE_SLUG" == "package-registry" && "$BUILDKITE_STEP_KEY" == "publish" ]] || \
-    [[ "$BUILDKITE_PIPELINE_SLUG" == "package-registry-release-package-registry-distribution" && "$BUILDKITE_STEP_KEY" == "release-distribution" ]]; then
-    docker logout "${DOCKER_REGISTRY}"
-fi
-
 unset_secrets

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,7 +5,7 @@ env:
   SETUP_MAGE_VERSION: '1.15.0'
   JQ_VERSION: '1.7'
   DOCKER_IMG: "docker.elastic.co/package-registry/package-registry"
-  DOCKER_IMG_PR: "docker.elasti.co/observability-ci/package-registry"
+  DOCKER_IMG_PR: "docker.elastic.co/observability-ci/package-registry"
   # Agent images used in pipeline steps
   LINUX_GOLANG_AGENT_IMAGE: "golang:${SETUP_GOLANG_VERSION}"
   WINDOWS_AGENT_IMAGE: "family/core-windows-2022"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,9 +4,8 @@ env:
   SETUP_GVM_VERSION: 'v0.5.2' # https://github.com/andrewkroh/gvm/issues/44#issuecomment-1013231151
   SETUP_MAGE_VERSION: '1.15.0'
   JQ_VERSION: '1.7'
-  DOCKER_REGISTRY: 'docker.elastic.co'
-  DOCKER_IMG: "${DOCKER_REGISTRY}/package-registry/package-registry"
-  DOCKER_IMG_PR: "${DOCKER_REGISTRY}/observability-ci/package-registry"
+  DOCKER_IMG: "docker.elastic.co/package-registry/package-registry"
+  DOCKER_IMG_PR: "docker.elasti.co/observability-ci/package-registry"
   # Agent images used in pipeline steps
   LINUX_GOLANG_AGENT_IMAGE: "golang:${SETUP_GOLANG_VERSION}"
   WINDOWS_AGENT_IMAGE: "family/core-windows-2022"
@@ -107,6 +106,9 @@ steps:
         allow_failure: false
       - step: "smoke-test-fake-gcs-server"
         allow_failure: false
+    plugins:
+      - elastic/vault-docker-login#v0.6.0:
+          secret_path: 'kv/ci-shared/platform-ingest/elastic_docker_registry'
 
   - trigger: "package-storage-infra-update-package-registry"
     label: ":esbuild: Downstream - Update package registry"

--- a/.buildkite/release-package-registry-distribution.yml
+++ b/.buildkite/release-package-registry-distribution.yml
@@ -1,7 +1,6 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
 
 env:
-  DOCKER_REGISTRY: 'docker.elastic.co'
   NOTIFY_TO: "ecosystem-team@elastic.co"
 
 steps:
@@ -37,6 +36,7 @@ steps:
           - "production"
     env:
       TAG_NAME: "{{matrix.tag_name}}"
+      DOCKER_IMAGE: "docker.elastic.co/package-registry/distribution"
       DRY_RUN: false
     command:
       - ".buildkite/scripts/publish-distribution.sh"
@@ -45,6 +45,9 @@ steps:
     depends_on:
       - step: "validate"
         allow_failure: false
+    plugins:
+      - elastic/vault-docker-login#v0.6.0:
+          secret_path: 'kv/ci-shared/platform-ingest/elastic_docker_registry'
 
 notify:
   - email: "$NOTIFY_TO"

--- a/.buildkite/scripts/publish-distribution.sh
+++ b/.buildkite/scripts/publish-distribution.sh
@@ -6,12 +6,13 @@ set -euo pipefail
 
 DOCKER_TAG=$(buildkite-agent meta-data get DOCKER_TAG)
 echo "version for tagging: ${DOCKER_TAG}"
-DOCKER_IMG_SOURCE="${DOCKER_REGISTRY}/package-registry/distribution:${TAG_NAME}"
+
+DOCKER_IMG_SOURCE="${DOCKER_IMAGE}:${TAG_NAME}"
 
 if [[ "${TAG_NAME}" == "production" ]]; then
-    DOCKER_IMG_TARGET="${DOCKER_REGISTRY}/package-registry/distribution:${DOCKER_TAG}"
+    DOCKER_IMG_TARGET="${DOCKER_IMAGE}:${DOCKER_TAG}"
 else
-    DOCKER_IMG_TARGET="${DOCKER_REGISTRY}/package-registry/distribution:${TAG_NAME}-${DOCKER_TAG}"
+    DOCKER_IMG_TARGET="${DOCKER_IMAGE}:${TAG_NAME}-${DOCKER_TAG}"
 fi
 
 echo "Docker retag"


### PR DESCRIPTION
See https://github.com/elastic/elastic-agent/pull/8444

- Remove docker login in the `pre-command` hook.
- Remove docker logout in the `pre-exit` hook
- Remove DOCKER_REGISTRY env variable.
- Use buildkite plugin to docker login in the steps, see https://github.com/elastic/vault-docker-login-buildkite-plugin.

Avoid the pattern of login with the pre-command and use the declarative plugin usage in the steps that require the login.