### PR TITLE
add asset_inventory  categories

### DIFF
--- a/categories/categories.yml
+++ b/categories/categories.yml
@@ -99,6 +99,8 @@ categories:
     subcategories:
       advanced_analytics_ueba:
         title: "Advanced Analytics (UEBA)"
+      asset_inventory:
+        title: "Asset Inventory"
       auditd:
         title: "AuditD"
       authentication:


### PR DESCRIPTION
Introduces a new integration category - `asset_inventory`
[- https://github.com/elastic/security-team/issues/8667](https://github.com/elastic/security-team/issues/13261)