### PR TITLE
Prepare release 1.30.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [unreleased](https://github.com/elastic/package-registry/compare/v1.30.0...main)
+## [v1.30.1](https://github.com/elastic/package-registry/compare/v1.30.0...v1.30.1)
 
 ### Breaking changes
 


### PR DESCRIPTION
Prepare changelog for release v1.30.1.

`main.go` already sets v1.30.1 as service version:
https://github.com/elastic/package-registry/blob/e4a22ee7eb480ac48eab14b2e3eb800242118dfc/main.go#L51