### PR TITLE
[CI] Update junit buildkite plugin

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -74,7 +74,7 @@ steps:
   - label: ":junit: Junit annotate"
     agents:
       # requires at least "bash", "curl" and "git"
-      image: "ruby:3.4.5-bookworm"
+      image: "docker.elastic.co/ci-agent-images/buildkite-junit-annotate:1.0"
     plugins:
       - junit-annotate#v2.7.0:
           artifacts: "tests-report-*.xml"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -72,14 +72,16 @@ steps:
           - "tests-report-darwin.xml"
 
   - label: ":junit: Junit annotate"
+    agents:
+      # requires at least "bash", "curl" and "git"
+      image: "ruby:3.4.5-bookworm"
     plugins:
-      - junit-annotate#v2.5.0:
+      - junit-annotate#v2.7.0:
           artifacts: "tests-report-*.xml"
           fail-build-on-error: true
           report-skipped: true
           always-annotate: true
-    agents:
-      provider: "gcp" #junit plugin requires docker
+          run-in-docker: false
     depends_on:
       - step: "test-linux"
         allow_failure: true


### PR DESCRIPTION
Update [Buildkite junit-annotate plugin](https://github.com/buildkite-plugins/junit-annotate-buildkite-plugin) up to version 2.7.0

Set `run-in-docker: false` to use the ruby from the agent.