### PR TITLE
Update default sql indexer batch size

### DIFF
--- a/internal/database/memoryrepository.go
+++ b/internal/database/memoryrepository.go
@@ -13,7 +13,8 @@ import (
 )
 
 type MemorySQLDBOptions struct {
-	Path string
+	Path             string
+	BatchSizeInserts int
 }
 
 func NewMemorySQLDB(options MemorySQLDBOptions) (*SQLiteRepository, error) {
@@ -26,7 +27,7 @@ func NewMemorySQLDB(options MemorySQLDBOptions) (*SQLiteRepository, error) {
 		return nil, fmt.Errorf("failed to connect to database: %w", err)
 	}
 
-	dbRepo, err := newSQLiteRepository(sqlDBOptions{db: db})
+	dbRepo, err := newSQLiteRepository(sqlDBOptions{db: db, batchSizeInserts: options.BatchSizeInserts})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create SQLite repository: %w", err)
 	}

--- a/internal/database/sqliterepository.go
+++ b/internal/database/sqliterepository.go
@@ -16,6 +16,8 @@ import (
 	"go.elastic.co/apm/v2"
 )
 
+const defaultMaxBulkAddBatch = 500
+
 var (
 	ErrDuplicate    = errors.New("record already exists")
 	ErrNotExists    = errors.New("row not exists")
@@ -44,8 +46,6 @@ var keys = []keyDefinition{
 	{"data", "BLOB NOT NULL"},
 	{"baseData", "BLOB NOT NULL"},
 }
-
-const defaultMaxBulkAddBatch = 2000
 
 type SQLiteRepository struct {
 	db                  *sql.DB

--- a/internal/storage/sqlindexer.go
+++ b/internal/storage/sqlindexer.go
@@ -243,11 +243,6 @@ func (i *SQLIndexer) updateIndex(ctx context.Context) error {
 	i.swapDatabases(ctx, currentCursor, numPackages)
 	i.logger.Debug("Elapsed time in lock for updating index database", zap.Duration("lock.duration", time.Since(startLock)))
 
-	if err != nil {
-		metrics.StorageIndexerUpdateIndexErrorsTotal.Inc()
-		return err
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
Update batch sizes used in the SQL indexer:
- Read packages batch size: 2000
- SQL insert batch size: 500