### PR TITLE
[SQL Storage indexer] Avoid storing in cache requests with package query parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bugfixes
 
 ### Added
+* Update default value for the batch size used in SQL storage indexer. [#1372](https://github.com/elastic/package-registry/pull/1372)
+* Skip adding to cache requests containing package query parameter. [#1378](https://github.com/elastic/package-registry/pull/1378)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bugfixes
 
 ### Added
+* New Security subcategory "asset_inventory" [#1357](https://github.com/elastic/package-registry/pull/1357)
 * Update default value for the batch size used in SQL storage indexer. [#1372](https://github.com/elastic/package-registry/pull/1372)
 * Skip adding to cache requests containing package query parameter. [#1378](https://github.com/elastic/package-registry/pull/1378)
 
@@ -47,7 +48,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Cleanup SQL storage indexer backup database only when a new index version is downloaded (technical preview). [#1334](https://github.com/elastic/package-registry/pull/1334)
 * Add support to discover content packages based on the datasets defined in the discovery parameter. [#1338](https://github.com/elastic/package-registry/pull/1338)
 * Include deployment modes in responses when they are defined at inputs of the policy templates. [#1345](https://github.com/elastic/package-registry/pull/1345)
-* New Security subcategory "asset_inventory" [#1357](https://github.com/elastic/package-registry/pull/1357)
 
 ### Deprecated
 

--- a/dev/launch_epr_service_storage_indexer.sh
+++ b/dev/launch_epr_service_storage_indexer.sh
@@ -11,7 +11,7 @@ CURRENT_DIR="$(pwd)"
 SCRIPT_DIR="$( cd -- "$(dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
 usage() {
-    echo "$0 [-b <bucket_name>] [-p <epr_address>] [-e <emulator_address>] [-i <index_path>] [-c <config_path>] [-s] [-C] [-h]"
+    echo "$0 [-b <bucket_name>] [-p <epr_address>] [-e <emulator_address>] [-i <index_path>] [-c <config_path>] [-s] [-C] [-d] [-h]"
     echo -e "\t-b <bucket_name>: Bucket name. Default: example"
     echo -e "\t-p <epr_address>: Address of the package registry service. Default: localhost:8080"
     echo -e "\t-e <emulator_address>: Address of the emulator host (fake GCS server). Default: localhost:4443"
@@ -20,6 +20,7 @@ usage() {
     echo -e "\t-c <config_path>: Path to the configurastion file. Default: \"\""
     echo -e "\t-s : Enable SQL Storage indexer. By default Storage Indexer is enabled."
     echo -e "\t-C : Enable Search Cache. Just supported with SQL Storage indexer. By default Search Cache is disabled."
+    echo -e "\t-d: Enable debug mode. Default: false"
     echo -e "\t-h: Show this message"
 }
 
@@ -30,8 +31,9 @@ EMULATOR_HOST="localhost:4443"
 CONFIG_PATH="${SCRIPT_DIR}/../config.yml"
 ENABLE_STORAGE_SQL_INDEXER=0
 ENABLE_SEARCH_CACHE=0
+ENABLE_DEBUG_MODE=0
 
-while getopts ":b:p:i:e:c:sCh" o; do
+while getopts ":b:p:i:e:c:sdCh" o; do
   case "${o}" in
     b)
       BUCKET_NAME="${OPTARG}"
@@ -53,6 +55,9 @@ while getopts ":b:p:i:e:c:sCh" o; do
       ;;
     C)
       ENABLE_SEARCH_CACHE=1
+      ;;
+    d)
+      ENABLE_DEBUG_MODE=1
       ;;
     h)
       usage
@@ -103,7 +108,9 @@ fi
 export EPR_DISABLE_PACKAGE_VALIDATION="true"
 export EPR_ADDRESS="${ADDRESS}"
 
-# export EPR_LOG_LEVEL="debug"
+if [[ "${ENABLE_DEBUG_MODE}" == 1 ]]; then
+    export EPR_LOG_LEVEL="debug"
+fi
 export EPR_CONFIG="${CONFIG_PATH}"
 # export EPR_SQL_INDEXER_DATABASE_FOLDER_PATH=/tmp
 # export EPR_SQL_INDEXER_SEARCH_CACHE_SIZE=100

--- a/search.go
+++ b/search.go
@@ -81,8 +81,12 @@ func searchHandlerWithProxyMode(logger *zap.Logger, indexer Indexer, proxyMode *
 		if cache != nil {
 			switch {
 			case filter.PackageName != "" && !filter.AllVersions:
-				// requests like `/search?package=foo` are not added to the cache
-				// but `/search?package=foo&all=true` is added
+				// Due to the potential for a large volume of unique requests,
+				// the cache could be easily filled just with those requests or causing evictions.
+				// Moreover, these requests (just querying for a package) typically have rapid response times,
+				// which means not using the cache is acceptable. Example:
+				// - `/search?package=foo` request is not added to the cache
+				// - `/search?package=foo&all=true` request is is added
 				logger.Debug("skipped add to cache for search request with package query parameter", zap.String("cache.url", r.URL.String()), zap.Int("cache.size", cache.Len()))
 			default:
 				val := cache.Add(r.URL.String(), data)


### PR DESCRIPTION
This PR avoids storing in the search cache requests that contain the `package=<package>` query parameter.

Due to the potential for a large volume of unique requests, the cache could be easily filled just with those requests or causing evictions. Moreover, these requests (just querying for a package) typically have rapid response times, which means not using the cache is acceptable.

### How to test this PR locally

Run in a terminal EPR setting up a SQL storage indexer with Debug log level:
```shell
bash dev/launch_epr_service_storage_indexer.sh \
  -i storage/testdata/search-index-all-full.json \
  -s -C -d \
  -p localhost:8081
```

In another terminal, run the following queries for the local EPR:
```shell
curl -s "http://localhost:8081/search?package=zoom&prerelease=true"

# it should appear a log message skipping the cache
# {"log.level":"debug",...,"message":"skipped add to cache for search request with package query parameter","cache.url":"/search?package=zoom&prerelease=true","cache.size":0}

curl -s "http://localhost:8081/search?package=zoom&prerelease=true&all=true"

# it should appear a log message storing response in the cache
# {"log.level":"debug",...,"message":"added to cache request","cache.url":"/search?package=zoom&prerelease=true&all=true","cache.size":1,"cache.eviction":false}

curl -s "http://localhost:8081/search?prerelease=true"

# it should appear a log message storing response in the cache
# {"log.level":"debug",...,"message":"added to cache request","cache.url":"/search?prerelease=true","cache.size":2,"cache.eviction":false}

```
