### PR TITLE
[SQL Storage Indexer] Skip unmarshalling JSON fields in statics, artifacts and static handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Avoid parsing JSON columns in queries performed to artifacts related endpoints (SQL storage indexer). [#1386](https://github.com/elastic/package-registry/pull/1386)
+
 ### Deprecated
 
 ### Known Issues

--- a/artifacts.go
+++ b/artifacts.go
@@ -82,7 +82,7 @@ func (h *artifactsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	opts := packages.NameVersionFilter(packageName, packageVersion)
-	opts.SkipJSON = true
+	opts.SkipPackageData = true
 
 	pkgs, err := h.indexer.Get(r.Context(), &opts)
 	if err != nil {

--- a/artifacts.go
+++ b/artifacts.go
@@ -82,6 +82,8 @@ func (h *artifactsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	opts := packages.NameVersionFilter(packageName, packageVersion)
+	opts.SkipJSON = true
+
 	pkgs, err := h.indexer.Get(r.Context(), &opts)
 	if err != nil {
 		logger.Error("getting package path failed",

--- a/internal/database/repository.go
+++ b/internal/database/repository.go
@@ -22,4 +22,5 @@ type Repository interface {
 type WhereOptions interface {
 	Where() (string, []any)
 	UseFullData() bool
+	SkipJSONFields() bool
 }

--- a/internal/database/sqliterepository.go
+++ b/internal/database/sqliterepository.go
@@ -16,7 +16,12 @@ import (
 	"go.elastic.co/apm/v2"
 )
 
-const defaultMaxBulkAddBatch = 500
+const (
+	defaultMaxBulkAddBatch = 500
+
+	dataColumnName     = "data"
+	baseDataColumnName = "baseData"
+)
 
 var (
 	ErrDuplicate    = errors.New("record already exists")
@@ -40,8 +45,8 @@ var keys = []keyDefinition{
 	{"kibanaVersion", "TEXT NOT NULL"},
 	{"type", "TEXT NOT NULL"},
 	{"path", "TEXT NOT NULL"},
-	{"data", "BLOB NOT NULL"},
-	{"baseData", "BLOB NOT NULL"},
+	{dataColumnName, "BLOB NOT NULL"},
+	{baseDataColumnName, "BLOB NOT NULL"},
 }
 
 type SQLiteRepository struct {
@@ -279,11 +284,11 @@ func (r *SQLiteRepository) AllFunc(ctx context.Context, database string, whereOp
 	query.WriteString("SELECT ")
 	for _, k := range keys {
 		switch {
-		case !useJSONFields && (k.Name == "data" || k.Name == "baseData"):
+		case !useJSONFields && (k.Name == dataColumnName || k.Name == baseDataColumnName):
 			continue
-		case k.Name == "data" && useBaseData:
+		case k.Name == dataColumnName && useBaseData:
 			continue
-		case k.Name == "baseData" && !useBaseData:
+		case k.Name == baseDataColumnName && !useBaseData:
 			continue
 		default:
 			getKeys = append(getKeys, k.Name)

--- a/internal/database/sqliterepository.go
+++ b/internal/database/sqliterepository.go
@@ -377,7 +377,7 @@ type SQLOptions struct {
 	CurrentCursor string
 
 	IncludeFullData bool // If true, the query will return the full data field instead of the base data field
-	SkipJSON        bool // If true, no need to retrieve Data nor BaseData fields
+	SkipPackageData bool // If true, no need to retrieve Data nor BaseData fields
 }
 
 func (o *SQLOptions) Where() (string, []any) {
@@ -447,5 +447,5 @@ func (o *SQLOptions) SkipJSONFields() bool {
 	if o == nil {
 		return false
 	}
-	return o.SkipJSON
+	return o.SkipPackageData
 }

--- a/internal/database/sqliterepository.go
+++ b/internal/database/sqliterepository.go
@@ -274,7 +274,7 @@ func (r *SQLiteRepository) AllFunc(ctx context.Context, database string, whereOp
 	useJSONFields := whereOptions == nil || !whereOptions.SkipJSONFields()
 	useBaseData := whereOptions == nil || !whereOptions.UseFullData()
 
-	var getKeys []string
+	getKeys := make([]string, 0, len(keys))
 	var query strings.Builder
 	query.WriteString("SELECT ")
 	for _, k := range keys {

--- a/internal/database/sqliterepository.go
+++ b/internal/database/sqliterepository.go
@@ -278,16 +278,16 @@ func (r *SQLiteRepository) AllFunc(ctx context.Context, database string, whereOp
 	var query strings.Builder
 	query.WriteString("SELECT ")
 	for _, k := range keys {
-		if !useJSONFields && (k.Name == "data" || k.Name == "baseData") {
+		switch {
+		case !useJSONFields && (k.Name == "data" || k.Name == "baseData"):
 			continue
-		}
-		if k.Name == "data" && useBaseData {
+		case k.Name == "data" && useBaseData:
 			continue
-		}
-		if k.Name == "baseData" && !useBaseData {
+		case k.Name == "baseData" && !useBaseData:
 			continue
+		default:
+			getKeys = append(getKeys, k.Name)
 		}
-		getKeys = append(getKeys, k.Name)
 	}
 	query.WriteString(strings.Join(getKeys, ", "))
 	query.WriteString(" FROM ")

--- a/internal/database/sqliterepository.go
+++ b/internal/database/sqliterepository.go
@@ -276,8 +276,8 @@ func (r *SQLiteRepository) AllFunc(ctx context.Context, database string, whereOp
 	span.Context.SetLabel("database.path", r.File(ctx))
 	defer span.End()
 
-	useJSONFields := whereOptions == nil || !whereOptions.SkipJSONFields()
-	useBaseData := whereOptions == nil || !whereOptions.UseFullData()
+	useJSONFields := !whereOptions.SkipJSONFields()
+	useBaseData := !whereOptions.UseFullData()
 
 	getKeys := make([]string, 0, len(keys))
 	var query strings.Builder

--- a/internal/storage/sqlindexer.go
+++ b/internal/storage/sqlindexer.go
@@ -374,11 +374,6 @@ func (i *SQLIndexer) Get(ctx context.Context, opts *packages.GetOptions) (packag
 			var err error
 			switch {
 			case opts != nil && opts.SkipPackageData:
-				// pkg, err = packages.NewPackageWithOpts(i.logger,
-				// 	packages.WithFormatVersion(p.FormatVersion),
-				// 	packages.WithPackageName(p.Name),
-				// 	packages.WithPackageVersion(p.Version),
-				// )
 				pkg, err = packages.NewMinimalPackage(p.Name, p.Version, p.FormatVersion)
 				if err != nil {
 					return fmt.Errorf("failed to create minimal package %s-%s: %w", p.Name, p.Version, err)

--- a/internal/storage/sqlindexer.go
+++ b/internal/storage/sqlindexer.go
@@ -407,11 +407,11 @@ func (i *SQLIndexer) Get(ctx context.Context, opts *packages.GetOptions) (packag
 		i.logger.Debug("Number of packages read from database", zap.Int("num.packages", len(readPackages)))
 
 		if opts != nil && opts.Filter != nil {
-			if opts.SkipPackageData && opts.Filter.PackageName != "" && opts.Filter.PackageVersion != "" {
+			if opts.Filter.PackageName != "" && opts.Filter.PackageVersion != "" {
 				if len(readPackages) > 1 {
 					return fmt.Errorf("expected at most one package when filtering by name and version, got %d", len(readPackages))
 				}
-				// If we are filtering by name and version and we are skipping package data, we can return early.
+				// If we are filtering by name and version at database level, there should be at most one package and it can be returned early.
 				return nil
 			}
 			readPackages, err = opts.Filter.Apply(ctx, readPackages)

--- a/internal/storage/sqlindexer.go
+++ b/internal/storage/sqlindexer.go
@@ -366,14 +366,14 @@ func (i *SQLIndexer) Get(ctx context.Context, opts *packages.GetOptions) (packag
 		}
 		if opts != nil {
 			options.IncludeFullData = opts.FullData
-			options.SkipJSON = opts.SkipJSON
+			options.SkipPackageData = opts.SkipPackageData
 		}
 
 		err := (*i.current).AllFunc(ctx, "packages", options, func(ctx context.Context, p *database.Package) error {
 			var pkg packages.Package
 			var err error
 			switch {
-			case opts != nil && opts.SkipJSON:
+			case opts != nil && opts.SkipPackageData:
 				var pPkg *packages.Package
 				pPkg, err = packages.NewPackageWithOpts(i.logger,
 					packages.WithFormatVersion(p.FormatVersion),

--- a/internal/storage/sqlindexer_test.go
+++ b/internal/storage/sqlindexer_test.go
@@ -204,11 +204,13 @@ func BenchmarkSQLIndexerGetStaticsAndArtifacts(b *testing.B) {
 			PackageName:    "aws",
 			PackageVersion: "1.16.4",
 			Prerelease:     true,
+			Experimental:   true,
 		}, SkipPackageData: skipJSON})
 		indexer.Get(context.Background(), &packages.GetOptions{Filter: &packages.Filter{
 			PackageName:    "zoom",
 			PackageVersion: "1.2.1",
 			Prerelease:     true,
+			Experimental:   true,
 		}, SkipPackageData: skipJSON})
 		indexer.Get(context.Background(), &packages.GetOptions{Filter: &packages.Filter{
 			PackageName:    "aws",

--- a/internal/storage/sqlindexer_test.go
+++ b/internal/storage/sqlindexer_test.go
@@ -6,6 +6,7 @@ package storage
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"path/filepath"
 	"testing"
@@ -183,7 +184,7 @@ func BenchmarkSQLIndexerGetStaticsAndArtifacts(b *testing.B) {
 	options, err := CreateFakeIndexerOptions(db, swapDb)
 	require.NoError(b, err)
 
-	fs := PrepareFakeServer(b, "../../storage/testdata/search-index-all-full.json")
+	fs := PrepareFakeServer(b, "../../storage/testdata/search-index-all.json")
 	defer fs.Stop()
 	storageClient := fs.Client()
 
@@ -538,4 +539,86 @@ func TestSQLGet_IndexUpdated(t *testing.T) {
 	require.Equal(t, "1password", foundPackages[0].Name)
 	require.Equal(t, "0.2.0", foundPackages[0].Version)
 	require.Equal(t, "1Password Events Reporting UPDATED", *foundPackages[0].Title)
+}
+
+func TestCreateDatabasePackage(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		title    string
+		cursor   string
+		pkgBytes []byte
+		expected *database.Package
+	}{
+		{
+			title: "package with minimum data",
+			pkgBytes: []byte(`{
+  "name": "mypackage",
+  "version": "1.2.3",
+  "format_version": "2.2.2",
+  "type": "integration",
+  "description": "My package description",
+  "categories": ["cat1", "cat2"],
+  "conditions": {
+    "kibana": {
+      "version": "^8.17.0"
+	}
+  }
+}`),
+			cursor: "1",
+			expected: &database.Package{
+				Cursor:        "1",
+				Name:          "mypackage",
+				Version:       "1.2.3",
+				KibanaVersion: "^8.17.0",
+				FormatVersion: "2.2.2",
+				Type:          "integration",
+				Path:          "mypackage-1.2.3.zip",
+				Data:          []byte(`{"name":"mypackage","version":"1.2.3","description":"My package description","type":"integration","download":"","path":"","conditions":{"kibana":{"version":"^8.17.0"}},"categories":["cat1","cat2"],"format_version":"2.2.2"}`),
+				BaseData:      []byte(`{"name":"mypackage","version":"1.2.3","description":"My package description","type":"integration","download":"","path":"","conditions":{"kibana":{"version":"^8.17.0"}},"categories":["cat1","cat2"]}`),
+				Prerelease:    false,
+			},
+		},
+		{
+			title: "prerelease package",
+			pkgBytes: []byte(`{
+  "name": "mypackage",
+  "version": "1.2.3-beta1",
+  "format_version": "2.2.2",
+  "type": "integration",
+  "description": "My package description",
+  "categories": ["cat1", "cat2"],
+  "conditions": {
+    "kibana": {
+      "version": "^8.17.0"
+	}
+  }
+}`),
+			cursor: "1",
+			expected: &database.Package{
+				Cursor:        "1",
+				Name:          "mypackage",
+				Version:       "1.2.3-beta1",
+				KibanaVersion: "^8.17.0",
+				FormatVersion: "2.2.2",
+				Type:          "integration",
+				Path:          "mypackage-1.2.3-beta1.zip",
+				Data:          []byte(`{"name":"mypackage","version":"1.2.3-beta1","description":"My package description","type":"integration","download":"","path":"","conditions":{"kibana":{"version":"^8.17.0"}},"categories":["cat1","cat2"],"format_version":"2.2.2"}`),
+				BaseData:      []byte(`{"name":"mypackage","version":"1.2.3-beta1","description":"My package description","type":"integration","download":"","path":"","conditions":{"kibana":{"version":"^8.17.0"}},"categories":["cat1","cat2"]}`),
+				Prerelease:    true,
+			},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.title, func(t *testing.T) {
+			// when
+			pkg := &packages.Package{}
+			err := json.Unmarshal(c.pkgBytes, pkg)
+			require.NoError(t, err, "package should be unmarshalled")
+			dbPkg, err := createDatabasePackage(pkg, c.cursor)
+			require.NoError(t, err, "database package should be created")
+			// then
+			assert.Equal(t, c.expected, dbPkg)
+		})
+	}
 }

--- a/internal/storage/sqlindexer_test.go
+++ b/internal/storage/sqlindexer_test.go
@@ -204,24 +204,24 @@ func BenchmarkSQLIndexerGetStaticsAndArtifacts(b *testing.B) {
 			PackageName:    "aws",
 			PackageVersion: "1.16.4",
 			Prerelease:     true,
-		}, SkipJSON: skipJSON})
+		}, SkipPackageData: skipJSON})
 		indexer.Get(context.Background(), &packages.GetOptions{Filter: &packages.Filter{
 			PackageName:    "zoom",
 			PackageVersion: "1.2.1",
 			Prerelease:     true,
-		}, SkipJSON: skipJSON})
+		}, SkipPackageData: skipJSON})
 		indexer.Get(context.Background(), &packages.GetOptions{Filter: &packages.Filter{
 			PackageName:    "aws",
 			PackageVersion: "1.16.4",
 			Prerelease:     true,
 			Experimental:   true,
-		}, SkipJSON: skipJSON})
+		}, SkipPackageData: skipJSON})
 		indexer.Get(context.Background(), &packages.GetOptions{Filter: &packages.Filter{
 			PackageName:    "zoom",
 			PackageVersion: "1.2.1",
 			Prerelease:     true,
 			Experimental:   true,
-		}, SkipJSON: skipJSON})
+		}, SkipPackageData: skipJSON})
 	}
 }
 

--- a/internal/storage/sqlindexer_test.go
+++ b/internal/storage/sqlindexer_test.go
@@ -196,7 +196,7 @@ func BenchmarkSQLIndexerGetStaticsAndArtifacts(b *testing.B) {
 	err = indexer.Init(ctx)
 	require.NoError(b, err)
 
-	skipJSON := false
+	skipJSON := true
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		// Mimic call to static handler
@@ -204,13 +204,23 @@ func BenchmarkSQLIndexerGetStaticsAndArtifacts(b *testing.B) {
 			PackageName:    "aws",
 			PackageVersion: "1.16.4",
 			Prerelease:     true,
-			// Experimental:   true,
 		}, SkipJSON: skipJSON})
 		indexer.Get(context.Background(), &packages.GetOptions{Filter: &packages.Filter{
 			PackageName:    "zoom",
 			PackageVersion: "1.2.1",
 			Prerelease:     true,
-			// Experimental:   true,
+		}, SkipJSON: skipJSON})
+		indexer.Get(context.Background(), &packages.GetOptions{Filter: &packages.Filter{
+			PackageName:    "aws",
+			PackageVersion: "1.16.4",
+			Prerelease:     true,
+			Experimental:   true,
+		}, SkipJSON: skipJSON})
+		indexer.Get(context.Background(), &packages.GetOptions{Filter: &packages.Filter{
+			PackageName:    "zoom",
+			PackageVersion: "1.2.1",
+			Prerelease:     true,
+			Experimental:   true,
 		}, SkipJSON: skipJSON})
 	}
 }

--- a/internal/storage/sqlindexer_test.go
+++ b/internal/storage/sqlindexer_test.go
@@ -183,7 +183,7 @@ func BenchmarkSQLIndexerGetStaticsAndArtifacts(b *testing.B) {
 	options, err := CreateFakeIndexerOptions(db, swapDb)
 	require.NoError(b, err)
 
-	fs := PrepareFakeServer(b, "testdata/search-index-all-full.json")
+	fs := PrepareFakeServer(b, "../../storage/testdata/search-index-all-full.json")
 	defer fs.Stop()
 	storageClient := fs.Client()
 

--- a/packages/package.go
+++ b/packages/package.go
@@ -247,25 +247,6 @@ func MustParsePackage(basePath string, fsBuilder FileSystemBuilder) (*Package, e
 	return p, nil
 }
 
-// NewMinimalPackage creates a new minimal package instance with the given name, version, and spec version
-// without loading any files from disk. It also sets runtime fields like versionSemVer and specMajorMinorSemVer.
-// It is used in scenarios where only basic package information is needed.
-// The returned package instance will not have fields like Assets, DataStreams, PolicyTemplates, etc. populated.
-func NewMinimalPackage(name, packageVersion, specVersion string) (*Package, error) {
-	p := Package{
-		FormatVersion: specVersion,
-	}
-	p.Name = name
-	p.Version = packageVersion
-
-	err := p.setRuntimeFields()
-	if err != nil {
-		return nil, err
-	}
-	p.Release = releaseForSemVerCompat(p.versionSemVer)
-	return &p, nil
-}
-
 // NewPackage creates a new package instances based on the given base path.
 // The path passed goes to the root of the package where the manifest.yml is.
 func NewPackage(logger *zap.Logger, basePath string, fsBuilder FileSystemBuilder) (*Package, error) {

--- a/packages/package.go
+++ b/packages/package.go
@@ -247,6 +247,21 @@ func MustParsePackage(basePath string, fsBuilder FileSystemBuilder) (*Package, e
 	return p, nil
 }
 
+func NewMinimalPackage(name, packageVersion, specVersion string) (*Package, error) {
+	p := Package{
+		FormatVersion: specVersion,
+	}
+	p.Name = name
+	p.Version = packageVersion
+
+	err := p.setRuntimeFields()
+	if err != nil {
+		return nil, err
+	}
+	p.Release = releaseForSemVerCompat(p.versionSemVer)
+	return &p, nil
+}
+
 type PackageOption func(p *Package) error
 
 func NewPackageWithOpts(logger *zap.Logger, opts ...PackageOption) (*Package, error) {

--- a/packages/packages.go
+++ b/packages/packages.go
@@ -91,6 +91,7 @@ type GetOptions struct {
 	Filter *Filter
 
 	FullData bool
+	SkipJSON bool
 }
 
 // FileSystemIndexer indexes packages from the filesystem.

--- a/packages/packages.go
+++ b/packages/packages.go
@@ -90,8 +90,8 @@ type GetOptions struct {
 	// where experimental packages are filtered by default.
 	Filter *Filter
 
-	FullData bool
-	SkipJSON bool
+	FullData        bool
+	SkipPackageData bool
 }
 
 // FileSystemIndexer indexes packages from the filesystem.

--- a/signatures.go
+++ b/signatures.go
@@ -82,7 +82,7 @@ func (h *signaturesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	opts := packages.NameVersionFilter(packageName, packageVersion)
-	opts.SkipJSON = true
+	opts.SkipPackageData = true
 
 	pkgs, err := h.indexer.Get(r.Context(), &opts)
 	if err != nil {

--- a/signatures.go
+++ b/signatures.go
@@ -82,6 +82,8 @@ func (h *signaturesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	opts := packages.NameVersionFilter(packageName, packageVersion)
+	opts.SkipJSON = true
+
 	pkgs, err := h.indexer.Get(r.Context(), &opts)
 	if err != nil {
 		logger.Error("getting package path failed",

--- a/static.go
+++ b/static.go
@@ -73,7 +73,7 @@ func (h *staticHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	opts := packages.NameVersionFilter(params.packageName, params.packageVersion)
-	opts.SkipJSON = true
+	opts.SkipPackageData = true
 
 	pkgs, err := h.indexer.Get(r.Context(), &opts)
 	if err != nil {

--- a/static.go
+++ b/static.go
@@ -73,6 +73,8 @@ func (h *staticHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	opts := packages.NameVersionFilter(params.packageName, params.packageVersion)
+	opts.SkipJSON = true
+
 	pkgs, err := h.indexer.Get(r.Context(), &opts)
 	if err != nil {
 		logger.Error("getting package path failed",


### PR DESCRIPTION
Closes https://github.com/elastic/package-registry/issues/1387

This PR allows to not read the JSON field from the database for requests received to statics, artifacts or signature handlers (`/package` and `/epr` endpoints):
- `/package/<package>/<version>/<static_file_path>` (staticsHandler)
- `/epr/<package>/<package>-<version>.zip` (artifactsHandler)
- `/epr/<package>/<package>-<version>.zip.sig` (signaturesHandler)

The required responses could be built without the information in `data` or `BaseData` columns from the SQL database (JSON blobs).

Results of a local benchmark for the specific Get calls executed in the API endpoints mentioned above:
```
goos: linux
goarch: amd64
pkg: github.com/elastic/package-registry/internal/storage
cpu: 11th Gen Intel(R) Core(TM) i7-11800H @ 2.30GHz
                                    │ sql_prod_get_statics_main.txt │   sql_prod_statics_skip_json.txt    │
                                    │            sec/op             │   sec/op     vs base                │
SQLIndexerGetStaticsAndArtifacts-16                     998.9µ ± 7%   247.1µ ± 4%  -75.27% (p=0.000 n=10)

                                    │ sql_prod_get_statics_main.txt │    sql_prod_statics_skip_json.txt    │
                                    │             B/op              │     B/op      vs base                │
SQLIndexerGetStaticsAndArtifacts-16                   171.81Ki ± 0%   28.22Ki ± 0%  -83.58% (p=0.000 n=10)

                                    │ sql_prod_get_statics_main.txt │   sql_prod_statics_skip_json.txt   │
                                    │           allocs/op           │ allocs/op   vs base                │
SQLIndexerGetStaticsAndArtifacts-16                     1612.0 ± 0%   404.0 ± 0%  -74.94% (p=0.000 n=10)
```