### PR TITLE
Apply validation of unknown query parameters just to search and categories endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Breaking changes
 
 ### Bugfixes
+* Update -allow-unknown-query-parameters flag to allow unknown query parameters by default. [#1395](https://github.com/elastic/package-registry/pull/1395)
+* Narrow the scope of the endpoints that validate the unknown parameters to just /search and /categories.. [#1395](https://github.com/elastic/package-registry/pull/1395)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Breaking changes
 
 ### Bugfixes
+
 * Update -allow-unknown-query-parameters flag to allow unknown query parameters by default. [#1395](https://github.com/elastic/package-registry/pull/1395)
 * Narrow the scope of the endpoints that validate the unknown parameters to just /search and /categories.. [#1395](https://github.com/elastic/package-registry/pull/1395)
 

--- a/artifacts.go
+++ b/artifacts.go
@@ -27,8 +27,7 @@ type artifactsHandler struct {
 	indexer   Indexer
 	cacheTime time.Duration
 
-	proxyMode                   *proxymode.ProxyMode
-	allowUnknownQueryParameters bool
+	proxyMode *proxymode.ProxyMode
 }
 
 type artifactsOption func(*artifactsHandler)
@@ -60,20 +59,8 @@ func artifactsWithProxy(pm *proxymode.ProxyMode) artifactsOption {
 	}
 }
 
-func artifactsWithAllowUnknownQueryParameters(allow bool) artifactsOption {
-	return func(h *artifactsHandler) {
-		h.allowUnknownQueryParameters = allow
-	}
-}
-
 func (h *artifactsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	logger := h.logger.With(apmzap.TraceContext(r.Context())...)
-
-	// Return error if any query parameter is present
-	if !h.allowUnknownQueryParameters && len(r.URL.Query()) > 0 {
-		badRequest(w, "not supported query parameters")
-		return
-	}
 
 	vars := mux.Vars(r)
 	packageName, ok := vars["packageName"]

--- a/categories.go
+++ b/categories.go
@@ -49,9 +49,10 @@ func newCategoriesHandler(logger *zap.Logger, indexer Indexer, cacheTime time.Du
 	}
 
 	h := &categoriesHandler{
-		logger:    logger,
-		indexer:   indexer,
-		cacheTime: cacheTime,
+		logger:                      logger,
+		indexer:                     indexer,
+		cacheTime:                   cacheTime,
+		allowUnknownQueryParameters: true,
 	}
 
 	for _, opt := range opts {

--- a/favicon.go
+++ b/favicon.go
@@ -16,39 +16,19 @@ var faviconBlob []byte
 
 type faviconHandler struct {
 	cacheTime time.Duration
-
-	allowUnknownQueryParameters bool
 }
 
-type faviconOption func(*faviconHandler)
-
-func newFaviconHandler(cacheTime time.Duration, opts ...faviconOption) (*faviconHandler, error) {
+func newFaviconHandler(cacheTime time.Duration) (*faviconHandler, error) {
 	if cacheTime <= 0 {
 		return nil, errors.New("cache time must be greater than 0s")
 	}
 
-	h := &faviconHandler{
+	return &faviconHandler{
 		cacheTime: cacheTime,
-	}
-	for _, opt := range opts {
-		opt(h)
-	}
-	return h, nil
-}
-
-func faviconWithAllowUnknownQueryParameters(allow bool) faviconOption {
-	return func(h *faviconHandler) {
-		h.allowUnknownQueryParameters = allow
-	}
+	}, nil
 }
 
 func (h *faviconHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	// Return error if any query parameter is present
-	if !h.allowUnknownQueryParameters && len(r.URL.Query()) > 0 {
-		badRequest(w, "not supported query parameters")
-		return
-	}
-
 	w.Header().Set("Content-Type", "image/x-icon")
 	cacheHeaders(w, h.cacheTime)
 	w.Write(faviconBlob)

--- a/health.go
+++ b/health.go
@@ -5,42 +5,15 @@
 package main
 
 import (
-	"fmt"
 	"net/http"
 )
 
 // healthHandler is used for Docker/K8s deployments. It returns 200 if the service is live
 // In addition ?ready=true can be used for a ready request. Currently both are identical.
-type healthHandler struct {
-	allowUnknownQueryParameters bool
+type healthHandler struct{}
+
+func newHealthHandler() *healthHandler {
+	return &healthHandler{}
 }
 
-type healthOption func(*healthHandler)
-
-func newHealthHandler(opts ...func(*healthHandler)) *healthHandler {
-	h := &healthHandler{}
-	for _, opt := range opts {
-		opt(h)
-	}
-	return h
-}
-
-func healthWithAllowUnknownQueryParameters(allow bool) healthOption {
-	return func(h *healthHandler) {
-		h.allowUnknownQueryParameters = allow
-	}
-}
-
-func (h *healthHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	for k := range r.URL.Query() {
-		switch k {
-		case "ready":
-			// Ready check, currently same as live check
-		default:
-			if !h.allowUnknownQueryParameters {
-				badRequest(w, fmt.Sprintf("unknown query parameter: %s", k))
-				return
-			}
-		}
-	}
-}
+func (h *healthHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {}

--- a/main.go
+++ b/main.go
@@ -114,7 +114,7 @@ func init() {
 	// This flag is experimental and might be removed in the future or renamed
 	flag.BoolVar(&dryRun, "dry-run", false, "Runs a dry-run of the registry without starting the web service (experimental).")
 	flag.BoolVar(&packages.ValidationDisabled, "disable-package-validation", false, "Disable package content validation.")
-	flag.BoolVar(&allowUnknownQueryParameters, "allow-unknown-query-parameters", false, "Allow unknown query parameters in the request. If set to false, the server will return an error if any unknown query parameter is present in the request.")
+	flag.BoolVar(&allowUnknownQueryParameters, "allow-unknown-query-parameters", true, "Allow unknown query parameters in the request. If set to false, the server will return an error if any unknown query parameter is present in the request.")
 
 	flag.BoolVar(&featureStorageIndexer, "feature-storage-indexer", false, "Enable storage indexer to include packages from Package Storage v2.")
 	flag.StringVar(&storageIndexerBucketInternal, "storage-indexer-bucket-internal", "", "Path to the internal Package Storage bucket (with gs:// prefix).")
@@ -635,33 +635,27 @@ func getRouter(logger *zap.Logger, options serverOptions) (*mux.Router, error) {
 	}
 	artifactsHandler, err := newArtifactsHandler(logger, options.indexer, options.config.CacheTimeCatchAll,
 		artifactsWithProxy(proxyMode),
-		artifactsWithAllowUnknownQueryParameters(allowUnknownQueryParameters),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("can't create artifacts handler: %w", err)
 	}
 	signaturesHandler, err := newSignaturesHandler(logger, options.indexer, options.config.CacheTimeCatchAll,
-		signaturesWithAllowUnknownQueryParameters(allowUnknownQueryParameters),
 		signaturesWithProxy(proxyMode),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("can't create signatures handler: %w", err)
 	}
-	faviconHandler, err := newFaviconHandler(options.config.CacheTimeCatchAll,
-		faviconWithAllowUnknownQueryParameters(allowUnknownQueryParameters),
-	)
+	faviconHandler, err := newFaviconHandler(options.config.CacheTimeCatchAll)
 	if err != nil {
 		return nil, fmt.Errorf("can't create favicon handler: %w", err)
 	}
 
-	indexHandler, err := newIndexHandler(options.config.CacheTimeIndex,
-		indexWithAllowUnknownQueryParameters(allowUnknownQueryParameters),
-	)
+	indexHandler, err := newIndexHandler(options.config.CacheTimeIndex)
 	if err != nil {
 		return nil, fmt.Errorf("can't create index handler: %w", err)
 	}
 
-	healthHandler := newHealthHandler(healthWithAllowUnknownQueryParameters(allowUnknownQueryParameters))
+	healthHandler := newHealthHandler()
 
 	categoriesHandler, err := newCategoriesHandler(logger, options.indexer, options.config.CacheTimeCategories,
 		categoriesWithProxy(proxyMode),
@@ -673,7 +667,6 @@ func getRouter(logger *zap.Logger, options serverOptions) (*mux.Router, error) {
 	}
 	packageIndexHandler, err := newPackageIndexHandler(logger, options.indexer, options.config.CacheTimeIndex,
 		packageIndexWithProxy(proxyMode),
-		packageIndexWithAllowUnknownQueryParameters(allowUnknownQueryParameters),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("can't create package index handler: %w", err)
@@ -689,7 +682,6 @@ func getRouter(logger *zap.Logger, options serverOptions) (*mux.Router, error) {
 	}
 	staticHandler, err := newStaticHandler(logger, options.indexer, options.config.CacheTimeCatchAll,
 		staticWithProxy(proxyMode),
-		staticWithAllowUnknownQueryParameters(allowUnknownQueryParameters),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("can't create static handler: %w", err)

--- a/main_test.go
+++ b/main_test.go
@@ -81,8 +81,8 @@ func TestEndpoints(t *testing.T) {
 	categoriesHandler, err := newCategoriesHandler(testLogger, indexer, testCacheTime)
 	require.NoError(t, err)
 
-	allowUnknownQueryParamsSearchHandler, err := newSearchHandler(testLogger, indexer, testCacheTime,
-		searchWithAllowUnknownQueryParameters(true),
+	disallowUnknownQueryParamsSearchHandler, err := newSearchHandler(testLogger, indexer, testCacheTime,
+		searchWithAllowUnknownQueryParameters(false),
 	)
 	require.NoError(t, err)
 
@@ -149,8 +149,8 @@ func TestEndpoints(t *testing.T) {
 		{"/search?internal=true", "/search", "search-package-internal.json", searchHandler},
 
 		// Test queries with unknown query parameters
-		{"/search?package=yamlpipeline&unknown=true", "/search", "search-unknown-query-parameter-error.txt", searchHandler},
-		{"/search?package=yamlpipeline&unknown=true", "/search", "search-allowed-unknown-query-parameter.json", allowUnknownQueryParamsSearchHandler},
+		{"/search?package=yamlpipeline&unknown=true", "/search", "search-unknown-query-parameter-error.txt", disallowUnknownQueryParamsSearchHandler},
+		{"/search?package=yamlpipeline&unknown=true", "/search", "search-allowed-unknown-query-parameter.json", searchHandler},
 	}
 
 	for _, test := range tests {

--- a/package_index.go
+++ b/package_index.go
@@ -32,8 +32,7 @@ type packageIndexHandler struct {
 	cacheTime time.Duration
 	indexer   Indexer
 
-	proxyMode                   *proxymode.ProxyMode
-	allowUnknownQueryParameters bool
+	proxyMode *proxymode.ProxyMode
 }
 
 type packageIndexOption func(*packageIndexHandler)
@@ -64,20 +63,8 @@ func packageIndexWithProxy(pm *proxymode.ProxyMode) packageIndexOption {
 		h.proxyMode = pm
 	}
 }
-func packageIndexWithAllowUnknownQueryParameters(allow bool) packageIndexOption {
-	return func(h *packageIndexHandler) {
-		h.allowUnknownQueryParameters = allow
-	}
-}
-
 func (h *packageIndexHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	logger := h.logger.With(apmzap.TraceContext(r.Context())...)
-
-	// Return error if any query parameter is present
-	if !h.allowUnknownQueryParameters && len(r.URL.Query()) > 0 {
-		badRequest(w, "not supported query parameters")
-		return
-	}
 
 	vars := mux.Vars(r)
 	packageName, ok := vars["packageName"]

--- a/package_storage_test.go
+++ b/package_storage_test.go
@@ -56,8 +56,8 @@ func generateTestCaseStorageEndpoints(indexer Indexer) ([]struct {
 	if err != nil {
 		return nil, err
 	}
-	allowUnknownQueryParamsSearchHandler, err := newSearchHandler(testLogger, indexer, testCacheTime,
-		searchWithAllowUnknownQueryParameters(true),
+	disallowUnknownQueryParamsSearchHandler, err := newSearchHandler(testLogger, indexer, testCacheTime,
+		searchWithAllowUnknownQueryParameters(false),
 	)
 	if err != nil {
 		return nil, err
@@ -97,8 +97,8 @@ func generateTestCaseStorageEndpoints(indexer Indexer) ([]struct {
 		{"/search?internal=true", "/search", "search-package-internal.json", searchHandler},
 
 		// Test queries with unknown query parameters
-		{"/search?package=yamlpipeline&unknown=true", "/search", "search-unknown-query-parameter-error.txt", searchHandler},
-		{"/search?package=yamlpipeline&unknown=true", "/search", "search-allowed-unknown-query-parameter.json", allowUnknownQueryParamsSearchHandler},
+		{"/search?package=yamlpipeline&unknown=true", "/search", "search-unknown-query-parameter-error.txt", disallowUnknownQueryParamsSearchHandler},
+		{"/search?package=yamlpipeline&unknown=true", "/search", "search-allowed-unknown-query-parameter.json", searchHandler},
 	}, nil
 }
 

--- a/search.go
+++ b/search.go
@@ -47,9 +47,10 @@ func newSearchHandler(logger *zap.Logger, indexer Indexer, cacheTime time.Durati
 	}
 
 	h := &searchHandler{
-		logger:    logger,
-		indexer:   indexer,
-		cacheTime: cacheTime,
+		logger:                      logger,
+		indexer:                     indexer,
+		cacheTime:                   cacheTime,
+		allowUnknownQueryParameters: true,
 	}
 
 	for _, opt := range opts {

--- a/signatures.go
+++ b/signatures.go
@@ -27,8 +27,7 @@ type signaturesHandler struct {
 	indexer   Indexer
 	cacheTime time.Duration
 
-	proxyMode                   *proxymode.ProxyMode
-	allowUnknownQueryParameters bool
+	proxyMode *proxymode.ProxyMode
 }
 
 type signaturesOption func(*signaturesHandler)
@@ -60,20 +59,8 @@ func signaturesWithProxy(pm *proxymode.ProxyMode) signaturesOption {
 	}
 }
 
-func signaturesWithAllowUnknownQueryParameters(allow bool) signaturesOption {
-	return func(h *signaturesHandler) {
-		h.allowUnknownQueryParameters = allow
-	}
-}
-
 func (h *signaturesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	logger := h.logger.With(apmzap.TraceContext(r.Context())...)
-
-	// Return error if any query parameter is present
-	if !h.allowUnknownQueryParameters && len(r.URL.Query()) > 0 {
-		badRequest(w, "not supported query parameters")
-		return
-	}
 
 	vars := mux.Vars(r)
 	packageName, ok := vars["packageName"]

--- a/static.go
+++ b/static.go
@@ -31,8 +31,7 @@ type staticHandler struct {
 	indexer   Indexer
 	cacheTime time.Duration
 
-	proxyMode                   *proxymode.ProxyMode
-	allowUnknownQueryParameters bool
+	proxyMode *proxymode.ProxyMode
 }
 
 type staticOption func(*staticHandler)
@@ -64,24 +63,12 @@ func staticWithProxy(pm *proxymode.ProxyMode) staticOption {
 	}
 }
 
-func staticWithAllowUnknownQueryParameters(allow bool) staticOption {
-	return func(h *staticHandler) {
-		h.allowUnknownQueryParameters = allow
-	}
-}
-
 func (h *staticHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	logger := h.logger.With(apmzap.TraceContext(r.Context())...)
 
 	params, err := staticParamsFromRequest(r)
 	if err != nil {
 		badRequest(w, err.Error())
-		return
-	}
-
-	// Return error if any query parameter is present
-	if !h.allowUnknownQueryParameters && len(r.URL.Query()) > 0 {
-		badRequest(w, "not supported query parameters")
 		return
 	}
 


### PR DESCRIPTION
Relates #1393
Relates #1373

This PR changes the default behavior to allow unknown query parameters. The default value for `allow-unknown-query-parameters` is now `true`.

Moreover, if the unknown query parameters are disallowed, this PR narrows the scope of this validation of disallowing the unknown query parameters to just the `/search` and `/categories` EPR endpoints. 


