### PR TITLE
feat: enable DCE and reduce binary size

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ TARGET_ARCH_arm64=arm64
 OSS ?= linux
 OSS_TARGETS=$(addprefix release-, $(OSS))
 
-BUILD_FLAGS=-trimpath -ldflags=-s
+BUILD_FLAGS=-tags=grpcnotrace -trimpath -ldflags=-s
 
 .PHONY: $(OSS_TARGETS)
 $(OSS_TARGETS): release-%:


### PR DESCRIPTION
pass ldflags=-s to omit symbol table and debug information

annotations needed for stacktraces are still there, only debug
symbols needed for debugging are stripped which don't make sense
in a production binary.

Binary size went from 60M to 41M

___

add -trimpath to help with reproducible builds

strip path from the host and use consistent paths

___

remove last blocker for enabling DCE (dead code elimination) by
passing grpcnotrace tags

grpcnotrace will avoid the dependency on x/net/trace in grpc
causing DCE to be disabled because of reflection usage in text/template

Binary size went from 41M to 33M

