### PR TITLE
Use testing context when possible

### DIFF
--- a/categories_test.go
+++ b/categories_test.go
@@ -5,7 +5,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -40,9 +39,9 @@ func TestCategoriesWithProxyMode(t *testing.T) {
 	defer webServer.Close()
 
 	indexerProxy := packages.NewFileSystemIndexer(testLogger, "./testdata/second_package_path")
-	defer indexerProxy.Close(context.Background())
+	defer indexerProxy.Close(t.Context())
 
-	err := indexerProxy.Init(context.Background())
+	err := indexerProxy.Init(t.Context())
 	require.NoError(t, err)
 
 	proxyMode, err := proxymode.NewProxyMode(
@@ -188,7 +187,7 @@ func TestGetCategories(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.Title, func(t *testing.T) {
-			result := getCategories(context.Background(), pkgs, c.IncludePolicyTemplates)
+			result := getCategories(t.Context(), pkgs, c.IncludePolicyTemplates)
 			assert.Equal(t, c.Expected, result)
 		})
 	}

--- a/internal/storage/fakestorage_test.go
+++ b/internal/storage/fakestorage_test.go
@@ -5,7 +5,6 @@
 package storage
 
 import (
-	"context"
 	"io"
 	"os"
 	"testing"
@@ -36,7 +35,7 @@ func TestPrepareFakeServer(t *testing.T) {
 }
 
 func readObject(t *testing.T, handle *storage.ObjectHandle) []byte {
-	reader, err := handle.NewReader(context.Background())
+	reader, err := handle.NewReader(t.Context())
 	require.NoErrorf(t, err, "can't initialize reader for object %s", handle.ObjectName())
 	content, err := io.ReadAll(reader)
 	require.NoErrorf(t, err, "io.ReadAll failed for object %s", handle.ObjectName())

--- a/internal/storage/sqlindexer_test.go
+++ b/internal/storage/sqlindexer_test.go
@@ -22,6 +22,8 @@ import (
 )
 
 func TestSQLInit(t *testing.T) {
+	t.Parallel()
+
 	// given
 	db, err := database.NewMemorySQLDB(database.MemorySQLDBOptions{Path: "main"})
 	require.NoError(t, err)
@@ -36,12 +38,11 @@ func TestSQLInit(t *testing.T) {
 	defer fs.Stop()
 	storageClient := fs.Client()
 
-	ctx := context.Background()
 	indexer := NewIndexer(util.NewTestLogger(), storageClient, options)
-	defer indexer.Close(ctx)
+	defer indexer.Close(t.Context())
 
 	// when
-	err = indexer.Init(ctx)
+	err = indexer.Init(t.Context())
 
 	// then
 	require.NoError(t, err)
@@ -68,15 +69,13 @@ func BenchmarkSQLInit(b *testing.B) {
 	logger := util.NewTestLoggerLevel(zapcore.FatalLevel)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		ctx := context.Background()
-
 		indexer := NewIndexer(logger, storageClient, options)
 
-		err := indexer.Init(ctx)
+		err := indexer.Init(b.Context())
 		require.NoError(b, err)
 
 		b.StopTimer()
-		require.NoError(b, indexer.Close(ctx))
+		require.NoError(b, indexer.Close(b.Context()))
 		b.StartTimer()
 	}
 }
@@ -100,13 +99,12 @@ func BenchmarkSQLIndexerUpdateIndex(b *testing.B) {
 	storageClient := fs.Client()
 
 	logger := util.NewTestLoggerLevel(zapcore.FatalLevel)
-	ctx := context.Background()
 
 	indexer := NewIndexer(logger, storageClient, options)
-	defer indexer.Close(ctx)
+	defer indexer.Close(b.Context())
 
 	start := time.Now()
-	err = indexer.Init(ctx)
+	err = indexer.Init(b.Context())
 	b.Logf("Elapsed time init database: %s", time.Since(start))
 	require.NoError(b, err)
 
@@ -117,7 +115,7 @@ func BenchmarkSQLIndexerUpdateIndex(b *testing.B) {
 		UpdateFakeServer(b, fs, revision, "../../storage/testdata/search-index-all-full.json")
 		b.StartTimer()
 		start = time.Now()
-		err = indexer.updateIndex(ctx)
+		err = indexer.updateIndex(b.Context())
 		b.Logf("Elapsed time updating database: %s", time.Since(start))
 		require.NoError(b, err, "index should be updated successfully")
 	}
@@ -143,27 +141,26 @@ func BenchmarkSQLIndexerGet(b *testing.B) {
 
 	logger := util.NewTestLoggerLevel(zapcore.FatalLevel)
 
-	ctx := context.Background()
 	indexer := NewIndexer(logger, storageClient, options)
-	defer indexer.Close(ctx)
+	defer indexer.Close(b.Context())
 
-	err = indexer.Init(ctx)
+	err = indexer.Init(b.Context())
 	require.NoError(b, err)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		indexer.Get(context.Background(), &packages.GetOptions{})
-		indexer.Get(context.Background(), &packages.GetOptions{
+		indexer.Get(b.Context(), &packages.GetOptions{})
+		indexer.Get(b.Context(), &packages.GetOptions{
 			Filter: &packages.Filter{
 				AllVersions: true,
 				Prerelease:  true,
 			},
 		})
-		indexer.Get(context.Background(), &packages.GetOptions{Filter: &packages.Filter{
+		indexer.Get(b.Context(), &packages.GetOptions{Filter: &packages.Filter{
 			AllVersions: false,
 			Prerelease:  false,
 		}})
-		indexer.Get(context.Background(), &packages.GetOptions{Filter: &packages.Filter{
+		indexer.Get(b.Context(), &packages.GetOptions{Filter: &packages.Filter{
 			AllVersions: false,
 			Prerelease:  false,
 			SpecMin:     semver.MustParse("3.0"),
@@ -173,6 +170,8 @@ func BenchmarkSQLIndexerGet(b *testing.B) {
 }
 
 func TestSQLGet_ListPackages(t *testing.T) {
+	t.Parallel()
+
 	// given
 	// db, err := database.NewMemorySQLDB(database.MemorySQLDBOptions{Path: "main"})
 	// require.NoError(t, err)
@@ -192,14 +191,13 @@ func TestSQLGet_ListPackages(t *testing.T) {
 	require.NoError(t, err)
 
 	fs := PrepareFakeServer(t, "../../storage/testdata/search-index-all-full.json")
-	defer fs.Stop()
+	t.Cleanup(fs.Stop)
 	storageClient := fs.Client()
 
-	ctx := context.Background()
 	indexer := NewIndexer(util.NewTestLogger(), storageClient, options)
-	defer indexer.Close(ctx)
+	t.Cleanup(func() { indexer.Close(context.Background()) })
 
-	err = indexer.Init(ctx)
+	err = indexer.Init(t.Context())
 	require.NoError(t, err, "storage indexer must be initialized properly")
 
 	cases := []struct {
@@ -365,9 +363,11 @@ func TestSQLGet_ListPackages(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+
 			// when
 			startTest := time.Now()
-			foundPackages, err := indexer.Get(ctx, c.options)
+			foundPackages, err := indexer.Get(t.Context(), c.options)
 			t.Logf("Elapsed time GET: %s", time.Since(startTest))
 			// then
 			require.NoError(t, err, "packages should be returned")
@@ -383,6 +383,8 @@ func TestSQLGet_ListPackages(t *testing.T) {
 }
 
 func TestSQLGet_IndexUpdated(t *testing.T) {
+	t.Parallel()
+
 	// given
 	db, err := database.NewMemorySQLDB(database.MemorySQLDBOptions{Path: "main"})
 	require.NoError(t, err)
@@ -394,18 +396,17 @@ func TestSQLGet_IndexUpdated(t *testing.T) {
 	require.NoError(t, err)
 
 	fs := PrepareFakeServer(t, "../../storage/testdata/search-index-all-small.json")
-	defer fs.Stop()
+	t.Cleanup(fs.Stop)
 	storageClient := fs.Client()
 
-	ctx := context.Background()
 	indexer := NewIndexer(util.NewTestLogger(), storageClient, options)
-	defer indexer.Close(ctx)
+	t.Cleanup(func() { indexer.Close(context.Background()) })
 
-	err = indexer.Init(ctx)
+	err = indexer.Init(t.Context())
 	require.NoError(t, err, "storage indexer must be initialized properly")
 
 	// when
-	foundPackages, err := indexer.Get(ctx, &packages.GetOptions{
+	foundPackages, err := indexer.Get(t.Context(), &packages.GetOptions{
 		Filter: &packages.Filter{
 			PackageName: "1password",
 			PackageType: "integration",
@@ -421,10 +422,10 @@ func TestSQLGet_IndexUpdated(t *testing.T) {
 
 	// when: index update is performed
 	UpdateFakeServer(t, fs, "2", "../../storage/testdata/search-index-all-full.json")
-	err = indexer.updateIndex(ctx)
+	err = indexer.updateIndex(t.Context())
 	require.NoError(t, err, "index should be updated successfully")
 
-	foundPackages, err = indexer.Get(ctx, &packages.GetOptions{
+	foundPackages, err = indexer.Get(t.Context(), &packages.GetOptions{
 		Filter: &packages.Filter{
 			PackageName: "1password",
 			PackageType: "integration",
@@ -440,10 +441,10 @@ func TestSQLGet_IndexUpdated(t *testing.T) {
 
 	// when: index update is performed removing packages
 	UpdateFakeServer(t, fs, "3", "../../storage/testdata/search-index-all-small.json")
-	err = indexer.updateIndex(ctx)
+	err = indexer.updateIndex(t.Context())
 	require.NoError(t, err, "index should be updated successfully")
 
-	foundPackages, err = indexer.Get(ctx, &packages.GetOptions{
+	foundPackages, err = indexer.Get(t.Context(), &packages.GetOptions{
 		Filter: &packages.Filter{
 			PackageName: "1password",
 			PackageType: "integration",
@@ -460,10 +461,10 @@ func TestSQLGet_IndexUpdated(t *testing.T) {
 
 	// when: index update is performed updating some field of an existing package
 	UpdateFakeServer(t, fs, "4", "../../storage/testdata/search-index-all-small-updated-fields.json")
-	err = indexer.updateIndex(ctx)
+	err = indexer.updateIndex(t.Context())
 	require.NoError(t, err, "index should be updated successfully")
 
-	foundPackages, err = indexer.Get(ctx, &packages.GetOptions{
+	foundPackages, err = indexer.Get(t.Context(), &packages.GetOptions{
 		Filter: &packages.Filter{
 			PackageName: "1password",
 			PackageType: "integration",

--- a/main_test.go
+++ b/main_test.go
@@ -41,7 +41,7 @@ func TestRouter(t *testing.T) {
 	logger := util.NewTestLogger()
 	config := defaultConfig
 	indexer := NewCombinedIndexer()
-	defer indexer.Close(context.Background())
+	defer indexer.Close(t.Context())
 
 	router, err := getRouter(logger, serverOptions{
 		config:  &config,
@@ -59,14 +59,16 @@ func TestRouter(t *testing.T) {
 }
 
 func TestEndpoints(t *testing.T) {
+	t.Parallel()
+
 	packagesBasePaths := []string{"./testdata/second_package_path", "./testdata/package"}
 	indexer := NewCombinedIndexer(
 		packages.NewZipFileSystemIndexer(testLogger, "./testdata/local-storage"),
 		packages.NewFileSystemIndexer(testLogger, packagesBasePaths...),
 	)
-	defer indexer.Close(context.Background())
+	t.Cleanup(func() { indexer.Close(context.Background()) })
 
-	err := indexer.Init(context.Background())
+	err := indexer.Init(t.Context())
 	require.NoError(t, err)
 
 	faviconHandler, err := newFaviconHandler(testCacheTime)
@@ -162,11 +164,13 @@ func TestEndpoints(t *testing.T) {
 }
 
 func TestArtifacts(t *testing.T) {
+	t.Parallel()
+
 	packagesBasePaths := []string{"./testdata/package"}
 	indexer := packages.NewFileSystemIndexer(testLogger, packagesBasePaths...)
-	defer indexer.Close(context.Background())
+	t.Cleanup(func() { indexer.Close(context.Background()) })
 
-	err := indexer.Init(context.Background())
+	err := indexer.Init(t.Context())
 	require.NoError(t, err)
 
 	artifactsHandler, err := newArtifactsHandler(testLogger, indexer, testCacheTime)
@@ -192,10 +196,12 @@ func TestArtifacts(t *testing.T) {
 }
 
 func TestSignatures(t *testing.T) {
-	indexer := packages.NewZipFileSystemIndexer(testLogger, "./testdata/local-storage")
-	defer indexer.Close(context.Background())
+	t.Parallel()
 
-	err := indexer.Init(context.Background())
+	indexer := packages.NewZipFileSystemIndexer(testLogger, "./testdata/local-storage")
+	t.Cleanup(func() { indexer.Close(context.Background()) })
+
+	err := indexer.Init(t.Context())
 	require.NoError(t, err)
 
 	signaturesHandler, err := newSignaturesHandler(testLogger, indexer, testCacheTime)
@@ -219,11 +225,13 @@ func TestSignatures(t *testing.T) {
 }
 
 func TestStatics(t *testing.T) {
+	t.Parallel()
+
 	packagesBasePaths := []string{"./testdata/package"}
 	indexer := packages.NewFileSystemIndexer(testLogger, packagesBasePaths...)
-	defer indexer.Close(context.Background())
+	t.Cleanup(func() { indexer.Close(context.Background()) })
 
-	err := indexer.Init(context.Background())
+	err := indexer.Init(t.Context())
 	require.NoError(t, err)
 
 	staticHandler, err := newStaticHandler(testLogger, indexer, testCacheTime)
@@ -247,6 +255,8 @@ func TestStatics(t *testing.T) {
 }
 
 func TestStaticsModifiedTime(t *testing.T) {
+	t.Parallel()
+
 	const ifModifiedSinceHeader = "If-Modified-Since"
 	const lastModifiedHeader = "Last-Modified"
 
@@ -313,9 +323,9 @@ func TestStaticsModifiedTime(t *testing.T) {
 		packages.NewZipFileSystemIndexer(testLogger, "./testdata/local-storage"),
 		packages.NewFileSystemIndexer(testLogger, "./testdata/package"),
 	)
-	defer indexer.Close(context.Background())
+	t.Cleanup(func() { indexer.Close(context.Background()) })
 
-	err := indexer.Init(context.Background())
+	err := indexer.Init(t.Context())
 	require.NoError(t, err)
 
 	router := mux.NewRouter()
@@ -344,10 +354,12 @@ func TestStaticsModifiedTime(t *testing.T) {
 }
 
 func TestZippedArtifacts(t *testing.T) {
-	indexer := packages.NewZipFileSystemIndexer(testLogger, "./testdata/local-storage")
-	defer indexer.Close(context.Background())
+	t.Parallel()
 
-	err := indexer.Init(context.Background())
+	indexer := packages.NewZipFileSystemIndexer(testLogger, "./testdata/local-storage")
+	t.Cleanup(func() { indexer.Close(context.Background()) })
+
+	err := indexer.Init(t.Context())
 	require.NoError(t, err)
 
 	artifactsHandler, err := newArtifactsHandler(testLogger, indexer, testCacheTime)
@@ -377,13 +389,15 @@ func TestZippedArtifacts(t *testing.T) {
 }
 
 func TestPackageIndex(t *testing.T) {
+	t.Parallel()
+
 	indexer := NewCombinedIndexer(
 		packages.NewZipFileSystemIndexer(testLogger, "./testdata/local-storage"),
 		packages.NewFileSystemIndexer(testLogger, "./testdata/package"),
 	)
-	defer indexer.Close(context.Background())
+	t.Cleanup(func() { indexer.Close(context.Background()) })
 
-	err := indexer.Init(context.Background())
+	err := indexer.Init(t.Context())
 	require.NoError(t, err)
 
 	packageIndexHandler, err := newPackageIndexHandler(testLogger, indexer, testCacheTime)
@@ -412,11 +426,13 @@ func TestPackageIndex(t *testing.T) {
 }
 
 func TestZippedPackageIndex(t *testing.T) {
+	t.Parallel()
+
 	packagesBasePaths := []string{"./testdata/local-storage"}
 	indexer := packages.NewZipFileSystemIndexer(testLogger, packagesBasePaths...)
-	defer indexer.Close(context.Background())
+	t.Cleanup(func() { indexer.Close(context.Background()) })
 
-	err := indexer.Init(context.Background())
+	err := indexer.Init(t.Context())
 	require.NoError(t, err)
 
 	packageIndexHandler, err := newPackageIndexHandler(testLogger, indexer, testCacheTime)
@@ -443,13 +459,15 @@ func TestZippedPackageIndex(t *testing.T) {
 
 // TestAllPackageIndex generates and compares all index.json files for the test packages
 func TestAllPackageIndex(t *testing.T) {
+	t.Parallel()
+
 	testPackagePath := filepath.Join("testdata", "package")
 	secondPackagePath := filepath.Join("testdata", "second_package_path")
 	packagesBasePaths := []string{secondPackagePath, testPackagePath}
 	indexer := packages.NewFileSystemIndexer(testLogger, packagesBasePaths...)
-	defer indexer.Close(context.Background())
+	t.Cleanup(func() { indexer.Close(context.Background()) })
 
-	err := indexer.Init(context.Background())
+	err := indexer.Init(t.Context())
 	require.NoError(t, err)
 
 	packageIndexHandler, err := newPackageIndexHandler(testLogger, indexer, testCacheTime)
@@ -487,6 +505,8 @@ func TestAllPackageIndex(t *testing.T) {
 }
 
 func TestContentTypes(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		endpoint    string
 		contentType string
@@ -505,9 +525,9 @@ func TestContentTypes(t *testing.T) {
 		packages.NewZipFileSystemIndexer(testLogger, "./testdata/local-storage"),
 		packages.NewFileSystemIndexer(testLogger, "./testdata/package"),
 	)
-	defer indexer.Close(context.Background())
+	t.Cleanup(func() { indexer.Close(context.Background()) })
 
-	err := indexer.Init(context.Background())
+	err := indexer.Init(t.Context())
 	require.NoError(t, err)
 
 	staticHandler, err := newStaticHandler(testLogger, indexer, testCacheTime)
@@ -533,13 +553,15 @@ func TestContentTypes(t *testing.T) {
 // TestRangeDownloads tests that range downloads continue working for packages stored
 // on different file systems.
 func TestRangeDownloads(t *testing.T) {
+	t.Parallel()
+
 	indexer := NewCombinedIndexer(
 		packages.NewZipFileSystemIndexer(testLogger, "./testdata/local-storage"),
 		packages.NewFileSystemIndexer(testLogger, "./testdata/package"),
 	)
-	defer indexer.Close(context.Background())
+	t.Cleanup(func() { indexer.Close(context.Background()) })
 
-	err := indexer.Init(context.Background())
+	err := indexer.Init(t.Context())
 	require.NoError(t, err)
 
 	router := mux.NewRouter()

--- a/package_storage_test.go
+++ b/package_storage_test.go
@@ -5,7 +5,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -133,9 +132,9 @@ func TestPackageStorage_Endpoints(t *testing.T) {
 	defer fs.Stop()
 
 	indexer := storage.NewIndexer(testLogger, fs.Client(), storage.FakeIndexerOptions)
-	defer indexer.Close(context.Background())
+	defer indexer.Close(t.Context())
 
-	err := indexer.Init(context.Background())
+	err := indexer.Init(t.Context())
 	require.NoError(t, err)
 
 	tests, err := generateTestCaseStorageEndpoints(indexer)
@@ -154,9 +153,9 @@ func TestPackageStorageSQL_Endpoints(t *testing.T) {
 
 	indexer, err := generateSQLStorageIndexer(fs, "")
 	require.NoError(t, err)
-	defer indexer.Close(context.Background())
+	defer indexer.Close(t.Context())
 
-	err = indexer.Init(context.Background())
+	err = indexer.Init(t.Context())
 	require.NoError(t, err)
 
 	tests, err := generateTestCaseStorageEndpoints(indexer)
@@ -195,9 +194,9 @@ func TestPackageStorage_PackageIndex(t *testing.T) {
 	fs := internalStorage.PrepareFakeServer(t, "./storage/testdata/search-index-all-full.json")
 	defer fs.Stop()
 	indexer := storage.NewIndexer(testLogger, fs.Client(), storage.FakeIndexerOptions)
-	defer indexer.Close(context.Background())
+	defer indexer.Close(t.Context())
 
-	err := indexer.Init(context.Background())
+	err := indexer.Init(t.Context())
 	require.NoError(t, err)
 
 	tests, err := generateTestPackageIndexEndpoints(indexer)
@@ -216,9 +215,9 @@ func TestPackageSQLStorage_PackageIndex(t *testing.T) {
 
 	indexer, err := generateSQLStorageIndexer(fs, "")
 	require.NoError(t, err)
-	defer indexer.Close(context.Background())
+	defer indexer.Close(t.Context())
 
-	err = indexer.Init(context.Background())
+	err = indexer.Init(t.Context())
 	require.NoError(t, err)
 
 	tests, err := generateTestPackageIndexEndpoints(indexer)
@@ -266,9 +265,9 @@ func TestPackageStorage_Artifacts(t *testing.T) {
 	testIndexerOptions.PackageStorageEndpoint = webServer.URL
 
 	indexer := storage.NewIndexer(testLogger, fs.Client(), testIndexerOptions)
-	defer indexer.Close(context.Background())
+	defer indexer.Close(t.Context())
 
-	err := indexer.Init(context.Background())
+	err := indexer.Init(t.Context())
 	require.NoError(t, err)
 
 	tests, err := generateTestArtifactsEndpoints(indexer)
@@ -292,9 +291,9 @@ func TestPackageSQLStorage_Artifacts(t *testing.T) {
 
 	indexer, err := generateSQLStorageIndexer(fs, webServer.URL)
 	require.NoError(t, err)
-	defer indexer.Close(context.Background())
+	defer indexer.Close(t.Context())
 
-	err = indexer.Init(context.Background())
+	err = indexer.Init(t.Context())
 	require.NoError(t, err)
 
 	tests, err := generateTestArtifactsEndpoints(indexer)
@@ -341,9 +340,9 @@ func TestPackageStorage_Signatures(t *testing.T) {
 	testIndexerOptions.PackageStorageEndpoint = webServer.URL
 
 	indexer := storage.NewIndexer(testLogger, fs.Client(), testIndexerOptions)
-	defer indexer.Close(context.Background())
+	defer indexer.Close(t.Context())
 
-	err := indexer.Init(context.Background())
+	err := indexer.Init(t.Context())
 	require.NoError(t, err)
 
 	tests, err := generateTestSignaturesEndpoints(indexer)
@@ -367,9 +366,9 @@ func TestPackageSQLStorage_Signatures(t *testing.T) {
 
 	indexer, err := generateSQLStorageIndexer(fs, webServer.URL)
 	require.NoError(t, err)
-	defer indexer.Close(context.Background())
+	defer indexer.Close(t.Context())
 
-	err = indexer.Init(context.Background())
+	err = indexer.Init(t.Context())
 	require.NoError(t, err)
 
 	tests, err := generateTestSignaturesEndpoints(indexer)
@@ -417,9 +416,9 @@ func TestPackageStorage_Statics(t *testing.T) {
 	testIndexerOptions.PackageStorageEndpoint = webServer.URL
 
 	indexer := storage.NewIndexer(testLogger, fs.Client(), testIndexerOptions)
-	defer indexer.Close(context.Background())
+	defer indexer.Close(t.Context())
 
-	err := indexer.Init(context.Background())
+	err := indexer.Init(t.Context())
 	require.NoError(t, err)
 
 	tests, err := generateTestStaticEndpoints(indexer)
@@ -443,9 +442,9 @@ func TestPackagesQLStorage_Statics(t *testing.T) {
 
 	indexer, err := generateSQLStorageIndexer(fs, webServer.URL)
 	require.NoError(t, err)
-	defer indexer.Close(context.Background())
+	defer indexer.Close(t.Context())
 
-	err = indexer.Init(context.Background())
+	err = indexer.Init(t.Context())
 	require.NoError(t, err)
 
 	tests, err := generateTestStaticEndpoints(indexer)
@@ -505,9 +504,9 @@ func TestPackageStorage_ResolverHeadersResponse(t *testing.T) {
 	testIndexerOptions.PackageStorageEndpoint = webServer.URL
 
 	indexer := storage.NewIndexer(testLogger, fs.Client(), testIndexerOptions)
-	defer indexer.Close(context.Background())
+	defer indexer.Close(t.Context())
 
-	err := indexer.Init(context.Background())
+	err := indexer.Init(t.Context())
 	require.NoError(t, err)
 
 	tests, err := generateTestResolveHeadersEndpoints(indexer)
@@ -534,9 +533,9 @@ func TestPackageSQLStorage_ResolverHeadersResponse(t *testing.T) {
 
 	indexer, err := generateSQLStorageIndexer(fs, webServer.URL)
 	require.NoError(t, err)
-	defer indexer.Close(context.Background())
+	defer indexer.Close(t.Context())
 
-	err = indexer.Init(context.Background())
+	err = indexer.Init(t.Context())
 	require.NoError(t, err)
 
 	tests, err := generateTestResolveHeadersEndpoints(indexer)
@@ -588,9 +587,9 @@ func TestPackageStorage_ResolverErrorResponse(t *testing.T) {
 	testIndexerOptions.PackageStorageEndpoint = webServer.URL
 
 	indexer := storage.NewIndexer(testLogger, fs.Client(), testIndexerOptions)
-	defer indexer.Close(context.Background())
+	defer indexer.Close(t.Context())
 
-	err := indexer.Init(context.Background())
+	err := indexer.Init(t.Context())
 	require.NoError(t, err)
 
 	tests, err := generateTestResolveErrorResponseEndpoints(indexer)
@@ -615,9 +614,9 @@ func TestPackageSQLStorage_ResolverErrorResponse(t *testing.T) {
 
 	indexer, err := generateSQLStorageIndexer(fs, webServer.URL)
 	require.NoError(t, err)
-	defer indexer.Close(context.Background())
+	defer indexer.Close(t.Context())
 
-	err = indexer.Init(context.Background())
+	err = indexer.Init(t.Context())
 	require.NoError(t, err)
 
 	tests, err := generateTestResolveErrorResponseEndpoints(indexer)

--- a/packages/marshaler_test.go
+++ b/packages/marshaler_test.go
@@ -5,7 +5,6 @@
 package packages
 
 import (
-	"context"
 	"encoding/json"
 	"flag"
 	"os"
@@ -25,9 +24,9 @@ func TestMarshalJSON(t *testing.T) {
 	// given
 	packagesBasePaths := []string{"../testdata/second_package_path", "../testdata/package"}
 	indexer := NewFileSystemIndexer(util.NewTestLogger(), packagesBasePaths...)
-	defer indexer.Close(context.Background())
+	defer indexer.Close(t.Context())
 
-	err := indexer.Init(context.Background())
+	err := indexer.Init(t.Context())
 	require.NoError(t, err, "can't initialize indexer")
 
 	// when
@@ -42,9 +41,9 @@ func TestUnmarshalJSON(t *testing.T) {
 	// given
 	packagesBasePaths := []string{"../testdata/second_package_path", "../testdata/package"}
 	indexer := NewFileSystemIndexer(util.NewTestLogger(), packagesBasePaths...)
-	defer indexer.Close(context.Background())
+	defer indexer.Close(t.Context())
 
-	err := indexer.Init(context.Background())
+	err := indexer.Init(t.Context())
 	require.NoError(t, err)
 
 	expectedFile, err := os.ReadFile(testFile)

--- a/packages/packages_test.go
+++ b/packages/packages_test.go
@@ -5,7 +5,6 @@
 package packages
 
 import (
-	"context"
 	"testing"
 
 	"github.com/Masterminds/semver/v3"
@@ -443,7 +442,7 @@ func TestPackagesFilter(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.Title, func(t *testing.T) {
-			result, err := c.Filter.Apply(context.Background(), packages)
+			result, err := c.Filter.Apply(t.Context(), packages)
 			require.NoError(t, err)
 			assertFilterPackagesResult(t, c.Expected, result)
 		})
@@ -773,7 +772,7 @@ func TestPackagesSpecMinMaxFilter(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.Title, func(t *testing.T) {
-			result, err := c.Filter.Apply(context.Background(), packages)
+			result, err := c.Filter.Apply(t.Context(), packages)
 			require.NoError(t, err)
 			assertFilterPackagesResult(t, c.Expected, result)
 		})

--- a/search_test.go
+++ b/search_test.go
@@ -5,7 +5,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -100,9 +99,9 @@ func TestSearchWithProxyMode(t *testing.T) {
 		packages.NewZipFileSystemIndexer(testLogger, "./testdata/local-storage"),
 		packages.NewFileSystemIndexer(testLogger, packagesBasePaths...),
 	)
-	defer indexer.Close(context.Background())
+	defer indexer.Close(t.Context())
 
-	err := indexer.Init(context.Background())
+	err := indexer.Init(t.Context())
 	require.NoError(t, err)
 
 	proxyMode, err := proxymode.NewProxyMode(

--- a/storage/indexer_test.go
+++ b/storage/indexer_test.go
@@ -25,10 +25,10 @@ func TestInit(t *testing.T) {
 	defer fs.Stop()
 	storageClient := fs.Client()
 	indexer := NewIndexer(util.NewTestLogger(), storageClient, FakeIndexerOptions)
-	defer indexer.Close(context.Background())
+	defer indexer.Close(t.Context())
 
 	// when
-	err := indexer.Init(context.Background())
+	err := indexer.Init(t.Context())
 
 	// then
 	require.NoError(t, err)
@@ -45,11 +45,11 @@ func BenchmarkInit(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		indexer := NewIndexer(logger, storageClient, FakeIndexerOptions)
 
-		err := indexer.Init(context.Background())
+		err := indexer.Init(b.Context())
 		require.NoError(b, err)
 
 		b.StopTimer()
-		require.NoError(b, indexer.Close(context.Background()))
+		require.NoError(b, indexer.Close(b.Context()))
 		b.StartTimer()
 	}
 }
@@ -62,9 +62,9 @@ func BenchmarkIndexerUpdateIndex(b *testing.B) {
 
 	logger := util.NewTestLoggerLevel(zapcore.FatalLevel)
 	indexer := NewIndexer(logger, storageClient, FakeIndexerOptions)
-	defer indexer.Close(context.Background())
+	defer indexer.Close(b.Context())
 
-	err := indexer.Init(context.Background())
+	err := indexer.Init(b.Context())
 	require.NoError(b, err)
 
 	b.ResetTimer()
@@ -73,7 +73,7 @@ func BenchmarkIndexerUpdateIndex(b *testing.B) {
 		revision := fmt.Sprintf("%d", i+2)
 		internalStorage.UpdateFakeServer(b, fs, revision, "testdata/search-index-all-full.json")
 		b.StartTimer()
-		err = indexer.updateIndex(context.Background())
+		err = indexer.updateIndex(b.Context())
 		require.NoError(b, err, "index should be updated successfully")
 	}
 }
@@ -86,25 +86,25 @@ func BenchmarkIndexerGet(b *testing.B) {
 
 	logger := util.NewTestLoggerLevel(zapcore.FatalLevel)
 	indexer := NewIndexer(logger, storageClient, FakeIndexerOptions)
-	defer indexer.Close(context.Background())
+	defer indexer.Close(b.Context())
 
-	err := indexer.Init(context.Background())
+	err := indexer.Init(b.Context())
 	require.NoError(b, err)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		indexer.Get(context.Background(), &packages.GetOptions{})
-		indexer.Get(context.Background(), &packages.GetOptions{
+		indexer.Get(b.Context(), &packages.GetOptions{})
+		indexer.Get(b.Context(), &packages.GetOptions{
 			Filter: &packages.Filter{
 				AllVersions: true,
 				Prerelease:  true,
 			},
 		})
-		indexer.Get(context.Background(), &packages.GetOptions{Filter: &packages.Filter{
+		indexer.Get(b.Context(), &packages.GetOptions{Filter: &packages.Filter{
 			AllVersions: false,
 			Prerelease:  false,
 		}})
-		indexer.Get(context.Background(), &packages.GetOptions{Filter: &packages.Filter{
+		indexer.Get(b.Context(), &packages.GetOptions{Filter: &packages.Filter{
 			AllVersions: false,
 			Prerelease:  false,
 			SpecMin:     semver.MustParse("3.0.0"),
@@ -114,15 +114,16 @@ func BenchmarkIndexerGet(b *testing.B) {
 }
 
 func TestGet_ListPackages(t *testing.T) {
+	t.Parallel()
+
 	// given
 	fs := internalStorage.PrepareFakeServer(t, "testdata/search-index-all-full.json")
-	defer fs.Stop()
+	t.Cleanup(fs.Stop)
 	storageClient := fs.Client()
 	indexer := NewIndexer(util.NewTestLogger(), storageClient, FakeIndexerOptions)
-	defer indexer.Close(context.Background())
+	t.Cleanup(func() { indexer.Close(context.Background()) })
 
-	ctx := context.Background()
-	err := indexer.Init(ctx)
+	err := indexer.Init(t.Context())
 	require.NoError(t, err, "storage indexer must be initialized properly")
 
 	cases := []struct {
@@ -288,8 +289,10 @@ func TestGet_ListPackages(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+
 			// when
-			foundPackages, err := indexer.Get(ctx, c.options)
+			foundPackages, err := indexer.Get(t.Context(), c.options)
 			// then
 			require.NoError(t, err, "packages should be returned")
 			require.Len(t, foundPackages, c.expected)
@@ -304,20 +307,21 @@ func TestGet_ListPackages(t *testing.T) {
 }
 
 func TestGet_IndexUpdated(t *testing.T) {
+	t.Parallel()
+
 	// given
 	fs := internalStorage.PrepareFakeServer(t, "testdata/search-index-all-small.json")
-	defer fs.Stop()
+	t.Cleanup(fs.Stop)
 	storageClient := fs.Client()
-	ctx := context.Background()
 
 	indexer := NewIndexer(util.NewTestLogger(), storageClient, FakeIndexerOptions)
-	defer indexer.Close(ctx)
+	t.Cleanup(func() { indexer.Close(context.Background()) })
 
-	err := indexer.Init(ctx)
+	err := indexer.Init(t.Context())
 	require.NoError(t, err, "storage indexer must be initialized properly")
 
 	// when
-	foundPackages, err := indexer.Get(ctx, &packages.GetOptions{
+	foundPackages, err := indexer.Get(t.Context(), &packages.GetOptions{
 		Filter: &packages.Filter{
 			PackageName: "1password",
 			PackageType: "integration",
@@ -334,10 +338,10 @@ func TestGet_IndexUpdated(t *testing.T) {
 	// when: index update is performed adding new packages
 	const secondRevision = "2"
 	internalStorage.UpdateFakeServer(t, fs, secondRevision, "testdata/search-index-all-full.json")
-	err = indexer.updateIndex(ctx)
+	err = indexer.updateIndex(t.Context())
 	require.NoError(t, err, "index should be updated successfully")
 
-	foundPackages, err = indexer.Get(ctx, &packages.GetOptions{
+	foundPackages, err = indexer.Get(t.Context(), &packages.GetOptions{
 		Filter: &packages.Filter{
 			PackageName: "1password",
 			PackageType: "integration",
@@ -354,10 +358,10 @@ func TestGet_IndexUpdated(t *testing.T) {
 	// when: index update is performed removing packages
 	const thirdRevision = "3"
 	internalStorage.UpdateFakeServer(t, fs, thirdRevision, "testdata/search-index-all-small.json")
-	err = indexer.updateIndex(ctx)
+	err = indexer.updateIndex(t.Context())
 	require.NoError(t, err, "index should be updated successfully")
 
-	foundPackages, err = indexer.Get(ctx, &packages.GetOptions{
+	foundPackages, err = indexer.Get(t.Context(), &packages.GetOptions{
 		Filter: &packages.Filter{
 			PackageName: "1password",
 			PackageType: "integration",
@@ -373,10 +377,10 @@ func TestGet_IndexUpdated(t *testing.T) {
 
 	// when: index update is performed updating some field of an existing pacakage
 	internalStorage.UpdateFakeServer(t, fs, "4", "testdata/search-index-all-small-updated-fields.json")
-	err = indexer.updateIndex(ctx)
+	err = indexer.updateIndex(t.Context())
 	require.NoError(t, err, "index should be updated successfully")
 
-	foundPackages, err = indexer.Get(ctx, &packages.GetOptions{
+	foundPackages, err = indexer.Get(t.Context(), &packages.GetOptions{
 		Filter: &packages.Filter{
 			PackageName: "1password",
 			PackageType: "integration",


### PR DESCRIPTION
Go 1.24.0 introduced a context in `testing` objects that is cancelled after the test is finished, but before registered cleanup functions are executed. See https://tip.golang.org/doc/go1.24#testingpkgtesting.

Apart from providing a non-nil context, this new context helps ensuring that resources that should be finished by context cancellation are actually finished.

In general there is no reason to don't use this context, the only reasons would be:
* Contexts in cleanup functions, as this context will be cancelled at this point.
* Contexts for resources that should persist along tests. Something I think we don't have in this project.

Indexer cleanups have been reorganized to use Cleanup instead of defer, so tests can be more easily parallelized.