### PR TITLE
#1423 : Autoinstrumentation for proxymode

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/prometheus/client_golang v1.23.2
 	github.com/stretchr/testify v1.11.1
 	go.elastic.co/apm/module/apmgorilla/v2 v2.7.1
+	go.elastic.co/apm/module/apmhttp/v2 v2.7.1
 	go.elastic.co/apm/module/apmzap/v2 v2.7.1
 	go.elastic.co/apm/v2 v2.7.1
 	go.elastic.co/ecszap v1.0.3
@@ -76,7 +77,6 @@ require (
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/spiffe/go-spiffe/v2 v2.5.0 // indirect
 	github.com/zeebo/errs v1.4.0 // indirect
-	go.elastic.co/apm/module/apmhttp/v2 v2.7.1 // indirect
 	go.elastic.co/fastjson v1.5.1 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect

--- a/proxymode/proxymode.go
+++ b/proxymode/proxymode.go
@@ -121,12 +121,10 @@ func (pm *ProxyMode) Search(r *http.Request) (packages.Packages, error) {
 	proxyURL.Scheme = pm.destinationURL.Scheme
 	proxyURL.User = pm.destinationURL.User
 
-	proxyRequest, err := retryablehttp.NewRequest(http.MethodGet, proxyURL.String(), nil)
+	proxyRequest, err := retryablehttp.NewRequestWithContext(r.Context(), http.MethodGet, proxyURL.String(), nil)
 	if err != nil {
 		return nil, fmt.Errorf("can't create proxy request: %w", err)
 	}
-
-	proxyRequest.Request = proxyRequest.Request.WithContext(r.Context())
 
 	pm.logger.Debug("Proxy /search request", zap.String("request.uri", proxyURL.String()))
 	response, err := pm.httpClient.Do(proxyRequest)
@@ -152,12 +150,10 @@ func (pm *ProxyMode) Categories(r *http.Request) ([]packages.Category, error) {
 	proxyURL.Scheme = pm.destinationURL.Scheme
 	proxyURL.User = pm.destinationURL.User
 
-	proxyRequest, err := retryablehttp.NewRequest(http.MethodGet, proxyURL.String(), nil)
+	proxyRequest, err := retryablehttp.NewRequestWithContext(r.Context(), http.MethodGet, proxyURL.String(), nil)
 	if err != nil {
 		return nil, fmt.Errorf("can't create proxy request: %w", err)
 	}
-
-	proxyRequest.Request = proxyRequest.Request.WithContext(r.Context())
 
 	pm.logger.Debug("Proxy /categories request", zap.String("request.uri", proxyURL.String()))
 	response, err := pm.httpClient.Do(proxyRequest)
@@ -188,12 +184,10 @@ func (pm *ProxyMode) Package(r *http.Request) (*packages.Package, error) {
 
 	urlPath := fmt.Sprintf("/package/%s/%s/", packageName, packageVersion)
 	proxyURL := pm.destinationURL.ResolveReference(&url.URL{Path: urlPath})
-	proxyRequest, err := retryablehttp.NewRequest(http.MethodGet, proxyURL.String(), nil)
+	proxyRequest, err := retryablehttp.NewRequestWithContext(r.Context(), http.MethodGet, proxyURL.String(), nil)
 	if err != nil {
 		return nil, fmt.Errorf("can't create proxy request: %w", err)
 	}
-
-	proxyRequest.Request = proxyRequest.Request.WithContext(r.Context())
 
 	pm.logger.Debug("Proxy /package request", zap.String("request.uri", proxyURL.String()))
 	response, err := pm.httpClient.Do(proxyRequest)


### PR DESCRIPTION
This pull request change the manual APM instrumentation to autoinstrumented to enable distributed tracing for outbound calls made in proxy mode.

Changes:
- The http.Client in proxymode.go is now instrumented using apmhttp.WrapRoundTripper to automatically trace outbound requests.
- The request context is propagated to the outbound calls
- Remove manual apm.StartSpan calls in favor of the new automatic instrumentation.