### PR TITLE
#1436 : Add serviceName as variable

### DIFF
--- a/main.go
+++ b/main.go
@@ -47,7 +47,6 @@ import (
 )
 
 const (
-	serviceName         = "package-registry"
 	version             = "1.32.2"
 	defaultInstanceName = "localhost"
 )
@@ -83,6 +82,7 @@ var (
 
 	featureProxyMode bool
 	proxyTo          string
+	serviceName      = getServiceName()
 
 	defaultConfig = Config{
 		CacheTimeIndex:               10 * time.Second,
@@ -334,6 +334,13 @@ func getHostname() string {
 		return defaultInstanceName
 	}
 	return hostname
+}
+
+func getServiceName() string {
+	if name := os.Getenv("ELASTIC_APM_SERVICE_NAME"); name != "" {
+		return name
+	}
+	return "package-registry"
 }
 
 func initMetricsServer(logger *zap.Logger) {


### PR DESCRIPTION
## Summary

This PR makes the `serviceName` used by Elastic APM configurable via the `ELASTIC_APM_SERVICE_NAME` environment variable.

By default, the service name remains `"package-registry"`, but it can now be overridden at runtime, improving flexibility for deployments across environments (e.g., staging, prod, multi-cluster setups).

## Changes

- Replaced the `const serviceName = "package-registry"` with a `var` that reads from `os.Getenv("ELASTIC_APM_SERVICE_NAME")`
- Ensured the value is read once at startup and reused consistently across APM tracer and logger initialization
