### PR TITLE
[Draft] Support Multiple Backends in Proxy Mode

### DIFF
--- a/main.go
+++ b/main.go
@@ -632,7 +632,7 @@ func getRouter(logger *zap.Logger, options serverOptions) (*mux.Router, error) {
 	}
 	proxyMode, err := proxymode.NewProxyMode(logger, proxymode.ProxyOptions{
 		Enabled: featureProxyMode,
-		ProxyTo: proxyTo,
+		ProxyTo: []string{proxyTo},
 	})
 	if err != nil {
 		return nil, fmt.Errorf("can't create proxy mode: %w", err)

--- a/main.go
+++ b/main.go
@@ -632,7 +632,7 @@ func getRouter(logger *zap.Logger, options serverOptions) (*mux.Router, error) {
 	}
 	proxyMode, err := proxymode.NewProxyMode(logger, proxymode.ProxyOptions{
 		Enabled: featureProxyMode,
-		ProxyTo: []string{proxyTo},
+		ProxyTo: strings.Split(proxyTo, ","),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("can't create proxy mode: %w", err)

--- a/main.go
+++ b/main.go
@@ -47,7 +47,6 @@ import (
 )
 
 const (
-	serviceName         = "package-registry"
 	version             = "1.32.2"
 	defaultInstanceName = "localhost"
 )
@@ -83,6 +82,7 @@ var (
 
 	featureProxyMode bool
 	proxyTo          string
+	serviceName      = getServiceName()
 
 	defaultConfig = Config{
 		CacheTimeIndex:               10 * time.Second,
@@ -334,6 +334,13 @@ func getHostname() string {
 		return defaultInstanceName
 	}
 	return hostname
+}
+
+func getServiceName() string {
+	if name := os.Getenv("ELASTIC_APM_SERVICE_NAME"); name != "" {
+		return name
+	}
+	return "package-registry"
 }
 
 func initMetricsServer(logger *zap.Logger) {

--- a/proxymode/proxymode.go
+++ b/proxymode/proxymode.go
@@ -16,8 +16,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/gorilla/mux"
 	"github.com/hashicorp/go-retryablehttp"
-	"github.comcom/gorilla/mux"
 	"go.elastic.co/apm/module/apmhttp/v2"
 	"go.uber.org/zap"
 

--- a/proxymode/proxymode.go
+++ b/proxymode/proxymode.go
@@ -11,30 +11,37 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
+	"sync"
 	"time"
 
-	"github.com/gorilla/mux"
 	"github.com/hashicorp/go-retryablehttp"
+	"github.comcom/gorilla/mux"
 	"go.elastic.co/apm/module/apmhttp/v2"
 	"go.uber.org/zap"
 
 	"github.com/elastic/package-registry/packages"
 )
 
-type ProxyMode struct {
-	options ProxyOptions
-
-	httpClient     *retryablehttp.Client
-	destinationURL *url.URL
-	resolver       *proxyResolver
-
-	logger *zap.Logger
+// backend holds the parsed information for a single proxy destination.
+type backend struct {
+	URL      *url.URL
+	Priority int
+	Resolver *proxyResolver
 }
 
+type ProxyMode struct {
+	options    ProxyOptions
+	httpClient *retryablehttp.Client
+	backends   []backend // Changed from single destinationURL
+	logger     *zap.Logger
+}
+
+// ProxyOptions now supports multiple backends.
 type ProxyOptions struct {
 	Enabled bool
-	ProxyTo string
+	ProxyTo []string // Changed from single string
 }
 
 func NoProxy(logger *zap.Logger) *ProxyMode {
@@ -71,13 +78,38 @@ func NewProxyMode(logger *zap.Logger, options ProxyOptions) (*ProxyMode, error) 
 		Backoff:      retryablehttp.DefaultBackoff,
 	}
 
-	var err error
-	pm.destinationURL, err = url.Parse(pm.options.ProxyTo)
-	if err != nil {
-		return nil, fmt.Errorf("can't create proxy destination URL: %w", err)
+	// Parse all configured backends.
+	pm.backends = make([]backend, 0, len(options.ProxyTo))
+	for _, proxyAddr := range options.ProxyTo {
+		parts := strings.Split(proxyAddr, ";")
+		addr := parts[0]
+		priority := 0 // Default priority
+
+		if len(parts) > 1 {
+			p, err := strconv.Atoi(parts[1])
+			if err == nil {
+				priority = p
+			} else {
+				logger.Warn("invalid priority format in proxy address, using default", zap.String("address", proxyAddr))
+			}
+		}
+
+		destURL, err := url.Parse(addr)
+		if err != nil {
+			return nil, fmt.Errorf("can't create proxy destination URL from '%s': %w", addr, err)
+		}
+
+		pm.backends = append(pm.backends, backend{
+			URL:      destURL,
+			Priority: priority,
+			Resolver: &proxyResolver{destinationURL: *destURL},
+		})
 	}
 
-	pm.resolver = &proxyResolver{destinationURL: *pm.destinationURL}
+	if len(pm.backends) == 0 {
+		return nil, errors.New("proxy mode is enabled but no backends are configured in 'proxy_to'")
+	}
+
 	return &pm, nil
 }
 
@@ -103,7 +135,6 @@ func proxyRetryPolicy(ctx context.Context, resp *http.Response, err error) (bool
 			return true, fmt.Errorf("unexpected content type: %s", contentType)
 		}
 	}
-
 	return false, nil
 }
 
@@ -114,103 +145,228 @@ func (pm *ProxyMode) Enabled() bool {
 	return pm.options.Enabled
 }
 
+// Search now queries all backends in parallel and merges the results.
 func (pm *ProxyMode) Search(r *http.Request) (packages.Packages, error) {
-
-	proxyURL := *r.URL
-	proxyURL.Host = pm.destinationURL.Host
-	proxyURL.Scheme = pm.destinationURL.Scheme
-	proxyURL.User = pm.destinationURL.User
-
-	proxyRequest, err := retryablehttp.NewRequestWithContext(r.Context(), http.MethodGet, proxyURL.String(), nil)
-	if err != nil {
-		return nil, fmt.Errorf("can't create proxy request: %w", err)
+	type searchResult struct {
+		Packages packages.Packages
+		Backend  backend
+		Err      error
 	}
 
-	pm.logger.Debug("Proxy /search request", zap.String("request.uri", proxyURL.String()))
-	response, err := pm.httpClient.Do(proxyRequest)
-	if err != nil {
-		return nil, fmt.Errorf("can't proxy search request: %w", err)
+	var wg sync.WaitGroup
+	resultsChan := make(chan searchResult, len(pm.backends))
+
+	for _, b := range pm.backends {
+		wg.Add(1)
+		go func(backend backend) {
+			defer wg.Done()
+			proxyURL := *r.URL
+			proxyURL.Host = backend.URL.Host
+			proxyURL.Scheme = backend.URL.Scheme
+			proxyURL.User = backend.URL.User
+
+			proxyRequest, err := retryablehttp.NewRequestWithContext(r.Context(), http.MethodGet, proxyURL.String(), nil)
+			if err != nil {
+				resultsChan <- searchResult{Err: fmt.Errorf("can't create proxy request for %s: %w", backend.URL, err)}
+				return
+			}
+
+			pm.logger.Debug("Proxying /search request", zap.String("request.uri", proxyURL.String()))
+			response, err := pm.httpClient.Do(proxyRequest)
+			if err != nil {
+				resultsChan <- searchResult{Err: fmt.Errorf("can't proxy search request to %s: %w", backend.URL, err)}
+				return
+			}
+			defer response.Body.Close()
+
+			var pkgs packages.Packages
+			if err := json.NewDecoder(response.Body).Decode(&pkgs); err != nil {
+				resultsChan <- searchResult{Err: fmt.Errorf("can't decode search response from %s: %w", backend.URL, err)}
+				return
+			}
+			resultsChan <- searchResult{Packages: pkgs, Backend: backend}
+		}(b)
 	}
-	defer response.Body.Close()
-	var pkgs packages.Packages
-	err = json.NewDecoder(response.Body).Decode(&pkgs)
-	if err != nil {
-		return nil, fmt.Errorf("can't proxy search request: %w", err)
+
+	go func() {
+		wg.Wait()
+		close(resultsChan)
+	}()
+
+	var mergedPackages packages.Packages
+	for result := range resultsChan {
+		if result.Err != nil {
+			pm.logger.Warn("Failed to fetch from proxy backend", zap.Error(result.Err))
+			continue
+		}
+		// Set the resolver for each package to its backend of origin.
+		for i := range result.Packages {
+			result.Packages[i].SetRemoteResolver(result.Backend.Resolver)
+		}
+		mergedPackages = mergedPackages.Join(result.Packages)
 	}
-	for i := 0; i < len(pkgs); i++ {
-		pkgs[i].SetRemoteResolver(pm.resolver)
-	}
-	return pkgs, nil
+
+	// NOTE: This is where complex merging/conflict resolution would be added.
+	// For now, we simply combine them.
+	return mergedPackages, nil
 }
 
 func (pm *ProxyMode) Categories(r *http.Request) ([]packages.Category, error) {
-
-	proxyURL := *r.URL
-	proxyURL.Host = pm.destinationURL.Host
-	proxyURL.Scheme = pm.destinationURL.Scheme
-	proxyURL.User = pm.destinationURL.User
-
-	proxyRequest, err := retryablehttp.NewRequestWithContext(r.Context(), http.MethodGet, proxyURL.String(), nil)
-	if err != nil {
-		return nil, fmt.Errorf("can't create proxy request: %w", err)
+	type categoriesResult struct {
+		Categories []packages.Category
+		Err        error
 	}
 
-	pm.logger.Debug("Proxy /categories request", zap.String("request.uri", proxyURL.String()))
-	response, err := pm.httpClient.Do(proxyRequest)
-	if err != nil {
-		return nil, fmt.Errorf("can't proxy categories request: %w", err)
+	var wg sync.WaitGroup
+	resultsChan := make(chan categoriesResult, len(pm.backends))
+
+	for _, b := range pm.backends {
+		wg.Add(1)
+		go func(backend backend) {
+			defer wg.Done()
+			proxyURL := *r.URL
+			proxyURL.Host = backend.URL.Host
+			proxyURL.Scheme = backend.URL.Scheme
+			proxyURL.User = backend.URL.User
+
+			proxyRequest, err := retryablehttp.NewRequestWithContext(r.Context(), http.MethodGet, proxyURL.String(), nil)
+			if err != nil {
+				resultsChan <- categoriesResult{Err: fmt.Errorf("can't create proxy request for %s: %w", backend.URL, err)}
+				return
+			}
+
+			pm.logger.Debug("Proxying /categories request", zap.String("request.uri", proxyURL.String()))
+			response, err := pm.httpClient.Do(proxyRequest)
+			if err != nil {
+				resultsChan <- categoriesResult{Err: fmt.Errorf("can't proxy categories request to %s: %w", backend.URL, err)}
+				return
+			}
+			defer response.Body.Close()
+
+			var cats []packages.Category
+			if err := json.NewDecoder(response.Body).Decode(&cats); err != nil {
+				resultsChan <- categoriesResult{Err: fmt.Errorf("can't decode categories response from %s: %w", backend.URL, err)}
+				return
+			}
+			resultsChan <- categoriesResult{Categories: cats}
+		}(b)
 	}
-	defer response.Body.Close()
-	var cats []packages.Category
-	err = json.NewDecoder(response.Body).Decode(&cats)
-	if err != nil {
-		return nil, fmt.Errorf("can't proxy categories request: %w", err)
+
+	go func() {
+		wg.Wait()
+		close(resultsChan)
+	}()
+
+	// Merge categories and sum counts for duplicates.
+	mergedCategories := make(map[string]packages.Category)
+	for result := range resultsChan {
+		if result.Err != nil {
+			pm.logger.Warn("Failed to fetch categories from proxy backend", zap.Error(result.Err))
+			continue
+		}
+		for _, cat := range result.Categories {
+			if existing, ok := mergedCategories[cat.Id]; ok {
+				existing.Count += cat.Count
+				mergedCategories[cat.Id] = existing
+			} else {
+				mergedCategories[cat.Id] = cat
+			}
+		}
 	}
-	return cats, nil
+
+	finalList := make([]packages.Category, 0, len(mergedCategories))
+	for _, cat := range mergedCategories {
+		finalList = append(finalList, cat)
+	}
+
+	return finalList, nil
 }
 
+// Package queries all backends in parallel and returns the first successful response.
 func (pm *ProxyMode) Package(r *http.Request) (*packages.Package, error) {
-
 	vars := mux.Vars(r)
 	packageName, ok := vars["packageName"]
 	if !ok {
 		return nil, errors.New("missing package name")
 	}
-
 	packageVersion, ok := vars["packageVersion"]
 	if !ok {
 		return nil, errors.New("missing package version")
 	}
 
-	urlPath := fmt.Sprintf("/package/%s/%s/", packageName, packageVersion)
-	proxyURL := pm.destinationURL.ResolveReference(&url.URL{Path: urlPath})
-	proxyRequest, err := retryablehttp.NewRequestWithContext(r.Context(), http.MethodGet, proxyURL.String(), nil)
-	if err != nil {
-		return nil, fmt.Errorf("can't create proxy request: %w", err)
+	type packageResult struct {
+		Package *packages.Package
+		Err     error
 	}
 
-	pm.logger.Debug("Proxy /package request", zap.String("request.uri", proxyURL.String()))
-	response, err := pm.httpClient.Do(proxyRequest)
-	if err != nil {
-		return nil, fmt.Errorf("can't proxy package request: %w", err)
-	}
-	defer response.Body.Close()
+	// We use a context that can be canceled once we find a result.
+	ctx, cancel := context.WithCancel(r.Context())
+	defer cancel()
 
-	switch response.StatusCode {
-	case http.StatusOK:
-		// Package found, all good.
-	case http.StatusNotFound:
-		// Package doesn't exist, don't try to parse the response, just return an empty package.
-		return nil, nil
-	default:
-		return nil, fmt.Errorf("unexpected status code %d received", response.StatusCode)
+	resultsChan := make(chan packageResult, len(pm.backends))
+	var wg sync.WaitGroup
+
+	for _, b := range pm.backends {
+		wg.Add(1)
+		go func(backend backend) {
+			defer wg.Done()
+			urlPath := fmt.Sprintf("/package/%s/%s/", packageName, packageVersion)
+			proxyURL := backend.URL.ResolveReference(&url.URL{Path: urlPath})
+
+			proxyRequest, err := retryablehttp.NewRequestWithContext(ctx, http.MethodGet, proxyURL.String(), nil)
+			if err != nil {
+				resultsChan <- packageResult{Err: fmt.Errorf("can't create proxy request for %s: %w", backend.URL, err)}
+				return
+			}
+
+			pm.logger.Debug("Proxying /package request", zap.String("request.uri", proxyURL.String()))
+			response, err := pm.httpClient.Do(proxyRequest)
+			if err != nil {
+				resultsChan <- packageResult{Err: fmt.Errorf("can't proxy package request to %s: %w", backend.URL, err)}
+				return
+			}
+			defer response.Body.Close()
+
+			switch response.StatusCode {
+			case http.StatusOK:
+				var pkg packages.Package
+				if err := json.NewDecoder(response.Body).Decode(&pkg); err != nil {
+					resultsChan <- packageResult{Err: fmt.Errorf("can't decode package response from %s: %w", backend.URL, err)}
+					return
+				}
+				pkg.SetRemoteResolver(backend.Resolver)
+				resultsChan <- packageResult{Package: &pkg}
+			case http.StatusNotFound:
+				// Not an error, just not found on this backend.
+				resultsChan <- packageResult{Package: nil}
+			default:
+				resultsChan <- packageResult{Err: fmt.Errorf("unexpected status code %d from %s", response.StatusCode, backend.URL)}
+			}
+		}(b)
 	}
 
-	var pkg packages.Package
-	err = json.NewDecoder(response.Body).Decode(&pkg)
-	if err != nil {
-		return nil, fmt.Errorf("can't proxy package request: %w", err)
+	go func() {
+		wg.Wait()
+		close(resultsChan)
+	}()
+
+	var lastErr error
+	for result := range resultsChan {
+		if result.Err != nil {
+			lastErr = result.Err
+			pm.logger.Warn("Failed to fetch package from proxy backend", zap.Error(result.Err))
+			continue
+		}
+		// If we found a package, cancel other requests and return immediately.
+		if result.Package != nil {
+			cancel() // Signal other goroutines to stop.
+			return result.Package, nil
+		}
 	}
-	pkg.SetRemoteResolver(pm.resolver)
-	return &pkg, nil
+
+	// If we get here, no package was found on any backend.
+	if lastErr != nil {
+		return nil, lastErr
+	}
+	return nil, nil // Not found
 }

--- a/proxymode/proxymode.go
+++ b/proxymode/proxymode.go
@@ -41,9 +41,12 @@ type ProxyMode struct {
 
 // ProxyOptions supports multiple backends and a configurable timeout.
 type ProxyOptions struct {
-	Enabled bool
-	ProxyTo []string
-	Timeout time.Duration
+	Enabled      bool
+	ProxyTo      []string
+	Timeout      time.Duration
+	RetryMax     int
+	RetryWaitMin time.Duration
+	RetryWaitMax time.Duration
 }
 
 func NoProxy(logger *zap.Logger) *ProxyMode {
@@ -160,9 +163,9 @@ func (pm *ProxyMode) Search(r *http.Request) (packages.Packages, error) {
 					Transport: pm.httpTransport,
 				},
 				Logger:       newZapLoggerAdapter(r.Context(), pm.logger),
-				RetryWaitMin: 1 * time.Second,
-				RetryWaitMax: 15 * time.Second,
-				RetryMax:     4,
+				RetryWaitMin: pm.options.RetryWaitMin,
+				RetryWaitMax: pm.options.RetryWaitMax,
+				RetryMax:     pm.options.RetryMax,
 				CheckRetry:   proxyRetryPolicy,
 				Backoff:      retryablehttp.DefaultBackoff,
 			}
@@ -236,9 +239,9 @@ func (pm *ProxyMode) Categories(r *http.Request) ([]packages.Category, error) {
 					Transport: pm.httpTransport,
 				},
 				Logger:       newZapLoggerAdapter(r.Context(), pm.logger),
-				RetryWaitMin: 1 * time.Second,
-				RetryWaitMax: 15 * time.Second,
-				RetryMax:     4,
+				RetryWaitMin: pm.options.RetryWaitMin,
+				RetryWaitMax: pm.options.RetryWaitMax,
+				RetryMax:     pm.options.RetryMax,
 				CheckRetry:   proxyRetryPolicy,
 				Backoff:      retryablehttp.DefaultBackoff,
 			}
@@ -334,9 +337,9 @@ func (pm *ProxyMode) Package(r *http.Request) (*packages.Package, error) {
 					Transport: pm.httpTransport,
 				},
 				Logger:       newZapLoggerAdapter(ctx, pm.logger),
-				RetryWaitMin: 1 * time.Second,
-				RetryWaitMax: 15 * time.Second,
-				RetryMax:     4,
+				RetryWaitMin: pm.options.RetryWaitMin,
+				RetryWaitMax: pm.options.RetryWaitMax,
+				RetryMax:     pm.options.RetryMax,
 				CheckRetry:   proxyRetryPolicy,
 				Backoff:      retryablehttp.DefaultBackoff,
 			}


### PR DESCRIPTION
This PR introduces the initial implementation for evolving proxymode to support fetching from multiple, parallel backends. The goal is to enable a highly-available and federated architecture, as presented in issue  #1439.

This is a draft PR to gather early feedback on the core architectural changes.

**Changes included in this draft:**
- The configuration (ProxyOptions) is updated to accept a list of backend URLs with optional priorities.
- The core fetching logic (Search, Categories, Package) is refactored to query all backends in parallel using a fan-out/fan-in concurrency pattern.
- A shared, instrumented http.Transport is used for efficient connection pooling, while a new retryablehttp.Client is created per-request to correctly handle state (timeouts, retries, logging context).

**Next Steps / To-Do:**
- Add unit and integration tests for the new concurrency model.

Seeking feedback on the overall approach to parallel fetching and configuration parsing.