### PR TITLE
[CI] Update GVM version

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
 
 env:
-  SETUP_GVM_VERSION: 'v0.5.2' # https://github.com/andrewkroh/gvm/issues/44#issuecomment-1013231151
+  SETUP_GVM_VERSION: 'v0.6.0' # https://github.com/andrewkroh/gvm/issues/44#issuecomment-1013231151
   SETUP_MAGE_VERSION: '1.15.0'
   JQ_VERSION: '1.7'
   DOCKER_IMG: "docker.elastic.co/package-registry/package-registry"


### PR DESCRIPTION
Update to the latest GVM version ([v0.6.0](https://github.com/andrewkroh/gvm/releases/tag/v0.6.0)) to avoid issues downloading Golang versions

As a context:
- https://github.com/elastic/integrations/pull/15675
- https://github.com/elastic/integrations/pull/15675#issuecomment-3416806751