### PR TITLE
Added missing mapping for azure/metrics input

### DIFF
--- a/internal/ingestionmethod/ingestion_method.yml
+++ b/internal/ingestionmethod/ingestion_method.yml
@@ -24,6 +24,7 @@ mappings:
   apache/metrics: API
   aws/metrics: API
   awsfargate/metrics: API
+  azure/metrics: API
   containerd/metrics: API
   docker/metrics: API
   elasticsearch/metrics: API


### PR DESCRIPTION
Following the initial addition of the ingestion_methods https://github.com/elastic/package-registry/pull/1402 , I realized I missed `azure/metrics`. After confirming the correct mapping with o11y, this PR adds it into the mapping list. 