### PR TITLE
[SQL indexer] Add transaction when updating index

### DIFF
--- a/internal/database/repository.go
+++ b/internal/database/repository.go
@@ -19,7 +19,7 @@ type Repository interface {
 	Drop(ctx context.Context, table string) error
 	Close(ctx context.Context) error
 
-	BeginTx(ctx context.Context) (*sql.Tx, error)
+	BeginTx(ctx context.Context, opts *sql.TxOptions) (*sql.Tx, error)
 
 	Ping(ctx context.Context) error
 

--- a/internal/database/sqliterepository.go
+++ b/internal/database/sqliterepository.go
@@ -185,8 +185,8 @@ func (r *SQLiteRepository) Initialize(ctx context.Context) error {
 	return nil
 }
 
-func (r *SQLiteRepository) BeginTx(ctx context.Context) (*sql.Tx, error) {
-	tx, err := r.db.BeginTx(ctx, nil)
+func (r *SQLiteRepository) BeginTx(ctx context.Context, opts *sql.TxOptions) (*sql.Tx, error) {
+	tx, err := r.db.BeginTx(ctx, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/storage/sqlindexer.go
+++ b/internal/storage/sqlindexer.go
@@ -249,7 +249,7 @@ func (i *SQLIndexer) updateDatabase(ctx context.Context, index *packages.Package
 	dbPackages := make([]*database.Package, 0, i.readPackagesBatchSize)
 
 	// Run all insert oprations (BulkAdd) in a single transaction for performance reasons.
-	tx, err := (*i.backup).BeginTx(ctx)
+	tx, err := (*i.backup).BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("failed to begin transaction in backup database: %w", err)
 	}


### PR DESCRIPTION
This PR adds a transaction for each operation of updating the index (writing to the database).

According to some best practices, adding a transaction helps improving the insertion.
- https://developer.android.com/topic/performance/sqlite-performance-best-practices#batch-multiple
- https://www.powersync.com/blog/sqlite-optimizations-for-ultra-high-performance

Benchmark:
```
goos: linux
goarch: amd64
pkg: github.com/elastic/package-registry/internal/storage
cpu: 11th Gen Intel(R) Core(TM) i7-11800H @ 2.30GHz
                         │ sql_prod_indexer_main_update_index.txt │ sql_prod_indexer_transaction_update_index.txt │
                         │                 sec/op                 │        sec/op          vs base                │
SQLIndexerUpdateIndex-16                              941.9m ± 1%             830.8m ± 1%  -11.79% (p=0.000 n=10)

                         │ sql_prod_indexer_main_update_index.txt │ sql_prod_indexer_transaction_update_index.txt │
                         │                  B/op                  │            B/op              vs base          │
SQLIndexerUpdateIndex-16                             236.8Mi ± 0%                  236.8Mi ± 0%  ~ (p=0.165 n=10)

                         │ sql_prod_indexer_main_update_index.txt │ sql_prod_indexer_transaction_update_index.txt │
                         │               allocs/op                │       allocs/op         vs base               │
SQLIndexerUpdateIndex-16                              533.1k ± 0%              533.1k ± 0%  +0.00% (p=0.000 n=10)
```

Some visualizations from APM with a large data/index:
- Before:
<img width="1478" height="747" alt="update_no_transaction" src="https://github.com/user-attachments/assets/dd62413d-a8c4-42e0-8d22-4503bda49206" />
- After:
<img width="1478" height="747" alt="update_transaction" src="https://github.com/user-attachments/assets/5221fa32-d822-47a8-9a0e-a726f281d219" />
