### PR TITLE
Revert use of WaitGroup.Go

### DIFF
--- a/workers/taskpool.go
+++ b/workers/taskpool.go
@@ -27,12 +27,14 @@ func NewTaskPool(size int) *taskPool {
 // Do runs the task in a goroutine, ensuring no more tasks are running than the size of the pool.
 func (p *taskPool) Do(task func() error) {
 	p.pool <- struct{}{}
-	p.wg.Go(func() {
+	p.wg.Add(1)
+	go func() {
+		defer p.wg.Done()
 		defer func() { <-p.pool }()
 
 		err := task()
 		p.recordError(err)
-	})
+	}()
 }
 
 func (p *taskPool) recordError(err error) {


### PR DESCRIPTION
`sync.WaitGroup.Go` was introduced in Go 1.25, but the project `go.mod` files indicate `go 1.24`. This is not failing in CI because `.go-version` has a 1.25 version.

By now I would revert the use of this new method, but in the future we should probably keep both versions aligned, or add a CI job that tests with the matrix of versions supported.

Alternatively, as 1.26 has been just released, we could also update everything to 1.25.