### PR TITLE
Add support for FIPS 140

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -71,6 +71,30 @@ steps:
         artifact_paths:
           - "tests-report-darwin.xml"
 
+  - group: ":lock: Run FIPS Unit tests"
+    key: fips-tests
+    steps:
+      - label: ":linux::lock: FIPS Test on Linux"
+        key: test-fips-linux
+        command:
+          - ".buildkite/scripts/run-tests-fips.sh"
+        agents:
+          image: "${LINUX_GOLANG_AGENT_IMAGE}"
+          cpu: "8"
+          memory: "4G"
+        artifact_paths:
+          - "tests-report-fips-linux.xml"
+
+      - label: ":macos::lock: FIPS Test on Macos ARM"
+        key: test-fips-macos-arm
+        command:
+          - ".buildkite/scripts/run-tests-fips.sh"
+        agents:
+          provider: "orka"
+          imagePrefix: "${MACOS_ARM_AGENT_IMAGE}"
+        artifact_paths:
+          - "tests-report-fips-darwin.xml"
+
   - label: ":junit: Junit annotate"
     agents:
       # requires at least "bash", "curl" and "git"
@@ -89,6 +113,10 @@ steps:
         allow_failure: true
       - step: "test-macos-arm"
         allow_failure: true
+      - step: "test-fips-linux"
+        allow_failure: true
+      - step: "test-fips-macos-arm"
+        allow_failure: true
 
   - label: ":docker: Publish docker image"
     key: "publish"
@@ -101,6 +129,10 @@ steps:
       - step: "test-win"
         allow_failure: false
       - step: "test-macos-arm"
+        allow_failure: false
+      - step: "test-fips-linux"
+        allow_failure: false
+      - step: "test-fips-macos-arm"
         allow_failure: false
       - step: "build"
         allow_failure: false

--- a/.buildkite/scripts/run-tests-fips.sh
+++ b/.buildkite/scripts/run-tests-fips.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+source .buildkite/scripts/pre-install-command.sh
+set -euo pipefail
+
+# Pre install:
+add_bin_path
+with_mage
+with_go_junit_report
+
+platform_type="$(uname | tr '[:upper:]' '[:lower:]')"
+tests_report_txt_file="tests-report-fips-${platform_type}.txt"
+tests_report_xml_file="tests-report-fips-${platform_type}.xml"
+echo "--- Run FIPS Unit tests"
+set +e
+mage -debug testFIPS > "${tests_report_txt_file}"
+exit_code=$?
+set -e
+
+# Buildkite collapse logs under --- symbols
+# need to change --- to anything else or switch off collapsing (note: not available at the moment of this commit)
+awk '{gsub("---", "----"); print }' "${tests_report_txt_file}"
+
+echo "Create Junit report for junit annotation plugin ${tests_report_xml_file}"
+go-junit-report > "${tests_report_xml_file}" < "${tests_report_txt_file}"
+exit $exit_code

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,10 +9,12 @@ This project uses [Mage](https://magefile.org) as its build tool. Run `mage` wit
 ```bash
 # Build
 mage build                # Build package-registry binary
+mage buildFIPS            # Build with FIPS 140 support
 go run .                  # Run directly without building
 
 # Test
 mage test                 # Run all tests
+mage testFIPS             # Run tests with FIPS 140 enabled
 go test ./...             # Alternative: run all tests
 go test -v ./packages     # Run tests for specific package
 go test . -generate       # Regenerate golden test files (after adding test packages)

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 PLATFORMS ?= linux/amd64 linux/arm64/v8 linux/arm64
 PLATFORM_TARGETS=$(addprefix release-, $(PLATFORMS))
+PLATFORM_FIPS_TARGETS=$(addprefix release-fips-, $(PLATFORMS))
 
 TARGET_ARCH_amd64=x86_64
 TARGET_ARCH_arm64=arm64
@@ -8,6 +9,7 @@ OSS ?= linux
 OSS_TARGETS=$(addprefix release-, $(OSS))
 
 BUILD_FLAGS=-tags=grpcnotrace -trimpath -ldflags=-s
+FIPS_BUILD_FLAGS=-tags=grpcnotrace -trimpath -ldflags=-s
 
 .PHONY: $(OSS_TARGETS)
 $(OSS_TARGETS): release-%:
@@ -20,3 +22,13 @@ $(PLATFORM_TARGETS): release-%:
 	$(eval $@_GO_ARCH := $(word 2, $(subst /, ,$(lastword $(subst release-, ,$@)))))
 	$(eval $@_ARCH := $(TARGET_ARCH_$($@_GO_ARCH)))
 	GOOS=$($@_OS) GOARCH=$($@_GO_ARCH) go build $(BUILD_FLAGS) .
+
+.PHONY: $(PLATFORM_FIPS_TARGETS)
+$(PLATFORM_FIPS_TARGETS): release-fips-%:
+	$(eval $@_OS := $(firstword $(subst /, ,$(lastword $(subst release-fips-, ,$@)))))
+	$(eval $@_GO_ARCH := $(word 2, $(subst /, ,$(lastword $(subst release-fips-, ,$@)))))
+	$(eval $@_ARCH := $(TARGET_ARCH_$($@_GO_ARCH)))
+	@echo ">> Downloading dependencies for FIPS build"
+	@go mod download
+	@echo ">> Building with FIPS 140 enabled"
+	GOFIPS140=v1.0.0 GODEBUG=fips140=only GOOS=$($@_OS) GOARCH=$($@_GO_ARCH) go build $(FIPS_BUILD_FLAGS) .

--- a/README.md
+++ b/README.md
@@ -103,6 +103,23 @@ mage build
 Once built, the Package Registry can be run as `./package-registry`. Find below
 more details about the available configuration options.
 
+#### FIPS 140 Support
+
+To build a FIPS 140 compliant binary, use:
+```
+mage buildFIPS
+```
+
+This builds the binary with Go's FIPS 140 mode enabled (`GOFIPS140=v1.0.0 GODEBUG=fips140=only`), ensuring all cryptographic operations use FIPS-validated implementations.
+
+**Testing with FIPS:**
+
+To run tests in FIPS mode:
+```
+mage testFIPS
+```
+
+Note: Tests that rely on third-party services (like fake-gcs-server for storage tests) are automatically skipped in FIPS mode, as these dependencies may use non-FIPS-compliant cryptographic operations.
 
 ### Docker
 

--- a/cmd/distribution/download_test.go
+++ b/cmd/distribution/download_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/ProtonMail/go-crypto/openpgp"
@@ -18,7 +19,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// isFIPSMode returns true if FIPS 140 mode is enabled
+func isFIPSMode() bool {
+	godebug := os.Getenv("GODEBUG")
+	return strings.Contains(godebug, "fips140=only") ||
+		strings.Contains(godebug, "fips140=on")
+}
+
 func TestDownloadActionInit(t *testing.T) {
+	if isFIPSMode() {
+		t.Skip("Skipping distribution tests in FIPS mode (go-crypto/openpgp is not FIPS-compliant)")
+	}
 	tempDir := t.TempDir()
 
 	action := &downloadAction{
@@ -91,6 +102,9 @@ func TestDownloadActionDownloadHTTPError(t *testing.T) {
 }
 
 func TestDownloadActionPerformSkipsIfAlreadyDownloaded(t *testing.T) {
+	if isFIPSMode() {
+		t.Skip("Skipping distribution tests in FIPS mode (go-crypto/openpgp is not FIPS-compliant)")
+	}
 	tempDir := t.TempDir()
 
 	// Create a simple test key for signing
@@ -142,6 +156,9 @@ func TestDownloadActionPerformSkipsIfAlreadyDownloaded(t *testing.T) {
 }
 
 func TestDownloadActionPerformDownloadsIfMissing(t *testing.T) {
+	if isFIPSMode() {
+		t.Skip("Skipping distribution tests in FIPS mode (go-crypto/openpgp is not FIPS-compliant)")
+	}
 	tempDir := t.TempDir()
 
 	// Create a simple test key for signing
@@ -203,6 +220,9 @@ func TestDownloadActionPerformDownloadsIfMissing(t *testing.T) {
 }
 
 func TestDownloadActionValid(t *testing.T) {
+	if isFIPSMode() {
+		t.Skip("Skipping distribution tests in FIPS mode (go-crypto/openpgp is not FIPS-compliant)")
+	}
 	tempDir := t.TempDir()
 
 	// Create a test key
@@ -242,6 +262,9 @@ func TestDownloadActionValid(t *testing.T) {
 }
 
 func TestDownloadActionValidInvalidSignature(t *testing.T) {
+	if isFIPSMode() {
+		t.Skip("Skipping distribution tests in FIPS mode (go-crypto/openpgp is not FIPS-compliant)")
+	}
 	tempDir := t.TempDir()
 
 	// Create test package
@@ -302,6 +325,9 @@ func TestDownloadActionValidMissingFiles(t *testing.T) {
 }
 
 func TestDownloadActionAddressInheritance(t *testing.T) {
+	if isFIPSMode() {
+		t.Skip("Skipping distribution tests in FIPS mode (go-crypto/openpgp is not FIPS-compliant)")
+	}
 	tempDir := t.TempDir()
 
 	tests := []struct {
@@ -343,6 +369,9 @@ func TestDownloadActionAddressInheritance(t *testing.T) {
 }
 
 func TestDownloadActionIntegration(t *testing.T) {
+	if isFIPSMode() {
+		t.Skip("Skipping distribution tests in FIPS mode (go-crypto/openpgp is not FIPS-compliant)")
+	}
 	tempDir := t.TempDir()
 
 	// Create test packages

--- a/internal/storage/fakestorage_test.go
+++ b/internal/storage/fakestorage_test.go
@@ -15,6 +15,9 @@ import (
 )
 
 func TestPrepareFakeServer(t *testing.T) {
+	if isFIPSMode() {
+		t.Skip("Skipping storage tests in FIPS mode (fake-gcs-server uses non-FIPS crypto)")
+	}
 	// given
 	indexFile := "../../storage/testdata/search-index-all-full.json"
 	testIndexFile, err := os.ReadFile(indexFile)

--- a/internal/storage/sqlindexer_test.go
+++ b/internal/storage/sqlindexer_test.go
@@ -8,7 +8,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -22,7 +24,16 @@ import (
 	"github.com/elastic/package-registry/packages"
 )
 
+func isFIPSMode() bool {
+	godebug := os.Getenv("GODEBUG")
+	return strings.Contains(godebug, "fips140=only") ||
+		strings.Contains(godebug, "fips140=on")
+}
+
 func TestSQLInit(t *testing.T) {
+	if isFIPSMode() {
+		t.Skip("Skipping storage tests in FIPS mode (fake-gcs-server uses non-FIPS crypto)")
+	}
 	t.Parallel()
 
 	// given
@@ -247,6 +258,9 @@ func BenchmarkSQLIndexerGetStaticsAndArtifacts(b *testing.B) {
 }
 
 func TestSQLGet_ListPackages(t *testing.T) {
+	if isFIPSMode() {
+		t.Skip("Skipping storage tests in FIPS mode (fake-gcs-server uses non-FIPS crypto)")
+	}
 	t.Parallel()
 
 	// given
@@ -459,6 +473,9 @@ func TestSQLGet_ListPackages(t *testing.T) {
 }
 
 func TestSQLGet_IndexUpdated(t *testing.T) {
+	if isFIPSMode() {
+		t.Skip("Skipping storage tests in FIPS mode (fake-gcs-server uses non-FIPS crypto)")
+	}
 	t.Parallel()
 
 	// given

--- a/magefile.go
+++ b/magefile.go
@@ -121,12 +121,16 @@ func Test() error {
 
 // TestFIPS runs all tests with FIPS 140 mode enabled.
 func TestFIPS() error {
-	fmt.Println(">> Downloading dependencies")
-	err := sh.Run("go", "mod", "download")
-	if err != nil {
-		return fmt.Errorf("failed to download dependencies: %w", err)
+	// Download dependencies for all modules first
+	for _, mod := range modules {
+		fmt.Printf(">> Downloading dependencies for %s\n", mod.name)
+		err := sh.RunWith(map[string]string{"PWD": mod.path}, "go", "mod", "download")
+		if err != nil {
+			return fmt.Errorf("failed to download dependencies for %s: %w", mod.name, err)
+		}
 	}
 
+	// Run tests with FIPS enabled
 	for _, mod := range modules {
 		fmt.Printf(">> Testing %s with FIPS 140 enabled\n", mod.name)
 		err := sh.RunWith(map[string]string{

--- a/package_storage_test.go
+++ b/package_storage_test.go
@@ -8,7 +8,9 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/fsouza/fake-gcs-server/fakestorage"
@@ -18,6 +20,13 @@ import (
 	internalStorage "github.com/elastic/package-registry/internal/storage"
 	"github.com/elastic/package-registry/storage"
 )
+
+// isFIPSMode returns true if FIPS 140 mode is enabled
+func isFIPSMode() bool {
+	godebug := os.Getenv("GODEBUG")
+	return strings.Contains(godebug, "fips140=only") ||
+		strings.Contains(godebug, "fips140=on")
+}
 
 const storageIndexerGoldenDir = "storage-indexer"
 
@@ -142,6 +151,9 @@ func generateTestCaseStorageEndpoints(indexer Indexer) ([]struct {
 }
 
 func TestPackageStorage_Endpoints(t *testing.T) {
+	if isFIPSMode() {
+		t.Skip("Skipping storage tests in FIPS mode (fake-gcs-server uses non-FIPS crypto)")
+	}
 	fs := internalStorage.PrepareFakeServer(t, "./storage/testdata/search-index-all-full.json")
 	defer fs.Stop()
 
@@ -162,6 +174,9 @@ func TestPackageStorage_Endpoints(t *testing.T) {
 }
 
 func TestPackageStorageSQL_Endpoints(t *testing.T) {
+	if isFIPSMode() {
+		t.Skip("Skipping storage tests in FIPS mode (fake-gcs-server uses non-FIPS crypto)")
+	}
 	fs := internalStorage.PrepareFakeServer(t, "./storage/testdata/search-index-all-full.json")
 	defer fs.Stop()
 
@@ -209,6 +224,9 @@ func generateTestPackageIndexEndpoints(indexer Indexer) ([]struct {
 }
 
 func TestPackageStorage_PackageIndex(t *testing.T) {
+	if isFIPSMode() {
+		t.Skip("Skipping storage tests in FIPS mode (fake-gcs-server uses non-FIPS crypto)")
+	}
 	fs := internalStorage.PrepareFakeServer(t, "./storage/testdata/search-index-all-full.json")
 	defer fs.Stop()
 	indexer := generateStorageIndexer(fs, storage.FakeIndexerOptions)
@@ -228,6 +246,9 @@ func TestPackageStorage_PackageIndex(t *testing.T) {
 }
 
 func TestPackageSQLStorage_PackageIndex(t *testing.T) {
+	if isFIPSMode() {
+		t.Skip("Skipping storage tests in FIPS mode (fake-gcs-server uses non-FIPS crypto)")
+	}
 	fs := internalStorage.PrepareFakeServer(t, "./storage/testdata/search-index-all-full.json")
 	defer fs.Stop()
 
@@ -271,6 +292,9 @@ func generateTestArtifactsEndpoints(indexer Indexer) ([]struct {
 }
 
 func TestPackageStorage_Artifacts(t *testing.T) {
+	if isFIPSMode() {
+		t.Skip("Skipping storage tests in FIPS mode (fake-gcs-server uses non-FIPS crypto)")
+	}
 	fs := internalStorage.PrepareFakeServer(t, "./storage/testdata/search-index-all-full.json")
 	defer fs.Stop()
 
@@ -299,6 +323,9 @@ func TestPackageStorage_Artifacts(t *testing.T) {
 }
 
 func TestPackageSQLStorage_Artifacts(t *testing.T) {
+	if isFIPSMode() {
+		t.Skip("Skipping storage tests in FIPS mode (fake-gcs-server uses non-FIPS crypto)")
+	}
 	fs := internalStorage.PrepareFakeServer(t, "./storage/testdata/search-index-all-full.json")
 	defer fs.Stop()
 
@@ -346,6 +373,9 @@ func generateTestSignaturesEndpoints(indexer Indexer) ([]struct {
 }
 
 func TestPackageStorage_Signatures(t *testing.T) {
+	if isFIPSMode() {
+		t.Skip("Skipping storage tests in FIPS mode (fake-gcs-server uses non-FIPS crypto)")
+	}
 	fs := internalStorage.PrepareFakeServer(t, "./storage/testdata/search-index-all-full.json")
 	defer fs.Stop()
 
@@ -374,6 +404,9 @@ func TestPackageStorage_Signatures(t *testing.T) {
 }
 
 func TestPackageSQLStorage_Signatures(t *testing.T) {
+	if isFIPSMode() {
+		t.Skip("Skipping storage tests in FIPS mode (fake-gcs-server uses non-FIPS crypto)")
+	}
 	fs := internalStorage.PrepareFakeServer(t, "./storage/testdata/search-index-all-full.json")
 	defer fs.Stop()
 
@@ -422,6 +455,9 @@ func generateTestStaticEndpoints(indexer Indexer) ([]struct {
 }
 
 func TestPackageStorage_Statics(t *testing.T) {
+	if isFIPSMode() {
+		t.Skip("Skipping storage tests in FIPS mode (fake-gcs-server uses non-FIPS crypto)")
+	}
 	fs := internalStorage.PrepareFakeServer(t, "./storage/testdata/search-index-all-full.json")
 	defer fs.Stop()
 
@@ -450,6 +486,9 @@ func TestPackageStorage_Statics(t *testing.T) {
 }
 
 func TestPackagesQLStorage_Statics(t *testing.T) {
+	if isFIPSMode() {
+		t.Skip("Skipping storage tests in FIPS mode (fake-gcs-server uses non-FIPS crypto)")
+	}
 	fs := internalStorage.PrepareFakeServer(t, "./storage/testdata/search-index-all-full.json")
 	defer fs.Stop()
 
@@ -507,6 +546,9 @@ func generateTestResolveHeadersEndpoints(indexer Indexer) ([]struct {
 }
 
 func TestPackageStorage_ResolverHeadersResponse(t *testing.T) {
+	if isFIPSMode() {
+		t.Skip("Skipping storage tests in FIPS mode (fake-gcs-server uses non-FIPS crypto)")
+	}
 	fs := internalStorage.PrepareFakeServer(t, "./storage/testdata/search-index-all-full.json")
 	defer fs.Stop()
 
@@ -538,6 +580,9 @@ func TestPackageStorage_ResolverHeadersResponse(t *testing.T) {
 }
 
 func TestPackageSQLStorage_ResolverHeadersResponse(t *testing.T) {
+	if isFIPSMode() {
+		t.Skip("Skipping storage tests in FIPS mode (fake-gcs-server uses non-FIPS crypto)")
+	}
 	fs := internalStorage.PrepareFakeServer(t, "./storage/testdata/search-index-all-full.json")
 	defer fs.Stop()
 
@@ -592,6 +637,9 @@ func generateTestResolveErrorResponseEndpoints(indexer Indexer) ([]struct {
 }
 
 func TestPackageStorage_ResolverErrorResponse(t *testing.T) {
+	if isFIPSMode() {
+		t.Skip("Skipping storage tests in FIPS mode (fake-gcs-server uses non-FIPS crypto)")
+	}
 	fs := internalStorage.PrepareFakeServer(t, "./storage/testdata/search-index-all-full.json")
 	defer fs.Stop()
 
@@ -621,6 +669,9 @@ func TestPackageStorage_ResolverErrorResponse(t *testing.T) {
 }
 
 func TestPackageSQLStorage_ResolverErrorResponse(t *testing.T) {
+	if isFIPSMode() {
+		t.Skip("Skipping storage tests in FIPS mode (fake-gcs-server uses non-FIPS crypto)")
+	}
 	fs := internalStorage.PrepareFakeServer(t, "./storage/testdata/search-index-all-full.json")
 	defer fs.Stop()
 

--- a/storage/indexer_test.go
+++ b/storage/indexer_test.go
@@ -7,6 +7,8 @@ package storage
 import (
 	"context"
 	"fmt"
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/Masterminds/semver/v3"
@@ -19,7 +21,16 @@ import (
 	"github.com/elastic/package-registry/packages"
 )
 
+func isFIPSMode() bool {
+	godebug := os.Getenv("GODEBUG")
+	return strings.Contains(godebug, "fips140=only") ||
+		strings.Contains(godebug, "fips140=on")
+}
+
 func TestInit(t *testing.T) {
+	if isFIPSMode() {
+		t.Skip("Skipping storage tests in FIPS mode (fake-gcs-server uses non-FIPS crypto)")
+	}
 	// given
 	fs := internalStorage.PrepareFakeServer(t, "testdata/search-index-all-full.json")
 	defer fs.Stop()
@@ -112,6 +123,9 @@ func BenchmarkIndexerGet(b *testing.B) {
 }
 
 func TestGet_ListPackages(t *testing.T) {
+	if isFIPSMode() {
+		t.Skip("Skipping storage tests in FIPS mode (fake-gcs-server uses non-FIPS crypto)")
+	}
 	t.Parallel()
 
 	// given
@@ -314,6 +328,9 @@ func TestGet_ListPackages(t *testing.T) {
 }
 
 func TestGet_IndexUpdated(t *testing.T) {
+	if isFIPSMode() {
+		t.Skip("Skipping storage tests in FIPS mode (fake-gcs-server uses non-FIPS crypto)")
+	}
 	t.Parallel()
 
 	// given


### PR DESCRIPTION
## Overview

Add tests and build options to support [FIPS 140](https://go.dev/doc/security/fips140)

Does not create a dockerfile for release

Had to skip tests related to `fake-gcs-server` as they all failed due to the package using not approved algorithms.

## Test
```bash
mage buildFIPS
mage testFIPS
```
closes #1569 