### PR TITLE
[CI] Update Buildkite configuration to trigger builds

### DIFF
--- a/.buildkite/pull-requests.json
+++ b/.buildkite/pull-requests.json
@@ -10,6 +10,15 @@
             "build_on_comment": true,
             "trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:build|test)\\W+(?:this|it))|^/test$",
             "always_trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:build|test)\\W+(?:this|it))|^/test$",
+            "skip_ci_labels": [ ],
+            "skip_target_branches": [ ],
+            "skip_ci_on_only_changed": [
+              "^.github/",
+              "^.mergify.yml$",
+              "^.buildkite/pull-requests.json$",
+              "^catalog-info.yaml$"
+            ],
+            "always_require_ci_on_changed": [ ]
         },
         {
             "enabled": true,


### PR DESCRIPTION
Update the buildkite configuration to trigger builds in pull requests to be similar to the one found in elastic-package:
- Update regex to re-trigger buildkite build via GitHub comment
- Skip triggering buildkite builds if just certain files are modified.

Reference:

https://github.com/elastic/elastic-package/blob/0f6700227fefc9b26f3e5ec79cf84f5823a7c6ae/.buildkite/pull-requests.json#L3-L28
