### PR TITLE
Fix package sort logic to use a more stable property name instead of title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bugfixes
 
+* Sort packages by name instead of title for a more stable and deterministic sort order. [#1689](https://github.com/elastic/package-registry/pull/1689)
+
 ### Added
 
 ### Deprecated

--- a/packages/packages.go
+++ b/packages/packages.go
@@ -41,8 +41,8 @@ type Packages []*Package
 func (p Packages) Len() int      { return len(p) }
 func (p Packages) Swap(i, j int) { p[i], p[j] = p[j], p[i] }
 func (p Packages) Less(i, j int) bool {
-	if p[i].Title != nil && p[j].Title != nil && *p[i].Title != *p[j].Title {
-		return *p[i].Title < *p[j].Title
+	if p[i].Name != p[j].Name {
+		return p[i].Name < p[j].Name
 	}
 	iSemVer, iErr := semver.NewVersion(p[i].Version)
 	jSemVer, jErr := semver.NewVersion(p[j].Version)

--- a/packages/packages_test.go
+++ b/packages/packages_test.go
@@ -1310,21 +1310,19 @@ func assertFilterPackagesResult(t *testing.T, expected []filterTestPackage, foun
 func strPtr(s string) *string { return &s }
 
 func TestPackagesSort(t *testing.T) {
-	t.Run("sorts by title alphabetically", func(t *testing.T) {
+	t.Run("sorts by name alphabetically", func(t *testing.T) {
 		pkgs := Packages{
-			{BasePackage: BasePackage{Name: "c_pkg", Title: strPtr("Zebra Integration"), Version: "1.0.0"}},
-			{BasePackage: BasePackage{Name: "a_pkg", Title: strPtr("Apple Integration"), Version: "1.0.0"}},
+			{BasePackage: BasePackage{Name: "c_pkg", Title: strPtr("Apple Integration"), Version: "1.0.0"}},
+			{BasePackage: BasePackage{Name: "a_pkg", Title: strPtr("Zebra Integration"), Version: "1.0.0"}},
 			{BasePackage: BasePackage{Name: "b_pkg", Title: strPtr("Mango Integration"), Version: "1.0.0"}},
 		}
 		sort.Sort(pkgs)
-		assert.Equal(t, "Apple Integration", *pkgs[0].Title)
-		assert.Equal(t, "Mango Integration", *pkgs[1].Title)
-		assert.Equal(t, "Zebra Integration", *pkgs[2].Title)
+		assert.Equal(t, "a_pkg", pkgs[0].Name)
+		assert.Equal(t, "b_pkg", pkgs[1].Name)
+		assert.Equal(t, "c_pkg", pkgs[2].Name)
 	})
 
-	t.Run("sorts by semver version when titles are equal", func(t *testing.T) {
-		// Regression test: lexicographic ordering would sort 8.19.2 after 8.19.15
-		// because "2" > "1", but semantic ordering puts 8.19.2 before 8.19.15.
+	t.Run("sorts by semver version when names are equal", func(t *testing.T) {
 		pkgs := Packages{
 			{BasePackage: BasePackage{Name: "security_detection_engine", Title: strPtr("Prebuilt Security Detection Rules"), Version: "8.19.15"}},
 			{BasePackage: BasePackage{Name: "security_detection_engine", Title: strPtr("Prebuilt Security Detection Rules"), Version: "8.19.2"}},
@@ -1340,7 +1338,7 @@ func TestPackagesSort(t *testing.T) {
 		assert.Equal(t, []string{"1.0.1", "8.2.1", "8.19.2", "8.19.9", "8.19.15"}, versions)
 	})
 
-	t.Run("sorts by title first, then version within same title", func(t *testing.T) {
+	t.Run("sorts by name first, then version within same name", func(t *testing.T) {
 		pkgs := Packages{
 			{BasePackage: BasePackage{Name: "b_pkg", Title: strPtr("Beta"), Version: "2.0.0"}},
 			{BasePackage: BasePackage{Name: "a_pkg", Title: strPtr("Alpha"), Version: "1.0.0"}},
@@ -1348,13 +1346,13 @@ func TestPackagesSort(t *testing.T) {
 			{BasePackage: BasePackage{Name: "a_pkg", Title: strPtr("Alpha"), Version: "9.0.0"}},
 		}
 		sort.Sort(pkgs)
-		assert.Equal(t, "Alpha", *pkgs[0].Title)
+		assert.Equal(t, "a_pkg", pkgs[0].Name)
 		assert.Equal(t, "1.0.0", pkgs[0].Version)
-		assert.Equal(t, "Alpha", *pkgs[1].Title)
+		assert.Equal(t, "a_pkg", pkgs[1].Name)
 		assert.Equal(t, "9.0.0", pkgs[1].Version)
-		assert.Equal(t, "Beta", *pkgs[2].Title)
+		assert.Equal(t, "b_pkg", pkgs[2].Name)
 		assert.Equal(t, "2.0.0", pkgs[2].Version)
-		assert.Equal(t, "Beta", *pkgs[3].Title)
+		assert.Equal(t, "b_pkg", pkgs[3].Name)
 		assert.Equal(t, "10.0.0", pkgs[3].Version)
 	})
 }

--- a/testdata/generated/search-all-proxy.json
+++ b/testdata/generated/search-all-proxy.json
@@ -54,51 +54,6 @@
     ]
   },
   {
-    "name": "datastream_without_release",
-    "title": "Apache Spark",
-    "version": "0.1.0",
-    "release": "beta",
-    "description": "Collect metrics from Apache Spark with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/datastream_without_release/datastream_without_release-0.1.0.zip",
-    "path": "/package/datastream_without_release/0.1.0",
-    "icons": [
-      {
-        "src": "/img/apache_spark-logo.svg",
-        "path": "/package/datastream_without_release/0.1.0/img/apache_spark-logo.svg",
-        "title": "Apache Spark logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "apache_spark",
-        "title": "Apache Spark metrics",
-        "description": "Collect Apache Spark metrics"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.1.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/obs-service-integrations"
-    },
-    "categories": [
-      "datastore",
-      "monitoring"
-    ],
-    "data_streams": [
-      {
-        "type": "metrics",
-        "dataset": "datastream_without_release.nodes",
-        "title": "Apache Spark nodes metrics"
-      }
-    ]
-  },
-  {
     "name": "dataset_is_prefix",
     "title": "DatasetIsPrefix Flag",
     "version": "0.0.1",
@@ -116,19 +71,6 @@
         "dataset": "dataset_is_prefix.test",
         "title": "dataset_is_prefix test data stream"
       }
-    ]
-  },
-  {
-    "name": "defaultrelease",
-    "title": "Default Release",
-    "version": "0.0.1",
-    "release": "beta",
-    "description": "Package without release, should be set to default",
-    "type": "solution",
-    "download": "/epr/defaultrelease/defaultrelease-0.0.1.zip",
-    "path": "/package/defaultrelease/0.0.1",
-    "categories": [
-      "aws"
     ]
   },
   {
@@ -174,29 +116,47 @@
     ]
   },
   {
-    "name": "ecs_style_dataset",
-    "title": "Default pipeline Integration",
-    "version": "0.0.1",
+    "name": "datastream_without_release",
+    "title": "Apache Spark",
+    "version": "0.1.0",
     "release": "beta",
-    "description": "Tests the registry validations works for dataset fields using the ecs style format",
+    "description": "Collect metrics from Apache Spark with Elastic Agent.",
     "type": "integration",
-    "download": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.zip",
-    "path": "/package/ecs_style_dataset/0.0.1",
-    "policy_templates": [
+    "download": "/epr/datastream_without_release/datastream_without_release-0.1.0.zip",
+    "path": "/package/datastream_without_release/0.1.0",
+    "icons": [
       {
-        "name": "logs",
-        "title": "Logs datasource",
-        "description": "Datasource for your log files."
+        "src": "/img/apache_spark-logo.svg",
+        "path": "/package/datastream_without_release/0.1.0/img/apache_spark-logo.svg",
+        "title": "Apache Spark logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
       }
     ],
+    "policy_templates": [
+      {
+        "name": "apache_spark",
+        "title": "Apache Spark metrics",
+        "description": "Collect Apache Spark metrics"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.1.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/obs-service-integrations"
+    },
     "categories": [
+      "datastore",
       "monitoring"
     ],
     "data_streams": [
       {
-        "type": "logs",
-        "dataset": "ecs_style_dataset.foo",
-        "title": "Foo"
+        "type": "metrics",
+        "dataset": "datastream_without_release.nodes",
+        "title": "Apache Spark nodes metrics"
       }
     ]
   },
@@ -226,6 +186,19 @@
         "dataset": "default_pipeline.foo",
         "title": "Foo"
       }
+    ]
+  },
+  {
+    "name": "defaultrelease",
+    "title": "Default Release",
+    "version": "0.0.1",
+    "release": "beta",
+    "description": "Package without release, should be set to default",
+    "type": "solution",
+    "download": "/epr/defaultrelease/defaultrelease-0.0.1.zip",
+    "path": "/package/defaultrelease/0.0.1",
+    "categories": [
+      "aws"
     ]
   },
   {
@@ -296,6 +269,208 @@
     ]
   },
   {
+    "name": "deprecated_input_package",
+    "title": "New Package",
+    "version": "1.0.0",
+    "release": "ga",
+    "source": {
+      "license": "Elastic-2.0"
+    },
+    "description": "This is a new package.",
+    "type": "input",
+    "download": "/epr/deprecated_input_package/deprecated_input_package-1.0.0.zip",
+    "path": "/package/deprecated_input_package/1.0.0",
+    "icons": [
+      {
+        "src": "/img/sample-logo.svg",
+        "path": "/package/deprecated_input_package/1.0.0/img/sample-logo.svg",
+        "title": "Sample logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "sample",
+        "title": "Sample logs",
+        "description": "Collect sample logs"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^9.2.3"
+      },
+      "elastic": {
+        "subscription": "basic"
+      }
+    },
+    "owner": {
+      "type": "elastic",
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "deprecated": {
+      "since": "1.2.0",
+      "description": "This input package is deprecated",
+      "replaced_by": {
+        "package": "new_input_package"
+      }
+    }
+  },
+  {
+    "name": "deprecated_input_policy",
+    "title": "New Package",
+    "version": "1.0.0",
+    "release": "ga",
+    "source": {
+      "license": "Elastic-2.0"
+    },
+    "description": "This is a new package.",
+    "type": "input",
+    "download": "/epr/deprecated_input_policy/deprecated_input_policy-1.0.0.zip",
+    "path": "/package/deprecated_input_policy/1.0.0",
+    "icons": [
+      {
+        "src": "/img/sample-logo.svg",
+        "path": "/package/deprecated_input_policy/1.0.0/img/sample-logo.svg",
+        "title": "Sample logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "sample_deprecated",
+        "title": "Sample logs",
+        "description": "Collect sample logs",
+        "deprecated": {
+          "since": "1.2.0",
+          "description": "This policy is deprecated",
+          "replaced_by": {
+            "policy_template": "sample"
+          }
+        }
+      },
+      {
+        "name": "sample",
+        "title": "Sample logs",
+        "description": "Collect sample logs"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^9.2.3"
+      },
+      "elastic": {
+        "subscription": "basic"
+      }
+    },
+    "owner": {
+      "type": "elastic",
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "custom"
+    ]
+  },
+  {
+    "name": "deprecated_integration_input",
+    "title": "New Package",
+    "version": "1.0.0",
+    "release": "ga",
+    "source": {
+      "license": "Elastic-2.0"
+    },
+    "description": "This is a new package.",
+    "type": "integration",
+    "download": "/epr/deprecated_integration_input/deprecated_integration_input-1.0.0.zip",
+    "path": "/package/deprecated_integration_input/1.0.0",
+    "icons": [
+      {
+        "src": "/img/sample-logo.svg",
+        "path": "/package/deprecated_integration_input/1.0.0/img/sample-logo.svg",
+        "title": "Sample logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "sample",
+        "title": "Sample logs",
+        "description": "Collect sample logs"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^9.2.3"
+      },
+      "elastic": {
+        "subscription": "basic"
+      }
+    },
+    "owner": {
+      "type": "elastic",
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "custom"
+    ]
+  },
+  {
+    "name": "deprecated_integration_stream",
+    "title": "New Package",
+    "version": "1.0.0",
+    "release": "ga",
+    "source": {
+      "license": "Elastic-2.0"
+    },
+    "description": "This is a new package.",
+    "type": "integration",
+    "download": "/epr/deprecated_integration_stream/deprecated_integration_stream-1.0.0.zip",
+    "path": "/package/deprecated_integration_stream/1.0.0",
+    "icons": [
+      {
+        "src": "/img/sample-logo.svg",
+        "path": "/package/deprecated_integration_stream/1.0.0/img/sample-logo.svg",
+        "title": "Sample logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "sample",
+        "title": "Sample logs",
+        "description": "Collect sample logs"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^9.2.3"
+      },
+      "elastic": {
+        "subscription": "basic"
+      }
+    },
+    "owner": {
+      "type": "elastic",
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "deprecated_integration_stream.new_data_stream",
+        "title": "New Data Stream"
+      }
+    ]
+  },
+  {
     "name": "discovery_empty",
     "title": "Discovery Empty",
     "version": "0.1.0",
@@ -330,6 +505,33 @@
     },
     "categories": [
       "support"
+    ]
+  },
+  {
+    "name": "ecs_style_dataset",
+    "title": "Default pipeline Integration",
+    "version": "0.0.1",
+    "release": "beta",
+    "description": "Tests the registry validations works for dataset fields using the ecs style format",
+    "type": "integration",
+    "download": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.zip",
+    "path": "/package/ecs_style_dataset/0.0.1",
+    "policy_templates": [
+      {
+        "name": "logs",
+        "title": "Logs datasource",
+        "description": "Datasource for your log files."
+      }
+    ],
+    "categories": [
+      "monitoring"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ecs_style_dataset.foo",
+        "title": "Foo"
+      }
     ]
   },
   {
@@ -373,42 +575,6 @@
     },
     "categories": [
       "web"
-    ]
-  },
-  {
-    "name": "nodirentries",
-    "title": "Example Integration",
-    "version": "1.0.0",
-    "release": "ga",
-    "description": "This is a zip package without directory entries.",
-    "type": "integration",
-    "download": "/epr/nodirentries/nodirentries-1.0.0.zip",
-    "path": "/package/nodirentries/1.0.0",
-    "policy_templates": [
-      {
-        "name": "logs",
-        "title": "Logs datasource",
-        "description": "Datasource for your log files."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "~7.x.x"
-      }
-    },
-    "owner": {
-      "github": "ruflin"
-    },
-    "categories": [
-      "crm",
-      "azure"
-    ],
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "nodirentries.foo",
-        "title": "Foo"
-      }
     ]
   },
   {
@@ -746,42 +912,6 @@
   },
   {
     "name": "integration_input",
-    "title": "Integration Input",
-    "version": "1.0.2",
-    "release": "ga",
-    "description": "Sample package that was an integration and got migrated to input",
-    "type": "input",
-    "download": "/epr/integration_input/integration_input-1.0.2.zip",
-    "path": "/package/integration_input/1.0.2",
-    "icons": [
-      {
-        "src": "/img/sample-logo.svg",
-        "path": "/package/integration_input/1.0.2/img/sample-logo.svg",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "sql_query",
-        "title": "SQL Query",
-        "description": "Query the database to capture metrics."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.4.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "custom",
-      "datastore"
-    ]
-  },
-  {
-    "name": "integration_input",
     "title": "Integration input",
     "version": "1.0.0",
     "release": "ga",
@@ -817,6 +947,42 @@
         "dataset": "integration_input.foo",
         "title": "Foo"
       }
+    ]
+  },
+  {
+    "name": "integration_input",
+    "title": "Integration Input",
+    "version": "1.0.2",
+    "release": "ga",
+    "description": "Sample package that was an integration and got migrated to input",
+    "type": "input",
+    "download": "/epr/integration_input/integration_input-1.0.2.zip",
+    "path": "/package/integration_input/1.0.2",
+    "icons": [
+      {
+        "src": "/img/sample-logo.svg",
+        "path": "/package/integration_input/1.0.2/img/sample-logo.svg",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "sql_query",
+        "title": "SQL Query",
+        "description": "Query the database to capture metrics."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.4.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "custom",
+      "datastore"
     ]
   },
   {
@@ -866,6 +1032,33 @@
     ],
     "categories": [
       "custom"
+    ]
+  },
+  {
+    "name": "multiple_false",
+    "title": "Multiple false",
+    "version": "0.0.1",
+    "release": "beta",
+    "description": "Tests that multiple can be set to false",
+    "type": "integration",
+    "download": "/epr/multiple_false/multiple_false-0.0.1.zip",
+    "path": "/package/multiple_false/0.0.1",
+    "policy_templates": [
+      {
+        "name": "logs",
+        "title": "Logs datasource",
+        "description": "Datasource for your log files."
+      }
+    ],
+    "categories": [
+      "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "multiple_false.foo",
+        "title": "Foo"
+      }
     ]
   },
   {
@@ -930,36 +1123,6 @@
   },
   {
     "name": "multiversion",
-    "title": "Multi Version",
-    "version": "1.2.0",
-    "release": "ga",
-    "description": "Multiple versions of this integration exist.\n",
-    "type": "integration",
-    "download": "/epr/multiversion/multiversion-1.2.0.zip",
-    "path": "/package/multiversion/1.2.0",
-    "icons": [
-      {
-        "src": "/img/icon.svg",
-        "path": "/package/multiversion/1.2.0/img/icon.svg",
-        "type": "image/svg+xml"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": ">6.7.0"
-      }
-    },
-    "categories": [
-      "custom",
-      "web"
-    ],
-    "deprecated": {
-      "since": "1.2.0",
-      "description": "This package is deprecated"
-    }
-  },
-  {
-    "name": "multiversion",
     "title": "Multi Version Second with the same version! This one should win, because it is first.",
     "version": "1.1.0",
     "release": "ga",
@@ -989,232 +1152,33 @@
     }
   },
   {
-    "name": "multiple_false",
-    "title": "Multiple false",
-    "version": "0.0.1",
-    "release": "beta",
-    "description": "Tests that multiple can be set to false",
+    "name": "multiversion",
+    "title": "Multi Version",
+    "version": "1.2.0",
+    "release": "ga",
+    "description": "Multiple versions of this integration exist.\n",
     "type": "integration",
-    "download": "/epr/multiple_false/multiple_false-0.0.1.zip",
-    "path": "/package/multiple_false/0.0.1",
-    "policy_templates": [
-      {
-        "name": "logs",
-        "title": "Logs datasource",
-        "description": "Datasource for your log files."
-      }
-    ],
-    "categories": [
-      "custom"
-    ],
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "multiple_false.foo",
-        "title": "Foo"
-      }
-    ]
-  },
-  {
-    "name": "deprecated_integration_stream",
-    "title": "New Package",
-    "version": "1.0.0",
-    "release": "ga",
-    "source": {
-      "license": "Elastic-2.0"
-    },
-    "description": "This is a new package.",
-    "type": "integration",
-    "download": "/epr/deprecated_integration_stream/deprecated_integration_stream-1.0.0.zip",
-    "path": "/package/deprecated_integration_stream/1.0.0",
+    "download": "/epr/multiversion/multiversion-1.2.0.zip",
+    "path": "/package/multiversion/1.2.0",
     "icons": [
       {
-        "src": "/img/sample-logo.svg",
-        "path": "/package/deprecated_integration_stream/1.0.0/img/sample-logo.svg",
-        "title": "Sample logo",
-        "size": "32x32",
+        "src": "/img/icon.svg",
+        "path": "/package/multiversion/1.2.0/img/icon.svg",
         "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "sample",
-        "title": "Sample logs",
-        "description": "Collect sample logs"
       }
     ],
     "conditions": {
       "kibana": {
-        "version": "^9.2.3"
-      },
-      "elastic": {
-        "subscription": "basic"
+        "version": ">6.7.0"
       }
-    },
-    "owner": {
-      "type": "elastic",
-      "github": "elastic/integrations"
     },
     "categories": [
-      "custom"
-    ],
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "deprecated_integration_stream.new_data_stream",
-        "title": "New Data Stream"
-      }
-    ]
-  },
-  {
-    "name": "deprecated_integration_input",
-    "title": "New Package",
-    "version": "1.0.0",
-    "release": "ga",
-    "source": {
-      "license": "Elastic-2.0"
-    },
-    "description": "This is a new package.",
-    "type": "integration",
-    "download": "/epr/deprecated_integration_input/deprecated_integration_input-1.0.0.zip",
-    "path": "/package/deprecated_integration_input/1.0.0",
-    "icons": [
-      {
-        "src": "/img/sample-logo.svg",
-        "path": "/package/deprecated_integration_input/1.0.0/img/sample-logo.svg",
-        "title": "Sample logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "sample",
-        "title": "Sample logs",
-        "description": "Collect sample logs"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^9.2.3"
-      },
-      "elastic": {
-        "subscription": "basic"
-      }
-    },
-    "owner": {
-      "type": "elastic",
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "custom"
-    ]
-  },
-  {
-    "name": "deprecated_input_policy",
-    "title": "New Package",
-    "version": "1.0.0",
-    "release": "ga",
-    "source": {
-      "license": "Elastic-2.0"
-    },
-    "description": "This is a new package.",
-    "type": "input",
-    "download": "/epr/deprecated_input_policy/deprecated_input_policy-1.0.0.zip",
-    "path": "/package/deprecated_input_policy/1.0.0",
-    "icons": [
-      {
-        "src": "/img/sample-logo.svg",
-        "path": "/package/deprecated_input_policy/1.0.0/img/sample-logo.svg",
-        "title": "Sample logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "sample_deprecated",
-        "title": "Sample logs",
-        "description": "Collect sample logs",
-        "deprecated": {
-          "since": "1.2.0",
-          "description": "This policy is deprecated",
-          "replaced_by": {
-            "policy_template": "sample"
-          }
-        }
-      },
-      {
-        "name": "sample",
-        "title": "Sample logs",
-        "description": "Collect sample logs"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^9.2.3"
-      },
-      "elastic": {
-        "subscription": "basic"
-      }
-    },
-    "owner": {
-      "type": "elastic",
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "custom"
-    ]
-  },
-  {
-    "name": "deprecated_input_package",
-    "title": "New Package",
-    "version": "1.0.0",
-    "release": "ga",
-    "source": {
-      "license": "Elastic-2.0"
-    },
-    "description": "This is a new package.",
-    "type": "input",
-    "download": "/epr/deprecated_input_package/deprecated_input_package-1.0.0.zip",
-    "path": "/package/deprecated_input_package/1.0.0",
-    "icons": [
-      {
-        "src": "/img/sample-logo.svg",
-        "path": "/package/deprecated_input_package/1.0.0/img/sample-logo.svg",
-        "title": "Sample logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "sample",
-        "title": "Sample logs",
-        "description": "Collect sample logs"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^9.2.3"
-      },
-      "elastic": {
-        "subscription": "basic"
-      }
-    },
-    "owner": {
-      "type": "elastic",
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "custom"
+      "custom",
+      "web"
     ],
     "deprecated": {
       "since": "1.2.0",
-      "description": "This input package is deprecated",
-      "replaced_by": {
-        "package": "new_input_package"
-      }
+      "description": "This package is deprecated"
     }
   },
   {
@@ -1273,6 +1237,42 @@
         "type": "logs",
         "dataset": "no_stream_configs.log",
         "title": "Log Yaml pipeline"
+      }
+    ]
+  },
+  {
+    "name": "nodirentries",
+    "title": "Example Integration",
+    "version": "1.0.0",
+    "release": "ga",
+    "description": "This is a zip package without directory entries.",
+    "type": "integration",
+    "download": "/epr/nodirentries/nodirentries-1.0.0.zip",
+    "path": "/package/nodirentries/1.0.0",
+    "policy_templates": [
+      {
+        "name": "logs",
+        "title": "Logs datasource",
+        "description": "Datasource for your log files."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "~7.x.x"
+      }
+    },
+    "owner": {
+      "github": "ruflin"
+    },
+    "categories": [
+      "crm",
+      "azure"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "nodirentries.foo",
+        "title": "Foo"
       }
     ]
   },

--- a/testdata/generated/search-all.json
+++ b/testdata/generated/search-all.json
@@ -54,51 +54,6 @@
     ]
   },
   {
-    "name": "datastream_without_release",
-    "title": "Apache Spark",
-    "version": "0.1.0",
-    "release": "beta",
-    "description": "Collect metrics from Apache Spark with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/datastream_without_release/datastream_without_release-0.1.0.zip",
-    "path": "/package/datastream_without_release/0.1.0",
-    "icons": [
-      {
-        "src": "/img/apache_spark-logo.svg",
-        "path": "/package/datastream_without_release/0.1.0/img/apache_spark-logo.svg",
-        "title": "Apache Spark logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "apache_spark",
-        "title": "Apache Spark metrics",
-        "description": "Collect Apache Spark metrics"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.1.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/obs-service-integrations"
-    },
-    "categories": [
-      "datastore",
-      "monitoring"
-    ],
-    "data_streams": [
-      {
-        "type": "metrics",
-        "dataset": "datastream_without_release.nodes",
-        "title": "Apache Spark nodes metrics"
-      }
-    ]
-  },
-  {
     "name": "dataset_is_prefix",
     "title": "DatasetIsPrefix Flag",
     "version": "0.0.1",
@@ -116,19 +71,6 @@
         "dataset": "dataset_is_prefix.test",
         "title": "dataset_is_prefix test data stream"
       }
-    ]
-  },
-  {
-    "name": "defaultrelease",
-    "title": "Default Release",
-    "version": "0.0.1",
-    "release": "beta",
-    "description": "Package without release, should be set to default",
-    "type": "solution",
-    "download": "/epr/defaultrelease/defaultrelease-0.0.1.zip",
-    "path": "/package/defaultrelease/0.0.1",
-    "categories": [
-      "aws"
     ]
   },
   {
@@ -174,29 +116,47 @@
     ]
   },
   {
-    "name": "ecs_style_dataset",
-    "title": "Default pipeline Integration",
-    "version": "0.0.1",
+    "name": "datastream_without_release",
+    "title": "Apache Spark",
+    "version": "0.1.0",
     "release": "beta",
-    "description": "Tests the registry validations works for dataset fields using the ecs style format",
+    "description": "Collect metrics from Apache Spark with Elastic Agent.",
     "type": "integration",
-    "download": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.zip",
-    "path": "/package/ecs_style_dataset/0.0.1",
-    "policy_templates": [
+    "download": "/epr/datastream_without_release/datastream_without_release-0.1.0.zip",
+    "path": "/package/datastream_without_release/0.1.0",
+    "icons": [
       {
-        "name": "logs",
-        "title": "Logs datasource",
-        "description": "Datasource for your log files."
+        "src": "/img/apache_spark-logo.svg",
+        "path": "/package/datastream_without_release/0.1.0/img/apache_spark-logo.svg",
+        "title": "Apache Spark logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
       }
     ],
+    "policy_templates": [
+      {
+        "name": "apache_spark",
+        "title": "Apache Spark metrics",
+        "description": "Collect Apache Spark metrics"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.1.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/obs-service-integrations"
+    },
     "categories": [
+      "datastore",
       "monitoring"
     ],
     "data_streams": [
       {
-        "type": "logs",
-        "dataset": "ecs_style_dataset.foo",
-        "title": "Foo"
+        "type": "metrics",
+        "dataset": "datastream_without_release.nodes",
+        "title": "Apache Spark nodes metrics"
       }
     ]
   },
@@ -226,6 +186,19 @@
         "dataset": "default_pipeline.foo",
         "title": "Foo"
       }
+    ]
+  },
+  {
+    "name": "defaultrelease",
+    "title": "Default Release",
+    "version": "0.0.1",
+    "release": "beta",
+    "description": "Package without release, should be set to default",
+    "type": "solution",
+    "download": "/epr/defaultrelease/defaultrelease-0.0.1.zip",
+    "path": "/package/defaultrelease/0.0.1",
+    "categories": [
+      "aws"
     ]
   },
   {
@@ -296,6 +269,208 @@
     ]
   },
   {
+    "name": "deprecated_input_package",
+    "title": "New Package",
+    "version": "1.0.0",
+    "release": "ga",
+    "source": {
+      "license": "Elastic-2.0"
+    },
+    "description": "This is a new package.",
+    "type": "input",
+    "download": "/epr/deprecated_input_package/deprecated_input_package-1.0.0.zip",
+    "path": "/package/deprecated_input_package/1.0.0",
+    "icons": [
+      {
+        "src": "/img/sample-logo.svg",
+        "path": "/package/deprecated_input_package/1.0.0/img/sample-logo.svg",
+        "title": "Sample logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "sample",
+        "title": "Sample logs",
+        "description": "Collect sample logs"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^9.2.3"
+      },
+      "elastic": {
+        "subscription": "basic"
+      }
+    },
+    "owner": {
+      "type": "elastic",
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "deprecated": {
+      "since": "1.2.0",
+      "description": "This input package is deprecated",
+      "replaced_by": {
+        "package": "new_input_package"
+      }
+    }
+  },
+  {
+    "name": "deprecated_input_policy",
+    "title": "New Package",
+    "version": "1.0.0",
+    "release": "ga",
+    "source": {
+      "license": "Elastic-2.0"
+    },
+    "description": "This is a new package.",
+    "type": "input",
+    "download": "/epr/deprecated_input_policy/deprecated_input_policy-1.0.0.zip",
+    "path": "/package/deprecated_input_policy/1.0.0",
+    "icons": [
+      {
+        "src": "/img/sample-logo.svg",
+        "path": "/package/deprecated_input_policy/1.0.0/img/sample-logo.svg",
+        "title": "Sample logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "sample_deprecated",
+        "title": "Sample logs",
+        "description": "Collect sample logs",
+        "deprecated": {
+          "since": "1.2.0",
+          "description": "This policy is deprecated",
+          "replaced_by": {
+            "policy_template": "sample"
+          }
+        }
+      },
+      {
+        "name": "sample",
+        "title": "Sample logs",
+        "description": "Collect sample logs"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^9.2.3"
+      },
+      "elastic": {
+        "subscription": "basic"
+      }
+    },
+    "owner": {
+      "type": "elastic",
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "custom"
+    ]
+  },
+  {
+    "name": "deprecated_integration_input",
+    "title": "New Package",
+    "version": "1.0.0",
+    "release": "ga",
+    "source": {
+      "license": "Elastic-2.0"
+    },
+    "description": "This is a new package.",
+    "type": "integration",
+    "download": "/epr/deprecated_integration_input/deprecated_integration_input-1.0.0.zip",
+    "path": "/package/deprecated_integration_input/1.0.0",
+    "icons": [
+      {
+        "src": "/img/sample-logo.svg",
+        "path": "/package/deprecated_integration_input/1.0.0/img/sample-logo.svg",
+        "title": "Sample logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "sample",
+        "title": "Sample logs",
+        "description": "Collect sample logs"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^9.2.3"
+      },
+      "elastic": {
+        "subscription": "basic"
+      }
+    },
+    "owner": {
+      "type": "elastic",
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "custom"
+    ]
+  },
+  {
+    "name": "deprecated_integration_stream",
+    "title": "New Package",
+    "version": "1.0.0",
+    "release": "ga",
+    "source": {
+      "license": "Elastic-2.0"
+    },
+    "description": "This is a new package.",
+    "type": "integration",
+    "download": "/epr/deprecated_integration_stream/deprecated_integration_stream-1.0.0.zip",
+    "path": "/package/deprecated_integration_stream/1.0.0",
+    "icons": [
+      {
+        "src": "/img/sample-logo.svg",
+        "path": "/package/deprecated_integration_stream/1.0.0/img/sample-logo.svg",
+        "title": "Sample logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "sample",
+        "title": "Sample logs",
+        "description": "Collect sample logs"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^9.2.3"
+      },
+      "elastic": {
+        "subscription": "basic"
+      }
+    },
+    "owner": {
+      "type": "elastic",
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "deprecated_integration_stream.new_data_stream",
+        "title": "New Data Stream"
+      }
+    ]
+  },
+  {
     "name": "discovery_empty",
     "title": "Discovery Empty",
     "version": "0.1.0",
@@ -330,6 +505,33 @@
     },
     "categories": [
       "support"
+    ]
+  },
+  {
+    "name": "ecs_style_dataset",
+    "title": "Default pipeline Integration",
+    "version": "0.0.1",
+    "release": "beta",
+    "description": "Tests the registry validations works for dataset fields using the ecs style format",
+    "type": "integration",
+    "download": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.zip",
+    "path": "/package/ecs_style_dataset/0.0.1",
+    "policy_templates": [
+      {
+        "name": "logs",
+        "title": "Logs datasource",
+        "description": "Datasource for your log files."
+      }
+    ],
+    "categories": [
+      "monitoring"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ecs_style_dataset.foo",
+        "title": "Foo"
+      }
     ]
   },
   {
@@ -373,42 +575,6 @@
     },
     "categories": [
       "web"
-    ]
-  },
-  {
-    "name": "nodirentries",
-    "title": "Example Integration",
-    "version": "1.0.0",
-    "release": "ga",
-    "description": "This is a zip package without directory entries.",
-    "type": "integration",
-    "download": "/epr/nodirentries/nodirentries-1.0.0.zip",
-    "path": "/package/nodirentries/1.0.0",
-    "policy_templates": [
-      {
-        "name": "logs",
-        "title": "Logs datasource",
-        "description": "Datasource for your log files."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "~7.x.x"
-      }
-    },
-    "owner": {
-      "github": "ruflin"
-    },
-    "categories": [
-      "crm",
-      "azure"
-    ],
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "nodirentries.foo",
-        "title": "Foo"
-      }
     ]
   },
   {
@@ -746,42 +912,6 @@
   },
   {
     "name": "integration_input",
-    "title": "Integration Input",
-    "version": "1.0.2",
-    "release": "ga",
-    "description": "Sample package that was an integration and got migrated to input",
-    "type": "input",
-    "download": "/epr/integration_input/integration_input-1.0.2.zip",
-    "path": "/package/integration_input/1.0.2",
-    "icons": [
-      {
-        "src": "/img/sample-logo.svg",
-        "path": "/package/integration_input/1.0.2/img/sample-logo.svg",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "sql_query",
-        "title": "SQL Query",
-        "description": "Query the database to capture metrics."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.4.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "custom",
-      "datastore"
-    ]
-  },
-  {
-    "name": "integration_input",
     "title": "Integration input",
     "version": "1.0.0",
     "release": "ga",
@@ -817,6 +947,42 @@
         "dataset": "integration_input.foo",
         "title": "Foo"
       }
+    ]
+  },
+  {
+    "name": "integration_input",
+    "title": "Integration Input",
+    "version": "1.0.2",
+    "release": "ga",
+    "description": "Sample package that was an integration and got migrated to input",
+    "type": "input",
+    "download": "/epr/integration_input/integration_input-1.0.2.zip",
+    "path": "/package/integration_input/1.0.2",
+    "icons": [
+      {
+        "src": "/img/sample-logo.svg",
+        "path": "/package/integration_input/1.0.2/img/sample-logo.svg",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "sql_query",
+        "title": "SQL Query",
+        "description": "Query the database to capture metrics."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.4.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "custom",
+      "datastore"
     ]
   },
   {
@@ -866,6 +1032,33 @@
     ],
     "categories": [
       "custom"
+    ]
+  },
+  {
+    "name": "multiple_false",
+    "title": "Multiple false",
+    "version": "0.0.1",
+    "release": "beta",
+    "description": "Tests that multiple can be set to false",
+    "type": "integration",
+    "download": "/epr/multiple_false/multiple_false-0.0.1.zip",
+    "path": "/package/multiple_false/0.0.1",
+    "policy_templates": [
+      {
+        "name": "logs",
+        "title": "Logs datasource",
+        "description": "Datasource for your log files."
+      }
+    ],
+    "categories": [
+      "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "multiple_false.foo",
+        "title": "Foo"
+      }
     ]
   },
   {
@@ -930,36 +1123,6 @@
   },
   {
     "name": "multiversion",
-    "title": "Multi Version",
-    "version": "1.2.0",
-    "release": "ga",
-    "description": "Multiple versions of this integration exist.\n",
-    "type": "integration",
-    "download": "/epr/multiversion/multiversion-1.2.0.zip",
-    "path": "/package/multiversion/1.2.0",
-    "icons": [
-      {
-        "src": "/img/icon.svg",
-        "path": "/package/multiversion/1.2.0/img/icon.svg",
-        "type": "image/svg+xml"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": ">6.7.0"
-      }
-    },
-    "categories": [
-      "custom",
-      "web"
-    ],
-    "deprecated": {
-      "since": "1.2.0",
-      "description": "This package is deprecated"
-    }
-  },
-  {
-    "name": "multiversion",
     "title": "Multi Version Second with the same version! This one should win, because it is first.",
     "version": "1.1.0",
     "release": "ga",
@@ -989,232 +1152,33 @@
     }
   },
   {
-    "name": "multiple_false",
-    "title": "Multiple false",
-    "version": "0.0.1",
-    "release": "beta",
-    "description": "Tests that multiple can be set to false",
+    "name": "multiversion",
+    "title": "Multi Version",
+    "version": "1.2.0",
+    "release": "ga",
+    "description": "Multiple versions of this integration exist.\n",
     "type": "integration",
-    "download": "/epr/multiple_false/multiple_false-0.0.1.zip",
-    "path": "/package/multiple_false/0.0.1",
-    "policy_templates": [
-      {
-        "name": "logs",
-        "title": "Logs datasource",
-        "description": "Datasource for your log files."
-      }
-    ],
-    "categories": [
-      "custom"
-    ],
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "multiple_false.foo",
-        "title": "Foo"
-      }
-    ]
-  },
-  {
-    "name": "deprecated_integration_stream",
-    "title": "New Package",
-    "version": "1.0.0",
-    "release": "ga",
-    "source": {
-      "license": "Elastic-2.0"
-    },
-    "description": "This is a new package.",
-    "type": "integration",
-    "download": "/epr/deprecated_integration_stream/deprecated_integration_stream-1.0.0.zip",
-    "path": "/package/deprecated_integration_stream/1.0.0",
+    "download": "/epr/multiversion/multiversion-1.2.0.zip",
+    "path": "/package/multiversion/1.2.0",
     "icons": [
       {
-        "src": "/img/sample-logo.svg",
-        "path": "/package/deprecated_integration_stream/1.0.0/img/sample-logo.svg",
-        "title": "Sample logo",
-        "size": "32x32",
+        "src": "/img/icon.svg",
+        "path": "/package/multiversion/1.2.0/img/icon.svg",
         "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "sample",
-        "title": "Sample logs",
-        "description": "Collect sample logs"
       }
     ],
     "conditions": {
       "kibana": {
-        "version": "^9.2.3"
-      },
-      "elastic": {
-        "subscription": "basic"
+        "version": ">6.7.0"
       }
-    },
-    "owner": {
-      "type": "elastic",
-      "github": "elastic/integrations"
     },
     "categories": [
-      "custom"
-    ],
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "deprecated_integration_stream.new_data_stream",
-        "title": "New Data Stream"
-      }
-    ]
-  },
-  {
-    "name": "deprecated_integration_input",
-    "title": "New Package",
-    "version": "1.0.0",
-    "release": "ga",
-    "source": {
-      "license": "Elastic-2.0"
-    },
-    "description": "This is a new package.",
-    "type": "integration",
-    "download": "/epr/deprecated_integration_input/deprecated_integration_input-1.0.0.zip",
-    "path": "/package/deprecated_integration_input/1.0.0",
-    "icons": [
-      {
-        "src": "/img/sample-logo.svg",
-        "path": "/package/deprecated_integration_input/1.0.0/img/sample-logo.svg",
-        "title": "Sample logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "sample",
-        "title": "Sample logs",
-        "description": "Collect sample logs"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^9.2.3"
-      },
-      "elastic": {
-        "subscription": "basic"
-      }
-    },
-    "owner": {
-      "type": "elastic",
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "custom"
-    ]
-  },
-  {
-    "name": "deprecated_input_policy",
-    "title": "New Package",
-    "version": "1.0.0",
-    "release": "ga",
-    "source": {
-      "license": "Elastic-2.0"
-    },
-    "description": "This is a new package.",
-    "type": "input",
-    "download": "/epr/deprecated_input_policy/deprecated_input_policy-1.0.0.zip",
-    "path": "/package/deprecated_input_policy/1.0.0",
-    "icons": [
-      {
-        "src": "/img/sample-logo.svg",
-        "path": "/package/deprecated_input_policy/1.0.0/img/sample-logo.svg",
-        "title": "Sample logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "sample_deprecated",
-        "title": "Sample logs",
-        "description": "Collect sample logs",
-        "deprecated": {
-          "since": "1.2.0",
-          "description": "This policy is deprecated",
-          "replaced_by": {
-            "policy_template": "sample"
-          }
-        }
-      },
-      {
-        "name": "sample",
-        "title": "Sample logs",
-        "description": "Collect sample logs"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^9.2.3"
-      },
-      "elastic": {
-        "subscription": "basic"
-      }
-    },
-    "owner": {
-      "type": "elastic",
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "custom"
-    ]
-  },
-  {
-    "name": "deprecated_input_package",
-    "title": "New Package",
-    "version": "1.0.0",
-    "release": "ga",
-    "source": {
-      "license": "Elastic-2.0"
-    },
-    "description": "This is a new package.",
-    "type": "input",
-    "download": "/epr/deprecated_input_package/deprecated_input_package-1.0.0.zip",
-    "path": "/package/deprecated_input_package/1.0.0",
-    "icons": [
-      {
-        "src": "/img/sample-logo.svg",
-        "path": "/package/deprecated_input_package/1.0.0/img/sample-logo.svg",
-        "title": "Sample logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "sample",
-        "title": "Sample logs",
-        "description": "Collect sample logs"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^9.2.3"
-      },
-      "elastic": {
-        "subscription": "basic"
-      }
-    },
-    "owner": {
-      "type": "elastic",
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "custom"
+      "custom",
+      "web"
     ],
     "deprecated": {
       "since": "1.2.0",
-      "description": "This input package is deprecated",
-      "replaced_by": {
-        "package": "new_input_package"
-      }
+      "description": "This package is deprecated"
     }
   },
   {
@@ -1234,6 +1198,42 @@
         "type": "logs",
         "dataset": "no_stream_configs.log",
         "title": "Log Yaml pipeline"
+      }
+    ]
+  },
+  {
+    "name": "nodirentries",
+    "title": "Example Integration",
+    "version": "1.0.0",
+    "release": "ga",
+    "description": "This is a zip package without directory entries.",
+    "type": "integration",
+    "download": "/epr/nodirentries/nodirentries-1.0.0.zip",
+    "path": "/package/nodirentries/1.0.0",
+    "policy_templates": [
+      {
+        "name": "logs",
+        "title": "Logs datasource",
+        "description": "Datasource for your log files."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "~7.x.x"
+      }
+    },
+    "owner": {
+      "github": "ruflin"
+    },
+    "categories": [
+      "crm",
+      "azure"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "nodirentries.foo",
+        "title": "Foo"
       }
     ]
   },

--- a/testdata/generated/search-category-custom.json
+++ b/testdata/generated/search-category-custom.json
@@ -183,6 +183,208 @@
     ]
   },
   {
+    "name": "deprecated_input_package",
+    "title": "New Package",
+    "version": "1.0.0",
+    "release": "ga",
+    "source": {
+      "license": "Elastic-2.0"
+    },
+    "description": "This is a new package.",
+    "type": "input",
+    "download": "/epr/deprecated_input_package/deprecated_input_package-1.0.0.zip",
+    "path": "/package/deprecated_input_package/1.0.0",
+    "icons": [
+      {
+        "src": "/img/sample-logo.svg",
+        "path": "/package/deprecated_input_package/1.0.0/img/sample-logo.svg",
+        "title": "Sample logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "sample",
+        "title": "Sample logs",
+        "description": "Collect sample logs"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^9.2.3"
+      },
+      "elastic": {
+        "subscription": "basic"
+      }
+    },
+    "owner": {
+      "type": "elastic",
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "deprecated": {
+      "since": "1.2.0",
+      "description": "This input package is deprecated",
+      "replaced_by": {
+        "package": "new_input_package"
+      }
+    }
+  },
+  {
+    "name": "deprecated_input_policy",
+    "title": "New Package",
+    "version": "1.0.0",
+    "release": "ga",
+    "source": {
+      "license": "Elastic-2.0"
+    },
+    "description": "This is a new package.",
+    "type": "input",
+    "download": "/epr/deprecated_input_policy/deprecated_input_policy-1.0.0.zip",
+    "path": "/package/deprecated_input_policy/1.0.0",
+    "icons": [
+      {
+        "src": "/img/sample-logo.svg",
+        "path": "/package/deprecated_input_policy/1.0.0/img/sample-logo.svg",
+        "title": "Sample logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "sample_deprecated",
+        "title": "Sample logs",
+        "description": "Collect sample logs",
+        "deprecated": {
+          "since": "1.2.0",
+          "description": "This policy is deprecated",
+          "replaced_by": {
+            "policy_template": "sample"
+          }
+        }
+      },
+      {
+        "name": "sample",
+        "title": "Sample logs",
+        "description": "Collect sample logs"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^9.2.3"
+      },
+      "elastic": {
+        "subscription": "basic"
+      }
+    },
+    "owner": {
+      "type": "elastic",
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "custom"
+    ]
+  },
+  {
+    "name": "deprecated_integration_input",
+    "title": "New Package",
+    "version": "1.0.0",
+    "release": "ga",
+    "source": {
+      "license": "Elastic-2.0"
+    },
+    "description": "This is a new package.",
+    "type": "integration",
+    "download": "/epr/deprecated_integration_input/deprecated_integration_input-1.0.0.zip",
+    "path": "/package/deprecated_integration_input/1.0.0",
+    "icons": [
+      {
+        "src": "/img/sample-logo.svg",
+        "path": "/package/deprecated_integration_input/1.0.0/img/sample-logo.svg",
+        "title": "Sample logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "sample",
+        "title": "Sample logs",
+        "description": "Collect sample logs"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^9.2.3"
+      },
+      "elastic": {
+        "subscription": "basic"
+      }
+    },
+    "owner": {
+      "type": "elastic",
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "custom"
+    ]
+  },
+  {
+    "name": "deprecated_integration_stream",
+    "title": "New Package",
+    "version": "1.0.0",
+    "release": "ga",
+    "source": {
+      "license": "Elastic-2.0"
+    },
+    "description": "This is a new package.",
+    "type": "integration",
+    "download": "/epr/deprecated_integration_stream/deprecated_integration_stream-1.0.0.zip",
+    "path": "/package/deprecated_integration_stream/1.0.0",
+    "icons": [
+      {
+        "src": "/img/sample-logo.svg",
+        "path": "/package/deprecated_integration_stream/1.0.0/img/sample-logo.svg",
+        "title": "Sample logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "sample",
+        "title": "Sample logs",
+        "description": "Collect sample logs"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^9.2.3"
+      },
+      "elastic": {
+        "subscription": "basic"
+      }
+    },
+    "owner": {
+      "type": "elastic",
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "deprecated_integration_stream.new_data_stream",
+        "title": "New Data Stream"
+      }
+    ]
+  },
+  {
     "name": "elasticsearch_privileges",
     "title": "Elasticsearch Privileges",
     "version": "1.0.0",
@@ -393,36 +595,6 @@
     ]
   },
   {
-    "name": "multiversion",
-    "title": "Multi Version",
-    "version": "1.2.0",
-    "release": "ga",
-    "description": "Multiple versions of this integration exist.\n",
-    "type": "integration",
-    "download": "/epr/multiversion/multiversion-1.2.0.zip",
-    "path": "/package/multiversion/1.2.0",
-    "icons": [
-      {
-        "src": "/img/icon.svg",
-        "path": "/package/multiversion/1.2.0/img/icon.svg",
-        "type": "image/svg+xml"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": ">6.7.0"
-      }
-    },
-    "categories": [
-      "custom",
-      "web"
-    ],
-    "deprecated": {
-      "since": "1.2.0",
-      "description": "This package is deprecated"
-    }
-  },
-  {
     "name": "multiple_false",
     "title": "Multiple false",
     "version": "0.0.1",
@@ -450,205 +622,33 @@
     ]
   },
   {
-    "name": "deprecated_integration_stream",
-    "title": "New Package",
-    "version": "1.0.0",
+    "name": "multiversion",
+    "title": "Multi Version",
+    "version": "1.2.0",
     "release": "ga",
-    "source": {
-      "license": "Elastic-2.0"
-    },
-    "description": "This is a new package.",
+    "description": "Multiple versions of this integration exist.\n",
     "type": "integration",
-    "download": "/epr/deprecated_integration_stream/deprecated_integration_stream-1.0.0.zip",
-    "path": "/package/deprecated_integration_stream/1.0.0",
+    "download": "/epr/multiversion/multiversion-1.2.0.zip",
+    "path": "/package/multiversion/1.2.0",
     "icons": [
       {
-        "src": "/img/sample-logo.svg",
-        "path": "/package/deprecated_integration_stream/1.0.0/img/sample-logo.svg",
-        "title": "Sample logo",
-        "size": "32x32",
+        "src": "/img/icon.svg",
+        "path": "/package/multiversion/1.2.0/img/icon.svg",
         "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "sample",
-        "title": "Sample logs",
-        "description": "Collect sample logs"
       }
     ],
     "conditions": {
       "kibana": {
-        "version": "^9.2.3"
-      },
-      "elastic": {
-        "subscription": "basic"
+        "version": ">6.7.0"
       }
-    },
-    "owner": {
-      "type": "elastic",
-      "github": "elastic/integrations"
     },
     "categories": [
-      "custom"
-    ],
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "deprecated_integration_stream.new_data_stream",
-        "title": "New Data Stream"
-      }
-    ]
-  },
-  {
-    "name": "deprecated_integration_input",
-    "title": "New Package",
-    "version": "1.0.0",
-    "release": "ga",
-    "source": {
-      "license": "Elastic-2.0"
-    },
-    "description": "This is a new package.",
-    "type": "integration",
-    "download": "/epr/deprecated_integration_input/deprecated_integration_input-1.0.0.zip",
-    "path": "/package/deprecated_integration_input/1.0.0",
-    "icons": [
-      {
-        "src": "/img/sample-logo.svg",
-        "path": "/package/deprecated_integration_input/1.0.0/img/sample-logo.svg",
-        "title": "Sample logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "sample",
-        "title": "Sample logs",
-        "description": "Collect sample logs"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^9.2.3"
-      },
-      "elastic": {
-        "subscription": "basic"
-      }
-    },
-    "owner": {
-      "type": "elastic",
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "custom"
-    ]
-  },
-  {
-    "name": "deprecated_input_policy",
-    "title": "New Package",
-    "version": "1.0.0",
-    "release": "ga",
-    "source": {
-      "license": "Elastic-2.0"
-    },
-    "description": "This is a new package.",
-    "type": "input",
-    "download": "/epr/deprecated_input_policy/deprecated_input_policy-1.0.0.zip",
-    "path": "/package/deprecated_input_policy/1.0.0",
-    "icons": [
-      {
-        "src": "/img/sample-logo.svg",
-        "path": "/package/deprecated_input_policy/1.0.0/img/sample-logo.svg",
-        "title": "Sample logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "sample_deprecated",
-        "title": "Sample logs",
-        "description": "Collect sample logs",
-        "deprecated": {
-          "since": "1.2.0",
-          "description": "This policy is deprecated",
-          "replaced_by": {
-            "policy_template": "sample"
-          }
-        }
-      },
-      {
-        "name": "sample",
-        "title": "Sample logs",
-        "description": "Collect sample logs"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^9.2.3"
-      },
-      "elastic": {
-        "subscription": "basic"
-      }
-    },
-    "owner": {
-      "type": "elastic",
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "custom"
-    ]
-  },
-  {
-    "name": "deprecated_input_package",
-    "title": "New Package",
-    "version": "1.0.0",
-    "release": "ga",
-    "source": {
-      "license": "Elastic-2.0"
-    },
-    "description": "This is a new package.",
-    "type": "input",
-    "download": "/epr/deprecated_input_package/deprecated_input_package-1.0.0.zip",
-    "path": "/package/deprecated_input_package/1.0.0",
-    "icons": [
-      {
-        "src": "/img/sample-logo.svg",
-        "path": "/package/deprecated_input_package/1.0.0/img/sample-logo.svg",
-        "title": "Sample logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "sample",
-        "title": "Sample logs",
-        "description": "Collect sample logs"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^9.2.3"
-      },
-      "elastic": {
-        "subscription": "basic"
-      }
-    },
-    "owner": {
-      "type": "elastic",
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "custom"
+      "custom",
+      "web"
     ],
     "deprecated": {
       "since": "1.2.0",
-      "description": "This input package is deprecated",
-      "replaced_by": {
-        "package": "new_input_package"
-      }
+      "description": "This package is deprecated"
     }
   },
   {

--- a/testdata/generated/search-category-observability-subcategories.json
+++ b/testdata/generated/search-category-observability-subcategories.json
@@ -74,33 +74,6 @@
     ]
   },
   {
-    "name": "ecs_style_dataset",
-    "title": "Default pipeline Integration",
-    "version": "0.0.1",
-    "release": "beta",
-    "description": "Tests the registry validations works for dataset fields using the ecs style format",
-    "type": "integration",
-    "download": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.zip",
-    "path": "/package/ecs_style_dataset/0.0.1",
-    "policy_templates": [
-      {
-        "name": "logs",
-        "title": "Logs datasource",
-        "description": "Datasource for your log files."
-      }
-    ],
-    "categories": [
-      "monitoring"
-    ],
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ecs_style_dataset.foo",
-        "title": "Foo"
-      }
-    ]
-  },
-  {
     "name": "default_pipeline",
     "title": "Default pipeline Integration",
     "version": "0.0.2",
@@ -124,6 +97,33 @@
       {
         "type": "logs",
         "dataset": "default_pipeline.foo",
+        "title": "Foo"
+      }
+    ]
+  },
+  {
+    "name": "ecs_style_dataset",
+    "title": "Default pipeline Integration",
+    "version": "0.0.1",
+    "release": "beta",
+    "description": "Tests the registry validations works for dataset fields using the ecs style format",
+    "type": "integration",
+    "download": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.zip",
+    "path": "/package/ecs_style_dataset/0.0.1",
+    "policy_templates": [
+      {
+        "name": "logs",
+        "title": "Logs datasource",
+        "description": "Datasource for your log files."
+      }
+    ],
+    "categories": [
+      "monitoring"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ecs_style_dataset.foo",
         "title": "Foo"
       }
     ]

--- a/testdata/generated/search-category-web-all.json
+++ b/testdata/generated/search-category-web-all.json
@@ -189,17 +189,17 @@
   },
   {
     "name": "multiversion",
-    "title": "Multi Version",
-    "version": "1.2.0",
+    "title": "Multi Version Second with the same version! This one should win, because it is first.",
+    "version": "1.1.0",
     "release": "ga",
     "description": "Multiple versions of this integration exist.\n",
     "type": "integration",
-    "download": "/epr/multiversion/multiversion-1.2.0.zip",
-    "path": "/package/multiversion/1.2.0",
+    "download": "/epr/multiversion/multiversion-1.1.0.zip",
+    "path": "/package/multiversion/1.1.0",
     "icons": [
       {
         "src": "/img/icon.svg",
-        "path": "/package/multiversion/1.2.0/img/icon.svg",
+        "path": "/package/multiversion/1.1.0/img/icon.svg",
         "type": "image/svg+xml"
       }
     ],
@@ -219,17 +219,17 @@
   },
   {
     "name": "multiversion",
-    "title": "Multi Version Second with the same version! This one should win, because it is first.",
-    "version": "1.1.0",
+    "title": "Multi Version",
+    "version": "1.2.0",
     "release": "ga",
     "description": "Multiple versions of this integration exist.\n",
     "type": "integration",
-    "download": "/epr/multiversion/multiversion-1.1.0.zip",
-    "path": "/package/multiversion/1.1.0",
+    "download": "/epr/multiversion/multiversion-1.2.0.zip",
+    "path": "/package/multiversion/1.2.0",
     "icons": [
       {
         "src": "/img/icon.svg",
-        "path": "/package/multiversion/1.1.0/img/icon.svg",
+        "path": "/package/multiversion/1.2.0/img/icon.svg",
         "type": "image/svg+xml"
       }
     ],

--- a/testdata/generated/search-deprecated-package-versions.json
+++ b/testdata/generated/search-deprecated-package-versions.json
@@ -61,17 +61,17 @@
   },
   {
     "name": "multiversion",
-    "title": "Multi Version",
-    "version": "1.2.0",
+    "title": "Multi Version Second with the same version! This one should win, because it is first.",
+    "version": "1.1.0",
     "release": "ga",
     "description": "Multiple versions of this integration exist.\n",
     "type": "integration",
-    "download": "/epr/multiversion/multiversion-1.2.0.zip",
-    "path": "/package/multiversion/1.2.0",
+    "download": "/epr/multiversion/multiversion-1.1.0.zip",
+    "path": "/package/multiversion/1.1.0",
     "icons": [
       {
         "src": "/img/icon.svg",
-        "path": "/package/multiversion/1.2.0/img/icon.svg",
+        "path": "/package/multiversion/1.1.0/img/icon.svg",
         "type": "image/svg+xml"
       }
     ],
@@ -91,17 +91,17 @@
   },
   {
     "name": "multiversion",
-    "title": "Multi Version Second with the same version! This one should win, because it is first.",
-    "version": "1.1.0",
+    "title": "Multi Version",
+    "version": "1.2.0",
     "release": "ga",
     "description": "Multiple versions of this integration exist.\n",
     "type": "integration",
-    "download": "/epr/multiversion/multiversion-1.1.0.zip",
-    "path": "/package/multiversion/1.1.0",
+    "download": "/epr/multiversion/multiversion-1.2.0.zip",
+    "path": "/package/multiversion/1.2.0",
     "icons": [
       {
         "src": "/img/icon.svg",
-        "path": "/package/multiversion/1.1.0/img/icon.svg",
+        "path": "/package/multiversion/1.2.0/img/icon.svg",
         "type": "image/svg+xml"
       }
     ],

--- a/testdata/generated/search-input-packages.json
+++ b/testdata/generated/search-input-packages.json
@@ -1,41 +1,5 @@
 [
   {
-    "name": "integration_input",
-    "title": "Integration Input",
-    "version": "1.0.2",
-    "release": "ga",
-    "description": "Sample package that was an integration and got migrated to input",
-    "type": "input",
-    "download": "/epr/integration_input/integration_input-1.0.2.zip",
-    "path": "/package/integration_input/1.0.2",
-    "icons": [
-      {
-        "src": "/img/sample-logo.svg",
-        "path": "/package/integration_input/1.0.2/img/sample-logo.svg",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "sql_query",
-        "title": "SQL Query",
-        "description": "Query the database to capture metrics."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.4.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "custom",
-      "datastore"
-    ]
-  },
-  {
     "name": "deprecated_input_package",
     "title": "New Package",
     "version": "1.0.0",
@@ -140,6 +104,42 @@
     },
     "categories": [
       "custom"
+    ]
+  },
+  {
+    "name": "integration_input",
+    "title": "Integration Input",
+    "version": "1.0.2",
+    "release": "ga",
+    "description": "Sample package that was an integration and got migrated to input",
+    "type": "input",
+    "download": "/epr/integration_input/integration_input-1.0.2.zip",
+    "path": "/package/integration_input/1.0.2",
+    "icons": [
+      {
+        "src": "/img/sample-logo.svg",
+        "path": "/package/integration_input/1.0.2/img/sample-logo.svg",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "sql_query",
+        "title": "SQL Query",
+        "description": "Query the database to capture metrics."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.4.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "custom",
+      "datastore"
     ]
   },
   {

--- a/testdata/generated/search-just-latest-proxy.json
+++ b/testdata/generated/search-just-latest-proxy.json
@@ -54,51 +54,6 @@
     ]
   },
   {
-    "name": "datastream_without_release",
-    "title": "Apache Spark",
-    "version": "0.1.0",
-    "release": "beta",
-    "description": "Collect metrics from Apache Spark with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/datastream_without_release/datastream_without_release-0.1.0.zip",
-    "path": "/package/datastream_without_release/0.1.0",
-    "icons": [
-      {
-        "src": "/img/apache_spark-logo.svg",
-        "path": "/package/datastream_without_release/0.1.0/img/apache_spark-logo.svg",
-        "title": "Apache Spark logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "apache_spark",
-        "title": "Apache Spark metrics",
-        "description": "Collect Apache Spark metrics"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.1.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/obs-service-integrations"
-    },
-    "categories": [
-      "datastore",
-      "monitoring"
-    ],
-    "data_streams": [
-      {
-        "type": "metrics",
-        "dataset": "datastream_without_release.nodes",
-        "title": "Apache Spark nodes metrics"
-      }
-    ]
-  },
-  {
     "name": "dataset_is_prefix",
     "title": "DatasetIsPrefix Flag",
     "version": "0.0.1",
@@ -116,19 +71,6 @@
         "dataset": "dataset_is_prefix.test",
         "title": "dataset_is_prefix test data stream"
       }
-    ]
-  },
-  {
-    "name": "defaultrelease",
-    "title": "Default Release",
-    "version": "0.0.1",
-    "release": "beta",
-    "description": "Package without release, should be set to default",
-    "type": "solution",
-    "download": "/epr/defaultrelease/defaultrelease-0.0.1.zip",
-    "path": "/package/defaultrelease/0.0.1",
-    "categories": [
-      "aws"
     ]
   },
   {
@@ -174,29 +116,47 @@
     ]
   },
   {
-    "name": "ecs_style_dataset",
-    "title": "Default pipeline Integration",
-    "version": "0.0.1",
+    "name": "datastream_without_release",
+    "title": "Apache Spark",
+    "version": "0.1.0",
     "release": "beta",
-    "description": "Tests the registry validations works for dataset fields using the ecs style format",
+    "description": "Collect metrics from Apache Spark with Elastic Agent.",
     "type": "integration",
-    "download": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.zip",
-    "path": "/package/ecs_style_dataset/0.0.1",
-    "policy_templates": [
+    "download": "/epr/datastream_without_release/datastream_without_release-0.1.0.zip",
+    "path": "/package/datastream_without_release/0.1.0",
+    "icons": [
       {
-        "name": "logs",
-        "title": "Logs datasource",
-        "description": "Datasource for your log files."
+        "src": "/img/apache_spark-logo.svg",
+        "path": "/package/datastream_without_release/0.1.0/img/apache_spark-logo.svg",
+        "title": "Apache Spark logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
       }
     ],
+    "policy_templates": [
+      {
+        "name": "apache_spark",
+        "title": "Apache Spark metrics",
+        "description": "Collect Apache Spark metrics"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.1.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/obs-service-integrations"
+    },
     "categories": [
+      "datastore",
       "monitoring"
     ],
     "data_streams": [
       {
-        "type": "logs",
-        "dataset": "ecs_style_dataset.foo",
-        "title": "Foo"
+        "type": "metrics",
+        "dataset": "datastream_without_release.nodes",
+        "title": "Apache Spark nodes metrics"
       }
     ]
   },
@@ -226,6 +186,19 @@
         "dataset": "default_pipeline.foo",
         "title": "Foo"
       }
+    ]
+  },
+  {
+    "name": "defaultrelease",
+    "title": "Default Release",
+    "version": "0.0.1",
+    "release": "beta",
+    "description": "Package without release, should be set to default",
+    "type": "solution",
+    "download": "/epr/defaultrelease/defaultrelease-0.0.1.zip",
+    "path": "/package/defaultrelease/0.0.1",
+    "categories": [
+      "aws"
     ]
   },
   {
@@ -296,6 +269,208 @@
     ]
   },
   {
+    "name": "deprecated_input_package",
+    "title": "New Package",
+    "version": "1.0.0",
+    "release": "ga",
+    "source": {
+      "license": "Elastic-2.0"
+    },
+    "description": "This is a new package.",
+    "type": "input",
+    "download": "/epr/deprecated_input_package/deprecated_input_package-1.0.0.zip",
+    "path": "/package/deprecated_input_package/1.0.0",
+    "icons": [
+      {
+        "src": "/img/sample-logo.svg",
+        "path": "/package/deprecated_input_package/1.0.0/img/sample-logo.svg",
+        "title": "Sample logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "sample",
+        "title": "Sample logs",
+        "description": "Collect sample logs"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^9.2.3"
+      },
+      "elastic": {
+        "subscription": "basic"
+      }
+    },
+    "owner": {
+      "type": "elastic",
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "deprecated": {
+      "since": "1.2.0",
+      "description": "This input package is deprecated",
+      "replaced_by": {
+        "package": "new_input_package"
+      }
+    }
+  },
+  {
+    "name": "deprecated_input_policy",
+    "title": "New Package",
+    "version": "1.0.0",
+    "release": "ga",
+    "source": {
+      "license": "Elastic-2.0"
+    },
+    "description": "This is a new package.",
+    "type": "input",
+    "download": "/epr/deprecated_input_policy/deprecated_input_policy-1.0.0.zip",
+    "path": "/package/deprecated_input_policy/1.0.0",
+    "icons": [
+      {
+        "src": "/img/sample-logo.svg",
+        "path": "/package/deprecated_input_policy/1.0.0/img/sample-logo.svg",
+        "title": "Sample logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "sample_deprecated",
+        "title": "Sample logs",
+        "description": "Collect sample logs",
+        "deprecated": {
+          "since": "1.2.0",
+          "description": "This policy is deprecated",
+          "replaced_by": {
+            "policy_template": "sample"
+          }
+        }
+      },
+      {
+        "name": "sample",
+        "title": "Sample logs",
+        "description": "Collect sample logs"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^9.2.3"
+      },
+      "elastic": {
+        "subscription": "basic"
+      }
+    },
+    "owner": {
+      "type": "elastic",
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "custom"
+    ]
+  },
+  {
+    "name": "deprecated_integration_input",
+    "title": "New Package",
+    "version": "1.0.0",
+    "release": "ga",
+    "source": {
+      "license": "Elastic-2.0"
+    },
+    "description": "This is a new package.",
+    "type": "integration",
+    "download": "/epr/deprecated_integration_input/deprecated_integration_input-1.0.0.zip",
+    "path": "/package/deprecated_integration_input/1.0.0",
+    "icons": [
+      {
+        "src": "/img/sample-logo.svg",
+        "path": "/package/deprecated_integration_input/1.0.0/img/sample-logo.svg",
+        "title": "Sample logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "sample",
+        "title": "Sample logs",
+        "description": "Collect sample logs"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^9.2.3"
+      },
+      "elastic": {
+        "subscription": "basic"
+      }
+    },
+    "owner": {
+      "type": "elastic",
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "custom"
+    ]
+  },
+  {
+    "name": "deprecated_integration_stream",
+    "title": "New Package",
+    "version": "1.0.0",
+    "release": "ga",
+    "source": {
+      "license": "Elastic-2.0"
+    },
+    "description": "This is a new package.",
+    "type": "integration",
+    "download": "/epr/deprecated_integration_stream/deprecated_integration_stream-1.0.0.zip",
+    "path": "/package/deprecated_integration_stream/1.0.0",
+    "icons": [
+      {
+        "src": "/img/sample-logo.svg",
+        "path": "/package/deprecated_integration_stream/1.0.0/img/sample-logo.svg",
+        "title": "Sample logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "sample",
+        "title": "Sample logs",
+        "description": "Collect sample logs"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^9.2.3"
+      },
+      "elastic": {
+        "subscription": "basic"
+      }
+    },
+    "owner": {
+      "type": "elastic",
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "deprecated_integration_stream.new_data_stream",
+        "title": "New Data Stream"
+      }
+    ]
+  },
+  {
     "name": "discovery_empty",
     "title": "Discovery Empty",
     "version": "0.1.0",
@@ -333,6 +508,33 @@
     ]
   },
   {
+    "name": "ecs_style_dataset",
+    "title": "Default pipeline Integration",
+    "version": "0.0.1",
+    "release": "beta",
+    "description": "Tests the registry validations works for dataset fields using the ecs style format",
+    "type": "integration",
+    "download": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.zip",
+    "path": "/package/ecs_style_dataset/0.0.1",
+    "policy_templates": [
+      {
+        "name": "logs",
+        "title": "Logs datasource",
+        "description": "Datasource for your log files."
+      }
+    ],
+    "categories": [
+      "monitoring"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ecs_style_dataset.foo",
+        "title": "Foo"
+      }
+    ]
+  },
+  {
     "name": "elasticsearch_privileges",
     "title": "Elasticsearch Privileges",
     "version": "1.0.0",
@@ -354,42 +556,6 @@
         "type": "metrics",
         "dataset": "elasticsearch_privileges.elasticsearch_privileges",
         "title": "Elasticsearch privileges data stream"
-      }
-    ]
-  },
-  {
-    "name": "nodirentries",
-    "title": "Example Integration",
-    "version": "1.0.0",
-    "release": "ga",
-    "description": "This is a zip package without directory entries.",
-    "type": "integration",
-    "download": "/epr/nodirentries/nodirentries-1.0.0.zip",
-    "path": "/package/nodirentries/1.0.0",
-    "policy_templates": [
-      {
-        "name": "logs",
-        "title": "Logs datasource",
-        "description": "Datasource for your log files."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "~7.x.x"
-      }
-    },
-    "owner": {
-      "github": "ruflin"
-    },
-    "categories": [
-      "crm",
-      "azure"
-    ],
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "nodirentries.foo",
-        "title": "Foo"
       }
     ]
   },
@@ -736,6 +902,33 @@
     ]
   },
   {
+    "name": "multiple_false",
+    "title": "Multiple false",
+    "version": "0.0.1",
+    "release": "beta",
+    "description": "Tests that multiple can be set to false",
+    "type": "integration",
+    "download": "/epr/multiple_false/multiple_false-0.0.1.zip",
+    "path": "/package/multiple_false/0.0.1",
+    "policy_templates": [
+      {
+        "name": "logs",
+        "title": "Logs datasource",
+        "description": "Datasource for your log files."
+      }
+    ],
+    "categories": [
+      "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "multiple_false.foo",
+        "title": "Foo"
+      }
+    ]
+  },
+  {
     "name": "multiversion",
     "title": "Multi Version",
     "version": "1.2.0",
@@ -764,235 +957,6 @@
       "since": "1.2.0",
       "description": "This package is deprecated"
     }
-  },
-  {
-    "name": "multiple_false",
-    "title": "Multiple false",
-    "version": "0.0.1",
-    "release": "beta",
-    "description": "Tests that multiple can be set to false",
-    "type": "integration",
-    "download": "/epr/multiple_false/multiple_false-0.0.1.zip",
-    "path": "/package/multiple_false/0.0.1",
-    "policy_templates": [
-      {
-        "name": "logs",
-        "title": "Logs datasource",
-        "description": "Datasource for your log files."
-      }
-    ],
-    "categories": [
-      "custom"
-    ],
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "multiple_false.foo",
-        "title": "Foo"
-      }
-    ]
-  },
-  {
-    "name": "deprecated_input_package",
-    "title": "New Package",
-    "version": "1.0.0",
-    "release": "ga",
-    "source": {
-      "license": "Elastic-2.0"
-    },
-    "description": "This is a new package.",
-    "type": "input",
-    "download": "/epr/deprecated_input_package/deprecated_input_package-1.0.0.zip",
-    "path": "/package/deprecated_input_package/1.0.0",
-    "icons": [
-      {
-        "src": "/img/sample-logo.svg",
-        "path": "/package/deprecated_input_package/1.0.0/img/sample-logo.svg",
-        "title": "Sample logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "sample",
-        "title": "Sample logs",
-        "description": "Collect sample logs"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^9.2.3"
-      },
-      "elastic": {
-        "subscription": "basic"
-      }
-    },
-    "owner": {
-      "type": "elastic",
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "deprecated": {
-      "since": "1.2.0",
-      "description": "This input package is deprecated",
-      "replaced_by": {
-        "package": "new_input_package"
-      }
-    }
-  },
-  {
-    "name": "deprecated_integration_input",
-    "title": "New Package",
-    "version": "1.0.0",
-    "release": "ga",
-    "source": {
-      "license": "Elastic-2.0"
-    },
-    "description": "This is a new package.",
-    "type": "integration",
-    "download": "/epr/deprecated_integration_input/deprecated_integration_input-1.0.0.zip",
-    "path": "/package/deprecated_integration_input/1.0.0",
-    "icons": [
-      {
-        "src": "/img/sample-logo.svg",
-        "path": "/package/deprecated_integration_input/1.0.0/img/sample-logo.svg",
-        "title": "Sample logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "sample",
-        "title": "Sample logs",
-        "description": "Collect sample logs"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^9.2.3"
-      },
-      "elastic": {
-        "subscription": "basic"
-      }
-    },
-    "owner": {
-      "type": "elastic",
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "custom"
-    ]
-  },
-  {
-    "name": "deprecated_input_policy",
-    "title": "New Package",
-    "version": "1.0.0",
-    "release": "ga",
-    "source": {
-      "license": "Elastic-2.0"
-    },
-    "description": "This is a new package.",
-    "type": "input",
-    "download": "/epr/deprecated_input_policy/deprecated_input_policy-1.0.0.zip",
-    "path": "/package/deprecated_input_policy/1.0.0",
-    "icons": [
-      {
-        "src": "/img/sample-logo.svg",
-        "path": "/package/deprecated_input_policy/1.0.0/img/sample-logo.svg",
-        "title": "Sample logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "sample_deprecated",
-        "title": "Sample logs",
-        "description": "Collect sample logs",
-        "deprecated": {
-          "since": "1.2.0",
-          "description": "This policy is deprecated",
-          "replaced_by": {
-            "policy_template": "sample"
-          }
-        }
-      },
-      {
-        "name": "sample",
-        "title": "Sample logs",
-        "description": "Collect sample logs"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^9.2.3"
-      },
-      "elastic": {
-        "subscription": "basic"
-      }
-    },
-    "owner": {
-      "type": "elastic",
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "custom"
-    ]
-  },
-  {
-    "name": "deprecated_integration_stream",
-    "title": "New Package",
-    "version": "1.0.0",
-    "release": "ga",
-    "source": {
-      "license": "Elastic-2.0"
-    },
-    "description": "This is a new package.",
-    "type": "integration",
-    "download": "/epr/deprecated_integration_stream/deprecated_integration_stream-1.0.0.zip",
-    "path": "/package/deprecated_integration_stream/1.0.0",
-    "icons": [
-      {
-        "src": "/img/sample-logo.svg",
-        "path": "/package/deprecated_integration_stream/1.0.0/img/sample-logo.svg",
-        "title": "Sample logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "sample",
-        "title": "Sample logs",
-        "description": "Collect sample logs"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^9.2.3"
-      },
-      "elastic": {
-        "subscription": "basic"
-      }
-    },
-    "owner": {
-      "type": "elastic",
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "deprecated_integration_stream.new_data_stream",
-        "title": "New Data Stream"
-      }
-    ]
   },
   {
     "name": "nginx",
@@ -1050,6 +1014,42 @@
         "type": "logs",
         "dataset": "no_stream_configs.log",
         "title": "Log Yaml pipeline"
+      }
+    ]
+  },
+  {
+    "name": "nodirentries",
+    "title": "Example Integration",
+    "version": "1.0.0",
+    "release": "ga",
+    "description": "This is a zip package without directory entries.",
+    "type": "integration",
+    "download": "/epr/nodirentries/nodirentries-1.0.0.zip",
+    "path": "/package/nodirentries/1.0.0",
+    "policy_templates": [
+      {
+        "name": "logs",
+        "title": "Logs datasource",
+        "description": "Datasource for your log files."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "~7.x.x"
+      }
+    },
+    "owner": {
+      "github": "ruflin"
+    },
+    "categories": [
+      "crm",
+      "azure"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "nodirentries.foo",
+        "title": "Foo"
       }
     ]
   },

--- a/testdata/generated/search-kibana652.json
+++ b/testdata/generated/search-kibana652.json
@@ -20,19 +20,6 @@
     ]
   },
   {
-    "name": "defaultrelease",
-    "title": "Default Release",
-    "version": "0.0.1",
-    "release": "beta",
-    "description": "Package without release, should be set to default",
-    "type": "solution",
-    "download": "/epr/defaultrelease/defaultrelease-0.0.1.zip",
-    "path": "/package/defaultrelease/0.0.1",
-    "categories": [
-      "aws"
-    ]
-  },
-  {
     "name": "datasources",
     "title": "Default datasource Integration",
     "version": "1.0.0",
@@ -75,33 +62,6 @@
     ]
   },
   {
-    "name": "ecs_style_dataset",
-    "title": "Default pipeline Integration",
-    "version": "0.0.1",
-    "release": "beta",
-    "description": "Tests the registry validations works for dataset fields using the ecs style format",
-    "type": "integration",
-    "download": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.zip",
-    "path": "/package/ecs_style_dataset/0.0.1",
-    "policy_templates": [
-      {
-        "name": "logs",
-        "title": "Logs datasource",
-        "description": "Datasource for your log files."
-      }
-    ],
-    "categories": [
-      "monitoring"
-    ],
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ecs_style_dataset.foo",
-        "title": "Foo"
-      }
-    ]
-  },
-  {
     "name": "default_pipeline",
     "title": "Default pipeline Integration",
     "version": "0.0.2",
@@ -125,6 +85,46 @@
       {
         "type": "logs",
         "dataset": "default_pipeline.foo",
+        "title": "Foo"
+      }
+    ]
+  },
+  {
+    "name": "defaultrelease",
+    "title": "Default Release",
+    "version": "0.0.1",
+    "release": "beta",
+    "description": "Package without release, should be set to default",
+    "type": "solution",
+    "download": "/epr/defaultrelease/defaultrelease-0.0.1.zip",
+    "path": "/package/defaultrelease/0.0.1",
+    "categories": [
+      "aws"
+    ]
+  },
+  {
+    "name": "ecs_style_dataset",
+    "title": "Default pipeline Integration",
+    "version": "0.0.1",
+    "release": "beta",
+    "description": "Tests the registry validations works for dataset fields using the ecs style format",
+    "type": "integration",
+    "download": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.zip",
+    "path": "/package/ecs_style_dataset/0.0.1",
+    "policy_templates": [
+      {
+        "name": "logs",
+        "title": "Logs datasource",
+        "description": "Datasource for your log files."
+      }
+    ],
+    "categories": [
+      "monitoring"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ecs_style_dataset.foo",
         "title": "Foo"
       }
     ]

--- a/testdata/generated/search-kibana721.json
+++ b/testdata/generated/search-kibana721.json
@@ -49,19 +49,6 @@
     ]
   },
   {
-    "name": "defaultrelease",
-    "title": "Default Release",
-    "version": "0.0.1",
-    "release": "beta",
-    "description": "Package without release, should be set to default",
-    "type": "solution",
-    "download": "/epr/defaultrelease/defaultrelease-0.0.1.zip",
-    "path": "/package/defaultrelease/0.0.1",
-    "categories": [
-      "aws"
-    ]
-  },
-  {
     "name": "datasources",
     "title": "Default datasource Integration",
     "version": "1.0.0",
@@ -104,33 +91,6 @@
     ]
   },
   {
-    "name": "ecs_style_dataset",
-    "title": "Default pipeline Integration",
-    "version": "0.0.1",
-    "release": "beta",
-    "description": "Tests the registry validations works for dataset fields using the ecs style format",
-    "type": "integration",
-    "download": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.zip",
-    "path": "/package/ecs_style_dataset/0.0.1",
-    "policy_templates": [
-      {
-        "name": "logs",
-        "title": "Logs datasource",
-        "description": "Datasource for your log files."
-      }
-    ],
-    "categories": [
-      "monitoring"
-    ],
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ecs_style_dataset.foo",
-        "title": "Foo"
-      }
-    ]
-  },
-  {
     "name": "default_pipeline",
     "title": "Default pipeline Integration",
     "version": "0.0.2",
@@ -159,14 +119,27 @@
     ]
   },
   {
-    "name": "nodirentries",
-    "title": "Example Integration",
-    "version": "1.0.0",
-    "release": "ga",
-    "description": "This is a zip package without directory entries.",
+    "name": "defaultrelease",
+    "title": "Default Release",
+    "version": "0.0.1",
+    "release": "beta",
+    "description": "Package without release, should be set to default",
+    "type": "solution",
+    "download": "/epr/defaultrelease/defaultrelease-0.0.1.zip",
+    "path": "/package/defaultrelease/0.0.1",
+    "categories": [
+      "aws"
+    ]
+  },
+  {
+    "name": "ecs_style_dataset",
+    "title": "Default pipeline Integration",
+    "version": "0.0.1",
+    "release": "beta",
+    "description": "Tests the registry validations works for dataset fields using the ecs style format",
     "type": "integration",
-    "download": "/epr/nodirentries/nodirentries-1.0.0.zip",
-    "path": "/package/nodirentries/1.0.0",
+    "download": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.zip",
+    "path": "/package/ecs_style_dataset/0.0.1",
     "policy_templates": [
       {
         "name": "logs",
@@ -174,22 +147,13 @@
         "description": "Datasource for your log files."
       }
     ],
-    "conditions": {
-      "kibana": {
-        "version": "~7.x.x"
-      }
-    },
-    "owner": {
-      "github": "ruflin"
-    },
     "categories": [
-      "crm",
-      "azure"
+      "monitoring"
     ],
     "data_streams": [
       {
         "type": "logs",
-        "dataset": "nodirentries.foo",
+        "dataset": "ecs_style_dataset.foo",
         "title": "Foo"
       }
     ]
@@ -419,6 +383,33 @@
     ]
   },
   {
+    "name": "multiple_false",
+    "title": "Multiple false",
+    "version": "0.0.1",
+    "release": "beta",
+    "description": "Tests that multiple can be set to false",
+    "type": "integration",
+    "download": "/epr/multiple_false/multiple_false-0.0.1.zip",
+    "path": "/package/multiple_false/0.0.1",
+    "policy_templates": [
+      {
+        "name": "logs",
+        "title": "Logs datasource",
+        "description": "Datasource for your log files."
+      }
+    ],
+    "categories": [
+      "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "multiple_false.foo",
+        "title": "Foo"
+      }
+    ]
+  },
+  {
     "name": "multiversion",
     "title": "Multi Version",
     "version": "1.2.0",
@@ -449,33 +440,6 @@
     }
   },
   {
-    "name": "multiple_false",
-    "title": "Multiple false",
-    "version": "0.0.1",
-    "release": "beta",
-    "description": "Tests that multiple can be set to false",
-    "type": "integration",
-    "download": "/epr/multiple_false/multiple_false-0.0.1.zip",
-    "path": "/package/multiple_false/0.0.1",
-    "policy_templates": [
-      {
-        "name": "logs",
-        "title": "Logs datasource",
-        "description": "Datasource for your log files."
-      }
-    ],
-    "categories": [
-      "custom"
-    ],
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "multiple_false.foo",
-        "title": "Foo"
-      }
-    ]
-  },
-  {
     "name": "no_stream_configs",
     "title": "No Stream configs",
     "version": "1.0.0",
@@ -492,6 +456,42 @@
         "type": "logs",
         "dataset": "no_stream_configs.log",
         "title": "Log Yaml pipeline"
+      }
+    ]
+  },
+  {
+    "name": "nodirentries",
+    "title": "Example Integration",
+    "version": "1.0.0",
+    "release": "ga",
+    "description": "This is a zip package without directory entries.",
+    "type": "integration",
+    "download": "/epr/nodirentries/nodirentries-1.0.0.zip",
+    "path": "/package/nodirentries/1.0.0",
+    "policy_templates": [
+      {
+        "name": "logs",
+        "title": "Logs datasource",
+        "description": "Datasource for your log files."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "~7.x.x"
+      }
+    },
+    "owner": {
+      "github": "ruflin"
+    },
+    "categories": [
+      "crm",
+      "azure"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "nodirentries.foo",
+        "title": "Foo"
       }
     ]
   },

--- a/testdata/generated/search-kibana800.json
+++ b/testdata/generated/search-kibana800.json
@@ -74,19 +74,6 @@
     ]
   },
   {
-    "name": "defaultrelease",
-    "title": "Default Release",
-    "version": "0.0.1",
-    "release": "beta",
-    "description": "Package without release, should be set to default",
-    "type": "solution",
-    "download": "/epr/defaultrelease/defaultrelease-0.0.1.zip",
-    "path": "/package/defaultrelease/0.0.1",
-    "categories": [
-      "aws"
-    ]
-  },
-  {
     "name": "datasources",
     "title": "Default datasource Integration",
     "version": "1.0.0",
@@ -129,33 +116,6 @@
     ]
   },
   {
-    "name": "ecs_style_dataset",
-    "title": "Default pipeline Integration",
-    "version": "0.0.1",
-    "release": "beta",
-    "description": "Tests the registry validations works for dataset fields using the ecs style format",
-    "type": "integration",
-    "download": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.zip",
-    "path": "/package/ecs_style_dataset/0.0.1",
-    "policy_templates": [
-      {
-        "name": "logs",
-        "title": "Logs datasource",
-        "description": "Datasource for your log files."
-      }
-    ],
-    "categories": [
-      "monitoring"
-    ],
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ecs_style_dataset.foo",
-        "title": "Foo"
-      }
-    ]
-  },
-  {
     "name": "default_pipeline",
     "title": "Default pipeline Integration",
     "version": "0.0.2",
@@ -179,6 +139,46 @@
       {
         "type": "logs",
         "dataset": "default_pipeline.foo",
+        "title": "Foo"
+      }
+    ]
+  },
+  {
+    "name": "defaultrelease",
+    "title": "Default Release",
+    "version": "0.0.1",
+    "release": "beta",
+    "description": "Package without release, should be set to default",
+    "type": "solution",
+    "download": "/epr/defaultrelease/defaultrelease-0.0.1.zip",
+    "path": "/package/defaultrelease/0.0.1",
+    "categories": [
+      "aws"
+    ]
+  },
+  {
+    "name": "ecs_style_dataset",
+    "title": "Default pipeline Integration",
+    "version": "0.0.1",
+    "release": "beta",
+    "description": "Tests the registry validations works for dataset fields using the ecs style format",
+    "type": "integration",
+    "download": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.zip",
+    "path": "/package/ecs_style_dataset/0.0.1",
+    "policy_templates": [
+      {
+        "name": "logs",
+        "title": "Logs datasource",
+        "description": "Datasource for your log files."
+      }
+    ],
+    "categories": [
+      "monitoring"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ecs_style_dataset.foo",
         "title": "Foo"
       }
     ]
@@ -400,6 +400,33 @@
     ]
   },
   {
+    "name": "multiple_false",
+    "title": "Multiple false",
+    "version": "0.0.1",
+    "release": "beta",
+    "description": "Tests that multiple can be set to false",
+    "type": "integration",
+    "download": "/epr/multiple_false/multiple_false-0.0.1.zip",
+    "path": "/package/multiple_false/0.0.1",
+    "policy_templates": [
+      {
+        "name": "logs",
+        "title": "Logs datasource",
+        "description": "Datasource for your log files."
+      }
+    ],
+    "categories": [
+      "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "multiple_false.foo",
+        "title": "Foo"
+      }
+    ]
+  },
+  {
     "name": "multiversion",
     "title": "Multi Version",
     "version": "1.2.0",
@@ -428,33 +455,6 @@
       "since": "1.2.0",
       "description": "This package is deprecated"
     }
-  },
-  {
-    "name": "multiple_false",
-    "title": "Multiple false",
-    "version": "0.0.1",
-    "release": "beta",
-    "description": "Tests that multiple can be set to false",
-    "type": "integration",
-    "download": "/epr/multiple_false/multiple_false-0.0.1.zip",
-    "path": "/package/multiple_false/0.0.1",
-    "policy_templates": [
-      {
-        "name": "logs",
-        "title": "Logs datasource",
-        "description": "Datasource for your log files."
-      }
-    ],
-    "categories": [
-      "custom"
-    ],
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "multiple_false.foo",
-        "title": "Foo"
-      }
-    ]
   },
   {
     "name": "no_stream_configs",

--- a/testdata/generated/search-package-experimental.json
+++ b/testdata/generated/search-package-experimental.json
@@ -54,51 +54,6 @@
     ]
   },
   {
-    "name": "datastream_without_release",
-    "title": "Apache Spark",
-    "version": "0.1.0",
-    "release": "beta",
-    "description": "Collect metrics from Apache Spark with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/datastream_without_release/datastream_without_release-0.1.0.zip",
-    "path": "/package/datastream_without_release/0.1.0",
-    "icons": [
-      {
-        "src": "/img/apache_spark-logo.svg",
-        "path": "/package/datastream_without_release/0.1.0/img/apache_spark-logo.svg",
-        "title": "Apache Spark logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "apache_spark",
-        "title": "Apache Spark metrics",
-        "description": "Collect Apache Spark metrics"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.1.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/obs-service-integrations"
-    },
-    "categories": [
-      "datastore",
-      "monitoring"
-    ],
-    "data_streams": [
-      {
-        "type": "metrics",
-        "dataset": "datastream_without_release.nodes",
-        "title": "Apache Spark nodes metrics"
-      }
-    ]
-  },
-  {
     "name": "dataset_is_prefix",
     "title": "DatasetIsPrefix Flag",
     "version": "0.0.1",
@@ -116,19 +71,6 @@
         "dataset": "dataset_is_prefix.test",
         "title": "dataset_is_prefix test data stream"
       }
-    ]
-  },
-  {
-    "name": "defaultrelease",
-    "title": "Default Release",
-    "version": "0.0.1",
-    "release": "beta",
-    "description": "Package without release, should be set to default",
-    "type": "solution",
-    "download": "/epr/defaultrelease/defaultrelease-0.0.1.zip",
-    "path": "/package/defaultrelease/0.0.1",
-    "categories": [
-      "aws"
     ]
   },
   {
@@ -174,29 +116,47 @@
     ]
   },
   {
-    "name": "ecs_style_dataset",
-    "title": "Default pipeline Integration",
-    "version": "0.0.1",
+    "name": "datastream_without_release",
+    "title": "Apache Spark",
+    "version": "0.1.0",
     "release": "beta",
-    "description": "Tests the registry validations works for dataset fields using the ecs style format",
+    "description": "Collect metrics from Apache Spark with Elastic Agent.",
     "type": "integration",
-    "download": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.zip",
-    "path": "/package/ecs_style_dataset/0.0.1",
-    "policy_templates": [
+    "download": "/epr/datastream_without_release/datastream_without_release-0.1.0.zip",
+    "path": "/package/datastream_without_release/0.1.0",
+    "icons": [
       {
-        "name": "logs",
-        "title": "Logs datasource",
-        "description": "Datasource for your log files."
+        "src": "/img/apache_spark-logo.svg",
+        "path": "/package/datastream_without_release/0.1.0/img/apache_spark-logo.svg",
+        "title": "Apache Spark logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
       }
     ],
+    "policy_templates": [
+      {
+        "name": "apache_spark",
+        "title": "Apache Spark metrics",
+        "description": "Collect Apache Spark metrics"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.1.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/obs-service-integrations"
+    },
     "categories": [
+      "datastore",
       "monitoring"
     ],
     "data_streams": [
       {
-        "type": "logs",
-        "dataset": "ecs_style_dataset.foo",
-        "title": "Foo"
+        "type": "metrics",
+        "dataset": "datastream_without_release.nodes",
+        "title": "Apache Spark nodes metrics"
       }
     ]
   },
@@ -226,6 +186,19 @@
         "dataset": "default_pipeline.foo",
         "title": "Foo"
       }
+    ]
+  },
+  {
+    "name": "defaultrelease",
+    "title": "Default Release",
+    "version": "0.0.1",
+    "release": "beta",
+    "description": "Package without release, should be set to default",
+    "type": "solution",
+    "download": "/epr/defaultrelease/defaultrelease-0.0.1.zip",
+    "path": "/package/defaultrelease/0.0.1",
+    "categories": [
+      "aws"
     ]
   },
   {
@@ -296,6 +269,208 @@
     ]
   },
   {
+    "name": "deprecated_input_package",
+    "title": "New Package",
+    "version": "1.0.0",
+    "release": "ga",
+    "source": {
+      "license": "Elastic-2.0"
+    },
+    "description": "This is a new package.",
+    "type": "input",
+    "download": "/epr/deprecated_input_package/deprecated_input_package-1.0.0.zip",
+    "path": "/package/deprecated_input_package/1.0.0",
+    "icons": [
+      {
+        "src": "/img/sample-logo.svg",
+        "path": "/package/deprecated_input_package/1.0.0/img/sample-logo.svg",
+        "title": "Sample logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "sample",
+        "title": "Sample logs",
+        "description": "Collect sample logs"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^9.2.3"
+      },
+      "elastic": {
+        "subscription": "basic"
+      }
+    },
+    "owner": {
+      "type": "elastic",
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "deprecated": {
+      "since": "1.2.0",
+      "description": "This input package is deprecated",
+      "replaced_by": {
+        "package": "new_input_package"
+      }
+    }
+  },
+  {
+    "name": "deprecated_input_policy",
+    "title": "New Package",
+    "version": "1.0.0",
+    "release": "ga",
+    "source": {
+      "license": "Elastic-2.0"
+    },
+    "description": "This is a new package.",
+    "type": "input",
+    "download": "/epr/deprecated_input_policy/deprecated_input_policy-1.0.0.zip",
+    "path": "/package/deprecated_input_policy/1.0.0",
+    "icons": [
+      {
+        "src": "/img/sample-logo.svg",
+        "path": "/package/deprecated_input_policy/1.0.0/img/sample-logo.svg",
+        "title": "Sample logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "sample_deprecated",
+        "title": "Sample logs",
+        "description": "Collect sample logs",
+        "deprecated": {
+          "since": "1.2.0",
+          "description": "This policy is deprecated",
+          "replaced_by": {
+            "policy_template": "sample"
+          }
+        }
+      },
+      {
+        "name": "sample",
+        "title": "Sample logs",
+        "description": "Collect sample logs"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^9.2.3"
+      },
+      "elastic": {
+        "subscription": "basic"
+      }
+    },
+    "owner": {
+      "type": "elastic",
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "custom"
+    ]
+  },
+  {
+    "name": "deprecated_integration_input",
+    "title": "New Package",
+    "version": "1.0.0",
+    "release": "ga",
+    "source": {
+      "license": "Elastic-2.0"
+    },
+    "description": "This is a new package.",
+    "type": "integration",
+    "download": "/epr/deprecated_integration_input/deprecated_integration_input-1.0.0.zip",
+    "path": "/package/deprecated_integration_input/1.0.0",
+    "icons": [
+      {
+        "src": "/img/sample-logo.svg",
+        "path": "/package/deprecated_integration_input/1.0.0/img/sample-logo.svg",
+        "title": "Sample logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "sample",
+        "title": "Sample logs",
+        "description": "Collect sample logs"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^9.2.3"
+      },
+      "elastic": {
+        "subscription": "basic"
+      }
+    },
+    "owner": {
+      "type": "elastic",
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "custom"
+    ]
+  },
+  {
+    "name": "deprecated_integration_stream",
+    "title": "New Package",
+    "version": "1.0.0",
+    "release": "ga",
+    "source": {
+      "license": "Elastic-2.0"
+    },
+    "description": "This is a new package.",
+    "type": "integration",
+    "download": "/epr/deprecated_integration_stream/deprecated_integration_stream-1.0.0.zip",
+    "path": "/package/deprecated_integration_stream/1.0.0",
+    "icons": [
+      {
+        "src": "/img/sample-logo.svg",
+        "path": "/package/deprecated_integration_stream/1.0.0/img/sample-logo.svg",
+        "title": "Sample logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "sample",
+        "title": "Sample logs",
+        "description": "Collect sample logs"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^9.2.3"
+      },
+      "elastic": {
+        "subscription": "basic"
+      }
+    },
+    "owner": {
+      "type": "elastic",
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "deprecated_integration_stream.new_data_stream",
+        "title": "New Data Stream"
+      }
+    ]
+  },
+  {
     "name": "discovery_empty",
     "title": "Discovery Empty",
     "version": "0.1.0",
@@ -333,6 +508,33 @@
     ]
   },
   {
+    "name": "ecs_style_dataset",
+    "title": "Default pipeline Integration",
+    "version": "0.0.1",
+    "release": "beta",
+    "description": "Tests the registry validations works for dataset fields using the ecs style format",
+    "type": "integration",
+    "download": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.zip",
+    "path": "/package/ecs_style_dataset/0.0.1",
+    "policy_templates": [
+      {
+        "name": "logs",
+        "title": "Logs datasource",
+        "description": "Datasource for your log files."
+      }
+    ],
+    "categories": [
+      "monitoring"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ecs_style_dataset.foo",
+        "title": "Foo"
+      }
+    ]
+  },
+  {
     "name": "elasticsearch_privileges",
     "title": "Elasticsearch Privileges",
     "version": "1.0.0",
@@ -354,42 +556,6 @@
         "type": "metrics",
         "dataset": "elasticsearch_privileges.elasticsearch_privileges",
         "title": "Elasticsearch privileges data stream"
-      }
-    ]
-  },
-  {
-    "name": "nodirentries",
-    "title": "Example Integration",
-    "version": "1.0.0",
-    "release": "ga",
-    "description": "This is a zip package without directory entries.",
-    "type": "integration",
-    "download": "/epr/nodirentries/nodirentries-1.0.0.zip",
-    "path": "/package/nodirentries/1.0.0",
-    "policy_templates": [
-      {
-        "name": "logs",
-        "title": "Logs datasource",
-        "description": "Datasource for your log files."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "~7.x.x"
-      }
-    },
-    "owner": {
-      "github": "ruflin"
-    },
-    "categories": [
-      "crm",
-      "azure"
-    ],
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "nodirentries.foo",
-        "title": "Foo"
       }
     ]
   },
@@ -736,6 +902,33 @@
     ]
   },
   {
+    "name": "multiple_false",
+    "title": "Multiple false",
+    "version": "0.0.1",
+    "release": "beta",
+    "description": "Tests that multiple can be set to false",
+    "type": "integration",
+    "download": "/epr/multiple_false/multiple_false-0.0.1.zip",
+    "path": "/package/multiple_false/0.0.1",
+    "policy_templates": [
+      {
+        "name": "logs",
+        "title": "Logs datasource",
+        "description": "Datasource for your log files."
+      }
+    ],
+    "categories": [
+      "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "multiple_false.foo",
+        "title": "Foo"
+      }
+    ]
+  },
+  {
     "name": "multiversion",
     "title": "Multi Version",
     "version": "1.2.0",
@@ -766,235 +959,6 @@
     }
   },
   {
-    "name": "multiple_false",
-    "title": "Multiple false",
-    "version": "0.0.1",
-    "release": "beta",
-    "description": "Tests that multiple can be set to false",
-    "type": "integration",
-    "download": "/epr/multiple_false/multiple_false-0.0.1.zip",
-    "path": "/package/multiple_false/0.0.1",
-    "policy_templates": [
-      {
-        "name": "logs",
-        "title": "Logs datasource",
-        "description": "Datasource for your log files."
-      }
-    ],
-    "categories": [
-      "custom"
-    ],
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "multiple_false.foo",
-        "title": "Foo"
-      }
-    ]
-  },
-  {
-    "name": "deprecated_input_package",
-    "title": "New Package",
-    "version": "1.0.0",
-    "release": "ga",
-    "source": {
-      "license": "Elastic-2.0"
-    },
-    "description": "This is a new package.",
-    "type": "input",
-    "download": "/epr/deprecated_input_package/deprecated_input_package-1.0.0.zip",
-    "path": "/package/deprecated_input_package/1.0.0",
-    "icons": [
-      {
-        "src": "/img/sample-logo.svg",
-        "path": "/package/deprecated_input_package/1.0.0/img/sample-logo.svg",
-        "title": "Sample logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "sample",
-        "title": "Sample logs",
-        "description": "Collect sample logs"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^9.2.3"
-      },
-      "elastic": {
-        "subscription": "basic"
-      }
-    },
-    "owner": {
-      "type": "elastic",
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "deprecated": {
-      "since": "1.2.0",
-      "description": "This input package is deprecated",
-      "replaced_by": {
-        "package": "new_input_package"
-      }
-    }
-  },
-  {
-    "name": "deprecated_input_policy",
-    "title": "New Package",
-    "version": "1.0.0",
-    "release": "ga",
-    "source": {
-      "license": "Elastic-2.0"
-    },
-    "description": "This is a new package.",
-    "type": "input",
-    "download": "/epr/deprecated_input_policy/deprecated_input_policy-1.0.0.zip",
-    "path": "/package/deprecated_input_policy/1.0.0",
-    "icons": [
-      {
-        "src": "/img/sample-logo.svg",
-        "path": "/package/deprecated_input_policy/1.0.0/img/sample-logo.svg",
-        "title": "Sample logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "sample_deprecated",
-        "title": "Sample logs",
-        "description": "Collect sample logs",
-        "deprecated": {
-          "since": "1.2.0",
-          "description": "This policy is deprecated",
-          "replaced_by": {
-            "policy_template": "sample"
-          }
-        }
-      },
-      {
-        "name": "sample",
-        "title": "Sample logs",
-        "description": "Collect sample logs"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^9.2.3"
-      },
-      "elastic": {
-        "subscription": "basic"
-      }
-    },
-    "owner": {
-      "type": "elastic",
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "custom"
-    ]
-  },
-  {
-    "name": "deprecated_integration_input",
-    "title": "New Package",
-    "version": "1.0.0",
-    "release": "ga",
-    "source": {
-      "license": "Elastic-2.0"
-    },
-    "description": "This is a new package.",
-    "type": "integration",
-    "download": "/epr/deprecated_integration_input/deprecated_integration_input-1.0.0.zip",
-    "path": "/package/deprecated_integration_input/1.0.0",
-    "icons": [
-      {
-        "src": "/img/sample-logo.svg",
-        "path": "/package/deprecated_integration_input/1.0.0/img/sample-logo.svg",
-        "title": "Sample logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "sample",
-        "title": "Sample logs",
-        "description": "Collect sample logs"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^9.2.3"
-      },
-      "elastic": {
-        "subscription": "basic"
-      }
-    },
-    "owner": {
-      "type": "elastic",
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "custom"
-    ]
-  },
-  {
-    "name": "deprecated_integration_stream",
-    "title": "New Package",
-    "version": "1.0.0",
-    "release": "ga",
-    "source": {
-      "license": "Elastic-2.0"
-    },
-    "description": "This is a new package.",
-    "type": "integration",
-    "download": "/epr/deprecated_integration_stream/deprecated_integration_stream-1.0.0.zip",
-    "path": "/package/deprecated_integration_stream/1.0.0",
-    "icons": [
-      {
-        "src": "/img/sample-logo.svg",
-        "path": "/package/deprecated_integration_stream/1.0.0/img/sample-logo.svg",
-        "title": "Sample logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "sample",
-        "title": "Sample logs",
-        "description": "Collect sample logs"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^9.2.3"
-      },
-      "elastic": {
-        "subscription": "basic"
-      }
-    },
-    "owner": {
-      "type": "elastic",
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "deprecated_integration_stream.new_data_stream",
-        "title": "New Data Stream"
-      }
-    ]
-  },
-  {
     "name": "no_stream_configs",
     "title": "No Stream configs",
     "version": "1.0.0",
@@ -1015,30 +979,38 @@
     ]
   },
   {
-    "name": "traces",
-    "title": "Not actually APM",
+    "name": "nodirentries",
+    "title": "Example Integration",
     "version": "1.0.0",
-    "release": "experimental",
-    "description": "Not actually APM",
+    "release": "ga",
+    "description": "This is a zip package without directory entries.",
     "type": "integration",
-    "download": "/epr/traces/traces-1.0.0.zip",
-    "path": "/package/traces/1.0.0",
+    "download": "/epr/nodirentries/nodirentries-1.0.0.zip",
+    "path": "/package/nodirentries/1.0.0",
+    "policy_templates": [
+      {
+        "name": "logs",
+        "title": "Logs datasource",
+        "description": "Datasource for your log files."
+      }
+    ],
     "conditions": {
       "kibana": {
         "version": "~7.x.x"
       }
     },
     "owner": {
-      "github": "github.com/elastic/not-apm"
+      "github": "ruflin"
     },
     "categories": [
-      "monitoring"
+      "crm",
+      "azure"
     ],
     "data_streams": [
       {
-        "type": "traces",
-        "dataset": "traces.traces",
-        "title": "notapmtraces"
+        "type": "logs",
+        "dataset": "nodirentries.foo",
+        "title": "Foo"
       }
     ]
   },
@@ -1185,6 +1157,34 @@
     "categories": [
       "custom",
       "datastore"
+    ]
+  },
+  {
+    "name": "traces",
+    "title": "Not actually APM",
+    "version": "1.0.0",
+    "release": "experimental",
+    "description": "Not actually APM",
+    "type": "integration",
+    "download": "/epr/traces/traces-1.0.0.zip",
+    "path": "/package/traces/1.0.0",
+    "conditions": {
+      "kibana": {
+        "version": "~7.x.x"
+      }
+    },
+    "owner": {
+      "github": "github.com/elastic/not-apm"
+    },
+    "categories": [
+      "monitoring"
+    ],
+    "data_streams": [
+      {
+        "type": "traces",
+        "dataset": "traces.traces",
+        "title": "notapmtraces"
+      }
     ]
   },
   {

--- a/testdata/generated/search-package-internal.json
+++ b/testdata/generated/search-package-internal.json
@@ -54,51 +54,6 @@
     ]
   },
   {
-    "name": "datastream_without_release",
-    "title": "Apache Spark",
-    "version": "0.1.0",
-    "release": "beta",
-    "description": "Collect metrics from Apache Spark with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/datastream_without_release/datastream_without_release-0.1.0.zip",
-    "path": "/package/datastream_without_release/0.1.0",
-    "icons": [
-      {
-        "src": "/img/apache_spark-logo.svg",
-        "path": "/package/datastream_without_release/0.1.0/img/apache_spark-logo.svg",
-        "title": "Apache Spark logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "apache_spark",
-        "title": "Apache Spark metrics",
-        "description": "Collect Apache Spark metrics"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.1.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/obs-service-integrations"
-    },
-    "categories": [
-      "datastore",
-      "monitoring"
-    ],
-    "data_streams": [
-      {
-        "type": "metrics",
-        "dataset": "datastream_without_release.nodes",
-        "title": "Apache Spark nodes metrics"
-      }
-    ]
-  },
-  {
     "name": "dataset_is_prefix",
     "title": "DatasetIsPrefix Flag",
     "version": "0.0.1",
@@ -116,19 +71,6 @@
         "dataset": "dataset_is_prefix.test",
         "title": "dataset_is_prefix test data stream"
       }
-    ]
-  },
-  {
-    "name": "defaultrelease",
-    "title": "Default Release",
-    "version": "0.0.1",
-    "release": "beta",
-    "description": "Package without release, should be set to default",
-    "type": "solution",
-    "download": "/epr/defaultrelease/defaultrelease-0.0.1.zip",
-    "path": "/package/defaultrelease/0.0.1",
-    "categories": [
-      "aws"
     ]
   },
   {
@@ -174,29 +116,47 @@
     ]
   },
   {
-    "name": "ecs_style_dataset",
-    "title": "Default pipeline Integration",
-    "version": "0.0.1",
+    "name": "datastream_without_release",
+    "title": "Apache Spark",
+    "version": "0.1.0",
     "release": "beta",
-    "description": "Tests the registry validations works for dataset fields using the ecs style format",
+    "description": "Collect metrics from Apache Spark with Elastic Agent.",
     "type": "integration",
-    "download": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.zip",
-    "path": "/package/ecs_style_dataset/0.0.1",
-    "policy_templates": [
+    "download": "/epr/datastream_without_release/datastream_without_release-0.1.0.zip",
+    "path": "/package/datastream_without_release/0.1.0",
+    "icons": [
       {
-        "name": "logs",
-        "title": "Logs datasource",
-        "description": "Datasource for your log files."
+        "src": "/img/apache_spark-logo.svg",
+        "path": "/package/datastream_without_release/0.1.0/img/apache_spark-logo.svg",
+        "title": "Apache Spark logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
       }
     ],
+    "policy_templates": [
+      {
+        "name": "apache_spark",
+        "title": "Apache Spark metrics",
+        "description": "Collect Apache Spark metrics"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.1.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/obs-service-integrations"
+    },
     "categories": [
+      "datastore",
       "monitoring"
     ],
     "data_streams": [
       {
-        "type": "logs",
-        "dataset": "ecs_style_dataset.foo",
-        "title": "Foo"
+        "type": "metrics",
+        "dataset": "datastream_without_release.nodes",
+        "title": "Apache Spark nodes metrics"
       }
     ]
   },
@@ -226,6 +186,19 @@
         "dataset": "default_pipeline.foo",
         "title": "Foo"
       }
+    ]
+  },
+  {
+    "name": "defaultrelease",
+    "title": "Default Release",
+    "version": "0.0.1",
+    "release": "beta",
+    "description": "Package without release, should be set to default",
+    "type": "solution",
+    "download": "/epr/defaultrelease/defaultrelease-0.0.1.zip",
+    "path": "/package/defaultrelease/0.0.1",
+    "categories": [
+      "aws"
     ]
   },
   {
@@ -296,6 +269,208 @@
     ]
   },
   {
+    "name": "deprecated_input_package",
+    "title": "New Package",
+    "version": "1.0.0",
+    "release": "ga",
+    "source": {
+      "license": "Elastic-2.0"
+    },
+    "description": "This is a new package.",
+    "type": "input",
+    "download": "/epr/deprecated_input_package/deprecated_input_package-1.0.0.zip",
+    "path": "/package/deprecated_input_package/1.0.0",
+    "icons": [
+      {
+        "src": "/img/sample-logo.svg",
+        "path": "/package/deprecated_input_package/1.0.0/img/sample-logo.svg",
+        "title": "Sample logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "sample",
+        "title": "Sample logs",
+        "description": "Collect sample logs"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^9.2.3"
+      },
+      "elastic": {
+        "subscription": "basic"
+      }
+    },
+    "owner": {
+      "type": "elastic",
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "deprecated": {
+      "since": "1.2.0",
+      "description": "This input package is deprecated",
+      "replaced_by": {
+        "package": "new_input_package"
+      }
+    }
+  },
+  {
+    "name": "deprecated_input_policy",
+    "title": "New Package",
+    "version": "1.0.0",
+    "release": "ga",
+    "source": {
+      "license": "Elastic-2.0"
+    },
+    "description": "This is a new package.",
+    "type": "input",
+    "download": "/epr/deprecated_input_policy/deprecated_input_policy-1.0.0.zip",
+    "path": "/package/deprecated_input_policy/1.0.0",
+    "icons": [
+      {
+        "src": "/img/sample-logo.svg",
+        "path": "/package/deprecated_input_policy/1.0.0/img/sample-logo.svg",
+        "title": "Sample logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "sample_deprecated",
+        "title": "Sample logs",
+        "description": "Collect sample logs",
+        "deprecated": {
+          "since": "1.2.0",
+          "description": "This policy is deprecated",
+          "replaced_by": {
+            "policy_template": "sample"
+          }
+        }
+      },
+      {
+        "name": "sample",
+        "title": "Sample logs",
+        "description": "Collect sample logs"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^9.2.3"
+      },
+      "elastic": {
+        "subscription": "basic"
+      }
+    },
+    "owner": {
+      "type": "elastic",
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "custom"
+    ]
+  },
+  {
+    "name": "deprecated_integration_input",
+    "title": "New Package",
+    "version": "1.0.0",
+    "release": "ga",
+    "source": {
+      "license": "Elastic-2.0"
+    },
+    "description": "This is a new package.",
+    "type": "integration",
+    "download": "/epr/deprecated_integration_input/deprecated_integration_input-1.0.0.zip",
+    "path": "/package/deprecated_integration_input/1.0.0",
+    "icons": [
+      {
+        "src": "/img/sample-logo.svg",
+        "path": "/package/deprecated_integration_input/1.0.0/img/sample-logo.svg",
+        "title": "Sample logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "sample",
+        "title": "Sample logs",
+        "description": "Collect sample logs"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^9.2.3"
+      },
+      "elastic": {
+        "subscription": "basic"
+      }
+    },
+    "owner": {
+      "type": "elastic",
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "custom"
+    ]
+  },
+  {
+    "name": "deprecated_integration_stream",
+    "title": "New Package",
+    "version": "1.0.0",
+    "release": "ga",
+    "source": {
+      "license": "Elastic-2.0"
+    },
+    "description": "This is a new package.",
+    "type": "integration",
+    "download": "/epr/deprecated_integration_stream/deprecated_integration_stream-1.0.0.zip",
+    "path": "/package/deprecated_integration_stream/1.0.0",
+    "icons": [
+      {
+        "src": "/img/sample-logo.svg",
+        "path": "/package/deprecated_integration_stream/1.0.0/img/sample-logo.svg",
+        "title": "Sample logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "sample",
+        "title": "Sample logs",
+        "description": "Collect sample logs"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^9.2.3"
+      },
+      "elastic": {
+        "subscription": "basic"
+      }
+    },
+    "owner": {
+      "type": "elastic",
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "deprecated_integration_stream.new_data_stream",
+        "title": "New Data Stream"
+      }
+    ]
+  },
+  {
     "name": "discovery_empty",
     "title": "Discovery Empty",
     "version": "0.1.0",
@@ -333,6 +508,33 @@
     ]
   },
   {
+    "name": "ecs_style_dataset",
+    "title": "Default pipeline Integration",
+    "version": "0.0.1",
+    "release": "beta",
+    "description": "Tests the registry validations works for dataset fields using the ecs style format",
+    "type": "integration",
+    "download": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.zip",
+    "path": "/package/ecs_style_dataset/0.0.1",
+    "policy_templates": [
+      {
+        "name": "logs",
+        "title": "Logs datasource",
+        "description": "Datasource for your log files."
+      }
+    ],
+    "categories": [
+      "monitoring"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ecs_style_dataset.foo",
+        "title": "Foo"
+      }
+    ]
+  },
+  {
     "name": "elasticsearch_privileges",
     "title": "Elasticsearch Privileges",
     "version": "1.0.0",
@@ -354,42 +556,6 @@
         "type": "metrics",
         "dataset": "elasticsearch_privileges.elasticsearch_privileges",
         "title": "Elasticsearch privileges data stream"
-      }
-    ]
-  },
-  {
-    "name": "nodirentries",
-    "title": "Example Integration",
-    "version": "1.0.0",
-    "release": "ga",
-    "description": "This is a zip package without directory entries.",
-    "type": "integration",
-    "download": "/epr/nodirentries/nodirentries-1.0.0.zip",
-    "path": "/package/nodirentries/1.0.0",
-    "policy_templates": [
-      {
-        "name": "logs",
-        "title": "Logs datasource",
-        "description": "Datasource for your log files."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "~7.x.x"
-      }
-    },
-    "owner": {
-      "github": "ruflin"
-    },
-    "categories": [
-      "crm",
-      "azure"
-    ],
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "nodirentries.foo",
-        "title": "Foo"
       }
     ]
   },
@@ -736,6 +902,33 @@
     ]
   },
   {
+    "name": "multiple_false",
+    "title": "Multiple false",
+    "version": "0.0.1",
+    "release": "beta",
+    "description": "Tests that multiple can be set to false",
+    "type": "integration",
+    "download": "/epr/multiple_false/multiple_false-0.0.1.zip",
+    "path": "/package/multiple_false/0.0.1",
+    "policy_templates": [
+      {
+        "name": "logs",
+        "title": "Logs datasource",
+        "description": "Datasource for your log files."
+      }
+    ],
+    "categories": [
+      "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "multiple_false.foo",
+        "title": "Foo"
+      }
+    ]
+  },
+  {
     "name": "multiversion",
     "title": "Multi Version",
     "version": "1.2.0",
@@ -766,235 +959,6 @@
     }
   },
   {
-    "name": "multiple_false",
-    "title": "Multiple false",
-    "version": "0.0.1",
-    "release": "beta",
-    "description": "Tests that multiple can be set to false",
-    "type": "integration",
-    "download": "/epr/multiple_false/multiple_false-0.0.1.zip",
-    "path": "/package/multiple_false/0.0.1",
-    "policy_templates": [
-      {
-        "name": "logs",
-        "title": "Logs datasource",
-        "description": "Datasource for your log files."
-      }
-    ],
-    "categories": [
-      "custom"
-    ],
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "multiple_false.foo",
-        "title": "Foo"
-      }
-    ]
-  },
-  {
-    "name": "deprecated_integration_stream",
-    "title": "New Package",
-    "version": "1.0.0",
-    "release": "ga",
-    "source": {
-      "license": "Elastic-2.0"
-    },
-    "description": "This is a new package.",
-    "type": "integration",
-    "download": "/epr/deprecated_integration_stream/deprecated_integration_stream-1.0.0.zip",
-    "path": "/package/deprecated_integration_stream/1.0.0",
-    "icons": [
-      {
-        "src": "/img/sample-logo.svg",
-        "path": "/package/deprecated_integration_stream/1.0.0/img/sample-logo.svg",
-        "title": "Sample logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "sample",
-        "title": "Sample logs",
-        "description": "Collect sample logs"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^9.2.3"
-      },
-      "elastic": {
-        "subscription": "basic"
-      }
-    },
-    "owner": {
-      "type": "elastic",
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "deprecated_integration_stream.new_data_stream",
-        "title": "New Data Stream"
-      }
-    ]
-  },
-  {
-    "name": "deprecated_integration_input",
-    "title": "New Package",
-    "version": "1.0.0",
-    "release": "ga",
-    "source": {
-      "license": "Elastic-2.0"
-    },
-    "description": "This is a new package.",
-    "type": "integration",
-    "download": "/epr/deprecated_integration_input/deprecated_integration_input-1.0.0.zip",
-    "path": "/package/deprecated_integration_input/1.0.0",
-    "icons": [
-      {
-        "src": "/img/sample-logo.svg",
-        "path": "/package/deprecated_integration_input/1.0.0/img/sample-logo.svg",
-        "title": "Sample logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "sample",
-        "title": "Sample logs",
-        "description": "Collect sample logs"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^9.2.3"
-      },
-      "elastic": {
-        "subscription": "basic"
-      }
-    },
-    "owner": {
-      "type": "elastic",
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "custom"
-    ]
-  },
-  {
-    "name": "deprecated_input_policy",
-    "title": "New Package",
-    "version": "1.0.0",
-    "release": "ga",
-    "source": {
-      "license": "Elastic-2.0"
-    },
-    "description": "This is a new package.",
-    "type": "input",
-    "download": "/epr/deprecated_input_policy/deprecated_input_policy-1.0.0.zip",
-    "path": "/package/deprecated_input_policy/1.0.0",
-    "icons": [
-      {
-        "src": "/img/sample-logo.svg",
-        "path": "/package/deprecated_input_policy/1.0.0/img/sample-logo.svg",
-        "title": "Sample logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "sample_deprecated",
-        "title": "Sample logs",
-        "description": "Collect sample logs",
-        "deprecated": {
-          "since": "1.2.0",
-          "description": "This policy is deprecated",
-          "replaced_by": {
-            "policy_template": "sample"
-          }
-        }
-      },
-      {
-        "name": "sample",
-        "title": "Sample logs",
-        "description": "Collect sample logs"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^9.2.3"
-      },
-      "elastic": {
-        "subscription": "basic"
-      }
-    },
-    "owner": {
-      "type": "elastic",
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "custom"
-    ]
-  },
-  {
-    "name": "deprecated_input_package",
-    "title": "New Package",
-    "version": "1.0.0",
-    "release": "ga",
-    "source": {
-      "license": "Elastic-2.0"
-    },
-    "description": "This is a new package.",
-    "type": "input",
-    "download": "/epr/deprecated_input_package/deprecated_input_package-1.0.0.zip",
-    "path": "/package/deprecated_input_package/1.0.0",
-    "icons": [
-      {
-        "src": "/img/sample-logo.svg",
-        "path": "/package/deprecated_input_package/1.0.0/img/sample-logo.svg",
-        "title": "Sample logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "sample",
-        "title": "Sample logs",
-        "description": "Collect sample logs"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^9.2.3"
-      },
-      "elastic": {
-        "subscription": "basic"
-      }
-    },
-    "owner": {
-      "type": "elastic",
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "deprecated": {
-      "since": "1.2.0",
-      "description": "This input package is deprecated",
-      "replaced_by": {
-        "package": "new_input_package"
-      }
-    }
-  },
-  {
     "name": "no_stream_configs",
     "title": "No Stream configs",
     "version": "1.0.0",
@@ -1011,6 +975,42 @@
         "type": "logs",
         "dataset": "no_stream_configs.log",
         "title": "Log Yaml pipeline"
+      }
+    ]
+  },
+  {
+    "name": "nodirentries",
+    "title": "Example Integration",
+    "version": "1.0.0",
+    "release": "ga",
+    "description": "This is a zip package without directory entries.",
+    "type": "integration",
+    "download": "/epr/nodirentries/nodirentries-1.0.0.zip",
+    "path": "/package/nodirentries/1.0.0",
+    "policy_templates": [
+      {
+        "name": "logs",
+        "title": "Logs datasource",
+        "description": "Datasource for your log files."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "~7.x.x"
+      }
+    },
+    "owner": {
+      "github": "ruflin"
+    },
+    "categories": [
+      "crm",
+      "azure"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "nodirentries.foo",
+        "title": "Foo"
       }
     ]
   },

--- a/testdata/generated/search-package-prerelease.json
+++ b/testdata/generated/search-package-prerelease.json
@@ -54,51 +54,6 @@
     ]
   },
   {
-    "name": "datastream_without_release",
-    "title": "Apache Spark",
-    "version": "0.1.0",
-    "release": "beta",
-    "description": "Collect metrics from Apache Spark with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/datastream_without_release/datastream_without_release-0.1.0.zip",
-    "path": "/package/datastream_without_release/0.1.0",
-    "icons": [
-      {
-        "src": "/img/apache_spark-logo.svg",
-        "path": "/package/datastream_without_release/0.1.0/img/apache_spark-logo.svg",
-        "title": "Apache Spark logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "apache_spark",
-        "title": "Apache Spark metrics",
-        "description": "Collect Apache Spark metrics"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.1.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/obs-service-integrations"
-    },
-    "categories": [
-      "datastore",
-      "monitoring"
-    ],
-    "data_streams": [
-      {
-        "type": "metrics",
-        "dataset": "datastream_without_release.nodes",
-        "title": "Apache Spark nodes metrics"
-      }
-    ]
-  },
-  {
     "name": "dataset_is_prefix",
     "title": "DatasetIsPrefix Flag",
     "version": "0.0.1",
@@ -116,19 +71,6 @@
         "dataset": "dataset_is_prefix.test",
         "title": "dataset_is_prefix test data stream"
       }
-    ]
-  },
-  {
-    "name": "defaultrelease",
-    "title": "Default Release",
-    "version": "0.0.1",
-    "release": "beta",
-    "description": "Package without release, should be set to default",
-    "type": "solution",
-    "download": "/epr/defaultrelease/defaultrelease-0.0.1.zip",
-    "path": "/package/defaultrelease/0.0.1",
-    "categories": [
-      "aws"
     ]
   },
   {
@@ -174,29 +116,47 @@
     ]
   },
   {
-    "name": "ecs_style_dataset",
-    "title": "Default pipeline Integration",
-    "version": "0.0.1",
+    "name": "datastream_without_release",
+    "title": "Apache Spark",
+    "version": "0.1.0",
     "release": "beta",
-    "description": "Tests the registry validations works for dataset fields using the ecs style format",
+    "description": "Collect metrics from Apache Spark with Elastic Agent.",
     "type": "integration",
-    "download": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.zip",
-    "path": "/package/ecs_style_dataset/0.0.1",
-    "policy_templates": [
+    "download": "/epr/datastream_without_release/datastream_without_release-0.1.0.zip",
+    "path": "/package/datastream_without_release/0.1.0",
+    "icons": [
       {
-        "name": "logs",
-        "title": "Logs datasource",
-        "description": "Datasource for your log files."
+        "src": "/img/apache_spark-logo.svg",
+        "path": "/package/datastream_without_release/0.1.0/img/apache_spark-logo.svg",
+        "title": "Apache Spark logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
       }
     ],
+    "policy_templates": [
+      {
+        "name": "apache_spark",
+        "title": "Apache Spark metrics",
+        "description": "Collect Apache Spark metrics"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.1.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/obs-service-integrations"
+    },
     "categories": [
+      "datastore",
       "monitoring"
     ],
     "data_streams": [
       {
-        "type": "logs",
-        "dataset": "ecs_style_dataset.foo",
-        "title": "Foo"
+        "type": "metrics",
+        "dataset": "datastream_without_release.nodes",
+        "title": "Apache Spark nodes metrics"
       }
     ]
   },
@@ -226,6 +186,19 @@
         "dataset": "default_pipeline.foo",
         "title": "Foo"
       }
+    ]
+  },
+  {
+    "name": "defaultrelease",
+    "title": "Default Release",
+    "version": "0.0.1",
+    "release": "beta",
+    "description": "Package without release, should be set to default",
+    "type": "solution",
+    "download": "/epr/defaultrelease/defaultrelease-0.0.1.zip",
+    "path": "/package/defaultrelease/0.0.1",
+    "categories": [
+      "aws"
     ]
   },
   {
@@ -296,6 +269,208 @@
     ]
   },
   {
+    "name": "deprecated_input_package",
+    "title": "New Package",
+    "version": "1.0.0",
+    "release": "ga",
+    "source": {
+      "license": "Elastic-2.0"
+    },
+    "description": "This is a new package.",
+    "type": "input",
+    "download": "/epr/deprecated_input_package/deprecated_input_package-1.0.0.zip",
+    "path": "/package/deprecated_input_package/1.0.0",
+    "icons": [
+      {
+        "src": "/img/sample-logo.svg",
+        "path": "/package/deprecated_input_package/1.0.0/img/sample-logo.svg",
+        "title": "Sample logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "sample",
+        "title": "Sample logs",
+        "description": "Collect sample logs"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^9.2.3"
+      },
+      "elastic": {
+        "subscription": "basic"
+      }
+    },
+    "owner": {
+      "type": "elastic",
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "deprecated": {
+      "since": "1.2.0",
+      "description": "This input package is deprecated",
+      "replaced_by": {
+        "package": "new_input_package"
+      }
+    }
+  },
+  {
+    "name": "deprecated_input_policy",
+    "title": "New Package",
+    "version": "1.0.0",
+    "release": "ga",
+    "source": {
+      "license": "Elastic-2.0"
+    },
+    "description": "This is a new package.",
+    "type": "input",
+    "download": "/epr/deprecated_input_policy/deprecated_input_policy-1.0.0.zip",
+    "path": "/package/deprecated_input_policy/1.0.0",
+    "icons": [
+      {
+        "src": "/img/sample-logo.svg",
+        "path": "/package/deprecated_input_policy/1.0.0/img/sample-logo.svg",
+        "title": "Sample logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "sample_deprecated",
+        "title": "Sample logs",
+        "description": "Collect sample logs",
+        "deprecated": {
+          "since": "1.2.0",
+          "description": "This policy is deprecated",
+          "replaced_by": {
+            "policy_template": "sample"
+          }
+        }
+      },
+      {
+        "name": "sample",
+        "title": "Sample logs",
+        "description": "Collect sample logs"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^9.2.3"
+      },
+      "elastic": {
+        "subscription": "basic"
+      }
+    },
+    "owner": {
+      "type": "elastic",
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "custom"
+    ]
+  },
+  {
+    "name": "deprecated_integration_input",
+    "title": "New Package",
+    "version": "1.0.0",
+    "release": "ga",
+    "source": {
+      "license": "Elastic-2.0"
+    },
+    "description": "This is a new package.",
+    "type": "integration",
+    "download": "/epr/deprecated_integration_input/deprecated_integration_input-1.0.0.zip",
+    "path": "/package/deprecated_integration_input/1.0.0",
+    "icons": [
+      {
+        "src": "/img/sample-logo.svg",
+        "path": "/package/deprecated_integration_input/1.0.0/img/sample-logo.svg",
+        "title": "Sample logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "sample",
+        "title": "Sample logs",
+        "description": "Collect sample logs"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^9.2.3"
+      },
+      "elastic": {
+        "subscription": "basic"
+      }
+    },
+    "owner": {
+      "type": "elastic",
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "custom"
+    ]
+  },
+  {
+    "name": "deprecated_integration_stream",
+    "title": "New Package",
+    "version": "1.0.0",
+    "release": "ga",
+    "source": {
+      "license": "Elastic-2.0"
+    },
+    "description": "This is a new package.",
+    "type": "integration",
+    "download": "/epr/deprecated_integration_stream/deprecated_integration_stream-1.0.0.zip",
+    "path": "/package/deprecated_integration_stream/1.0.0",
+    "icons": [
+      {
+        "src": "/img/sample-logo.svg",
+        "path": "/package/deprecated_integration_stream/1.0.0/img/sample-logo.svg",
+        "title": "Sample logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "sample",
+        "title": "Sample logs",
+        "description": "Collect sample logs"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^9.2.3"
+      },
+      "elastic": {
+        "subscription": "basic"
+      }
+    },
+    "owner": {
+      "type": "elastic",
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "deprecated_integration_stream.new_data_stream",
+        "title": "New Data Stream"
+      }
+    ]
+  },
+  {
     "name": "discovery_empty",
     "title": "Discovery Empty",
     "version": "0.1.0",
@@ -333,6 +508,33 @@
     ]
   },
   {
+    "name": "ecs_style_dataset",
+    "title": "Default pipeline Integration",
+    "version": "0.0.1",
+    "release": "beta",
+    "description": "Tests the registry validations works for dataset fields using the ecs style format",
+    "type": "integration",
+    "download": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.zip",
+    "path": "/package/ecs_style_dataset/0.0.1",
+    "policy_templates": [
+      {
+        "name": "logs",
+        "title": "Logs datasource",
+        "description": "Datasource for your log files."
+      }
+    ],
+    "categories": [
+      "monitoring"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ecs_style_dataset.foo",
+        "title": "Foo"
+      }
+    ]
+  },
+  {
     "name": "elasticsearch_privileges",
     "title": "Elasticsearch Privileges",
     "version": "1.0.0",
@@ -354,42 +556,6 @@
         "type": "metrics",
         "dataset": "elasticsearch_privileges.elasticsearch_privileges",
         "title": "Elasticsearch privileges data stream"
-      }
-    ]
-  },
-  {
-    "name": "nodirentries",
-    "title": "Example Integration",
-    "version": "1.0.0",
-    "release": "ga",
-    "description": "This is a zip package without directory entries.",
-    "type": "integration",
-    "download": "/epr/nodirentries/nodirentries-1.0.0.zip",
-    "path": "/package/nodirentries/1.0.0",
-    "policy_templates": [
-      {
-        "name": "logs",
-        "title": "Logs datasource",
-        "description": "Datasource for your log files."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "~7.x.x"
-      }
-    },
-    "owner": {
-      "github": "ruflin"
-    },
-    "categories": [
-      "crm",
-      "azure"
-    ],
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "nodirentries.foo",
-        "title": "Foo"
       }
     ]
   },
@@ -744,6 +910,33 @@
     ]
   },
   {
+    "name": "multiple_false",
+    "title": "Multiple false",
+    "version": "0.0.1",
+    "release": "beta",
+    "description": "Tests that multiple can be set to false",
+    "type": "integration",
+    "download": "/epr/multiple_false/multiple_false-0.0.1.zip",
+    "path": "/package/multiple_false/0.0.1",
+    "policy_templates": [
+      {
+        "name": "logs",
+        "title": "Logs datasource",
+        "description": "Datasource for your log files."
+      }
+    ],
+    "categories": [
+      "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "multiple_false.foo",
+        "title": "Foo"
+      }
+    ]
+  },
+  {
     "name": "multiversion",
     "title": "Multi Version",
     "version": "1.2.0",
@@ -774,235 +967,6 @@
     }
   },
   {
-    "name": "multiple_false",
-    "title": "Multiple false",
-    "version": "0.0.1",
-    "release": "beta",
-    "description": "Tests that multiple can be set to false",
-    "type": "integration",
-    "download": "/epr/multiple_false/multiple_false-0.0.1.zip",
-    "path": "/package/multiple_false/0.0.1",
-    "policy_templates": [
-      {
-        "name": "logs",
-        "title": "Logs datasource",
-        "description": "Datasource for your log files."
-      }
-    ],
-    "categories": [
-      "custom"
-    ],
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "multiple_false.foo",
-        "title": "Foo"
-      }
-    ]
-  },
-  {
-    "name": "deprecated_input_package",
-    "title": "New Package",
-    "version": "1.0.0",
-    "release": "ga",
-    "source": {
-      "license": "Elastic-2.0"
-    },
-    "description": "This is a new package.",
-    "type": "input",
-    "download": "/epr/deprecated_input_package/deprecated_input_package-1.0.0.zip",
-    "path": "/package/deprecated_input_package/1.0.0",
-    "icons": [
-      {
-        "src": "/img/sample-logo.svg",
-        "path": "/package/deprecated_input_package/1.0.0/img/sample-logo.svg",
-        "title": "Sample logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "sample",
-        "title": "Sample logs",
-        "description": "Collect sample logs"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^9.2.3"
-      },
-      "elastic": {
-        "subscription": "basic"
-      }
-    },
-    "owner": {
-      "type": "elastic",
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "deprecated": {
-      "since": "1.2.0",
-      "description": "This input package is deprecated",
-      "replaced_by": {
-        "package": "new_input_package"
-      }
-    }
-  },
-  {
-    "name": "deprecated_input_policy",
-    "title": "New Package",
-    "version": "1.0.0",
-    "release": "ga",
-    "source": {
-      "license": "Elastic-2.0"
-    },
-    "description": "This is a new package.",
-    "type": "input",
-    "download": "/epr/deprecated_input_policy/deprecated_input_policy-1.0.0.zip",
-    "path": "/package/deprecated_input_policy/1.0.0",
-    "icons": [
-      {
-        "src": "/img/sample-logo.svg",
-        "path": "/package/deprecated_input_policy/1.0.0/img/sample-logo.svg",
-        "title": "Sample logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "sample_deprecated",
-        "title": "Sample logs",
-        "description": "Collect sample logs",
-        "deprecated": {
-          "since": "1.2.0",
-          "description": "This policy is deprecated",
-          "replaced_by": {
-            "policy_template": "sample"
-          }
-        }
-      },
-      {
-        "name": "sample",
-        "title": "Sample logs",
-        "description": "Collect sample logs"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^9.2.3"
-      },
-      "elastic": {
-        "subscription": "basic"
-      }
-    },
-    "owner": {
-      "type": "elastic",
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "custom"
-    ]
-  },
-  {
-    "name": "deprecated_integration_input",
-    "title": "New Package",
-    "version": "1.0.0",
-    "release": "ga",
-    "source": {
-      "license": "Elastic-2.0"
-    },
-    "description": "This is a new package.",
-    "type": "integration",
-    "download": "/epr/deprecated_integration_input/deprecated_integration_input-1.0.0.zip",
-    "path": "/package/deprecated_integration_input/1.0.0",
-    "icons": [
-      {
-        "src": "/img/sample-logo.svg",
-        "path": "/package/deprecated_integration_input/1.0.0/img/sample-logo.svg",
-        "title": "Sample logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "sample",
-        "title": "Sample logs",
-        "description": "Collect sample logs"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^9.2.3"
-      },
-      "elastic": {
-        "subscription": "basic"
-      }
-    },
-    "owner": {
-      "type": "elastic",
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "custom"
-    ]
-  },
-  {
-    "name": "deprecated_integration_stream",
-    "title": "New Package",
-    "version": "1.0.0",
-    "release": "ga",
-    "source": {
-      "license": "Elastic-2.0"
-    },
-    "description": "This is a new package.",
-    "type": "integration",
-    "download": "/epr/deprecated_integration_stream/deprecated_integration_stream-1.0.0.zip",
-    "path": "/package/deprecated_integration_stream/1.0.0",
-    "icons": [
-      {
-        "src": "/img/sample-logo.svg",
-        "path": "/package/deprecated_integration_stream/1.0.0/img/sample-logo.svg",
-        "title": "Sample logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "sample",
-        "title": "Sample logs",
-        "description": "Collect sample logs"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^9.2.3"
-      },
-      "elastic": {
-        "subscription": "basic"
-      }
-    },
-    "owner": {
-      "type": "elastic",
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "deprecated_integration_stream.new_data_stream",
-        "title": "New Data Stream"
-      }
-    ]
-  },
-  {
     "name": "no_stream_configs",
     "title": "No Stream configs",
     "version": "1.0.0",
@@ -1023,30 +987,38 @@
     ]
   },
   {
-    "name": "traces",
-    "title": "Not actually APM",
+    "name": "nodirentries",
+    "title": "Example Integration",
     "version": "1.0.0",
-    "release": "experimental",
-    "description": "Not actually APM",
+    "release": "ga",
+    "description": "This is a zip package without directory entries.",
     "type": "integration",
-    "download": "/epr/traces/traces-1.0.0.zip",
-    "path": "/package/traces/1.0.0",
+    "download": "/epr/nodirentries/nodirentries-1.0.0.zip",
+    "path": "/package/nodirentries/1.0.0",
+    "policy_templates": [
+      {
+        "name": "logs",
+        "title": "Logs datasource",
+        "description": "Datasource for your log files."
+      }
+    ],
     "conditions": {
       "kibana": {
         "version": "~7.x.x"
       }
     },
     "owner": {
-      "github": "github.com/elastic/not-apm"
+      "github": "ruflin"
     },
     "categories": [
-      "monitoring"
+      "crm",
+      "azure"
     ],
     "data_streams": [
       {
-        "type": "traces",
-        "dataset": "traces.traces",
-        "title": "notapmtraces"
+        "type": "logs",
+        "dataset": "nodirentries.foo",
+        "title": "Foo"
       }
     ]
   },
@@ -1193,6 +1165,34 @@
     "categories": [
       "custom",
       "datastore"
+    ]
+  },
+  {
+    "name": "traces",
+    "title": "Not actually APM",
+    "version": "1.0.0",
+    "release": "experimental",
+    "description": "Not actually APM",
+    "type": "integration",
+    "download": "/epr/traces/traces-1.0.0.zip",
+    "path": "/package/traces/1.0.0",
+    "conditions": {
+      "kibana": {
+        "version": "~7.x.x"
+      }
+    },
+    "owner": {
+      "github": "github.com/elastic/not-apm"
+    },
+    "categories": [
+      "monitoring"
+    ],
+    "data_streams": [
+      {
+        "type": "traces",
+        "dataset": "traces.traces",
+        "title": "notapmtraces"
+      }
     ]
   },
   {

--- a/testdata/generated/search-prerelease-capabilities-none.json
+++ b/testdata/generated/search-prerelease-capabilities-none.json
@@ -54,51 +54,6 @@
     ]
   },
   {
-    "name": "datastream_without_release",
-    "title": "Apache Spark",
-    "version": "0.1.0",
-    "release": "beta",
-    "description": "Collect metrics from Apache Spark with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/datastream_without_release/datastream_without_release-0.1.0.zip",
-    "path": "/package/datastream_without_release/0.1.0",
-    "icons": [
-      {
-        "src": "/img/apache_spark-logo.svg",
-        "path": "/package/datastream_without_release/0.1.0/img/apache_spark-logo.svg",
-        "title": "Apache Spark logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "apache_spark",
-        "title": "Apache Spark metrics",
-        "description": "Collect Apache Spark metrics"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.1.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/obs-service-integrations"
-    },
-    "categories": [
-      "datastore",
-      "monitoring"
-    ],
-    "data_streams": [
-      {
-        "type": "metrics",
-        "dataset": "datastream_without_release.nodes",
-        "title": "Apache Spark nodes metrics"
-      }
-    ]
-  },
-  {
     "name": "dataset_is_prefix",
     "title": "DatasetIsPrefix Flag",
     "version": "0.0.1",
@@ -116,19 +71,6 @@
         "dataset": "dataset_is_prefix.test",
         "title": "dataset_is_prefix test data stream"
       }
-    ]
-  },
-  {
-    "name": "defaultrelease",
-    "title": "Default Release",
-    "version": "0.0.1",
-    "release": "beta",
-    "description": "Package without release, should be set to default",
-    "type": "solution",
-    "download": "/epr/defaultrelease/defaultrelease-0.0.1.zip",
-    "path": "/package/defaultrelease/0.0.1",
-    "categories": [
-      "aws"
     ]
   },
   {
@@ -174,29 +116,47 @@
     ]
   },
   {
-    "name": "ecs_style_dataset",
-    "title": "Default pipeline Integration",
-    "version": "0.0.1",
+    "name": "datastream_without_release",
+    "title": "Apache Spark",
+    "version": "0.1.0",
     "release": "beta",
-    "description": "Tests the registry validations works for dataset fields using the ecs style format",
+    "description": "Collect metrics from Apache Spark with Elastic Agent.",
     "type": "integration",
-    "download": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.zip",
-    "path": "/package/ecs_style_dataset/0.0.1",
-    "policy_templates": [
+    "download": "/epr/datastream_without_release/datastream_without_release-0.1.0.zip",
+    "path": "/package/datastream_without_release/0.1.0",
+    "icons": [
       {
-        "name": "logs",
-        "title": "Logs datasource",
-        "description": "Datasource for your log files."
+        "src": "/img/apache_spark-logo.svg",
+        "path": "/package/datastream_without_release/0.1.0/img/apache_spark-logo.svg",
+        "title": "Apache Spark logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
       }
     ],
+    "policy_templates": [
+      {
+        "name": "apache_spark",
+        "title": "Apache Spark metrics",
+        "description": "Collect Apache Spark metrics"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.1.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/obs-service-integrations"
+    },
     "categories": [
+      "datastore",
       "monitoring"
     ],
     "data_streams": [
       {
-        "type": "logs",
-        "dataset": "ecs_style_dataset.foo",
-        "title": "Foo"
+        "type": "metrics",
+        "dataset": "datastream_without_release.nodes",
+        "title": "Apache Spark nodes metrics"
       }
     ]
   },
@@ -226,6 +186,19 @@
         "dataset": "default_pipeline.foo",
         "title": "Foo"
       }
+    ]
+  },
+  {
+    "name": "defaultrelease",
+    "title": "Default Release",
+    "version": "0.0.1",
+    "release": "beta",
+    "description": "Package without release, should be set to default",
+    "type": "solution",
+    "download": "/epr/defaultrelease/defaultrelease-0.0.1.zip",
+    "path": "/package/defaultrelease/0.0.1",
+    "categories": [
+      "aws"
     ]
   },
   {
@@ -296,6 +269,208 @@
     ]
   },
   {
+    "name": "deprecated_input_package",
+    "title": "New Package",
+    "version": "1.0.0",
+    "release": "ga",
+    "source": {
+      "license": "Elastic-2.0"
+    },
+    "description": "This is a new package.",
+    "type": "input",
+    "download": "/epr/deprecated_input_package/deprecated_input_package-1.0.0.zip",
+    "path": "/package/deprecated_input_package/1.0.0",
+    "icons": [
+      {
+        "src": "/img/sample-logo.svg",
+        "path": "/package/deprecated_input_package/1.0.0/img/sample-logo.svg",
+        "title": "Sample logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "sample",
+        "title": "Sample logs",
+        "description": "Collect sample logs"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^9.2.3"
+      },
+      "elastic": {
+        "subscription": "basic"
+      }
+    },
+    "owner": {
+      "type": "elastic",
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "deprecated": {
+      "since": "1.2.0",
+      "description": "This input package is deprecated",
+      "replaced_by": {
+        "package": "new_input_package"
+      }
+    }
+  },
+  {
+    "name": "deprecated_input_policy",
+    "title": "New Package",
+    "version": "1.0.0",
+    "release": "ga",
+    "source": {
+      "license": "Elastic-2.0"
+    },
+    "description": "This is a new package.",
+    "type": "input",
+    "download": "/epr/deprecated_input_policy/deprecated_input_policy-1.0.0.zip",
+    "path": "/package/deprecated_input_policy/1.0.0",
+    "icons": [
+      {
+        "src": "/img/sample-logo.svg",
+        "path": "/package/deprecated_input_policy/1.0.0/img/sample-logo.svg",
+        "title": "Sample logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "sample_deprecated",
+        "title": "Sample logs",
+        "description": "Collect sample logs",
+        "deprecated": {
+          "since": "1.2.0",
+          "description": "This policy is deprecated",
+          "replaced_by": {
+            "policy_template": "sample"
+          }
+        }
+      },
+      {
+        "name": "sample",
+        "title": "Sample logs",
+        "description": "Collect sample logs"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^9.2.3"
+      },
+      "elastic": {
+        "subscription": "basic"
+      }
+    },
+    "owner": {
+      "type": "elastic",
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "custom"
+    ]
+  },
+  {
+    "name": "deprecated_integration_input",
+    "title": "New Package",
+    "version": "1.0.0",
+    "release": "ga",
+    "source": {
+      "license": "Elastic-2.0"
+    },
+    "description": "This is a new package.",
+    "type": "integration",
+    "download": "/epr/deprecated_integration_input/deprecated_integration_input-1.0.0.zip",
+    "path": "/package/deprecated_integration_input/1.0.0",
+    "icons": [
+      {
+        "src": "/img/sample-logo.svg",
+        "path": "/package/deprecated_integration_input/1.0.0/img/sample-logo.svg",
+        "title": "Sample logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "sample",
+        "title": "Sample logs",
+        "description": "Collect sample logs"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^9.2.3"
+      },
+      "elastic": {
+        "subscription": "basic"
+      }
+    },
+    "owner": {
+      "type": "elastic",
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "custom"
+    ]
+  },
+  {
+    "name": "deprecated_integration_stream",
+    "title": "New Package",
+    "version": "1.0.0",
+    "release": "ga",
+    "source": {
+      "license": "Elastic-2.0"
+    },
+    "description": "This is a new package.",
+    "type": "integration",
+    "download": "/epr/deprecated_integration_stream/deprecated_integration_stream-1.0.0.zip",
+    "path": "/package/deprecated_integration_stream/1.0.0",
+    "icons": [
+      {
+        "src": "/img/sample-logo.svg",
+        "path": "/package/deprecated_integration_stream/1.0.0/img/sample-logo.svg",
+        "title": "Sample logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "sample",
+        "title": "Sample logs",
+        "description": "Collect sample logs"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^9.2.3"
+      },
+      "elastic": {
+        "subscription": "basic"
+      }
+    },
+    "owner": {
+      "type": "elastic",
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "deprecated_integration_stream.new_data_stream",
+        "title": "New Data Stream"
+      }
+    ]
+  },
+  {
     "name": "discovery_empty",
     "title": "Discovery Empty",
     "version": "0.1.0",
@@ -333,6 +508,33 @@
     ]
   },
   {
+    "name": "ecs_style_dataset",
+    "title": "Default pipeline Integration",
+    "version": "0.0.1",
+    "release": "beta",
+    "description": "Tests the registry validations works for dataset fields using the ecs style format",
+    "type": "integration",
+    "download": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.zip",
+    "path": "/package/ecs_style_dataset/0.0.1",
+    "policy_templates": [
+      {
+        "name": "logs",
+        "title": "Logs datasource",
+        "description": "Datasource for your log files."
+      }
+    ],
+    "categories": [
+      "monitoring"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ecs_style_dataset.foo",
+        "title": "Foo"
+      }
+    ]
+  },
+  {
     "name": "elasticsearch_privileges",
     "title": "Elasticsearch Privileges",
     "version": "1.0.0",
@@ -354,42 +556,6 @@
         "type": "metrics",
         "dataset": "elasticsearch_privileges.elasticsearch_privileges",
         "title": "Elasticsearch privileges data stream"
-      }
-    ]
-  },
-  {
-    "name": "nodirentries",
-    "title": "Example Integration",
-    "version": "1.0.0",
-    "release": "ga",
-    "description": "This is a zip package without directory entries.",
-    "type": "integration",
-    "download": "/epr/nodirentries/nodirentries-1.0.0.zip",
-    "path": "/package/nodirentries/1.0.0",
-    "policy_templates": [
-      {
-        "name": "logs",
-        "title": "Logs datasource",
-        "description": "Datasource for your log files."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "~7.x.x"
-      }
-    },
-    "owner": {
-      "github": "ruflin"
-    },
-    "categories": [
-      "crm",
-      "azure"
-    ],
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "nodirentries.foo",
-        "title": "Foo"
       }
     ]
   },
@@ -711,6 +877,33 @@
     ]
   },
   {
+    "name": "multiple_false",
+    "title": "Multiple false",
+    "version": "0.0.1",
+    "release": "beta",
+    "description": "Tests that multiple can be set to false",
+    "type": "integration",
+    "download": "/epr/multiple_false/multiple_false-0.0.1.zip",
+    "path": "/package/multiple_false/0.0.1",
+    "policy_templates": [
+      {
+        "name": "logs",
+        "title": "Logs datasource",
+        "description": "Datasource for your log files."
+      }
+    ],
+    "categories": [
+      "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "multiple_false.foo",
+        "title": "Foo"
+      }
+    ]
+  },
+  {
     "name": "multiversion",
     "title": "Multi Version",
     "version": "1.2.0",
@@ -741,235 +934,6 @@
     }
   },
   {
-    "name": "multiple_false",
-    "title": "Multiple false",
-    "version": "0.0.1",
-    "release": "beta",
-    "description": "Tests that multiple can be set to false",
-    "type": "integration",
-    "download": "/epr/multiple_false/multiple_false-0.0.1.zip",
-    "path": "/package/multiple_false/0.0.1",
-    "policy_templates": [
-      {
-        "name": "logs",
-        "title": "Logs datasource",
-        "description": "Datasource for your log files."
-      }
-    ],
-    "categories": [
-      "custom"
-    ],
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "multiple_false.foo",
-        "title": "Foo"
-      }
-    ]
-  },
-  {
-    "name": "deprecated_integration_stream",
-    "title": "New Package",
-    "version": "1.0.0",
-    "release": "ga",
-    "source": {
-      "license": "Elastic-2.0"
-    },
-    "description": "This is a new package.",
-    "type": "integration",
-    "download": "/epr/deprecated_integration_stream/deprecated_integration_stream-1.0.0.zip",
-    "path": "/package/deprecated_integration_stream/1.0.0",
-    "icons": [
-      {
-        "src": "/img/sample-logo.svg",
-        "path": "/package/deprecated_integration_stream/1.0.0/img/sample-logo.svg",
-        "title": "Sample logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "sample",
-        "title": "Sample logs",
-        "description": "Collect sample logs"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^9.2.3"
-      },
-      "elastic": {
-        "subscription": "basic"
-      }
-    },
-    "owner": {
-      "type": "elastic",
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "deprecated_integration_stream.new_data_stream",
-        "title": "New Data Stream"
-      }
-    ]
-  },
-  {
-    "name": "deprecated_integration_input",
-    "title": "New Package",
-    "version": "1.0.0",
-    "release": "ga",
-    "source": {
-      "license": "Elastic-2.0"
-    },
-    "description": "This is a new package.",
-    "type": "integration",
-    "download": "/epr/deprecated_integration_input/deprecated_integration_input-1.0.0.zip",
-    "path": "/package/deprecated_integration_input/1.0.0",
-    "icons": [
-      {
-        "src": "/img/sample-logo.svg",
-        "path": "/package/deprecated_integration_input/1.0.0/img/sample-logo.svg",
-        "title": "Sample logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "sample",
-        "title": "Sample logs",
-        "description": "Collect sample logs"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^9.2.3"
-      },
-      "elastic": {
-        "subscription": "basic"
-      }
-    },
-    "owner": {
-      "type": "elastic",
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "custom"
-    ]
-  },
-  {
-    "name": "deprecated_input_policy",
-    "title": "New Package",
-    "version": "1.0.0",
-    "release": "ga",
-    "source": {
-      "license": "Elastic-2.0"
-    },
-    "description": "This is a new package.",
-    "type": "input",
-    "download": "/epr/deprecated_input_policy/deprecated_input_policy-1.0.0.zip",
-    "path": "/package/deprecated_input_policy/1.0.0",
-    "icons": [
-      {
-        "src": "/img/sample-logo.svg",
-        "path": "/package/deprecated_input_policy/1.0.0/img/sample-logo.svg",
-        "title": "Sample logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "sample_deprecated",
-        "title": "Sample logs",
-        "description": "Collect sample logs",
-        "deprecated": {
-          "since": "1.2.0",
-          "description": "This policy is deprecated",
-          "replaced_by": {
-            "policy_template": "sample"
-          }
-        }
-      },
-      {
-        "name": "sample",
-        "title": "Sample logs",
-        "description": "Collect sample logs"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^9.2.3"
-      },
-      "elastic": {
-        "subscription": "basic"
-      }
-    },
-    "owner": {
-      "type": "elastic",
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "custom"
-    ]
-  },
-  {
-    "name": "deprecated_input_package",
-    "title": "New Package",
-    "version": "1.0.0",
-    "release": "ga",
-    "source": {
-      "license": "Elastic-2.0"
-    },
-    "description": "This is a new package.",
-    "type": "input",
-    "download": "/epr/deprecated_input_package/deprecated_input_package-1.0.0.zip",
-    "path": "/package/deprecated_input_package/1.0.0",
-    "icons": [
-      {
-        "src": "/img/sample-logo.svg",
-        "path": "/package/deprecated_input_package/1.0.0/img/sample-logo.svg",
-        "title": "Sample logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "sample",
-        "title": "Sample logs",
-        "description": "Collect sample logs"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^9.2.3"
-      },
-      "elastic": {
-        "subscription": "basic"
-      }
-    },
-    "owner": {
-      "type": "elastic",
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "deprecated": {
-      "since": "1.2.0",
-      "description": "This input package is deprecated",
-      "replaced_by": {
-        "package": "new_input_package"
-      }
-    }
-  },
-  {
     "name": "no_stream_configs",
     "title": "No Stream configs",
     "version": "1.0.0",
@@ -990,30 +954,38 @@
     ]
   },
   {
-    "name": "traces",
-    "title": "Not actually APM",
+    "name": "nodirentries",
+    "title": "Example Integration",
     "version": "1.0.0",
-    "release": "experimental",
-    "description": "Not actually APM",
+    "release": "ga",
+    "description": "This is a zip package without directory entries.",
     "type": "integration",
-    "download": "/epr/traces/traces-1.0.0.zip",
-    "path": "/package/traces/1.0.0",
+    "download": "/epr/nodirentries/nodirentries-1.0.0.zip",
+    "path": "/package/nodirentries/1.0.0",
+    "policy_templates": [
+      {
+        "name": "logs",
+        "title": "Logs datasource",
+        "description": "Datasource for your log files."
+      }
+    ],
     "conditions": {
       "kibana": {
         "version": "~7.x.x"
       }
     },
     "owner": {
-      "github": "github.com/elastic/not-apm"
+      "github": "ruflin"
     },
     "categories": [
-      "monitoring"
+      "crm",
+      "azure"
     ],
     "data_streams": [
       {
-        "type": "traces",
-        "dataset": "traces.traces",
-        "title": "notapmtraces"
+        "type": "logs",
+        "dataset": "nodirentries.foo",
+        "title": "Foo"
       }
     ]
   },
@@ -1160,6 +1132,34 @@
     "categories": [
       "custom",
       "datastore"
+    ]
+  },
+  {
+    "name": "traces",
+    "title": "Not actually APM",
+    "version": "1.0.0",
+    "release": "experimental",
+    "description": "Not actually APM",
+    "type": "integration",
+    "download": "/epr/traces/traces-1.0.0.zip",
+    "path": "/package/traces/1.0.0",
+    "conditions": {
+      "kibana": {
+        "version": "~7.x.x"
+      }
+    },
+    "owner": {
+      "github": "github.com/elastic/not-apm"
+    },
+    "categories": [
+      "monitoring"
+    ],
+    "data_streams": [
+      {
+        "type": "traces",
+        "dataset": "traces.traces",
+        "title": "notapmtraces"
+      }
     ]
   },
   {

--- a/testdata/generated/search-prerelease-capabilities-observability-security.json
+++ b/testdata/generated/search-prerelease-capabilities-observability-security.json
@@ -54,51 +54,6 @@
     ]
   },
   {
-    "name": "datastream_without_release",
-    "title": "Apache Spark",
-    "version": "0.1.0",
-    "release": "beta",
-    "description": "Collect metrics from Apache Spark with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/datastream_without_release/datastream_without_release-0.1.0.zip",
-    "path": "/package/datastream_without_release/0.1.0",
-    "icons": [
-      {
-        "src": "/img/apache_spark-logo.svg",
-        "path": "/package/datastream_without_release/0.1.0/img/apache_spark-logo.svg",
-        "title": "Apache Spark logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "apache_spark",
-        "title": "Apache Spark metrics",
-        "description": "Collect Apache Spark metrics"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.1.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/obs-service-integrations"
-    },
-    "categories": [
-      "datastore",
-      "monitoring"
-    ],
-    "data_streams": [
-      {
-        "type": "metrics",
-        "dataset": "datastream_without_release.nodes",
-        "title": "Apache Spark nodes metrics"
-      }
-    ]
-  },
-  {
     "name": "dataset_is_prefix",
     "title": "DatasetIsPrefix Flag",
     "version": "0.0.1",
@@ -116,19 +71,6 @@
         "dataset": "dataset_is_prefix.test",
         "title": "dataset_is_prefix test data stream"
       }
-    ]
-  },
-  {
-    "name": "defaultrelease",
-    "title": "Default Release",
-    "version": "0.0.1",
-    "release": "beta",
-    "description": "Package without release, should be set to default",
-    "type": "solution",
-    "download": "/epr/defaultrelease/defaultrelease-0.0.1.zip",
-    "path": "/package/defaultrelease/0.0.1",
-    "categories": [
-      "aws"
     ]
   },
   {
@@ -174,29 +116,47 @@
     ]
   },
   {
-    "name": "ecs_style_dataset",
-    "title": "Default pipeline Integration",
-    "version": "0.0.1",
+    "name": "datastream_without_release",
+    "title": "Apache Spark",
+    "version": "0.1.0",
     "release": "beta",
-    "description": "Tests the registry validations works for dataset fields using the ecs style format",
+    "description": "Collect metrics from Apache Spark with Elastic Agent.",
     "type": "integration",
-    "download": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.zip",
-    "path": "/package/ecs_style_dataset/0.0.1",
-    "policy_templates": [
+    "download": "/epr/datastream_without_release/datastream_without_release-0.1.0.zip",
+    "path": "/package/datastream_without_release/0.1.0",
+    "icons": [
       {
-        "name": "logs",
-        "title": "Logs datasource",
-        "description": "Datasource for your log files."
+        "src": "/img/apache_spark-logo.svg",
+        "path": "/package/datastream_without_release/0.1.0/img/apache_spark-logo.svg",
+        "title": "Apache Spark logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
       }
     ],
+    "policy_templates": [
+      {
+        "name": "apache_spark",
+        "title": "Apache Spark metrics",
+        "description": "Collect Apache Spark metrics"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.1.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/obs-service-integrations"
+    },
     "categories": [
+      "datastore",
       "monitoring"
     ],
     "data_streams": [
       {
-        "type": "logs",
-        "dataset": "ecs_style_dataset.foo",
-        "title": "Foo"
+        "type": "metrics",
+        "dataset": "datastream_without_release.nodes",
+        "title": "Apache Spark nodes metrics"
       }
     ]
   },
@@ -226,6 +186,19 @@
         "dataset": "default_pipeline.foo",
         "title": "Foo"
       }
+    ]
+  },
+  {
+    "name": "defaultrelease",
+    "title": "Default Release",
+    "version": "0.0.1",
+    "release": "beta",
+    "description": "Package without release, should be set to default",
+    "type": "solution",
+    "download": "/epr/defaultrelease/defaultrelease-0.0.1.zip",
+    "path": "/package/defaultrelease/0.0.1",
+    "categories": [
+      "aws"
     ]
   },
   {
@@ -296,6 +269,208 @@
     ]
   },
   {
+    "name": "deprecated_input_package",
+    "title": "New Package",
+    "version": "1.0.0",
+    "release": "ga",
+    "source": {
+      "license": "Elastic-2.0"
+    },
+    "description": "This is a new package.",
+    "type": "input",
+    "download": "/epr/deprecated_input_package/deprecated_input_package-1.0.0.zip",
+    "path": "/package/deprecated_input_package/1.0.0",
+    "icons": [
+      {
+        "src": "/img/sample-logo.svg",
+        "path": "/package/deprecated_input_package/1.0.0/img/sample-logo.svg",
+        "title": "Sample logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "sample",
+        "title": "Sample logs",
+        "description": "Collect sample logs"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^9.2.3"
+      },
+      "elastic": {
+        "subscription": "basic"
+      }
+    },
+    "owner": {
+      "type": "elastic",
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "deprecated": {
+      "since": "1.2.0",
+      "description": "This input package is deprecated",
+      "replaced_by": {
+        "package": "new_input_package"
+      }
+    }
+  },
+  {
+    "name": "deprecated_input_policy",
+    "title": "New Package",
+    "version": "1.0.0",
+    "release": "ga",
+    "source": {
+      "license": "Elastic-2.0"
+    },
+    "description": "This is a new package.",
+    "type": "input",
+    "download": "/epr/deprecated_input_policy/deprecated_input_policy-1.0.0.zip",
+    "path": "/package/deprecated_input_policy/1.0.0",
+    "icons": [
+      {
+        "src": "/img/sample-logo.svg",
+        "path": "/package/deprecated_input_policy/1.0.0/img/sample-logo.svg",
+        "title": "Sample logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "sample_deprecated",
+        "title": "Sample logs",
+        "description": "Collect sample logs",
+        "deprecated": {
+          "since": "1.2.0",
+          "description": "This policy is deprecated",
+          "replaced_by": {
+            "policy_template": "sample"
+          }
+        }
+      },
+      {
+        "name": "sample",
+        "title": "Sample logs",
+        "description": "Collect sample logs"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^9.2.3"
+      },
+      "elastic": {
+        "subscription": "basic"
+      }
+    },
+    "owner": {
+      "type": "elastic",
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "custom"
+    ]
+  },
+  {
+    "name": "deprecated_integration_input",
+    "title": "New Package",
+    "version": "1.0.0",
+    "release": "ga",
+    "source": {
+      "license": "Elastic-2.0"
+    },
+    "description": "This is a new package.",
+    "type": "integration",
+    "download": "/epr/deprecated_integration_input/deprecated_integration_input-1.0.0.zip",
+    "path": "/package/deprecated_integration_input/1.0.0",
+    "icons": [
+      {
+        "src": "/img/sample-logo.svg",
+        "path": "/package/deprecated_integration_input/1.0.0/img/sample-logo.svg",
+        "title": "Sample logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "sample",
+        "title": "Sample logs",
+        "description": "Collect sample logs"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^9.2.3"
+      },
+      "elastic": {
+        "subscription": "basic"
+      }
+    },
+    "owner": {
+      "type": "elastic",
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "custom"
+    ]
+  },
+  {
+    "name": "deprecated_integration_stream",
+    "title": "New Package",
+    "version": "1.0.0",
+    "release": "ga",
+    "source": {
+      "license": "Elastic-2.0"
+    },
+    "description": "This is a new package.",
+    "type": "integration",
+    "download": "/epr/deprecated_integration_stream/deprecated_integration_stream-1.0.0.zip",
+    "path": "/package/deprecated_integration_stream/1.0.0",
+    "icons": [
+      {
+        "src": "/img/sample-logo.svg",
+        "path": "/package/deprecated_integration_stream/1.0.0/img/sample-logo.svg",
+        "title": "Sample logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "sample",
+        "title": "Sample logs",
+        "description": "Collect sample logs"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^9.2.3"
+      },
+      "elastic": {
+        "subscription": "basic"
+      }
+    },
+    "owner": {
+      "type": "elastic",
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "deprecated_integration_stream.new_data_stream",
+        "title": "New Data Stream"
+      }
+    ]
+  },
+  {
     "name": "discovery_empty",
     "title": "Discovery Empty",
     "version": "0.1.0",
@@ -333,6 +508,33 @@
     ]
   },
   {
+    "name": "ecs_style_dataset",
+    "title": "Default pipeline Integration",
+    "version": "0.0.1",
+    "release": "beta",
+    "description": "Tests the registry validations works for dataset fields using the ecs style format",
+    "type": "integration",
+    "download": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.zip",
+    "path": "/package/ecs_style_dataset/0.0.1",
+    "policy_templates": [
+      {
+        "name": "logs",
+        "title": "Logs datasource",
+        "description": "Datasource for your log files."
+      }
+    ],
+    "categories": [
+      "monitoring"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ecs_style_dataset.foo",
+        "title": "Foo"
+      }
+    ]
+  },
+  {
     "name": "elasticsearch_privileges",
     "title": "Elasticsearch Privileges",
     "version": "1.0.0",
@@ -354,42 +556,6 @@
         "type": "metrics",
         "dataset": "elasticsearch_privileges.elasticsearch_privileges",
         "title": "Elasticsearch privileges data stream"
-      }
-    ]
-  },
-  {
-    "name": "nodirentries",
-    "title": "Example Integration",
-    "version": "1.0.0",
-    "release": "ga",
-    "description": "This is a zip package without directory entries.",
-    "type": "integration",
-    "download": "/epr/nodirentries/nodirentries-1.0.0.zip",
-    "path": "/package/nodirentries/1.0.0",
-    "policy_templates": [
-      {
-        "name": "logs",
-        "title": "Logs datasource",
-        "description": "Datasource for your log files."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "~7.x.x"
-      }
-    },
-    "owner": {
-      "github": "ruflin"
-    },
-    "categories": [
-      "crm",
-      "azure"
-    ],
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "nodirentries.foo",
-        "title": "Foo"
       }
     ]
   },
@@ -719,6 +885,33 @@
     ]
   },
   {
+    "name": "multiple_false",
+    "title": "Multiple false",
+    "version": "0.0.1",
+    "release": "beta",
+    "description": "Tests that multiple can be set to false",
+    "type": "integration",
+    "download": "/epr/multiple_false/multiple_false-0.0.1.zip",
+    "path": "/package/multiple_false/0.0.1",
+    "policy_templates": [
+      {
+        "name": "logs",
+        "title": "Logs datasource",
+        "description": "Datasource for your log files."
+      }
+    ],
+    "categories": [
+      "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "multiple_false.foo",
+        "title": "Foo"
+      }
+    ]
+  },
+  {
     "name": "multiversion",
     "title": "Multi Version",
     "version": "1.2.0",
@@ -749,235 +942,6 @@
     }
   },
   {
-    "name": "multiple_false",
-    "title": "Multiple false",
-    "version": "0.0.1",
-    "release": "beta",
-    "description": "Tests that multiple can be set to false",
-    "type": "integration",
-    "download": "/epr/multiple_false/multiple_false-0.0.1.zip",
-    "path": "/package/multiple_false/0.0.1",
-    "policy_templates": [
-      {
-        "name": "logs",
-        "title": "Logs datasource",
-        "description": "Datasource for your log files."
-      }
-    ],
-    "categories": [
-      "custom"
-    ],
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "multiple_false.foo",
-        "title": "Foo"
-      }
-    ]
-  },
-  {
-    "name": "deprecated_integration_stream",
-    "title": "New Package",
-    "version": "1.0.0",
-    "release": "ga",
-    "source": {
-      "license": "Elastic-2.0"
-    },
-    "description": "This is a new package.",
-    "type": "integration",
-    "download": "/epr/deprecated_integration_stream/deprecated_integration_stream-1.0.0.zip",
-    "path": "/package/deprecated_integration_stream/1.0.0",
-    "icons": [
-      {
-        "src": "/img/sample-logo.svg",
-        "path": "/package/deprecated_integration_stream/1.0.0/img/sample-logo.svg",
-        "title": "Sample logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "sample",
-        "title": "Sample logs",
-        "description": "Collect sample logs"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^9.2.3"
-      },
-      "elastic": {
-        "subscription": "basic"
-      }
-    },
-    "owner": {
-      "type": "elastic",
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "deprecated_integration_stream.new_data_stream",
-        "title": "New Data Stream"
-      }
-    ]
-  },
-  {
-    "name": "deprecated_integration_input",
-    "title": "New Package",
-    "version": "1.0.0",
-    "release": "ga",
-    "source": {
-      "license": "Elastic-2.0"
-    },
-    "description": "This is a new package.",
-    "type": "integration",
-    "download": "/epr/deprecated_integration_input/deprecated_integration_input-1.0.0.zip",
-    "path": "/package/deprecated_integration_input/1.0.0",
-    "icons": [
-      {
-        "src": "/img/sample-logo.svg",
-        "path": "/package/deprecated_integration_input/1.0.0/img/sample-logo.svg",
-        "title": "Sample logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "sample",
-        "title": "Sample logs",
-        "description": "Collect sample logs"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^9.2.3"
-      },
-      "elastic": {
-        "subscription": "basic"
-      }
-    },
-    "owner": {
-      "type": "elastic",
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "custom"
-    ]
-  },
-  {
-    "name": "deprecated_input_policy",
-    "title": "New Package",
-    "version": "1.0.0",
-    "release": "ga",
-    "source": {
-      "license": "Elastic-2.0"
-    },
-    "description": "This is a new package.",
-    "type": "input",
-    "download": "/epr/deprecated_input_policy/deprecated_input_policy-1.0.0.zip",
-    "path": "/package/deprecated_input_policy/1.0.0",
-    "icons": [
-      {
-        "src": "/img/sample-logo.svg",
-        "path": "/package/deprecated_input_policy/1.0.0/img/sample-logo.svg",
-        "title": "Sample logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "sample_deprecated",
-        "title": "Sample logs",
-        "description": "Collect sample logs",
-        "deprecated": {
-          "since": "1.2.0",
-          "description": "This policy is deprecated",
-          "replaced_by": {
-            "policy_template": "sample"
-          }
-        }
-      },
-      {
-        "name": "sample",
-        "title": "Sample logs",
-        "description": "Collect sample logs"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^9.2.3"
-      },
-      "elastic": {
-        "subscription": "basic"
-      }
-    },
-    "owner": {
-      "type": "elastic",
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "custom"
-    ]
-  },
-  {
-    "name": "deprecated_input_package",
-    "title": "New Package",
-    "version": "1.0.0",
-    "release": "ga",
-    "source": {
-      "license": "Elastic-2.0"
-    },
-    "description": "This is a new package.",
-    "type": "input",
-    "download": "/epr/deprecated_input_package/deprecated_input_package-1.0.0.zip",
-    "path": "/package/deprecated_input_package/1.0.0",
-    "icons": [
-      {
-        "src": "/img/sample-logo.svg",
-        "path": "/package/deprecated_input_package/1.0.0/img/sample-logo.svg",
-        "title": "Sample logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "sample",
-        "title": "Sample logs",
-        "description": "Collect sample logs"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^9.2.3"
-      },
-      "elastic": {
-        "subscription": "basic"
-      }
-    },
-    "owner": {
-      "type": "elastic",
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "deprecated": {
-      "since": "1.2.0",
-      "description": "This input package is deprecated",
-      "replaced_by": {
-        "package": "new_input_package"
-      }
-    }
-  },
-  {
     "name": "no_stream_configs",
     "title": "No Stream configs",
     "version": "1.0.0",
@@ -998,30 +962,38 @@
     ]
   },
   {
-    "name": "traces",
-    "title": "Not actually APM",
+    "name": "nodirentries",
+    "title": "Example Integration",
     "version": "1.0.0",
-    "release": "experimental",
-    "description": "Not actually APM",
+    "release": "ga",
+    "description": "This is a zip package without directory entries.",
     "type": "integration",
-    "download": "/epr/traces/traces-1.0.0.zip",
-    "path": "/package/traces/1.0.0",
+    "download": "/epr/nodirentries/nodirentries-1.0.0.zip",
+    "path": "/package/nodirentries/1.0.0",
+    "policy_templates": [
+      {
+        "name": "logs",
+        "title": "Logs datasource",
+        "description": "Datasource for your log files."
+      }
+    ],
     "conditions": {
       "kibana": {
         "version": "~7.x.x"
       }
     },
     "owner": {
-      "github": "github.com/elastic/not-apm"
+      "github": "ruflin"
     },
     "categories": [
-      "monitoring"
+      "crm",
+      "azure"
     ],
     "data_streams": [
       {
-        "type": "traces",
-        "dataset": "traces.traces",
-        "title": "notapmtraces"
+        "type": "logs",
+        "dataset": "nodirentries.foo",
+        "title": "Foo"
       }
     ]
   },
@@ -1168,6 +1140,34 @@
     "categories": [
       "custom",
       "datastore"
+    ]
+  },
+  {
+    "name": "traces",
+    "title": "Not actually APM",
+    "version": "1.0.0",
+    "release": "experimental",
+    "description": "Not actually APM",
+    "type": "integration",
+    "download": "/epr/traces/traces-1.0.0.zip",
+    "path": "/package/traces/1.0.0",
+    "conditions": {
+      "kibana": {
+        "version": "~7.x.x"
+      }
+    },
+    "owner": {
+      "github": "github.com/elastic/not-apm"
+    },
+    "categories": [
+      "monitoring"
+    ],
+    "data_streams": [
+      {
+        "type": "traces",
+        "dataset": "traces.traces",
+        "title": "notapmtraces"
+      }
     ]
   },
   {

--- a/testdata/generated/search-spec-max-2.10.0.json
+++ b/testdata/generated/search-spec-max-2.10.0.json
@@ -54,51 +54,6 @@
     ]
   },
   {
-    "name": "datastream_without_release",
-    "title": "Apache Spark",
-    "version": "0.1.0",
-    "release": "beta",
-    "description": "Collect metrics from Apache Spark with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/datastream_without_release/datastream_without_release-0.1.0.zip",
-    "path": "/package/datastream_without_release/0.1.0",
-    "icons": [
-      {
-        "src": "/img/apache_spark-logo.svg",
-        "path": "/package/datastream_without_release/0.1.0/img/apache_spark-logo.svg",
-        "title": "Apache Spark logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "apache_spark",
-        "title": "Apache Spark metrics",
-        "description": "Collect Apache Spark metrics"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.1.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/obs-service-integrations"
-    },
-    "categories": [
-      "datastore",
-      "monitoring"
-    ],
-    "data_streams": [
-      {
-        "type": "metrics",
-        "dataset": "datastream_without_release.nodes",
-        "title": "Apache Spark nodes metrics"
-      }
-    ]
-  },
-  {
     "name": "dataset_is_prefix",
     "title": "DatasetIsPrefix Flag",
     "version": "0.0.1",
@@ -116,19 +71,6 @@
         "dataset": "dataset_is_prefix.test",
         "title": "dataset_is_prefix test data stream"
       }
-    ]
-  },
-  {
-    "name": "defaultrelease",
-    "title": "Default Release",
-    "version": "0.0.1",
-    "release": "beta",
-    "description": "Package without release, should be set to default",
-    "type": "solution",
-    "download": "/epr/defaultrelease/defaultrelease-0.0.1.zip",
-    "path": "/package/defaultrelease/0.0.1",
-    "categories": [
-      "aws"
     ]
   },
   {
@@ -174,29 +116,47 @@
     ]
   },
   {
-    "name": "ecs_style_dataset",
-    "title": "Default pipeline Integration",
-    "version": "0.0.1",
+    "name": "datastream_without_release",
+    "title": "Apache Spark",
+    "version": "0.1.0",
     "release": "beta",
-    "description": "Tests the registry validations works for dataset fields using the ecs style format",
+    "description": "Collect metrics from Apache Spark with Elastic Agent.",
     "type": "integration",
-    "download": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.zip",
-    "path": "/package/ecs_style_dataset/0.0.1",
-    "policy_templates": [
+    "download": "/epr/datastream_without_release/datastream_without_release-0.1.0.zip",
+    "path": "/package/datastream_without_release/0.1.0",
+    "icons": [
       {
-        "name": "logs",
-        "title": "Logs datasource",
-        "description": "Datasource for your log files."
+        "src": "/img/apache_spark-logo.svg",
+        "path": "/package/datastream_without_release/0.1.0/img/apache_spark-logo.svg",
+        "title": "Apache Spark logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
       }
     ],
+    "policy_templates": [
+      {
+        "name": "apache_spark",
+        "title": "Apache Spark metrics",
+        "description": "Collect Apache Spark metrics"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.1.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/obs-service-integrations"
+    },
     "categories": [
+      "datastore",
       "monitoring"
     ],
     "data_streams": [
       {
-        "type": "logs",
-        "dataset": "ecs_style_dataset.foo",
-        "title": "Foo"
+        "type": "metrics",
+        "dataset": "datastream_without_release.nodes",
+        "title": "Apache Spark nodes metrics"
       }
     ]
   },
@@ -229,6 +189,46 @@
     ]
   },
   {
+    "name": "defaultrelease",
+    "title": "Default Release",
+    "version": "0.0.1",
+    "release": "beta",
+    "description": "Package without release, should be set to default",
+    "type": "solution",
+    "download": "/epr/defaultrelease/defaultrelease-0.0.1.zip",
+    "path": "/package/defaultrelease/0.0.1",
+    "categories": [
+      "aws"
+    ]
+  },
+  {
+    "name": "ecs_style_dataset",
+    "title": "Default pipeline Integration",
+    "version": "0.0.1",
+    "release": "beta",
+    "description": "Tests the registry validations works for dataset fields using the ecs style format",
+    "type": "integration",
+    "download": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.zip",
+    "path": "/package/ecs_style_dataset/0.0.1",
+    "policy_templates": [
+      {
+        "name": "logs",
+        "title": "Logs datasource",
+        "description": "Datasource for your log files."
+      }
+    ],
+    "categories": [
+      "monitoring"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ecs_style_dataset.foo",
+        "title": "Foo"
+      }
+    ]
+  },
+  {
     "name": "elasticsearch_privileges",
     "title": "Elasticsearch Privileges",
     "version": "1.0.0",
@@ -250,42 +250,6 @@
         "type": "metrics",
         "dataset": "elasticsearch_privileges.elasticsearch_privileges",
         "title": "Elasticsearch privileges data stream"
-      }
-    ]
-  },
-  {
-    "name": "nodirentries",
-    "title": "Example Integration",
-    "version": "1.0.0",
-    "release": "ga",
-    "description": "This is a zip package without directory entries.",
-    "type": "integration",
-    "download": "/epr/nodirentries/nodirentries-1.0.0.zip",
-    "path": "/package/nodirentries/1.0.0",
-    "policy_templates": [
-      {
-        "name": "logs",
-        "title": "Logs datasource",
-        "description": "Datasource for your log files."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "~7.x.x"
-      }
-    },
-    "owner": {
-      "github": "ruflin"
-    },
-    "categories": [
-      "crm",
-      "azure"
-    ],
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "nodirentries.foo",
-        "title": "Foo"
       }
     ]
   },
@@ -580,6 +544,33 @@
     ]
   },
   {
+    "name": "multiple_false",
+    "title": "Multiple false",
+    "version": "0.0.1",
+    "release": "beta",
+    "description": "Tests that multiple can be set to false",
+    "type": "integration",
+    "download": "/epr/multiple_false/multiple_false-0.0.1.zip",
+    "path": "/package/multiple_false/0.0.1",
+    "policy_templates": [
+      {
+        "name": "logs",
+        "title": "Logs datasource",
+        "description": "Datasource for your log files."
+      }
+    ],
+    "categories": [
+      "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "multiple_false.foo",
+        "title": "Foo"
+      }
+    ]
+  },
+  {
     "name": "multiversion",
     "title": "Multi Version",
     "version": "1.2.0",
@@ -610,33 +601,6 @@
     }
   },
   {
-    "name": "multiple_false",
-    "title": "Multiple false",
-    "version": "0.0.1",
-    "release": "beta",
-    "description": "Tests that multiple can be set to false",
-    "type": "integration",
-    "download": "/epr/multiple_false/multiple_false-0.0.1.zip",
-    "path": "/package/multiple_false/0.0.1",
-    "policy_templates": [
-      {
-        "name": "logs",
-        "title": "Logs datasource",
-        "description": "Datasource for your log files."
-      }
-    ],
-    "categories": [
-      "custom"
-    ],
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "multiple_false.foo",
-        "title": "Foo"
-      }
-    ]
-  },
-  {
     "name": "no_stream_configs",
     "title": "No Stream configs",
     "version": "1.0.0",
@@ -657,30 +621,38 @@
     ]
   },
   {
-    "name": "traces",
-    "title": "Not actually APM",
+    "name": "nodirentries",
+    "title": "Example Integration",
     "version": "1.0.0",
-    "release": "experimental",
-    "description": "Not actually APM",
+    "release": "ga",
+    "description": "This is a zip package without directory entries.",
     "type": "integration",
-    "download": "/epr/traces/traces-1.0.0.zip",
-    "path": "/package/traces/1.0.0",
+    "download": "/epr/nodirentries/nodirentries-1.0.0.zip",
+    "path": "/package/nodirentries/1.0.0",
+    "policy_templates": [
+      {
+        "name": "logs",
+        "title": "Logs datasource",
+        "description": "Datasource for your log files."
+      }
+    ],
     "conditions": {
       "kibana": {
         "version": "~7.x.x"
       }
     },
     "owner": {
-      "github": "github.com/elastic/not-apm"
+      "github": "ruflin"
     },
     "categories": [
-      "monitoring"
+      "crm",
+      "azure"
     ],
     "data_streams": [
       {
-        "type": "traces",
-        "dataset": "traces.traces",
-        "title": "notapmtraces"
+        "type": "logs",
+        "dataset": "nodirentries.foo",
+        "title": "Foo"
       }
     ]
   },
@@ -758,6 +730,34 @@
     "categories": [
       "custom",
       "datastore"
+    ]
+  },
+  {
+    "name": "traces",
+    "title": "Not actually APM",
+    "version": "1.0.0",
+    "release": "experimental",
+    "description": "Not actually APM",
+    "type": "integration",
+    "download": "/epr/traces/traces-1.0.0.zip",
+    "path": "/package/traces/1.0.0",
+    "conditions": {
+      "kibana": {
+        "version": "~7.x.x"
+      }
+    },
+    "owner": {
+      "github": "github.com/elastic/not-apm"
+    },
+    "categories": [
+      "monitoring"
+    ],
+    "data_streams": [
+      {
+        "type": "traces",
+        "dataset": "traces.traces",
+        "title": "notapmtraces"
+      }
     ]
   },
   {

--- a/testdata/generated/search.json
+++ b/testdata/generated/search.json
@@ -54,51 +54,6 @@
     ]
   },
   {
-    "name": "datastream_without_release",
-    "title": "Apache Spark",
-    "version": "0.1.0",
-    "release": "beta",
-    "description": "Collect metrics from Apache Spark with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/datastream_without_release/datastream_without_release-0.1.0.zip",
-    "path": "/package/datastream_without_release/0.1.0",
-    "icons": [
-      {
-        "src": "/img/apache_spark-logo.svg",
-        "path": "/package/datastream_without_release/0.1.0/img/apache_spark-logo.svg",
-        "title": "Apache Spark logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "apache_spark",
-        "title": "Apache Spark metrics",
-        "description": "Collect Apache Spark metrics"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.1.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/obs-service-integrations"
-    },
-    "categories": [
-      "datastore",
-      "monitoring"
-    ],
-    "data_streams": [
-      {
-        "type": "metrics",
-        "dataset": "datastream_without_release.nodes",
-        "title": "Apache Spark nodes metrics"
-      }
-    ]
-  },
-  {
     "name": "dataset_is_prefix",
     "title": "DatasetIsPrefix Flag",
     "version": "0.0.1",
@@ -116,19 +71,6 @@
         "dataset": "dataset_is_prefix.test",
         "title": "dataset_is_prefix test data stream"
       }
-    ]
-  },
-  {
-    "name": "defaultrelease",
-    "title": "Default Release",
-    "version": "0.0.1",
-    "release": "beta",
-    "description": "Package without release, should be set to default",
-    "type": "solution",
-    "download": "/epr/defaultrelease/defaultrelease-0.0.1.zip",
-    "path": "/package/defaultrelease/0.0.1",
-    "categories": [
-      "aws"
     ]
   },
   {
@@ -174,29 +116,47 @@
     ]
   },
   {
-    "name": "ecs_style_dataset",
-    "title": "Default pipeline Integration",
-    "version": "0.0.1",
+    "name": "datastream_without_release",
+    "title": "Apache Spark",
+    "version": "0.1.0",
     "release": "beta",
-    "description": "Tests the registry validations works for dataset fields using the ecs style format",
+    "description": "Collect metrics from Apache Spark with Elastic Agent.",
     "type": "integration",
-    "download": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.zip",
-    "path": "/package/ecs_style_dataset/0.0.1",
-    "policy_templates": [
+    "download": "/epr/datastream_without_release/datastream_without_release-0.1.0.zip",
+    "path": "/package/datastream_without_release/0.1.0",
+    "icons": [
       {
-        "name": "logs",
-        "title": "Logs datasource",
-        "description": "Datasource for your log files."
+        "src": "/img/apache_spark-logo.svg",
+        "path": "/package/datastream_without_release/0.1.0/img/apache_spark-logo.svg",
+        "title": "Apache Spark logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
       }
     ],
+    "policy_templates": [
+      {
+        "name": "apache_spark",
+        "title": "Apache Spark metrics",
+        "description": "Collect Apache Spark metrics"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.1.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/obs-service-integrations"
+    },
     "categories": [
+      "datastore",
       "monitoring"
     ],
     "data_streams": [
       {
-        "type": "logs",
-        "dataset": "ecs_style_dataset.foo",
-        "title": "Foo"
+        "type": "metrics",
+        "dataset": "datastream_without_release.nodes",
+        "title": "Apache Spark nodes metrics"
       }
     ]
   },
@@ -226,6 +186,19 @@
         "dataset": "default_pipeline.foo",
         "title": "Foo"
       }
+    ]
+  },
+  {
+    "name": "defaultrelease",
+    "title": "Default Release",
+    "version": "0.0.1",
+    "release": "beta",
+    "description": "Package without release, should be set to default",
+    "type": "solution",
+    "download": "/epr/defaultrelease/defaultrelease-0.0.1.zip",
+    "path": "/package/defaultrelease/0.0.1",
+    "categories": [
+      "aws"
     ]
   },
   {
@@ -296,6 +269,208 @@
     ]
   },
   {
+    "name": "deprecated_input_package",
+    "title": "New Package",
+    "version": "1.0.0",
+    "release": "ga",
+    "source": {
+      "license": "Elastic-2.0"
+    },
+    "description": "This is a new package.",
+    "type": "input",
+    "download": "/epr/deprecated_input_package/deprecated_input_package-1.0.0.zip",
+    "path": "/package/deprecated_input_package/1.0.0",
+    "icons": [
+      {
+        "src": "/img/sample-logo.svg",
+        "path": "/package/deprecated_input_package/1.0.0/img/sample-logo.svg",
+        "title": "Sample logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "sample",
+        "title": "Sample logs",
+        "description": "Collect sample logs"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^9.2.3"
+      },
+      "elastic": {
+        "subscription": "basic"
+      }
+    },
+    "owner": {
+      "type": "elastic",
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "deprecated": {
+      "since": "1.2.0",
+      "description": "This input package is deprecated",
+      "replaced_by": {
+        "package": "new_input_package"
+      }
+    }
+  },
+  {
+    "name": "deprecated_input_policy",
+    "title": "New Package",
+    "version": "1.0.0",
+    "release": "ga",
+    "source": {
+      "license": "Elastic-2.0"
+    },
+    "description": "This is a new package.",
+    "type": "input",
+    "download": "/epr/deprecated_input_policy/deprecated_input_policy-1.0.0.zip",
+    "path": "/package/deprecated_input_policy/1.0.0",
+    "icons": [
+      {
+        "src": "/img/sample-logo.svg",
+        "path": "/package/deprecated_input_policy/1.0.0/img/sample-logo.svg",
+        "title": "Sample logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "sample_deprecated",
+        "title": "Sample logs",
+        "description": "Collect sample logs",
+        "deprecated": {
+          "since": "1.2.0",
+          "description": "This policy is deprecated",
+          "replaced_by": {
+            "policy_template": "sample"
+          }
+        }
+      },
+      {
+        "name": "sample",
+        "title": "Sample logs",
+        "description": "Collect sample logs"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^9.2.3"
+      },
+      "elastic": {
+        "subscription": "basic"
+      }
+    },
+    "owner": {
+      "type": "elastic",
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "custom"
+    ]
+  },
+  {
+    "name": "deprecated_integration_input",
+    "title": "New Package",
+    "version": "1.0.0",
+    "release": "ga",
+    "source": {
+      "license": "Elastic-2.0"
+    },
+    "description": "This is a new package.",
+    "type": "integration",
+    "download": "/epr/deprecated_integration_input/deprecated_integration_input-1.0.0.zip",
+    "path": "/package/deprecated_integration_input/1.0.0",
+    "icons": [
+      {
+        "src": "/img/sample-logo.svg",
+        "path": "/package/deprecated_integration_input/1.0.0/img/sample-logo.svg",
+        "title": "Sample logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "sample",
+        "title": "Sample logs",
+        "description": "Collect sample logs"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^9.2.3"
+      },
+      "elastic": {
+        "subscription": "basic"
+      }
+    },
+    "owner": {
+      "type": "elastic",
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "custom"
+    ]
+  },
+  {
+    "name": "deprecated_integration_stream",
+    "title": "New Package",
+    "version": "1.0.0",
+    "release": "ga",
+    "source": {
+      "license": "Elastic-2.0"
+    },
+    "description": "This is a new package.",
+    "type": "integration",
+    "download": "/epr/deprecated_integration_stream/deprecated_integration_stream-1.0.0.zip",
+    "path": "/package/deprecated_integration_stream/1.0.0",
+    "icons": [
+      {
+        "src": "/img/sample-logo.svg",
+        "path": "/package/deprecated_integration_stream/1.0.0/img/sample-logo.svg",
+        "title": "Sample logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "sample",
+        "title": "Sample logs",
+        "description": "Collect sample logs"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^9.2.3"
+      },
+      "elastic": {
+        "subscription": "basic"
+      }
+    },
+    "owner": {
+      "type": "elastic",
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "deprecated_integration_stream.new_data_stream",
+        "title": "New Data Stream"
+      }
+    ]
+  },
+  {
     "name": "discovery_empty",
     "title": "Discovery Empty",
     "version": "0.1.0",
@@ -333,6 +508,33 @@
     ]
   },
   {
+    "name": "ecs_style_dataset",
+    "title": "Default pipeline Integration",
+    "version": "0.0.1",
+    "release": "beta",
+    "description": "Tests the registry validations works for dataset fields using the ecs style format",
+    "type": "integration",
+    "download": "/epr/ecs_style_dataset/ecs_style_dataset-0.0.1.zip",
+    "path": "/package/ecs_style_dataset/0.0.1",
+    "policy_templates": [
+      {
+        "name": "logs",
+        "title": "Logs datasource",
+        "description": "Datasource for your log files."
+      }
+    ],
+    "categories": [
+      "monitoring"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ecs_style_dataset.foo",
+        "title": "Foo"
+      }
+    ]
+  },
+  {
     "name": "elasticsearch_privileges",
     "title": "Elasticsearch Privileges",
     "version": "1.0.0",
@@ -354,42 +556,6 @@
         "type": "metrics",
         "dataset": "elasticsearch_privileges.elasticsearch_privileges",
         "title": "Elasticsearch privileges data stream"
-      }
-    ]
-  },
-  {
-    "name": "nodirentries",
-    "title": "Example Integration",
-    "version": "1.0.0",
-    "release": "ga",
-    "description": "This is a zip package without directory entries.",
-    "type": "integration",
-    "download": "/epr/nodirentries/nodirentries-1.0.0.zip",
-    "path": "/package/nodirentries/1.0.0",
-    "policy_templates": [
-      {
-        "name": "logs",
-        "title": "Logs datasource",
-        "description": "Datasource for your log files."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "~7.x.x"
-      }
-    },
-    "owner": {
-      "github": "ruflin"
-    },
-    "categories": [
-      "crm",
-      "azure"
-    ],
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "nodirentries.foo",
-        "title": "Foo"
       }
     ]
   },
@@ -736,6 +902,33 @@
     ]
   },
   {
+    "name": "multiple_false",
+    "title": "Multiple false",
+    "version": "0.0.1",
+    "release": "beta",
+    "description": "Tests that multiple can be set to false",
+    "type": "integration",
+    "download": "/epr/multiple_false/multiple_false-0.0.1.zip",
+    "path": "/package/multiple_false/0.0.1",
+    "policy_templates": [
+      {
+        "name": "logs",
+        "title": "Logs datasource",
+        "description": "Datasource for your log files."
+      }
+    ],
+    "categories": [
+      "custom"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "multiple_false.foo",
+        "title": "Foo"
+      }
+    ]
+  },
+  {
     "name": "multiversion",
     "title": "Multi Version",
     "version": "1.2.0",
@@ -766,235 +959,6 @@
     }
   },
   {
-    "name": "multiple_false",
-    "title": "Multiple false",
-    "version": "0.0.1",
-    "release": "beta",
-    "description": "Tests that multiple can be set to false",
-    "type": "integration",
-    "download": "/epr/multiple_false/multiple_false-0.0.1.zip",
-    "path": "/package/multiple_false/0.0.1",
-    "policy_templates": [
-      {
-        "name": "logs",
-        "title": "Logs datasource",
-        "description": "Datasource for your log files."
-      }
-    ],
-    "categories": [
-      "custom"
-    ],
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "multiple_false.foo",
-        "title": "Foo"
-      }
-    ]
-  },
-  {
-    "name": "deprecated_integration_stream",
-    "title": "New Package",
-    "version": "1.0.0",
-    "release": "ga",
-    "source": {
-      "license": "Elastic-2.0"
-    },
-    "description": "This is a new package.",
-    "type": "integration",
-    "download": "/epr/deprecated_integration_stream/deprecated_integration_stream-1.0.0.zip",
-    "path": "/package/deprecated_integration_stream/1.0.0",
-    "icons": [
-      {
-        "src": "/img/sample-logo.svg",
-        "path": "/package/deprecated_integration_stream/1.0.0/img/sample-logo.svg",
-        "title": "Sample logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "sample",
-        "title": "Sample logs",
-        "description": "Collect sample logs"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^9.2.3"
-      },
-      "elastic": {
-        "subscription": "basic"
-      }
-    },
-    "owner": {
-      "type": "elastic",
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "deprecated_integration_stream.new_data_stream",
-        "title": "New Data Stream"
-      }
-    ]
-  },
-  {
-    "name": "deprecated_integration_input",
-    "title": "New Package",
-    "version": "1.0.0",
-    "release": "ga",
-    "source": {
-      "license": "Elastic-2.0"
-    },
-    "description": "This is a new package.",
-    "type": "integration",
-    "download": "/epr/deprecated_integration_input/deprecated_integration_input-1.0.0.zip",
-    "path": "/package/deprecated_integration_input/1.0.0",
-    "icons": [
-      {
-        "src": "/img/sample-logo.svg",
-        "path": "/package/deprecated_integration_input/1.0.0/img/sample-logo.svg",
-        "title": "Sample logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "sample",
-        "title": "Sample logs",
-        "description": "Collect sample logs"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^9.2.3"
-      },
-      "elastic": {
-        "subscription": "basic"
-      }
-    },
-    "owner": {
-      "type": "elastic",
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "custom"
-    ]
-  },
-  {
-    "name": "deprecated_input_policy",
-    "title": "New Package",
-    "version": "1.0.0",
-    "release": "ga",
-    "source": {
-      "license": "Elastic-2.0"
-    },
-    "description": "This is a new package.",
-    "type": "input",
-    "download": "/epr/deprecated_input_policy/deprecated_input_policy-1.0.0.zip",
-    "path": "/package/deprecated_input_policy/1.0.0",
-    "icons": [
-      {
-        "src": "/img/sample-logo.svg",
-        "path": "/package/deprecated_input_policy/1.0.0/img/sample-logo.svg",
-        "title": "Sample logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "sample_deprecated",
-        "title": "Sample logs",
-        "description": "Collect sample logs",
-        "deprecated": {
-          "since": "1.2.0",
-          "description": "This policy is deprecated",
-          "replaced_by": {
-            "policy_template": "sample"
-          }
-        }
-      },
-      {
-        "name": "sample",
-        "title": "Sample logs",
-        "description": "Collect sample logs"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^9.2.3"
-      },
-      "elastic": {
-        "subscription": "basic"
-      }
-    },
-    "owner": {
-      "type": "elastic",
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "custom"
-    ]
-  },
-  {
-    "name": "deprecated_input_package",
-    "title": "New Package",
-    "version": "1.0.0",
-    "release": "ga",
-    "source": {
-      "license": "Elastic-2.0"
-    },
-    "description": "This is a new package.",
-    "type": "input",
-    "download": "/epr/deprecated_input_package/deprecated_input_package-1.0.0.zip",
-    "path": "/package/deprecated_input_package/1.0.0",
-    "icons": [
-      {
-        "src": "/img/sample-logo.svg",
-        "path": "/package/deprecated_input_package/1.0.0/img/sample-logo.svg",
-        "title": "Sample logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "sample",
-        "title": "Sample logs",
-        "description": "Collect sample logs"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^9.2.3"
-      },
-      "elastic": {
-        "subscription": "basic"
-      }
-    },
-    "owner": {
-      "type": "elastic",
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "deprecated": {
-      "since": "1.2.0",
-      "description": "This input package is deprecated",
-      "replaced_by": {
-        "package": "new_input_package"
-      }
-    }
-  },
-  {
     "name": "no_stream_configs",
     "title": "No Stream configs",
     "version": "1.0.0",
@@ -1011,6 +975,42 @@
         "type": "logs",
         "dataset": "no_stream_configs.log",
         "title": "Log Yaml pipeline"
+      }
+    ]
+  },
+  {
+    "name": "nodirentries",
+    "title": "Example Integration",
+    "version": "1.0.0",
+    "release": "ga",
+    "description": "This is a zip package without directory entries.",
+    "type": "integration",
+    "download": "/epr/nodirentries/nodirentries-1.0.0.zip",
+    "path": "/package/nodirentries/1.0.0",
+    "policy_templates": [
+      {
+        "name": "logs",
+        "title": "Logs datasource",
+        "description": "Datasource for your log files."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "~7.x.x"
+      }
+    },
+    "owner": {
+      "github": "ruflin"
+    },
+    "categories": [
+      "crm",
+      "azure"
+    ],
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "nodirentries.foo",
+        "title": "Foo"
       }
     ]
   },

--- a/testdata/generated/storage-indexer/search-all.json
+++ b/testdata/generated/storage-indexer/search-all.json
@@ -1,60 +1,6 @@
 [
   {
     "name": "1password",
-    "title": "1Password",
-    "version": "1.4.0",
-    "release": "ga",
-    "description": "Collect events from 1Password Events API with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/1password/1password-1.4.0.zip",
-    "path": "/package/1password/1.4.0",
-    "icons": [
-      {
-        "src": "/img/1password-logo-light-bg.svg",
-        "path": "/package/1password/1.4.0/img/1password-logo-light-bg.svg",
-        "title": "1Password",
-        "size": "116x116",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "1password",
-        "title": "1Password Events",
-        "description": "Collect events from 1Password Events Reporting"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      },
-      "agent": {
-        "version": "^9.2.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security",
-      "credential_management"
-    ],
-    "signature_path": "/epr/1password/1password-1.4.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "1password.item_usages",
-        "title": "Collect 1Password item usages events"
-      },
-      {
-        "type": "logs",
-        "dataset": "1password.signin_attempts",
-        "title": "1Password sign-in attempt events"
-      }
-    ]
-  },
-  {
-    "name": "1password",
     "title": "1Password Events Reporting",
     "version": "0.1.1",
     "release": "beta",
@@ -500,6 +446,2914 @@
         "type": "logs",
         "dataset": "1password.signin_attempts",
         "title": "1Password sign-in attempt events"
+      }
+    ]
+  },
+  {
+    "name": "1password",
+    "title": "1Password",
+    "version": "1.4.0",
+    "release": "ga",
+    "description": "Collect events from 1Password Events API with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/1password/1password-1.4.0.zip",
+    "path": "/package/1password/1.4.0",
+    "icons": [
+      {
+        "src": "/img/1password-logo-light-bg.svg",
+        "path": "/package/1password/1.4.0/img/1password-logo-light-bg.svg",
+        "title": "1Password",
+        "size": "116x116",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "1password",
+        "title": "1Password Events",
+        "description": "Collect events from 1Password Events Reporting"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      },
+      "agent": {
+        "version": "^9.2.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security",
+      "credential_management"
+    ],
+    "signature_path": "/epr/1password/1password-1.4.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "1password.item_usages",
+        "title": "Collect 1Password item usages events"
+      },
+      {
+        "type": "logs",
+        "dataset": "1password.signin_attempts",
+        "title": "1Password sign-in attempt events"
+      }
+    ]
+  },
+  {
+    "name": "activemq",
+    "title": "ActiveMQ",
+    "version": "0.2.0",
+    "release": "beta",
+    "description": "Collect logs and metrics from ActiveMQ instances with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/activemq/activemq-0.2.0.zip",
+    "path": "/package/activemq/0.2.0",
+    "icons": [
+      {
+        "src": "/img/activemq.svg",
+        "path": "/package/activemq/0.2.0/img/activemq.svg",
+        "title": "activemq",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "activemq",
+        "title": "ActiveMQ logs and metrics",
+        "description": "Collect logs and metrics from ActiveMQ instances"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "web"
+    ],
+    "signature_path": "/epr/activemq/activemq-0.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "activemq.audit",
+        "title": "ActiveMQ audit logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "activemq.broker",
+        "title": "ActiveMQ broker metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "activemq.log",
+        "title": "ActiveMQ log logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "activemq.queue",
+        "title": "ActiveMQ queue metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "activemq.topic",
+        "title": "ActiveMQ topic metrics"
+      }
+    ]
+  },
+  {
+    "name": "activemq",
+    "title": "ActiveMQ",
+    "version": "0.3.0",
+    "release": "beta",
+    "description": "Collect logs and metrics from ActiveMQ instances with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/activemq/activemq-0.3.0.zip",
+    "path": "/package/activemq/0.3.0",
+    "icons": [
+      {
+        "src": "/img/activemq.svg",
+        "path": "/package/activemq/0.3.0/img/activemq.svg",
+        "title": "activemq",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "activemq",
+        "title": "ActiveMQ logs and metrics",
+        "description": "Collect logs and metrics from ActiveMQ instances"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "web"
+    ],
+    "signature_path": "/epr/activemq/activemq-0.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "activemq.audit",
+        "title": "ActiveMQ audit logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "activemq.broker",
+        "title": "ActiveMQ broker metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "activemq.log",
+        "title": "ActiveMQ log logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "activemq.queue",
+        "title": "ActiveMQ queue metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "activemq.topic",
+        "title": "ActiveMQ topic metrics"
+      }
+    ]
+  },
+  {
+    "name": "akamai",
+    "title": "Akamai",
+    "version": "0.1.0",
+    "release": "beta",
+    "description": "Akamai Integration",
+    "type": "integration",
+    "download": "/epr/akamai/akamai-0.1.0.zip",
+    "path": "/package/akamai/0.1.0",
+    "icons": [
+      {
+        "src": "/img/akamai_logo.svg",
+        "path": "/package/akamai/0.1.0/img/akamai_logo.svg",
+        "title": "Akamai",
+        "size": "409×167",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "akamai",
+        "title": "Akamai logs",
+        "description": "Collect SIEM logs from Akamai"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security",
+      "network",
+      "web",
+      "cloud"
+    ],
+    "signature_path": "/epr/akamai/akamai-0.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "akamai.siem",
+        "title": "Akamai SIEM Logs"
+      }
+    ]
+  },
+  {
+    "name": "akamai",
+    "title": "Akamai",
+    "version": "0.1.1",
+    "release": "beta",
+    "description": "Akamai Integration",
+    "type": "integration",
+    "download": "/epr/akamai/akamai-0.1.1.zip",
+    "path": "/package/akamai/0.1.1",
+    "icons": [
+      {
+        "src": "/img/akamai_logo.svg",
+        "path": "/package/akamai/0.1.1/img/akamai_logo.svg",
+        "title": "Akamai",
+        "size": "409×167",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "akamai",
+        "title": "Akamai logs",
+        "description": "Collect SIEM logs from Akamai"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security",
+      "network",
+      "web",
+      "cloud"
+    ],
+    "signature_path": "/epr/akamai/akamai-0.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "akamai.siem",
+        "title": "Akamai SIEM Logs"
+      }
+    ]
+  },
+  {
+    "name": "akamai",
+    "title": "Akamai",
+    "version": "0.1.2",
+    "release": "beta",
+    "description": "Akamai Integration",
+    "type": "integration",
+    "download": "/epr/akamai/akamai-0.1.2.zip",
+    "path": "/package/akamai/0.1.2",
+    "icons": [
+      {
+        "src": "/img/akamai_logo.svg",
+        "path": "/package/akamai/0.1.2/img/akamai_logo.svg",
+        "title": "Akamai",
+        "size": "409×167",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "akamai",
+        "title": "Akamai logs",
+        "description": "Collect SIEM logs from Akamai"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security",
+      "network",
+      "web",
+      "cloud"
+    ],
+    "signature_path": "/epr/akamai/akamai-0.1.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "akamai.siem",
+        "title": "Akamai SIEM Logs"
+      }
+    ]
+  },
+  {
+    "name": "akamai",
+    "title": "Akamai",
+    "version": "0.1.3",
+    "release": "beta",
+    "description": "Akamai Integration",
+    "type": "integration",
+    "download": "/epr/akamai/akamai-0.1.3.zip",
+    "path": "/package/akamai/0.1.3",
+    "icons": [
+      {
+        "src": "/img/akamai_logo.svg",
+        "path": "/package/akamai/0.1.3/img/akamai_logo.svg",
+        "title": "Akamai",
+        "size": "409×167",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "akamai",
+        "title": "Akamai logs",
+        "description": "Collect SIEM logs from Akamai"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security",
+      "network",
+      "web",
+      "cloud"
+    ],
+    "signature_path": "/epr/akamai/akamai-0.1.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "akamai.siem",
+        "title": "Akamai SIEM Logs"
+      }
+    ]
+  },
+  {
+    "name": "akamai",
+    "title": "Akamai",
+    "version": "0.2.0",
+    "release": "beta",
+    "description": "Akamai Integration",
+    "type": "integration",
+    "download": "/epr/akamai/akamai-0.2.0.zip",
+    "path": "/package/akamai/0.2.0",
+    "icons": [
+      {
+        "src": "/img/akamai_logo.svg",
+        "path": "/package/akamai/0.2.0/img/akamai_logo.svg",
+        "title": "Akamai",
+        "size": "409×167",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "akamai",
+        "title": "Akamai logs",
+        "description": "Collect SIEM logs from Akamai"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security",
+      "network",
+      "web",
+      "cloud"
+    ],
+    "signature_path": "/epr/akamai/akamai-0.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "akamai.siem",
+        "title": "Akamai SIEM Logs"
+      }
+    ]
+  },
+  {
+    "name": "akamai",
+    "title": "Akamai",
+    "version": "1.0.0",
+    "release": "ga",
+    "description": "Akamai Integration",
+    "type": "integration",
+    "download": "/epr/akamai/akamai-1.0.0.zip",
+    "path": "/package/akamai/1.0.0",
+    "icons": [
+      {
+        "src": "/img/akamai_logo.svg",
+        "path": "/package/akamai/1.0.0/img/akamai_logo.svg",
+        "title": "Akamai",
+        "size": "409×167",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "akamai",
+        "title": "Akamai logs",
+        "description": "Collect SIEM logs from Akamai"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security",
+      "network",
+      "web",
+      "cloud"
+    ],
+    "signature_path": "/epr/akamai/akamai-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "akamai.siem",
+        "title": "Akamai SIEM Logs"
+      }
+    ]
+  },
+  {
+    "name": "akamai",
+    "title": "Akamai",
+    "version": "2.28.0",
+    "release": "ga",
+    "description": "Collect logs from Akamai with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/akamai/akamai-2.28.0.zip",
+    "path": "/package/akamai/2.28.0",
+    "icons": [
+      {
+        "src": "/img/akamai_logo.svg",
+        "path": "/package/akamai/2.28.0/img/akamai_logo.svg",
+        "title": "Akamai",
+        "size": "409×167",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "akamai",
+        "title": "Akamai logs",
+        "description": "Collect SIEM logs from Akamai"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.13.0 || ^9.0.0"
+      }
+    },
+    "owner": {
+      "type": "community",
+      "github": "elastic/security-service-integrations"
+    },
+    "categories": [
+      "security",
+      "cdn_security"
+    ],
+    "signature_path": "/epr/akamai/akamai-2.28.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "akamai.siem",
+        "title": "Akamai SIEM Logs"
+      }
+    ]
+  },
+  {
+    "name": "apache",
+    "title": "Apache",
+    "version": "1.1.0",
+    "release": "ga",
+    "description": "This Elastic integration collects logs and metrics from Apache servers",
+    "type": "integration",
+    "download": "/epr/apache/apache-1.1.0.zip",
+    "path": "/package/apache/1.1.0",
+    "icons": [
+      {
+        "src": "/img/logo_apache.svg",
+        "path": "/package/apache/1.1.0/img/logo_apache.svg",
+        "title": "Apache Logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "apache",
+        "title": "Apache logs and metrics",
+        "description": "Collect logs and metrics from Apache instances"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "web"
+    ],
+    "signature_path": "/epr/apache/apache-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "apache.access",
+        "title": "Apache access logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "apache.error",
+        "title": "Apache error logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apache.status",
+        "title": "Apache status metrics"
+      }
+    ],
+    "deprecated": {
+      "since": "1.3.0",
+      "description": "This package is deprecated"
+    }
+  },
+  {
+    "name": "apache",
+    "title": "Apache HTTP Server",
+    "version": "1.3.0",
+    "release": "ga",
+    "description": "Collect logs and metrics from Apache servers with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/apache/apache-1.3.0.zip",
+    "path": "/package/apache/1.3.0",
+    "icons": [
+      {
+        "src": "/img/logo_apache.svg",
+        "path": "/package/apache/1.3.0/img/logo_apache.svg",
+        "title": "Apache Logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "apache",
+        "title": "Apache logs and metrics",
+        "description": "Collect logs and metrics from Apache instances"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "web"
+    ],
+    "signature_path": "/epr/apache/apache-1.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "apache.access",
+        "title": "Apache access logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "apache.error",
+        "title": "Apache error logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apache.status",
+        "title": "Apache status metrics"
+      }
+    ],
+    "deprecated": {
+      "since": "1.3.0",
+      "description": "This package is deprecated"
+    }
+  },
+  {
+    "name": "apache",
+    "title": "Apache HTTP Server",
+    "version": "1.3.2",
+    "release": "ga",
+    "description": "Collect logs and metrics from Apache servers with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/apache/apache-1.3.2.zip",
+    "path": "/package/apache/1.3.2",
+    "icons": [
+      {
+        "src": "/img/logo_apache.svg",
+        "path": "/package/apache/1.3.2/img/logo_apache.svg",
+        "title": "Apache Logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "apache",
+        "title": "Apache logs and metrics",
+        "description": "Collect logs and metrics from Apache instances"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "web"
+    ],
+    "signature_path": "/epr/apache/apache-1.3.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "apache.access",
+        "title": "Apache access logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "apache.error",
+        "title": "Apache error logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apache.status",
+        "title": "Apache status metrics"
+      }
+    ],
+    "deprecated": {
+      "since": "1.3.0",
+      "description": "This package is deprecated"
+    }
+  },
+  {
+    "name": "apache",
+    "title": "Apache HTTP Server",
+    "version": "1.3.5",
+    "release": "ga",
+    "description": "Collect logs and metrics from Apache servers with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/apache/apache-1.3.5.zip",
+    "path": "/package/apache/1.3.5",
+    "icons": [
+      {
+        "src": "/img/logo_apache.svg",
+        "path": "/package/apache/1.3.5/img/logo_apache.svg",
+        "title": "Apache Logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "apache",
+        "title": "Apache logs and metrics",
+        "description": "Collect logs and metrics from Apache instances"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "web"
+    ],
+    "signature_path": "/epr/apache/apache-1.3.5.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "apache.access",
+        "title": "Apache access logs",
+        "deprecated": {
+          "since": "1.3.5",
+          "description": "This data stream is deprecated"
+        }
+      },
+      {
+        "type": "logs",
+        "dataset": "apache.error",
+        "title": "Apache error logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apache.status",
+        "title": "Apache status metrics"
+      }
+    ],
+    "deprecated": {
+      "since": "1.3.0",
+      "description": "This package is deprecated"
+    }
+  },
+  {
+    "name": "apm",
+    "title": "Elastic APM",
+    "version": "0.4.0",
+    "release": "beta",
+    "description": "Ingest APM data",
+    "type": "integration",
+    "download": "/epr/apm/apm-0.4.0.zip",
+    "path": "/package/apm/0.4.0",
+    "icons": [
+      {
+        "src": "/img/logo_apm.svg",
+        "path": "/package/apm/0.4.0/img/logo_apm.svg",
+        "title": "APM Logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "apmserver",
+        "title": "Elastic APM Integration",
+        "description": "Elastic APM Integration"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.13.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/apm-server"
+    },
+    "categories": [
+      "elastic_stack",
+      "monitoring"
+    ],
+    "signature_path": "/epr/apm/apm-0.4.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "apm.app",
+        "title": "APM application metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "apm.error",
+        "title": "APM logs and errors"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.internal",
+        "title": "APM internal metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.profiling",
+        "title": "APM profiles"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm.sampled",
+        "title": "APM tail-sampled traces"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm",
+        "title": "APM traces"
+      }
+    ]
+  },
+  {
+    "name": "apm",
+    "title": "Elastic APM",
+    "version": "7.16.0",
+    "release": "ga",
+    "description": "Ingest APM data",
+    "type": "integration",
+    "download": "/epr/apm/apm-7.16.0.zip",
+    "path": "/package/apm/7.16.0",
+    "icons": [
+      {
+        "src": "/img/logo_apm.svg",
+        "path": "/package/apm/7.16.0/img/logo_apm.svg",
+        "title": "APM Logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "apmserver",
+        "title": "Elastic APM Integration",
+        "description": "Elastic APM Integration"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/apm-server"
+    },
+    "categories": [
+      "elastic_stack",
+      "monitoring"
+    ],
+    "signature_path": "/epr/apm/apm-7.16.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "apm.app",
+        "title": "APM application metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "apm.error",
+        "title": "APM logs and errors"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.internal",
+        "title": "APM internal metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.profiling",
+        "title": "APM profiles"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm.sampled",
+        "title": "APM tail-sampled traces"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm",
+        "title": "APM traces"
+      }
+    ]
+  },
+  {
+    "name": "apm",
+    "title": "Elastic APM",
+    "version": "7.16.1",
+    "release": "ga",
+    "description": "Ingest APM data",
+    "type": "integration",
+    "download": "/epr/apm/apm-7.16.1.zip",
+    "path": "/package/apm/7.16.1",
+    "icons": [
+      {
+        "src": "/img/logo_apm.svg",
+        "path": "/package/apm/7.16.1/img/logo_apm.svg",
+        "title": "APM Logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "apmserver",
+        "title": "Elastic APM Integration",
+        "description": "Elastic APM Integration"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.1"
+      }
+    },
+    "owner": {
+      "github": "elastic/apm-server"
+    },
+    "categories": [
+      "elastic_stack",
+      "monitoring"
+    ],
+    "signature_path": "/epr/apm/apm-7.16.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "apm.app",
+        "title": "APM application metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "apm.error",
+        "title": "APM logs and errors"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.internal",
+        "title": "APM internal metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.profiling",
+        "title": "APM profiles"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm.sampled",
+        "title": "APM tail-sampled traces"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm",
+        "title": "APM traces"
+      }
+    ]
+  },
+  {
+    "name": "apm",
+    "title": "Elastic APM",
+    "version": "7.16.2",
+    "release": "ga",
+    "description": "Ingest APM data",
+    "type": "integration",
+    "download": "/epr/apm/apm-7.16.2.zip",
+    "path": "/package/apm/7.16.2",
+    "icons": [
+      {
+        "src": "/img/logo_apm.svg",
+        "path": "/package/apm/7.16.2/img/logo_apm.svg",
+        "title": "APM Logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "apmserver",
+        "title": "Elastic APM Integration",
+        "description": "Elastic APM Integration"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/apm-server"
+    },
+    "categories": [
+      "elastic_stack",
+      "monitoring"
+    ],
+    "signature_path": "/epr/apm/apm-7.16.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "apm.app",
+        "title": "APM application logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.app",
+        "title": "APM application metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "apm.error",
+        "title": "APM logs and errors"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.internal",
+        "title": "APM internal metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.profiling",
+        "title": "APM profiles"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm.sampled",
+        "title": "APM tail-sampled traces"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm",
+        "title": "APM traces"
+      }
+    ]
+  },
+  {
+    "name": "apm",
+    "title": "Elastic APM",
+    "version": "7.17.0",
+    "release": "ga",
+    "description": "Ingest APM data",
+    "type": "integration",
+    "download": "/epr/apm/apm-7.17.0.zip",
+    "path": "/package/apm/7.17.0",
+    "icons": [
+      {
+        "src": "/img/logo_apm.svg",
+        "path": "/package/apm/7.17.0/img/logo_apm.svg",
+        "title": "APM Logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "apmserver",
+        "title": "Elastic APM Integration",
+        "description": "Elastic APM Integration"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.17.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/apm-server"
+    },
+    "categories": [
+      "elastic_stack",
+      "monitoring"
+    ],
+    "signature_path": "/epr/apm/apm-7.17.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "apm.app",
+        "title": "APM application logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.app",
+        "title": "APM application metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "apm.error",
+        "title": "APM logs and errors"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.internal",
+        "title": "APM internal metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.profiling",
+        "title": "APM profiles"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm.sampled",
+        "title": "APM tail-sampled traces"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm",
+        "title": "APM traces"
+      }
+    ]
+  },
+  {
+    "name": "apm",
+    "title": "Elastic APM",
+    "version": "8.0.0",
+    "release": "ga",
+    "description": "Ingest APM data",
+    "type": "integration",
+    "download": "/epr/apm/apm-8.0.0.zip",
+    "path": "/package/apm/8.0.0",
+    "icons": [
+      {
+        "src": "/img/logo_apm.svg",
+        "path": "/package/apm/8.0.0/img/logo_apm.svg",
+        "title": "APM Logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "apmserver",
+        "title": "Elastic APM Integration",
+        "description": "Elastic APM Integration"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/apm-server"
+    },
+    "categories": [
+      "elastic_stack",
+      "monitoring"
+    ],
+    "signature_path": "/epr/apm/apm-8.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "apm.app",
+        "title": "APM application logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.app",
+        "title": "APM application metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "apm.error",
+        "title": "APM errors"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.internal",
+        "title": "APM internal metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.profiling",
+        "title": "APM profiles"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm.rum",
+        "title": "APM RUM traces"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm.sampled",
+        "title": "APM tail-sampled traces"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm",
+        "title": "APM traces"
+      }
+    ]
+  },
+  {
+    "name": "apm",
+    "title": "Elastic APM",
+    "version": "8.1.0",
+    "release": "ga",
+    "description": "Ingest APM data",
+    "type": "integration",
+    "download": "/epr/apm/apm-8.1.0.zip",
+    "path": "/package/apm/8.1.0",
+    "icons": [
+      {
+        "src": "/img/logo_apm.svg",
+        "path": "/package/apm/8.1.0/img/logo_apm.svg",
+        "title": "APM Logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "apmserver",
+        "title": "Elastic APM Integration",
+        "description": "Elastic APM Integration"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.1.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/apm-server"
+    },
+    "categories": [
+      "elastic_stack",
+      "monitoring"
+    ],
+    "signature_path": "/epr/apm/apm-8.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "apm.app",
+        "title": "APM application logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.app",
+        "title": "APM application metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "apm.error",
+        "title": "APM errors"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.internal",
+        "title": "APM internal metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.profiling",
+        "title": "APM profiles"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm.rum",
+        "title": "APM RUM traces"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm.sampled",
+        "title": "APM tail-sampled traces"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm",
+        "title": "APM traces"
+      }
+    ]
+  },
+  {
+    "name": "apm",
+    "title": "Elastic APM",
+    "version": "8.1.2",
+    "release": "ga",
+    "description": "Ingest APM data",
+    "type": "integration",
+    "download": "/epr/apm/apm-8.1.2.zip",
+    "path": "/package/apm/8.1.2",
+    "icons": [
+      {
+        "src": "/img/logo_apm.svg",
+        "path": "/package/apm/8.1.2/img/logo_apm.svg",
+        "title": "APM Logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "apmserver",
+        "title": "Elastic APM Integration",
+        "description": "Elastic APM Integration"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.1.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/apm-server"
+    },
+    "categories": [
+      "elastic_stack",
+      "monitoring"
+    ],
+    "signature_path": "/epr/apm/apm-8.1.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "apm.app",
+        "title": "APM application logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.app",
+        "title": "APM application metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "apm.error",
+        "title": "APM errors"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.internal",
+        "title": "APM internal metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.profiling",
+        "title": "APM profiles"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm.rum",
+        "title": "APM RUM traces"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm.sampled",
+        "title": "APM tail-sampled traces"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm",
+        "title": "APM traces"
+      }
+    ]
+  },
+  {
+    "name": "apm",
+    "title": "Elastic APM",
+    "version": "8.2.0",
+    "release": "ga",
+    "description": "Ingest APM data",
+    "type": "integration",
+    "download": "/epr/apm/apm-8.2.0.zip",
+    "path": "/package/apm/8.2.0",
+    "icons": [
+      {
+        "src": "/img/logo_apm.svg",
+        "path": "/package/apm/8.2.0/img/logo_apm.svg",
+        "title": "APM Logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "apmserver",
+        "title": "Elastic APM Integration",
+        "description": "Elastic APM Integration"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.2.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/apm-server"
+    },
+    "categories": [
+      "elastic_stack",
+      "monitoring"
+    ],
+    "signature_path": "/epr/apm/apm-8.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "apm.app",
+        "title": "APM application logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.app",
+        "title": "APM application metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "apm.error",
+        "title": "APM errors"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.internal",
+        "title": "APM internal metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.profiling",
+        "title": "APM profiles"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm.rum",
+        "title": "APM RUM traces"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm.sampled",
+        "title": "APM tail-sampled traces"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm",
+        "title": "APM traces"
+      }
+    ]
+  },
+  {
+    "name": "atlassian_bitbucket",
+    "title": "Atlassian Bitbucket",
+    "version": "1.0.0",
+    "release": "ga",
+    "description": "Collect logs from Atlassian Bitbucket with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.0.0.zip",
+    "path": "/package/atlassian_bitbucket/1.0.0",
+    "icons": [
+      {
+        "src": "/img/bitbucket-logo.svg",
+        "path": "/package/atlassian_bitbucket/1.0.0/img/bitbucket-logo.svg",
+        "title": "Bitbucket Logo",
+        "size": "625x564",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "audit",
+        "title": "Audit Logs",
+        "description": "Collect audit logs from Atlassian Bitbucket with Elastic Agent."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security",
+      "web"
+    ],
+    "signature_path": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_bitbucket.audit",
+        "title": "Bitbucket Audit Logs"
+      }
+    ]
+  },
+  {
+    "name": "atlassian_bitbucket",
+    "title": "Atlassian Bitbucket",
+    "version": "1.0.1",
+    "release": "ga",
+    "description": "Collect logs from Atlassian Bitbucket with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.0.1.zip",
+    "path": "/package/atlassian_bitbucket/1.0.1",
+    "icons": [
+      {
+        "src": "/img/bitbucket-logo.svg",
+        "path": "/package/atlassian_bitbucket/1.0.1/img/bitbucket-logo.svg",
+        "title": "Bitbucket Logo",
+        "size": "625x564",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "audit",
+        "title": "Audit Logs",
+        "description": "Collect audit logs from Atlassian Bitbucket with Elastic Agent."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security",
+      "web"
+    ],
+    "signature_path": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_bitbucket.audit",
+        "title": "Bitbucket Audit Logs"
+      }
+    ]
+  },
+  {
+    "name": "atlassian_bitbucket",
+    "title": "Atlassian Bitbucket",
+    "version": "1.1.0",
+    "release": "ga",
+    "description": "Collect logs from Atlassian Bitbucket with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.1.0.zip",
+    "path": "/package/atlassian_bitbucket/1.1.0",
+    "icons": [
+      {
+        "src": "/img/bitbucket-logo.svg",
+        "path": "/package/atlassian_bitbucket/1.1.0/img/bitbucket-logo.svg",
+        "title": "Bitbucket Logo",
+        "size": "625x564",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "audit",
+        "title": "Audit Logs",
+        "description": "Collect audit logs from Atlassian Bitbucket with Elastic Agent."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security",
+      "web"
+    ],
+    "signature_path": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_bitbucket.audit",
+        "title": "Bitbucket Audit Logs"
+      }
+    ]
+  },
+  {
+    "name": "atlassian_bitbucket",
+    "title": "Atlassian Bitbucket",
+    "version": "1.1.1",
+    "release": "ga",
+    "description": "Collect logs from Atlassian Bitbucket with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.1.1.zip",
+    "path": "/package/atlassian_bitbucket/1.1.1",
+    "icons": [
+      {
+        "src": "/img/bitbucket-logo.svg",
+        "path": "/package/atlassian_bitbucket/1.1.1/img/bitbucket-logo.svg",
+        "title": "Bitbucket Logo",
+        "size": "625x564",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "audit",
+        "title": "Audit Logs",
+        "description": "Collect audit logs from Atlassian Bitbucket with Elastic Agent."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security",
+      "web"
+    ],
+    "signature_path": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_bitbucket.audit",
+        "title": "Bitbucket Audit Logs"
+      }
+    ]
+  },
+  {
+    "name": "atlassian_bitbucket",
+    "title": "Atlassian Bitbucket",
+    "version": "1.2.1",
+    "release": "ga",
+    "description": "Collect logs from Atlassian Bitbucket with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.2.1.zip",
+    "path": "/package/atlassian_bitbucket/1.2.1",
+    "icons": [
+      {
+        "src": "/img/bitbucket-logo.svg",
+        "path": "/package/atlassian_bitbucket/1.2.1/img/bitbucket-logo.svg",
+        "title": "Bitbucket Logo",
+        "size": "625x564",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "audit",
+        "title": "Audit Logs",
+        "description": "Collect audit logs from Atlassian Bitbucket with Elastic Agent."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security",
+      "web"
+    ],
+    "signature_path": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_bitbucket.audit",
+        "title": "Bitbucket Audit Logs"
+      }
+    ]
+  },
+  {
+    "name": "atlassian_confluence",
+    "title": "Atlassian Confluence",
+    "version": "1.0.1",
+    "release": "ga",
+    "description": "Collect logs from Atlassian Confluence with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/atlassian_confluence/atlassian_confluence-1.0.1.zip",
+    "path": "/package/atlassian_confluence/1.0.1",
+    "icons": [
+      {
+        "src": "/img/confluence-logo.svg",
+        "path": "/package/atlassian_confluence/1.0.1/img/confluence-logo.svg",
+        "title": "Confluence Logo",
+        "size": "400x400",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "audit",
+        "title": "Audit Logs",
+        "description": "Collect audit logs from Atlassian Confluence with Elastic Agent."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security",
+      "web"
+    ],
+    "signature_path": "/epr/atlassian_confluence/atlassian_confluence-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_confluence.audit",
+        "title": "Confluence Audit Logs"
+      }
+    ]
+  },
+  {
+    "name": "atlassian_confluence",
+    "title": "Atlassian Confluence",
+    "version": "1.1.0",
+    "release": "ga",
+    "description": "Collect logs from Atlassian Confluence with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/atlassian_confluence/atlassian_confluence-1.1.0.zip",
+    "path": "/package/atlassian_confluence/1.1.0",
+    "icons": [
+      {
+        "src": "/img/confluence-logo.svg",
+        "path": "/package/atlassian_confluence/1.1.0/img/confluence-logo.svg",
+        "title": "Confluence Logo",
+        "size": "400x400",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "audit",
+        "title": "Audit Logs",
+        "description": "Collect audit logs from Atlassian Confluence with Elastic Agent."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security",
+      "web"
+    ],
+    "signature_path": "/epr/atlassian_confluence/atlassian_confluence-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_confluence.audit",
+        "title": "Confluence Audit Logs"
+      }
+    ]
+  },
+  {
+    "name": "atlassian_confluence",
+    "title": "Atlassian Confluence",
+    "version": "1.1.1",
+    "release": "ga",
+    "description": "Collect logs from Atlassian Confluence with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/atlassian_confluence/atlassian_confluence-1.1.1.zip",
+    "path": "/package/atlassian_confluence/1.1.1",
+    "icons": [
+      {
+        "src": "/img/confluence-logo.svg",
+        "path": "/package/atlassian_confluence/1.1.1/img/confluence-logo.svg",
+        "title": "Confluence Logo",
+        "size": "400x400",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "audit",
+        "title": "Audit Logs",
+        "description": "Collect audit logs from Atlassian Confluence with Elastic Agent."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security",
+      "web"
+    ],
+    "signature_path": "/epr/atlassian_confluence/atlassian_confluence-1.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_confluence.audit",
+        "title": "Confluence Audit Logs"
+      }
+    ]
+  },
+  {
+    "name": "atlassian_confluence",
+    "title": "Atlassian Confluence",
+    "version": "1.1.2",
+    "release": "ga",
+    "description": "Collect logs from Atlassian Confluence with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/atlassian_confluence/atlassian_confluence-1.1.2.zip",
+    "path": "/package/atlassian_confluence/1.1.2",
+    "icons": [
+      {
+        "src": "/img/confluence-logo.svg",
+        "path": "/package/atlassian_confluence/1.1.2/img/confluence-logo.svg",
+        "title": "Confluence Logo",
+        "size": "400x400",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "audit",
+        "title": "Audit Logs",
+        "description": "Collect audit logs from Atlassian Confluence with Elastic Agent."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security",
+      "web"
+    ],
+    "signature_path": "/epr/atlassian_confluence/atlassian_confluence-1.1.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_confluence.audit",
+        "title": "Confluence Audit Logs"
+      }
+    ]
+  },
+  {
+    "name": "atlassian_confluence",
+    "title": "Atlassian Confluence",
+    "version": "1.3.0",
+    "release": "ga",
+    "description": "Collect logs from Atlassian Confluence with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/atlassian_confluence/atlassian_confluence-1.3.0.zip",
+    "path": "/package/atlassian_confluence/1.3.0",
+    "icons": [
+      {
+        "src": "/img/confluence-logo.svg",
+        "path": "/package/atlassian_confluence/1.3.0/img/confluence-logo.svg",
+        "title": "Confluence Logo",
+        "size": "400x400",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "audit",
+        "title": "Audit Logs",
+        "description": "Collect audit logs from Atlassian Confluence with Elastic Agent."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security",
+      "web"
+    ],
+    "signature_path": "/epr/atlassian_confluence/atlassian_confluence-1.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_confluence.audit",
+        "title": "Confluence Audit Logs"
+      }
+    ]
+  },
+  {
+    "name": "atlassian_jira",
+    "title": "Atlassian Jira",
+    "version": "1.0.0",
+    "release": "ga",
+    "description": "Collect logs from Atlassian Jira with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/atlassian_jira/atlassian_jira-1.0.0.zip",
+    "path": "/package/atlassian_jira/1.0.0",
+    "icons": [
+      {
+        "src": "/img/jira-software-logo.svg",
+        "path": "/package/atlassian_jira/1.0.0/img/jira-software-logo.svg",
+        "title": "Jira Software Logo",
+        "size": "590x625",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "audit",
+        "title": "Audit Logs",
+        "description": "Collect audit logs from Atlassian Jira with Elastic Agent."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security",
+      "web"
+    ],
+    "signature_path": "/epr/atlassian_jira/atlassian_jira-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_jira.audit",
+        "title": "Jira Audit Logs"
+      }
+    ]
+  },
+  {
+    "name": "atlassian_jira",
+    "title": "Atlassian Jira",
+    "version": "1.0.1",
+    "release": "ga",
+    "description": "Collect logs from Atlassian Jira with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/atlassian_jira/atlassian_jira-1.0.1.zip",
+    "path": "/package/atlassian_jira/1.0.1",
+    "icons": [
+      {
+        "src": "/img/jira-software-logo.svg",
+        "path": "/package/atlassian_jira/1.0.1/img/jira-software-logo.svg",
+        "title": "Jira Software Logo",
+        "size": "590x625",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "audit",
+        "title": "Audit Logs",
+        "description": "Collect audit logs from Atlassian Jira with Elastic Agent."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security",
+      "web"
+    ],
+    "signature_path": "/epr/atlassian_jira/atlassian_jira-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_jira.audit",
+        "title": "Jira Audit Logs"
+      }
+    ]
+  },
+  {
+    "name": "atlassian_jira",
+    "title": "Atlassian Jira",
+    "version": "1.1.0",
+    "release": "ga",
+    "description": "Collect logs from Atlassian Jira with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/atlassian_jira/atlassian_jira-1.1.0.zip",
+    "path": "/package/atlassian_jira/1.1.0",
+    "icons": [
+      {
+        "src": "/img/jira-software-logo.svg",
+        "path": "/package/atlassian_jira/1.1.0/img/jira-software-logo.svg",
+        "title": "Jira Software Logo",
+        "size": "590x625",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "audit",
+        "title": "Audit Logs",
+        "description": "Collect audit logs from Atlassian Jira with Elastic Agent."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security",
+      "web"
+    ],
+    "signature_path": "/epr/atlassian_jira/atlassian_jira-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_jira.audit",
+        "title": "Jira Audit Logs"
+      }
+    ]
+  },
+  {
+    "name": "atlassian_jira",
+    "title": "Atlassian Jira",
+    "version": "1.1.1",
+    "release": "ga",
+    "description": "Collect logs from Atlassian Jira with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/atlassian_jira/atlassian_jira-1.1.1.zip",
+    "path": "/package/atlassian_jira/1.1.1",
+    "icons": [
+      {
+        "src": "/img/jira-software-logo.svg",
+        "path": "/package/atlassian_jira/1.1.1/img/jira-software-logo.svg",
+        "title": "Jira Software Logo",
+        "size": "590x625",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "audit",
+        "title": "Audit Logs",
+        "description": "Collect audit logs from Atlassian Jira with Elastic Agent."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security",
+      "web"
+    ],
+    "signature_path": "/epr/atlassian_jira/atlassian_jira-1.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_jira.audit",
+        "title": "Jira Audit Logs"
+      }
+    ]
+  },
+  {
+    "name": "atlassian_jira",
+    "title": "Atlassian Jira",
+    "version": "1.1.2",
+    "release": "ga",
+    "description": "Collect logs from Atlassian Jira with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/atlassian_jira/atlassian_jira-1.1.2.zip",
+    "path": "/package/atlassian_jira/1.1.2",
+    "icons": [
+      {
+        "src": "/img/jira-software-logo.svg",
+        "path": "/package/atlassian_jira/1.1.2/img/jira-software-logo.svg",
+        "title": "Jira Software Logo",
+        "size": "590x625",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "audit",
+        "title": "Audit Logs",
+        "description": "Collect audit logs from Atlassian Jira with Elastic Agent."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security",
+      "web"
+    ],
+    "signature_path": "/epr/atlassian_jira/atlassian_jira-1.1.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_jira.audit",
+        "title": "Jira Audit Logs"
+      }
+    ]
+  },
+  {
+    "name": "atlassian_jira",
+    "title": "Atlassian Jira",
+    "version": "1.2.0",
+    "release": "ga",
+    "description": "Collect logs from Atlassian Jira with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/atlassian_jira/atlassian_jira-1.2.0.zip",
+    "path": "/package/atlassian_jira/1.2.0",
+    "icons": [
+      {
+        "src": "/img/jira-software-logo.svg",
+        "path": "/package/atlassian_jira/1.2.0/img/jira-software-logo.svg",
+        "title": "Jira Software Logo",
+        "size": "590x625",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "audit",
+        "title": "Audit Logs",
+        "description": "Collect audit logs from Atlassian Jira with Elastic Agent."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security",
+      "web"
+    ],
+    "signature_path": "/epr/atlassian_jira/atlassian_jira-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_jira.audit",
+        "title": "Jira Audit Logs"
+      }
+    ]
+  },
+  {
+    "name": "atlassian_jira",
+    "title": "Atlassian Jira",
+    "version": "1.3.0",
+    "release": "ga",
+    "description": "Collect logs from Atlassian Jira with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/atlassian_jira/atlassian_jira-1.3.0.zip",
+    "path": "/package/atlassian_jira/1.3.0",
+    "icons": [
+      {
+        "src": "/img/jira-software-logo.svg",
+        "path": "/package/atlassian_jira/1.3.0/img/jira-software-logo.svg",
+        "title": "Jira Software Logo",
+        "size": "590x625",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "audit",
+        "title": "Audit Logs",
+        "description": "Collect audit logs from Atlassian Jira with Elastic Agent."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security",
+      "web"
+    ],
+    "signature_path": "/epr/atlassian_jira/atlassian_jira-1.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_jira.audit",
+        "title": "Jira Audit Logs"
+      }
+    ]
+  },
+  {
+    "name": "auditd",
+    "title": "Auditd",
+    "version": "1.0.0",
+    "release": "ga",
+    "description": "Auditd Integration",
+    "type": "integration",
+    "download": "/epr/auditd/auditd-1.0.0.zip",
+    "path": "/package/auditd/1.0.0",
+    "icons": [
+      {
+        "src": "/img/linux.svg",
+        "path": "/package/auditd/1.0.0/img/linux.svg",
+        "title": "linux",
+        "size": "299x354",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "auditd",
+        "title": "Auditd logs",
+        "description": "Collect logs from Auditd instances"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "os_system"
+    ],
+    "signature_path": "/epr/auditd/auditd-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "auditd.log",
+        "title": "Auditd logs"
+      }
+    ]
+  },
+  {
+    "name": "auditd",
+    "title": "Auditd",
+    "version": "1.2.0",
+    "release": "ga",
+    "description": "This Elastic integration collects and parses logs from the Audit daemon (auditd)",
+    "type": "integration",
+    "download": "/epr/auditd/auditd-1.2.0.zip",
+    "path": "/package/auditd/1.2.0",
+    "icons": [
+      {
+        "src": "/img/linux.svg",
+        "path": "/package/auditd/1.2.0/img/linux.svg",
+        "title": "linux",
+        "size": "299x354",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "auditd",
+        "title": "Auditd logs",
+        "description": "Collect logs from Auditd instances"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "os_system"
+    ],
+    "signature_path": "/epr/auditd/auditd-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "auditd.log",
+        "title": "Auditd logs"
+      }
+    ]
+  },
+  {
+    "name": "auditd",
+    "title": "Auditd",
+    "version": "1.2.2",
+    "release": "ga",
+    "description": "This Elastic integration collects and parses logs from the Audit daemon (auditd)",
+    "type": "integration",
+    "download": "/epr/auditd/auditd-1.2.2.zip",
+    "path": "/package/auditd/1.2.2",
+    "icons": [
+      {
+        "src": "/img/linux.svg",
+        "path": "/package/auditd/1.2.2/img/linux.svg",
+        "title": "linux",
+        "size": "299x354",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "auditd",
+        "title": "Auditd logs",
+        "description": "Collect logs from Auditd instances"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "os_system"
+    ],
+    "signature_path": "/epr/auditd/auditd-1.2.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "auditd.log",
+        "title": "Auditd logs"
+      }
+    ]
+  },
+  {
+    "name": "auditd",
+    "title": "Auditd",
+    "version": "1.2.4",
+    "release": "ga",
+    "description": "Collect logs from Linux audit daemon with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/auditd/auditd-1.2.4.zip",
+    "path": "/package/auditd/1.2.4",
+    "icons": [
+      {
+        "src": "/img/linux.svg",
+        "path": "/package/auditd/1.2.4/img/linux.svg",
+        "title": "linux",
+        "size": "299x354",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "auditd",
+        "title": "Auditd logs",
+        "description": "Collect logs from Auditd instances"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "os_system"
+    ],
+    "signature_path": "/epr/auditd/auditd-1.2.4.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "auditd.log",
+        "title": "Auditd logs"
+      }
+    ]
+  },
+  {
+    "name": "auditd",
+    "title": "Auditd",
+    "version": "1.3.0",
+    "release": "ga",
+    "description": "Collect logs from Linux audit daemon with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/auditd/auditd-1.3.0.zip",
+    "path": "/package/auditd/1.3.0",
+    "icons": [
+      {
+        "src": "/img/linux.svg",
+        "path": "/package/auditd/1.3.0/img/linux.svg",
+        "title": "linux",
+        "size": "299x354",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "auditd",
+        "title": "Auditd logs",
+        "description": "Collect logs from Auditd instances"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "os_system"
+    ],
+    "signature_path": "/epr/auditd/auditd-1.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "auditd.log",
+        "title": "Auditd logs"
+      }
+    ]
+  },
+  {
+    "name": "auditd",
+    "title": "Auditd",
+    "version": "1.3.1",
+    "release": "ga",
+    "description": "Collect logs from Linux audit daemon with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/auditd/auditd-1.3.1.zip",
+    "path": "/package/auditd/1.3.1",
+    "icons": [
+      {
+        "src": "/img/linux.svg",
+        "path": "/package/auditd/1.3.1/img/linux.svg",
+        "title": "linux",
+        "size": "299x354",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "auditd",
+        "title": "Auditd logs",
+        "description": "Collect logs from Auditd instances"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "os_system"
+    ],
+    "signature_path": "/epr/auditd/auditd-1.3.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "auditd.log",
+        "title": "Auditd logs"
+      }
+    ]
+  },
+  {
+    "name": "auditd",
+    "title": "Auditd",
+    "version": "2.0.0",
+    "release": "ga",
+    "description": "Collect logs from Linux audit daemon with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/auditd/auditd-2.0.0.zip",
+    "path": "/package/auditd/2.0.0",
+    "icons": [
+      {
+        "src": "/img/linux.svg",
+        "path": "/package/auditd/2.0.0/img/linux.svg",
+        "title": "linux",
+        "size": "299x354",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "auditd",
+        "title": "Auditd logs",
+        "description": "Collect logs from Auditd instances"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.17.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "os_system"
+    ],
+    "signature_path": "/epr/auditd/auditd-2.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "auditd.log",
+        "title": "Auditd logs"
+      }
+    ]
+  },
+  {
+    "name": "auditd",
+    "title": "Auditd",
+    "version": "2.1.0",
+    "release": "ga",
+    "description": "Collect logs from Linux audit daemon with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/auditd/auditd-2.1.0.zip",
+    "path": "/package/auditd/2.1.0",
+    "icons": [
+      {
+        "src": "/img/linux.svg",
+        "path": "/package/auditd/2.1.0/img/linux.svg",
+        "title": "linux",
+        "size": "299x354",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "auditd",
+        "title": "Auditd logs",
+        "description": "Collect logs from Auditd instances"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.17.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "os_system"
+    ],
+    "signature_path": "/epr/auditd/auditd-2.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "auditd.log",
+        "title": "Auditd logs"
+      }
+    ]
+  },
+  {
+    "name": "auditd",
+    "title": "Auditd",
+    "version": "2.1.1",
+    "release": "ga",
+    "description": "Collect logs from Linux audit daemon with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/auditd/auditd-2.1.1.zip",
+    "path": "/package/auditd/2.1.1",
+    "icons": [
+      {
+        "src": "/img/linux.svg",
+        "path": "/package/auditd/2.1.1/img/linux.svg",
+        "title": "linux",
+        "size": "299x354",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "auditd",
+        "title": "Auditd logs",
+        "description": "Collect logs from Auditd instances"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.17.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "os_system"
+    ],
+    "signature_path": "/epr/auditd/auditd-2.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "auditd.log",
+        "title": "Auditd logs"
+      }
+    ]
+  },
+  {
+    "name": "auditd",
+    "title": "Auditd",
+    "version": "2.1.2",
+    "release": "ga",
+    "description": "Collect logs from Linux audit daemon with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/auditd/auditd-2.1.2.zip",
+    "path": "/package/auditd/2.1.2",
+    "icons": [
+      {
+        "src": "/img/linux.svg",
+        "path": "/package/auditd/2.1.2/img/linux.svg",
+        "title": "linux",
+        "size": "299x354",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "auditd",
+        "title": "Auditd logs",
+        "description": "Collect logs from Auditd instances"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.17.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "os_system"
+    ],
+    "signature_path": "/epr/auditd/auditd-2.1.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "auditd.log",
+        "title": "Auditd logs"
+      }
+    ]
+  },
+  {
+    "name": "auditd",
+    "title": "Auditd",
+    "version": "2.2.0",
+    "release": "ga",
+    "description": "Collect logs from Linux audit daemon with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/auditd/auditd-2.2.0.zip",
+    "path": "/package/auditd/2.2.0",
+    "icons": [
+      {
+        "src": "/img/linux.svg",
+        "path": "/package/auditd/2.2.0/img/linux.svg",
+        "title": "linux",
+        "size": "299x354",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "auditd",
+        "title": "Auditd logs",
+        "description": "Collect logs from Auditd instances"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.17.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "os_system"
+    ],
+    "signature_path": "/epr/auditd/auditd-2.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "auditd.log",
+        "title": "Auditd logs"
+      }
+    ]
+  },
+  {
+    "name": "auditd",
+    "title": "Auditd",
+    "version": "3.0.0",
+    "release": "ga",
+    "description": "Collect logs from Linux audit daemon with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/auditd/auditd-3.0.0.zip",
+    "path": "/package/auditd/3.0.0",
+    "icons": [
+      {
+        "src": "/img/linux.svg",
+        "path": "/package/auditd/3.0.0/img/linux.svg",
+        "title": "linux",
+        "size": "299x354",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "auditd",
+        "title": "Auditd logs",
+        "description": "Collect logs from Auditd instances"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "os_system"
+    ],
+    "signature_path": "/epr/auditd/auditd-3.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "auditd.log",
+        "title": "Auditd logs"
+      }
+    ]
+  },
+  {
+    "name": "auditd",
+    "title": "Auditd Logs",
+    "version": "3.1.0",
+    "release": "ga",
+    "description": "Collect logs from Linux audit daemon with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/auditd/auditd-3.1.0.zip",
+    "path": "/package/auditd/3.1.0",
+    "icons": [
+      {
+        "src": "/img/linux.svg",
+        "path": "/package/auditd/3.1.0/img/linux.svg",
+        "title": "linux",
+        "size": "299x354",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "auditd",
+        "title": "Auditd logs",
+        "description": "Collect logs from Auditd instances"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "os_system"
+    ],
+    "signature_path": "/epr/auditd/auditd-3.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "auditd.log",
+        "title": "Auditd logs"
+      }
+    ]
+  },
+  {
+    "name": "auditd_manager",
+    "title": "Auditd Manager",
+    "version": "1.0.0",
+    "release": "ga",
+    "description": "The Auditd Manager Integration receives audit events from the Linux Audit Framework that is a part of the Linux kernel.",
+    "type": "integration",
+    "download": "/epr/auditd_manager/auditd_manager-1.0.0.zip",
+    "path": "/package/auditd_manager/1.0.0",
+    "icons": [
+      {
+        "src": "/img/linux.svg",
+        "path": "/package/auditd_manager/1.0.0/img/linux.svg",
+        "title": "linux",
+        "size": "299x354",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "auditd",
+        "title": "Auditd",
+        "description": "Collect auditd events"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.2.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "os_system",
+      "security"
+    ],
+    "signature_path": "/epr/auditd_manager/auditd_manager-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "auditd_manager.auditd",
+        "title": "Auditd Manager"
+      }
+    ]
+  },
+  {
+    "name": "auth0",
+    "title": "Auth0 Log Streams Integration",
+    "version": "1.0.0",
+    "release": "ga",
+    "description": "Collect logs from Auth0 with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/auth0/auth0-1.0.0.zip",
+    "path": "/package/auth0/1.0.0",
+    "icons": [
+      {
+        "src": "/img/auth0-logo.svg",
+        "path": "/package/auth0/1.0.0/img/auth0-logo.svg",
+        "title": "Auth0 logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "auth0_events",
+        "title": "Auth0 log stream events via Webhooks",
+        "description": "Collect Auth0 log streams events via Webhooks."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "cloud",
+      "network",
+      "security"
+    ],
+    "signature_path": "/epr/auth0/auth0-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "auth0.logs",
+        "title": "Auth0 logs via Webhooks"
       }
     ]
   },
@@ -12393,6 +15247,51 @@
     ]
   },
   {
+    "name": "aws_logs",
+    "title": "Custom AWS Logs",
+    "version": "0.2.1",
+    "release": "beta",
+    "description": "Collect raw logs from AWS S3 or CloudWatch with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/aws_logs/aws_logs-0.2.1.zip",
+    "path": "/package/aws_logs/0.2.1",
+    "icons": [
+      {
+        "src": "/img/icon.svg",
+        "path": "/package/aws_logs/0.2.1/img/icon.svg",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "aws_logs",
+        "title": "Custom AWS Logs",
+        "description": "Collect raw logs from AWS S3 or CloudWatch with Elastic Agent."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/obs-cloud-monitoring"
+    },
+    "categories": [
+      "custom",
+      "cloud",
+      "aws"
+    ],
+    "signature_path": "/epr/aws_logs/aws_logs-0.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "aws_logs.generic",
+        "title": "Custom logs from AWS"
+      }
+    ]
+  },
+  {
     "name": "awsfargate",
     "title": "AWS Fargate",
     "version": "0.1.1",
@@ -12436,3448 +15335,6 @@
         "type": "metrics",
         "dataset": "awsfargate.task_stats",
         "title": "AWS Fargate task_stats metrics"
-      }
-    ]
-  },
-  {
-    "name": "ti_abusech",
-    "title": "AbuseCH",
-    "version": "1.0.4",
-    "release": "ga",
-    "description": "Collect threat intelligence from AbuseCH API with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/ti_abusech/ti_abusech-1.0.4.zip",
-    "path": "/package/ti_abusech/1.0.4",
-    "icons": [
-      {
-        "src": "/img/abusech2.svg",
-        "path": "/package/ti_abusech/1.0.4/img/abusech2.svg",
-        "title": "AbuseCH",
-        "size": "512x512",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "ti_abusech",
-        "title": "AbuseCH API",
-        "description": "Collect threat intelligence from the AbuseCH API"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/ti_abusech/ti_abusech-1.0.4.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ti_abusech.malware",
-        "title": "AbuseCH Malware logs"
-      },
-      {
-        "type": "logs",
-        "dataset": "ti_abusech.malwarebazaar",
-        "title": "AbuseCH MalwareBazaar logs"
-      },
-      {
-        "type": "logs",
-        "dataset": "ti_abusech.url",
-        "title": "AbuseCH URL logs"
-      }
-    ]
-  },
-  {
-    "name": "ti_abusech",
-    "title": "AbuseCH",
-    "version": "1.1.0",
-    "release": "ga",
-    "description": "Collect threat intelligence from AbuseCH API with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/ti_abusech/ti_abusech-1.1.0.zip",
-    "path": "/package/ti_abusech/1.1.0",
-    "icons": [
-      {
-        "src": "/img/abusech2.svg",
-        "path": "/package/ti_abusech/1.1.0/img/abusech2.svg",
-        "title": "AbuseCH",
-        "size": "512x512",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "ti_abusech",
-        "title": "AbuseCH API",
-        "description": "Collect threat intelligence from the AbuseCH API"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/ti_abusech/ti_abusech-1.1.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ti_abusech.malware",
-        "title": "AbuseCH Malware logs"
-      },
-      {
-        "type": "logs",
-        "dataset": "ti_abusech.malwarebazaar",
-        "title": "AbuseCH MalwareBazaar logs"
-      },
-      {
-        "type": "logs",
-        "dataset": "ti_abusech.url",
-        "title": "AbuseCH URL logs"
-      }
-    ]
-  },
-  {
-    "name": "ti_abusech",
-    "title": "AbuseCH",
-    "version": "1.1.4",
-    "release": "ga",
-    "description": "Collect threat intelligence from AbuseCH API with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/ti_abusech/ti_abusech-1.1.4.zip",
-    "path": "/package/ti_abusech/1.1.4",
-    "icons": [
-      {
-        "src": "/img/abusech2.svg",
-        "path": "/package/ti_abusech/1.1.4/img/abusech2.svg",
-        "title": "AbuseCH",
-        "size": "512x512",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "ti_abusech",
-        "title": "AbuseCH API",
-        "description": "Collect threat intelligence from the AbuseCH API"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/ti_abusech/ti_abusech-1.1.4.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ti_abusech.malware",
-        "title": "AbuseCH Malware logs"
-      },
-      {
-        "type": "logs",
-        "dataset": "ti_abusech.malwarebazaar",
-        "title": "AbuseCH MalwareBazaar logs"
-      },
-      {
-        "type": "logs",
-        "dataset": "ti_abusech.url",
-        "title": "AbuseCH URL logs"
-      }
-    ]
-  },
-  {
-    "name": "ti_abusech",
-    "title": "AbuseCH",
-    "version": "1.1.5",
-    "release": "ga",
-    "description": "Collect threat intelligence from AbuseCH API with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/ti_abusech/ti_abusech-1.1.5.zip",
-    "path": "/package/ti_abusech/1.1.5",
-    "icons": [
-      {
-        "src": "/img/abusech2.svg",
-        "path": "/package/ti_abusech/1.1.5/img/abusech2.svg",
-        "title": "AbuseCH",
-        "size": "512x512",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "ti_abusech",
-        "title": "AbuseCH API",
-        "description": "Collect threat intelligence from the AbuseCH API"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/ti_abusech/ti_abusech-1.1.5.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ti_abusech.malware",
-        "title": "AbuseCH Malware logs"
-      },
-      {
-        "type": "logs",
-        "dataset": "ti_abusech.malwarebazaar",
-        "title": "AbuseCH MalwareBazaar logs"
-      },
-      {
-        "type": "logs",
-        "dataset": "ti_abusech.url",
-        "title": "AbuseCH URL logs"
-      }
-    ]
-  },
-  {
-    "name": "ti_abusech",
-    "title": "AbuseCH",
-    "version": "1.2.0",
-    "release": "ga",
-    "description": "Collect threat intelligence from AbuseCH API with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/ti_abusech/ti_abusech-1.2.0.zip",
-    "path": "/package/ti_abusech/1.2.0",
-    "icons": [
-      {
-        "src": "/img/abusech2.svg",
-        "path": "/package/ti_abusech/1.2.0/img/abusech2.svg",
-        "title": "AbuseCH",
-        "size": "512x512",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "ti_abusech",
-        "title": "AbuseCH API",
-        "description": "Collect threat intelligence from the AbuseCH API"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/ti_abusech/ti_abusech-1.2.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ti_abusech.malware",
-        "title": "AbuseCH Malware logs"
-      },
-      {
-        "type": "logs",
-        "dataset": "ti_abusech.malwarebazaar",
-        "title": "AbuseCH MalwareBazaar logs"
-      },
-      {
-        "type": "logs",
-        "dataset": "ti_abusech.url",
-        "title": "AbuseCH URL logs"
-      }
-    ]
-  },
-  {
-    "name": "ti_abusech",
-    "title": "AbuseCH",
-    "version": "1.2.2",
-    "release": "ga",
-    "description": "Collect threat intelligence from AbuseCH API with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/ti_abusech/ti_abusech-1.2.2.zip",
-    "path": "/package/ti_abusech/1.2.2",
-    "icons": [
-      {
-        "src": "/img/abusech2.svg",
-        "path": "/package/ti_abusech/1.2.2/img/abusech2.svg",
-        "title": "AbuseCH",
-        "size": "512x512",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "ti_abusech",
-        "title": "AbuseCH API",
-        "description": "Collect threat intelligence from the AbuseCH API"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/ti_abusech/ti_abusech-1.2.2.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ti_abusech.malware",
-        "title": "AbuseCH Malware logs"
-      },
-      {
-        "type": "logs",
-        "dataset": "ti_abusech.malwarebazaar",
-        "title": "AbuseCH MalwareBazaar logs"
-      },
-      {
-        "type": "logs",
-        "dataset": "ti_abusech.url",
-        "title": "AbuseCH URL logs"
-      }
-    ]
-  },
-  {
-    "name": "ti_abusech",
-    "title": "AbuseCH",
-    "version": "1.2.3",
-    "release": "ga",
-    "description": "Collect threat intelligence from AbuseCH API with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/ti_abusech/ti_abusech-1.2.3.zip",
-    "path": "/package/ti_abusech/1.2.3",
-    "icons": [
-      {
-        "src": "/img/abusech2.svg",
-        "path": "/package/ti_abusech/1.2.3/img/abusech2.svg",
-        "title": "AbuseCH",
-        "size": "512x512",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "ti_abusech",
-        "title": "AbuseCH API",
-        "description": "Collect threat intelligence from the AbuseCH API"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/ti_abusech/ti_abusech-1.2.3.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ti_abusech.malware",
-        "title": "AbuseCH Malware logs"
-      },
-      {
-        "type": "logs",
-        "dataset": "ti_abusech.malwarebazaar",
-        "title": "AbuseCH MalwareBazaar logs"
-      },
-      {
-        "type": "logs",
-        "dataset": "ti_abusech.url",
-        "title": "AbuseCH URL logs"
-      }
-    ]
-  },
-  {
-    "name": "activemq",
-    "title": "ActiveMQ",
-    "version": "0.2.0",
-    "release": "beta",
-    "description": "Collect logs and metrics from ActiveMQ instances with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/activemq/activemq-0.2.0.zip",
-    "path": "/package/activemq/0.2.0",
-    "icons": [
-      {
-        "src": "/img/activemq.svg",
-        "path": "/package/activemq/0.2.0/img/activemq.svg",
-        "title": "activemq",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "activemq",
-        "title": "ActiveMQ logs and metrics",
-        "description": "Collect logs and metrics from ActiveMQ instances"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "web"
-    ],
-    "signature_path": "/epr/activemq/activemq-0.2.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "activemq.audit",
-        "title": "ActiveMQ audit logs"
-      },
-      {
-        "type": "metrics",
-        "dataset": "activemq.broker",
-        "title": "ActiveMQ broker metrics"
-      },
-      {
-        "type": "logs",
-        "dataset": "activemq.log",
-        "title": "ActiveMQ log logs"
-      },
-      {
-        "type": "metrics",
-        "dataset": "activemq.queue",
-        "title": "ActiveMQ queue metrics"
-      },
-      {
-        "type": "metrics",
-        "dataset": "activemq.topic",
-        "title": "ActiveMQ topic metrics"
-      }
-    ]
-  },
-  {
-    "name": "activemq",
-    "title": "ActiveMQ",
-    "version": "0.3.0",
-    "release": "beta",
-    "description": "Collect logs and metrics from ActiveMQ instances with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/activemq/activemq-0.3.0.zip",
-    "path": "/package/activemq/0.3.0",
-    "icons": [
-      {
-        "src": "/img/activemq.svg",
-        "path": "/package/activemq/0.3.0/img/activemq.svg",
-        "title": "activemq",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "activemq",
-        "title": "ActiveMQ logs and metrics",
-        "description": "Collect logs and metrics from ActiveMQ instances"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "web"
-    ],
-    "signature_path": "/epr/activemq/activemq-0.3.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "activemq.audit",
-        "title": "ActiveMQ audit logs"
-      },
-      {
-        "type": "metrics",
-        "dataset": "activemq.broker",
-        "title": "ActiveMQ broker metrics"
-      },
-      {
-        "type": "logs",
-        "dataset": "activemq.log",
-        "title": "ActiveMQ log logs"
-      },
-      {
-        "type": "metrics",
-        "dataset": "activemq.queue",
-        "title": "ActiveMQ queue metrics"
-      },
-      {
-        "type": "metrics",
-        "dataset": "activemq.topic",
-        "title": "ActiveMQ topic metrics"
-      }
-    ]
-  },
-  {
-    "name": "akamai",
-    "title": "Akamai",
-    "version": "0.1.0",
-    "release": "beta",
-    "description": "Akamai Integration",
-    "type": "integration",
-    "download": "/epr/akamai/akamai-0.1.0.zip",
-    "path": "/package/akamai/0.1.0",
-    "icons": [
-      {
-        "src": "/img/akamai_logo.svg",
-        "path": "/package/akamai/0.1.0/img/akamai_logo.svg",
-        "title": "Akamai",
-        "size": "409×167",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "akamai",
-        "title": "Akamai logs",
-        "description": "Collect SIEM logs from Akamai"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security",
-      "network",
-      "web",
-      "cloud"
-    ],
-    "signature_path": "/epr/akamai/akamai-0.1.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "akamai.siem",
-        "title": "Akamai SIEM Logs"
-      }
-    ]
-  },
-  {
-    "name": "akamai",
-    "title": "Akamai",
-    "version": "0.1.1",
-    "release": "beta",
-    "description": "Akamai Integration",
-    "type": "integration",
-    "download": "/epr/akamai/akamai-0.1.1.zip",
-    "path": "/package/akamai/0.1.1",
-    "icons": [
-      {
-        "src": "/img/akamai_logo.svg",
-        "path": "/package/akamai/0.1.1/img/akamai_logo.svg",
-        "title": "Akamai",
-        "size": "409×167",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "akamai",
-        "title": "Akamai logs",
-        "description": "Collect SIEM logs from Akamai"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security",
-      "network",
-      "web",
-      "cloud"
-    ],
-    "signature_path": "/epr/akamai/akamai-0.1.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "akamai.siem",
-        "title": "Akamai SIEM Logs"
-      }
-    ]
-  },
-  {
-    "name": "akamai",
-    "title": "Akamai",
-    "version": "0.1.2",
-    "release": "beta",
-    "description": "Akamai Integration",
-    "type": "integration",
-    "download": "/epr/akamai/akamai-0.1.2.zip",
-    "path": "/package/akamai/0.1.2",
-    "icons": [
-      {
-        "src": "/img/akamai_logo.svg",
-        "path": "/package/akamai/0.1.2/img/akamai_logo.svg",
-        "title": "Akamai",
-        "size": "409×167",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "akamai",
-        "title": "Akamai logs",
-        "description": "Collect SIEM logs from Akamai"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security",
-      "network",
-      "web",
-      "cloud"
-    ],
-    "signature_path": "/epr/akamai/akamai-0.1.2.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "akamai.siem",
-        "title": "Akamai SIEM Logs"
-      }
-    ]
-  },
-  {
-    "name": "akamai",
-    "title": "Akamai",
-    "version": "0.1.3",
-    "release": "beta",
-    "description": "Akamai Integration",
-    "type": "integration",
-    "download": "/epr/akamai/akamai-0.1.3.zip",
-    "path": "/package/akamai/0.1.3",
-    "icons": [
-      {
-        "src": "/img/akamai_logo.svg",
-        "path": "/package/akamai/0.1.3/img/akamai_logo.svg",
-        "title": "Akamai",
-        "size": "409×167",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "akamai",
-        "title": "Akamai logs",
-        "description": "Collect SIEM logs from Akamai"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security",
-      "network",
-      "web",
-      "cloud"
-    ],
-    "signature_path": "/epr/akamai/akamai-0.1.3.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "akamai.siem",
-        "title": "Akamai SIEM Logs"
-      }
-    ]
-  },
-  {
-    "name": "akamai",
-    "title": "Akamai",
-    "version": "0.2.0",
-    "release": "beta",
-    "description": "Akamai Integration",
-    "type": "integration",
-    "download": "/epr/akamai/akamai-0.2.0.zip",
-    "path": "/package/akamai/0.2.0",
-    "icons": [
-      {
-        "src": "/img/akamai_logo.svg",
-        "path": "/package/akamai/0.2.0/img/akamai_logo.svg",
-        "title": "Akamai",
-        "size": "409×167",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "akamai",
-        "title": "Akamai logs",
-        "description": "Collect SIEM logs from Akamai"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security",
-      "network",
-      "web",
-      "cloud"
-    ],
-    "signature_path": "/epr/akamai/akamai-0.2.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "akamai.siem",
-        "title": "Akamai SIEM Logs"
-      }
-    ]
-  },
-  {
-    "name": "akamai",
-    "title": "Akamai",
-    "version": "1.0.0",
-    "release": "ga",
-    "description": "Akamai Integration",
-    "type": "integration",
-    "download": "/epr/akamai/akamai-1.0.0.zip",
-    "path": "/package/akamai/1.0.0",
-    "icons": [
-      {
-        "src": "/img/akamai_logo.svg",
-        "path": "/package/akamai/1.0.0/img/akamai_logo.svg",
-        "title": "Akamai",
-        "size": "409×167",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "akamai",
-        "title": "Akamai logs",
-        "description": "Collect SIEM logs from Akamai"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security",
-      "network",
-      "web",
-      "cloud"
-    ],
-    "signature_path": "/epr/akamai/akamai-1.0.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "akamai.siem",
-        "title": "Akamai SIEM Logs"
-      }
-    ]
-  },
-  {
-    "name": "akamai",
-    "title": "Akamai",
-    "version": "2.28.0",
-    "release": "ga",
-    "description": "Collect logs from Akamai with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/akamai/akamai-2.28.0.zip",
-    "path": "/package/akamai/2.28.0",
-    "icons": [
-      {
-        "src": "/img/akamai_logo.svg",
-        "path": "/package/akamai/2.28.0/img/akamai_logo.svg",
-        "title": "Akamai",
-        "size": "409×167",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "akamai",
-        "title": "Akamai logs",
-        "description": "Collect SIEM logs from Akamai"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.13.0 || ^9.0.0"
-      }
-    },
-    "owner": {
-      "type": "community",
-      "github": "elastic/security-service-integrations"
-    },
-    "categories": [
-      "security",
-      "cdn_security"
-    ],
-    "signature_path": "/epr/akamai/akamai-2.28.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "akamai.siem",
-        "title": "Akamai SIEM Logs"
-      }
-    ]
-  },
-  {
-    "name": "ti_otx",
-    "title": "AlienVault OTX",
-    "version": "1.0.2",
-    "release": "ga",
-    "description": "Collect threat intelligence from AlienVault OTX with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/ti_otx/ti_otx-1.0.2.zip",
-    "path": "/package/ti_otx/1.0.2",
-    "icons": [
-      {
-        "src": "/img/otx.svg",
-        "path": "/package/ti_otx/1.0.2/img/otx.svg",
-        "title": "Alienvault OTX",
-        "size": "216x216",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "ti_otx",
-        "title": "Alienvault OTX",
-        "description": "Collect threat intelligence from the Alienvault OTX"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/ti_otx/ti_otx-1.0.2.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ti_otx.threat",
-        "title": "Alienvault OTX logs"
-      }
-    ]
-  },
-  {
-    "name": "ti_otx",
-    "title": "AlienVault OTX",
-    "version": "1.0.3",
-    "release": "ga",
-    "description": "Collect threat intelligence from AlienVault OTX with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/ti_otx/ti_otx-1.0.3.zip",
-    "path": "/package/ti_otx/1.0.3",
-    "icons": [
-      {
-        "src": "/img/otx.svg",
-        "path": "/package/ti_otx/1.0.3/img/otx.svg",
-        "title": "Alienvault OTX",
-        "size": "216x216",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "ti_otx",
-        "title": "Alienvault OTX",
-        "description": "Collect threat intelligence from the Alienvault OTX"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/ti_otx/ti_otx-1.0.3.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ti_otx.threat",
-        "title": "Alienvault OTX logs"
-      }
-    ]
-  },
-  {
-    "name": "ti_otx",
-    "title": "AlienVault OTX",
-    "version": "1.1.0",
-    "release": "ga",
-    "description": "Collect threat intelligence from AlienVault OTX with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/ti_otx/ti_otx-1.1.0.zip",
-    "path": "/package/ti_otx/1.1.0",
-    "icons": [
-      {
-        "src": "/img/otx.svg",
-        "path": "/package/ti_otx/1.1.0/img/otx.svg",
-        "title": "Alienvault OTX",
-        "size": "216x216",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "ti_otx",
-        "title": "Alienvault OTX",
-        "description": "Collect threat intelligence from the Alienvault OTX"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/ti_otx/ti_otx-1.1.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ti_otx.threat",
-        "title": "Alienvault OTX logs"
-      }
-    ]
-  },
-  {
-    "name": "ti_otx",
-    "title": "AlienVault OTX",
-    "version": "1.2.0",
-    "release": "ga",
-    "description": "Collect threat intelligence from AlienVault OTX with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/ti_otx/ti_otx-1.2.0.zip",
-    "path": "/package/ti_otx/1.2.0",
-    "icons": [
-      {
-        "src": "/img/otx.svg",
-        "path": "/package/ti_otx/1.2.0/img/otx.svg",
-        "title": "Alienvault OTX",
-        "size": "216x216",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "ti_otx",
-        "title": "Alienvault OTX",
-        "description": "Collect threat intelligence from the Alienvault OTX"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/ti_otx/ti_otx-1.2.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ti_otx.threat",
-        "title": "Alienvault OTX logs"
-      }
-    ]
-  },
-  {
-    "name": "ti_otx",
-    "title": "AlienVault OTX",
-    "version": "1.2.1",
-    "release": "ga",
-    "description": "Collect threat intelligence from AlienVault OTX with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/ti_otx/ti_otx-1.2.1.zip",
-    "path": "/package/ti_otx/1.2.1",
-    "icons": [
-      {
-        "src": "/img/otx.svg",
-        "path": "/package/ti_otx/1.2.1/img/otx.svg",
-        "title": "Alienvault OTX",
-        "size": "216x216",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "ti_otx",
-        "title": "Alienvault OTX",
-        "description": "Collect threat intelligence from the Alienvault OTX"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/ti_otx/ti_otx-1.2.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ti_otx.threat",
-        "title": "Alienvault OTX logs"
-      }
-    ]
-  },
-  {
-    "name": "ti_otx",
-    "title": "AlienVault OTX",
-    "version": "1.2.2",
-    "release": "ga",
-    "description": "Collect threat intelligence from AlienVault OTX with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/ti_otx/ti_otx-1.2.2.zip",
-    "path": "/package/ti_otx/1.2.2",
-    "icons": [
-      {
-        "src": "/img/otx.svg",
-        "path": "/package/ti_otx/1.2.2/img/otx.svg",
-        "title": "Alienvault OTX",
-        "size": "216x216",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "ti_otx",
-        "title": "Alienvault OTX",
-        "description": "Collect threat intelligence from the Alienvault OTX"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/ti_otx/ti_otx-1.2.2.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ti_otx.threat",
-        "title": "Alienvault OTX logs"
-      }
-    ]
-  },
-  {
-    "name": "ti_anomali",
-    "title": "Anomali",
-    "version": "1.0.2",
-    "release": "ga",
-    "description": "Collect threat intelligence from Anomali APIs with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/ti_anomali/ti_anomali-1.0.2.zip",
-    "path": "/package/ti_anomali/1.0.2",
-    "icons": [
-      {
-        "src": "/img/anomali.svg",
-        "path": "/package/ti_anomali/1.0.2/img/anomali.svg",
-        "title": "Anomali",
-        "size": "216x216",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "ti_anomali",
-        "title": "Anomali",
-        "description": "Collect threat intelligence from the Anomali Limo API and Anomali Threatstream."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/ti_anomali/ti_anomali-1.0.2.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ti_anomali.limo",
-        "title": "Anomali Limo"
-      },
-      {
-        "type": "logs",
-        "dataset": "ti_anomali.threatstream",
-        "title": "Anomali Threatstream"
-      }
-    ]
-  },
-  {
-    "name": "ti_anomali",
-    "title": "Anomali",
-    "version": "1.1.3",
-    "release": "ga",
-    "description": "Collect threat intelligence from Anomali APIs with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/ti_anomali/ti_anomali-1.1.3.zip",
-    "path": "/package/ti_anomali/1.1.3",
-    "icons": [
-      {
-        "src": "/img/anomali.svg",
-        "path": "/package/ti_anomali/1.1.3/img/anomali.svg",
-        "title": "Anomali",
-        "size": "216x216",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "ti_anomali",
-        "title": "Anomali",
-        "description": "Collect threat intelligence from the Anomali Limo API and Anomali Threatstream."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/ti_anomali/ti_anomali-1.1.3.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ti_anomali.limo",
-        "title": "Anomali Limo"
-      },
-      {
-        "type": "logs",
-        "dataset": "ti_anomali.threatstream",
-        "title": "Anomali Threatstream"
-      }
-    ]
-  },
-  {
-    "name": "ti_anomali",
-    "title": "Anomali",
-    "version": "1.2.0",
-    "release": "ga",
-    "description": "Collect threat intelligence from Anomali APIs with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/ti_anomali/ti_anomali-1.2.0.zip",
-    "path": "/package/ti_anomali/1.2.0",
-    "icons": [
-      {
-        "src": "/img/anomali.svg",
-        "path": "/package/ti_anomali/1.2.0/img/anomali.svg",
-        "title": "Anomali",
-        "size": "216x216",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "ti_anomali",
-        "title": "Anomali",
-        "description": "Collect threat intelligence from the Anomali Limo API and Anomali Threatstream."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/ti_anomali/ti_anomali-1.2.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ti_anomali.limo",
-        "title": "Anomali Limo"
-      },
-      {
-        "type": "logs",
-        "dataset": "ti_anomali.threatstream",
-        "title": "Anomali Threatstream"
-      }
-    ]
-  },
-  {
-    "name": "ti_anomali",
-    "title": "Anomali",
-    "version": "1.2.1",
-    "release": "ga",
-    "description": "Collect threat intelligence from Anomali APIs with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/ti_anomali/ti_anomali-1.2.1.zip",
-    "path": "/package/ti_anomali/1.2.1",
-    "icons": [
-      {
-        "src": "/img/anomali.svg",
-        "path": "/package/ti_anomali/1.2.1/img/anomali.svg",
-        "title": "Anomali",
-        "size": "216x216",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "ti_anomali",
-        "title": "Anomali",
-        "description": "Collect threat intelligence from the Anomali Limo API and Anomali Threatstream."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/ti_anomali/ti_anomali-1.2.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ti_anomali.limo",
-        "title": "Anomali Limo"
-      },
-      {
-        "type": "logs",
-        "dataset": "ti_anomali.threatstream",
-        "title": "Anomali Threatstream"
-      }
-    ]
-  },
-  {
-    "name": "ti_anomali",
-    "title": "Anomali",
-    "version": "1.2.2",
-    "release": "ga",
-    "description": "Collect threat intelligence from Anomali APIs with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/ti_anomali/ti_anomali-1.2.2.zip",
-    "path": "/package/ti_anomali/1.2.2",
-    "icons": [
-      {
-        "src": "/img/anomali.svg",
-        "path": "/package/ti_anomali/1.2.2/img/anomali.svg",
-        "title": "Anomali",
-        "size": "216x216",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "ti_anomali",
-        "title": "Anomali",
-        "description": "Collect threat intelligence from the Anomali Limo API and Anomali Threatstream."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/ti_anomali/ti_anomali-1.2.2.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ti_anomali.limo",
-        "title": "Anomali Limo"
-      },
-      {
-        "type": "logs",
-        "dataset": "ti_anomali.threatstream",
-        "title": "Anomali Threatstream"
-      }
-    ]
-  },
-  {
-    "name": "ti_anomali",
-    "title": "Anomali",
-    "version": "1.2.3",
-    "release": "ga",
-    "description": "Collect threat intelligence from Anomali APIs with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/ti_anomali/ti_anomali-1.2.3.zip",
-    "path": "/package/ti_anomali/1.2.3",
-    "icons": [
-      {
-        "src": "/img/anomali.svg",
-        "path": "/package/ti_anomali/1.2.3/img/anomali.svg",
-        "title": "Anomali",
-        "size": "216x216",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "ti_anomali",
-        "title": "Anomali",
-        "description": "Collect threat intelligence from the Anomali Limo API and Anomali Threatstream."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/ti_anomali/ti_anomali-1.2.3.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ti_anomali.limo",
-        "title": "Anomali Limo"
-      },
-      {
-        "type": "logs",
-        "dataset": "ti_anomali.threatstream",
-        "title": "Anomali Threatstream"
-      }
-    ]
-  },
-  {
-    "name": "apache",
-    "title": "Apache",
-    "version": "1.1.0",
-    "release": "ga",
-    "description": "This Elastic integration collects logs and metrics from Apache servers",
-    "type": "integration",
-    "download": "/epr/apache/apache-1.1.0.zip",
-    "path": "/package/apache/1.1.0",
-    "icons": [
-      {
-        "src": "/img/logo_apache.svg",
-        "path": "/package/apache/1.1.0/img/logo_apache.svg",
-        "title": "Apache Logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "apache",
-        "title": "Apache logs and metrics",
-        "description": "Collect logs and metrics from Apache instances"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "web"
-    ],
-    "signature_path": "/epr/apache/apache-1.1.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "apache.access",
-        "title": "Apache access logs"
-      },
-      {
-        "type": "logs",
-        "dataset": "apache.error",
-        "title": "Apache error logs"
-      },
-      {
-        "type": "metrics",
-        "dataset": "apache.status",
-        "title": "Apache status metrics"
-      }
-    ],
-    "deprecated": {
-      "since": "1.3.0",
-      "description": "This package is deprecated"
-    }
-  },
-  {
-    "name": "apache",
-    "title": "Apache HTTP Server",
-    "version": "1.3.0",
-    "release": "ga",
-    "description": "Collect logs and metrics from Apache servers with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/apache/apache-1.3.0.zip",
-    "path": "/package/apache/1.3.0",
-    "icons": [
-      {
-        "src": "/img/logo_apache.svg",
-        "path": "/package/apache/1.3.0/img/logo_apache.svg",
-        "title": "Apache Logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "apache",
-        "title": "Apache logs and metrics",
-        "description": "Collect logs and metrics from Apache instances"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "web"
-    ],
-    "signature_path": "/epr/apache/apache-1.3.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "apache.access",
-        "title": "Apache access logs"
-      },
-      {
-        "type": "logs",
-        "dataset": "apache.error",
-        "title": "Apache error logs"
-      },
-      {
-        "type": "metrics",
-        "dataset": "apache.status",
-        "title": "Apache status metrics"
-      }
-    ],
-    "deprecated": {
-      "since": "1.3.0",
-      "description": "This package is deprecated"
-    }
-  },
-  {
-    "name": "apache",
-    "title": "Apache HTTP Server",
-    "version": "1.3.2",
-    "release": "ga",
-    "description": "Collect logs and metrics from Apache servers with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/apache/apache-1.3.2.zip",
-    "path": "/package/apache/1.3.2",
-    "icons": [
-      {
-        "src": "/img/logo_apache.svg",
-        "path": "/package/apache/1.3.2/img/logo_apache.svg",
-        "title": "Apache Logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "apache",
-        "title": "Apache logs and metrics",
-        "description": "Collect logs and metrics from Apache instances"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "web"
-    ],
-    "signature_path": "/epr/apache/apache-1.3.2.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "apache.access",
-        "title": "Apache access logs"
-      },
-      {
-        "type": "logs",
-        "dataset": "apache.error",
-        "title": "Apache error logs"
-      },
-      {
-        "type": "metrics",
-        "dataset": "apache.status",
-        "title": "Apache status metrics"
-      }
-    ],
-    "deprecated": {
-      "since": "1.3.0",
-      "description": "This package is deprecated"
-    }
-  },
-  {
-    "name": "apache",
-    "title": "Apache HTTP Server",
-    "version": "1.3.5",
-    "release": "ga",
-    "description": "Collect logs and metrics from Apache servers with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/apache/apache-1.3.5.zip",
-    "path": "/package/apache/1.3.5",
-    "icons": [
-      {
-        "src": "/img/logo_apache.svg",
-        "path": "/package/apache/1.3.5/img/logo_apache.svg",
-        "title": "Apache Logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "apache",
-        "title": "Apache logs and metrics",
-        "description": "Collect logs and metrics from Apache instances"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "web"
-    ],
-    "signature_path": "/epr/apache/apache-1.3.5.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "apache.access",
-        "title": "Apache access logs",
-        "deprecated": {
-          "since": "1.3.5",
-          "description": "This data stream is deprecated"
-        }
-      },
-      {
-        "type": "logs",
-        "dataset": "apache.error",
-        "title": "Apache error logs"
-      },
-      {
-        "type": "metrics",
-        "dataset": "apache.status",
-        "title": "Apache status metrics"
-      }
-    ],
-    "deprecated": {
-      "since": "1.3.0",
-      "description": "This package is deprecated"
-    }
-  },
-  {
-    "name": "tomcat",
-    "title": "Apache Tomcat",
-    "version": "1.0.0",
-    "release": "ga",
-    "description": "This Elastic integration collects logs from Apache Tomcat",
-    "type": "integration",
-    "download": "/epr/tomcat/tomcat-1.0.0.zip",
-    "path": "/package/tomcat/1.0.0",
-    "icons": [
-      {
-        "src": "/img/logo.svg",
-        "path": "/package/tomcat/1.0.0/img/logo.svg",
-        "title": "Apache Tomcat logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "log",
-        "title": "Apache Tomcat",
-        "description": "Collect Apache Tomcat logs from syslog or a file."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.1"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "web",
-      "security"
-    ],
-    "signature_path": "/epr/tomcat/tomcat-1.0.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "tomcat.log",
-        "title": "Apache Tomcat logs"
-      }
-    ]
-  },
-  {
-    "name": "tomcat",
-    "title": "Apache Tomcat",
-    "version": "1.1.0",
-    "release": "ga",
-    "description": "This Elastic integration collects logs from Apache Tomcat",
-    "type": "integration",
-    "download": "/epr/tomcat/tomcat-1.1.0.zip",
-    "path": "/package/tomcat/1.1.0",
-    "icons": [
-      {
-        "src": "/img/logo.svg",
-        "path": "/package/tomcat/1.1.0/img/logo.svg",
-        "title": "Apache Tomcat logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "log",
-        "title": "Apache Tomcat",
-        "description": "Collect Apache Tomcat logs from syslog or a file."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.1"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "web",
-      "security"
-    ],
-    "signature_path": "/epr/tomcat/tomcat-1.1.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "tomcat.log",
-        "title": "Apache Tomcat logs"
-      }
-    ]
-  },
-  {
-    "name": "tomcat",
-    "title": "Apache Tomcat",
-    "version": "1.1.4",
-    "release": "ga",
-    "description": "Collect and parse logs from Apache Tomcat servers with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/tomcat/tomcat-1.1.4.zip",
-    "path": "/package/tomcat/1.1.4",
-    "icons": [
-      {
-        "src": "/img/logo.svg",
-        "path": "/package/tomcat/1.1.4/img/logo.svg",
-        "title": "Apache Tomcat logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "log",
-        "title": "Apache Tomcat",
-        "description": "Collect Apache Tomcat logs from syslog or a file."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.1"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "web",
-      "security"
-    ],
-    "signature_path": "/epr/tomcat/tomcat-1.1.4.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "tomcat.log",
-        "title": "Apache Tomcat logs"
-      }
-    ]
-  },
-  {
-    "name": "tomcat",
-    "title": "Apache Tomcat",
-    "version": "1.2.0",
-    "release": "ga",
-    "description": "Collect and parse logs from Apache Tomcat servers with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/tomcat/tomcat-1.2.0.zip",
-    "path": "/package/tomcat/1.2.0",
-    "icons": [
-      {
-        "src": "/img/logo.svg",
-        "path": "/package/tomcat/1.2.0/img/logo.svg",
-        "title": "Apache Tomcat logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "log",
-        "title": "Apache Tomcat",
-        "description": "Collect Apache Tomcat logs from syslog or a file."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.1 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "web",
-      "security"
-    ],
-    "signature_path": "/epr/tomcat/tomcat-1.2.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "tomcat.log",
-        "title": "Apache Tomcat logs"
-      }
-    ]
-  },
-  {
-    "name": "tomcat",
-    "title": "Apache Tomcat",
-    "version": "1.2.1",
-    "release": "ga",
-    "description": "Collect and parse logs from Apache Tomcat servers with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/tomcat/tomcat-1.2.1.zip",
-    "path": "/package/tomcat/1.2.1",
-    "icons": [
-      {
-        "src": "/img/logo.svg",
-        "path": "/package/tomcat/1.2.1/img/logo.svg",
-        "title": "Apache Tomcat logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "log",
-        "title": "Apache Tomcat",
-        "description": "Collect Apache Tomcat logs from syslog or a file."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.1 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "web",
-      "security"
-    ],
-    "signature_path": "/epr/tomcat/tomcat-1.2.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "tomcat.log",
-        "title": "Apache Tomcat logs"
-      }
-    ]
-  },
-  {
-    "name": "tomcat",
-    "title": "Apache Tomcat",
-    "version": "1.3.0",
-    "release": "ga",
-    "description": "Collect and parse logs from Apache Tomcat servers with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/tomcat/tomcat-1.3.0.zip",
-    "path": "/package/tomcat/1.3.0",
-    "icons": [
-      {
-        "src": "/img/logo.svg",
-        "path": "/package/tomcat/1.3.0/img/logo.svg",
-        "title": "Apache Tomcat logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "log",
-        "title": "Apache Tomcat",
-        "description": "Collect Apache Tomcat logs from syslog or a file."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.1 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "web",
-      "security"
-    ],
-    "signature_path": "/epr/tomcat/tomcat-1.3.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "tomcat.log",
-        "title": "Apache Tomcat logs"
-      }
-    ]
-  },
-  {
-    "name": "tomcat",
-    "title": "Apache Tomcat",
-    "version": "1.3.1",
-    "release": "ga",
-    "description": "Collect and parse logs from Apache Tomcat servers with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/tomcat/tomcat-1.3.1.zip",
-    "path": "/package/tomcat/1.3.1",
-    "icons": [
-      {
-        "src": "/img/logo.svg",
-        "path": "/package/tomcat/1.3.1/img/logo.svg",
-        "title": "Apache Tomcat logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "log",
-        "title": "Apache Tomcat",
-        "description": "Collect Apache Tomcat logs from syslog or a file."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.1 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "web",
-      "security"
-    ],
-    "signature_path": "/epr/tomcat/tomcat-1.3.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "tomcat.log",
-        "title": "Apache Tomcat logs"
-      }
-    ]
-  },
-  {
-    "name": "atlassian_bitbucket",
-    "title": "Atlassian Bitbucket",
-    "version": "1.0.0",
-    "release": "ga",
-    "description": "Collect logs from Atlassian Bitbucket with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.0.0.zip",
-    "path": "/package/atlassian_bitbucket/1.0.0",
-    "icons": [
-      {
-        "src": "/img/bitbucket-logo.svg",
-        "path": "/package/atlassian_bitbucket/1.0.0/img/bitbucket-logo.svg",
-        "title": "Bitbucket Logo",
-        "size": "625x564",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "audit",
-        "title": "Audit Logs",
-        "description": "Collect audit logs from Atlassian Bitbucket with Elastic Agent."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security",
-      "web"
-    ],
-    "signature_path": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.0.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "atlassian_bitbucket.audit",
-        "title": "Bitbucket Audit Logs"
-      }
-    ]
-  },
-  {
-    "name": "atlassian_bitbucket",
-    "title": "Atlassian Bitbucket",
-    "version": "1.0.1",
-    "release": "ga",
-    "description": "Collect logs from Atlassian Bitbucket with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.0.1.zip",
-    "path": "/package/atlassian_bitbucket/1.0.1",
-    "icons": [
-      {
-        "src": "/img/bitbucket-logo.svg",
-        "path": "/package/atlassian_bitbucket/1.0.1/img/bitbucket-logo.svg",
-        "title": "Bitbucket Logo",
-        "size": "625x564",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "audit",
-        "title": "Audit Logs",
-        "description": "Collect audit logs from Atlassian Bitbucket with Elastic Agent."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security",
-      "web"
-    ],
-    "signature_path": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.0.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "atlassian_bitbucket.audit",
-        "title": "Bitbucket Audit Logs"
-      }
-    ]
-  },
-  {
-    "name": "atlassian_bitbucket",
-    "title": "Atlassian Bitbucket",
-    "version": "1.1.0",
-    "release": "ga",
-    "description": "Collect logs from Atlassian Bitbucket with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.1.0.zip",
-    "path": "/package/atlassian_bitbucket/1.1.0",
-    "icons": [
-      {
-        "src": "/img/bitbucket-logo.svg",
-        "path": "/package/atlassian_bitbucket/1.1.0/img/bitbucket-logo.svg",
-        "title": "Bitbucket Logo",
-        "size": "625x564",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "audit",
-        "title": "Audit Logs",
-        "description": "Collect audit logs from Atlassian Bitbucket with Elastic Agent."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security",
-      "web"
-    ],
-    "signature_path": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.1.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "atlassian_bitbucket.audit",
-        "title": "Bitbucket Audit Logs"
-      }
-    ]
-  },
-  {
-    "name": "atlassian_bitbucket",
-    "title": "Atlassian Bitbucket",
-    "version": "1.1.1",
-    "release": "ga",
-    "description": "Collect logs from Atlassian Bitbucket with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.1.1.zip",
-    "path": "/package/atlassian_bitbucket/1.1.1",
-    "icons": [
-      {
-        "src": "/img/bitbucket-logo.svg",
-        "path": "/package/atlassian_bitbucket/1.1.1/img/bitbucket-logo.svg",
-        "title": "Bitbucket Logo",
-        "size": "625x564",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "audit",
-        "title": "Audit Logs",
-        "description": "Collect audit logs from Atlassian Bitbucket with Elastic Agent."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security",
-      "web"
-    ],
-    "signature_path": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.1.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "atlassian_bitbucket.audit",
-        "title": "Bitbucket Audit Logs"
-      }
-    ]
-  },
-  {
-    "name": "atlassian_bitbucket",
-    "title": "Atlassian Bitbucket",
-    "version": "1.2.1",
-    "release": "ga",
-    "description": "Collect logs from Atlassian Bitbucket with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.2.1.zip",
-    "path": "/package/atlassian_bitbucket/1.2.1",
-    "icons": [
-      {
-        "src": "/img/bitbucket-logo.svg",
-        "path": "/package/atlassian_bitbucket/1.2.1/img/bitbucket-logo.svg",
-        "title": "Bitbucket Logo",
-        "size": "625x564",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "audit",
-        "title": "Audit Logs",
-        "description": "Collect audit logs from Atlassian Bitbucket with Elastic Agent."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security",
-      "web"
-    ],
-    "signature_path": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.2.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "atlassian_bitbucket.audit",
-        "title": "Bitbucket Audit Logs"
-      }
-    ]
-  },
-  {
-    "name": "atlassian_confluence",
-    "title": "Atlassian Confluence",
-    "version": "1.0.1",
-    "release": "ga",
-    "description": "Collect logs from Atlassian Confluence with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/atlassian_confluence/atlassian_confluence-1.0.1.zip",
-    "path": "/package/atlassian_confluence/1.0.1",
-    "icons": [
-      {
-        "src": "/img/confluence-logo.svg",
-        "path": "/package/atlassian_confluence/1.0.1/img/confluence-logo.svg",
-        "title": "Confluence Logo",
-        "size": "400x400",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "audit",
-        "title": "Audit Logs",
-        "description": "Collect audit logs from Atlassian Confluence with Elastic Agent."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security",
-      "web"
-    ],
-    "signature_path": "/epr/atlassian_confluence/atlassian_confluence-1.0.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "atlassian_confluence.audit",
-        "title": "Confluence Audit Logs"
-      }
-    ]
-  },
-  {
-    "name": "atlassian_confluence",
-    "title": "Atlassian Confluence",
-    "version": "1.1.0",
-    "release": "ga",
-    "description": "Collect logs from Atlassian Confluence with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/atlassian_confluence/atlassian_confluence-1.1.0.zip",
-    "path": "/package/atlassian_confluence/1.1.0",
-    "icons": [
-      {
-        "src": "/img/confluence-logo.svg",
-        "path": "/package/atlassian_confluence/1.1.0/img/confluence-logo.svg",
-        "title": "Confluence Logo",
-        "size": "400x400",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "audit",
-        "title": "Audit Logs",
-        "description": "Collect audit logs from Atlassian Confluence with Elastic Agent."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security",
-      "web"
-    ],
-    "signature_path": "/epr/atlassian_confluence/atlassian_confluence-1.1.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "atlassian_confluence.audit",
-        "title": "Confluence Audit Logs"
-      }
-    ]
-  },
-  {
-    "name": "atlassian_confluence",
-    "title": "Atlassian Confluence",
-    "version": "1.1.1",
-    "release": "ga",
-    "description": "Collect logs from Atlassian Confluence with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/atlassian_confluence/atlassian_confluence-1.1.1.zip",
-    "path": "/package/atlassian_confluence/1.1.1",
-    "icons": [
-      {
-        "src": "/img/confluence-logo.svg",
-        "path": "/package/atlassian_confluence/1.1.1/img/confluence-logo.svg",
-        "title": "Confluence Logo",
-        "size": "400x400",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "audit",
-        "title": "Audit Logs",
-        "description": "Collect audit logs from Atlassian Confluence with Elastic Agent."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security",
-      "web"
-    ],
-    "signature_path": "/epr/atlassian_confluence/atlassian_confluence-1.1.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "atlassian_confluence.audit",
-        "title": "Confluence Audit Logs"
-      }
-    ]
-  },
-  {
-    "name": "atlassian_confluence",
-    "title": "Atlassian Confluence",
-    "version": "1.1.2",
-    "release": "ga",
-    "description": "Collect logs from Atlassian Confluence with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/atlassian_confluence/atlassian_confluence-1.1.2.zip",
-    "path": "/package/atlassian_confluence/1.1.2",
-    "icons": [
-      {
-        "src": "/img/confluence-logo.svg",
-        "path": "/package/atlassian_confluence/1.1.2/img/confluence-logo.svg",
-        "title": "Confluence Logo",
-        "size": "400x400",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "audit",
-        "title": "Audit Logs",
-        "description": "Collect audit logs from Atlassian Confluence with Elastic Agent."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security",
-      "web"
-    ],
-    "signature_path": "/epr/atlassian_confluence/atlassian_confluence-1.1.2.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "atlassian_confluence.audit",
-        "title": "Confluence Audit Logs"
-      }
-    ]
-  },
-  {
-    "name": "atlassian_confluence",
-    "title": "Atlassian Confluence",
-    "version": "1.3.0",
-    "release": "ga",
-    "description": "Collect logs from Atlassian Confluence with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/atlassian_confluence/atlassian_confluence-1.3.0.zip",
-    "path": "/package/atlassian_confluence/1.3.0",
-    "icons": [
-      {
-        "src": "/img/confluence-logo.svg",
-        "path": "/package/atlassian_confluence/1.3.0/img/confluence-logo.svg",
-        "title": "Confluence Logo",
-        "size": "400x400",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "audit",
-        "title": "Audit Logs",
-        "description": "Collect audit logs from Atlassian Confluence with Elastic Agent."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security",
-      "web"
-    ],
-    "signature_path": "/epr/atlassian_confluence/atlassian_confluence-1.3.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "atlassian_confluence.audit",
-        "title": "Confluence Audit Logs"
-      }
-    ]
-  },
-  {
-    "name": "atlassian_jira",
-    "title": "Atlassian Jira",
-    "version": "1.0.0",
-    "release": "ga",
-    "description": "Collect logs from Atlassian Jira with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/atlassian_jira/atlassian_jira-1.0.0.zip",
-    "path": "/package/atlassian_jira/1.0.0",
-    "icons": [
-      {
-        "src": "/img/jira-software-logo.svg",
-        "path": "/package/atlassian_jira/1.0.0/img/jira-software-logo.svg",
-        "title": "Jira Software Logo",
-        "size": "590x625",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "audit",
-        "title": "Audit Logs",
-        "description": "Collect audit logs from Atlassian Jira with Elastic Agent."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security",
-      "web"
-    ],
-    "signature_path": "/epr/atlassian_jira/atlassian_jira-1.0.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "atlassian_jira.audit",
-        "title": "Jira Audit Logs"
-      }
-    ]
-  },
-  {
-    "name": "atlassian_jira",
-    "title": "Atlassian Jira",
-    "version": "1.0.1",
-    "release": "ga",
-    "description": "Collect logs from Atlassian Jira with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/atlassian_jira/atlassian_jira-1.0.1.zip",
-    "path": "/package/atlassian_jira/1.0.1",
-    "icons": [
-      {
-        "src": "/img/jira-software-logo.svg",
-        "path": "/package/atlassian_jira/1.0.1/img/jira-software-logo.svg",
-        "title": "Jira Software Logo",
-        "size": "590x625",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "audit",
-        "title": "Audit Logs",
-        "description": "Collect audit logs from Atlassian Jira with Elastic Agent."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security",
-      "web"
-    ],
-    "signature_path": "/epr/atlassian_jira/atlassian_jira-1.0.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "atlassian_jira.audit",
-        "title": "Jira Audit Logs"
-      }
-    ]
-  },
-  {
-    "name": "atlassian_jira",
-    "title": "Atlassian Jira",
-    "version": "1.1.0",
-    "release": "ga",
-    "description": "Collect logs from Atlassian Jira with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/atlassian_jira/atlassian_jira-1.1.0.zip",
-    "path": "/package/atlassian_jira/1.1.0",
-    "icons": [
-      {
-        "src": "/img/jira-software-logo.svg",
-        "path": "/package/atlassian_jira/1.1.0/img/jira-software-logo.svg",
-        "title": "Jira Software Logo",
-        "size": "590x625",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "audit",
-        "title": "Audit Logs",
-        "description": "Collect audit logs from Atlassian Jira with Elastic Agent."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security",
-      "web"
-    ],
-    "signature_path": "/epr/atlassian_jira/atlassian_jira-1.1.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "atlassian_jira.audit",
-        "title": "Jira Audit Logs"
-      }
-    ]
-  },
-  {
-    "name": "atlassian_jira",
-    "title": "Atlassian Jira",
-    "version": "1.1.1",
-    "release": "ga",
-    "description": "Collect logs from Atlassian Jira with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/atlassian_jira/atlassian_jira-1.1.1.zip",
-    "path": "/package/atlassian_jira/1.1.1",
-    "icons": [
-      {
-        "src": "/img/jira-software-logo.svg",
-        "path": "/package/atlassian_jira/1.1.1/img/jira-software-logo.svg",
-        "title": "Jira Software Logo",
-        "size": "590x625",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "audit",
-        "title": "Audit Logs",
-        "description": "Collect audit logs from Atlassian Jira with Elastic Agent."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security",
-      "web"
-    ],
-    "signature_path": "/epr/atlassian_jira/atlassian_jira-1.1.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "atlassian_jira.audit",
-        "title": "Jira Audit Logs"
-      }
-    ]
-  },
-  {
-    "name": "atlassian_jira",
-    "title": "Atlassian Jira",
-    "version": "1.1.2",
-    "release": "ga",
-    "description": "Collect logs from Atlassian Jira with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/atlassian_jira/atlassian_jira-1.1.2.zip",
-    "path": "/package/atlassian_jira/1.1.2",
-    "icons": [
-      {
-        "src": "/img/jira-software-logo.svg",
-        "path": "/package/atlassian_jira/1.1.2/img/jira-software-logo.svg",
-        "title": "Jira Software Logo",
-        "size": "590x625",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "audit",
-        "title": "Audit Logs",
-        "description": "Collect audit logs from Atlassian Jira with Elastic Agent."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security",
-      "web"
-    ],
-    "signature_path": "/epr/atlassian_jira/atlassian_jira-1.1.2.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "atlassian_jira.audit",
-        "title": "Jira Audit Logs"
-      }
-    ]
-  },
-  {
-    "name": "atlassian_jira",
-    "title": "Atlassian Jira",
-    "version": "1.2.0",
-    "release": "ga",
-    "description": "Collect logs from Atlassian Jira with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/atlassian_jira/atlassian_jira-1.2.0.zip",
-    "path": "/package/atlassian_jira/1.2.0",
-    "icons": [
-      {
-        "src": "/img/jira-software-logo.svg",
-        "path": "/package/atlassian_jira/1.2.0/img/jira-software-logo.svg",
-        "title": "Jira Software Logo",
-        "size": "590x625",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "audit",
-        "title": "Audit Logs",
-        "description": "Collect audit logs from Atlassian Jira with Elastic Agent."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security",
-      "web"
-    ],
-    "signature_path": "/epr/atlassian_jira/atlassian_jira-1.2.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "atlassian_jira.audit",
-        "title": "Jira Audit Logs"
-      }
-    ]
-  },
-  {
-    "name": "atlassian_jira",
-    "title": "Atlassian Jira",
-    "version": "1.3.0",
-    "release": "ga",
-    "description": "Collect logs from Atlassian Jira with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/atlassian_jira/atlassian_jira-1.3.0.zip",
-    "path": "/package/atlassian_jira/1.3.0",
-    "icons": [
-      {
-        "src": "/img/jira-software-logo.svg",
-        "path": "/package/atlassian_jira/1.3.0/img/jira-software-logo.svg",
-        "title": "Jira Software Logo",
-        "size": "590x625",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "audit",
-        "title": "Audit Logs",
-        "description": "Collect audit logs from Atlassian Jira with Elastic Agent."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security",
-      "web"
-    ],
-    "signature_path": "/epr/atlassian_jira/atlassian_jira-1.3.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "atlassian_jira.audit",
-        "title": "Jira Audit Logs"
-      }
-    ]
-  },
-  {
-    "name": "auditd",
-    "title": "Auditd",
-    "version": "1.0.0",
-    "release": "ga",
-    "description": "Auditd Integration",
-    "type": "integration",
-    "download": "/epr/auditd/auditd-1.0.0.zip",
-    "path": "/package/auditd/1.0.0",
-    "icons": [
-      {
-        "src": "/img/linux.svg",
-        "path": "/package/auditd/1.0.0/img/linux.svg",
-        "title": "linux",
-        "size": "299x354",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "auditd",
-        "title": "Auditd logs",
-        "description": "Collect logs from Auditd instances"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "os_system"
-    ],
-    "signature_path": "/epr/auditd/auditd-1.0.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "auditd.log",
-        "title": "Auditd logs"
-      }
-    ]
-  },
-  {
-    "name": "auditd",
-    "title": "Auditd",
-    "version": "1.2.0",
-    "release": "ga",
-    "description": "This Elastic integration collects and parses logs from the Audit daemon (auditd)",
-    "type": "integration",
-    "download": "/epr/auditd/auditd-1.2.0.zip",
-    "path": "/package/auditd/1.2.0",
-    "icons": [
-      {
-        "src": "/img/linux.svg",
-        "path": "/package/auditd/1.2.0/img/linux.svg",
-        "title": "linux",
-        "size": "299x354",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "auditd",
-        "title": "Auditd logs",
-        "description": "Collect logs from Auditd instances"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "os_system"
-    ],
-    "signature_path": "/epr/auditd/auditd-1.2.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "auditd.log",
-        "title": "Auditd logs"
-      }
-    ]
-  },
-  {
-    "name": "auditd",
-    "title": "Auditd",
-    "version": "1.2.2",
-    "release": "ga",
-    "description": "This Elastic integration collects and parses logs from the Audit daemon (auditd)",
-    "type": "integration",
-    "download": "/epr/auditd/auditd-1.2.2.zip",
-    "path": "/package/auditd/1.2.2",
-    "icons": [
-      {
-        "src": "/img/linux.svg",
-        "path": "/package/auditd/1.2.2/img/linux.svg",
-        "title": "linux",
-        "size": "299x354",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "auditd",
-        "title": "Auditd logs",
-        "description": "Collect logs from Auditd instances"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "os_system"
-    ],
-    "signature_path": "/epr/auditd/auditd-1.2.2.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "auditd.log",
-        "title": "Auditd logs"
-      }
-    ]
-  },
-  {
-    "name": "auditd",
-    "title": "Auditd",
-    "version": "1.2.4",
-    "release": "ga",
-    "description": "Collect logs from Linux audit daemon with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/auditd/auditd-1.2.4.zip",
-    "path": "/package/auditd/1.2.4",
-    "icons": [
-      {
-        "src": "/img/linux.svg",
-        "path": "/package/auditd/1.2.4/img/linux.svg",
-        "title": "linux",
-        "size": "299x354",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "auditd",
-        "title": "Auditd logs",
-        "description": "Collect logs from Auditd instances"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "os_system"
-    ],
-    "signature_path": "/epr/auditd/auditd-1.2.4.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "auditd.log",
-        "title": "Auditd logs"
-      }
-    ]
-  },
-  {
-    "name": "auditd",
-    "title": "Auditd",
-    "version": "1.3.0",
-    "release": "ga",
-    "description": "Collect logs from Linux audit daemon with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/auditd/auditd-1.3.0.zip",
-    "path": "/package/auditd/1.3.0",
-    "icons": [
-      {
-        "src": "/img/linux.svg",
-        "path": "/package/auditd/1.3.0/img/linux.svg",
-        "title": "linux",
-        "size": "299x354",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "auditd",
-        "title": "Auditd logs",
-        "description": "Collect logs from Auditd instances"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "os_system"
-    ],
-    "signature_path": "/epr/auditd/auditd-1.3.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "auditd.log",
-        "title": "Auditd logs"
-      }
-    ]
-  },
-  {
-    "name": "auditd",
-    "title": "Auditd",
-    "version": "1.3.1",
-    "release": "ga",
-    "description": "Collect logs from Linux audit daemon with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/auditd/auditd-1.3.1.zip",
-    "path": "/package/auditd/1.3.1",
-    "icons": [
-      {
-        "src": "/img/linux.svg",
-        "path": "/package/auditd/1.3.1/img/linux.svg",
-        "title": "linux",
-        "size": "299x354",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "auditd",
-        "title": "Auditd logs",
-        "description": "Collect logs from Auditd instances"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "os_system"
-    ],
-    "signature_path": "/epr/auditd/auditd-1.3.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "auditd.log",
-        "title": "Auditd logs"
-      }
-    ]
-  },
-  {
-    "name": "auditd",
-    "title": "Auditd",
-    "version": "2.0.0",
-    "release": "ga",
-    "description": "Collect logs from Linux audit daemon with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/auditd/auditd-2.0.0.zip",
-    "path": "/package/auditd/2.0.0",
-    "icons": [
-      {
-        "src": "/img/linux.svg",
-        "path": "/package/auditd/2.0.0/img/linux.svg",
-        "title": "linux",
-        "size": "299x354",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "auditd",
-        "title": "Auditd logs",
-        "description": "Collect logs from Auditd instances"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.17.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "os_system"
-    ],
-    "signature_path": "/epr/auditd/auditd-2.0.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "auditd.log",
-        "title": "Auditd logs"
-      }
-    ]
-  },
-  {
-    "name": "auditd",
-    "title": "Auditd",
-    "version": "2.1.0",
-    "release": "ga",
-    "description": "Collect logs from Linux audit daemon with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/auditd/auditd-2.1.0.zip",
-    "path": "/package/auditd/2.1.0",
-    "icons": [
-      {
-        "src": "/img/linux.svg",
-        "path": "/package/auditd/2.1.0/img/linux.svg",
-        "title": "linux",
-        "size": "299x354",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "auditd",
-        "title": "Auditd logs",
-        "description": "Collect logs from Auditd instances"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.17.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "os_system"
-    ],
-    "signature_path": "/epr/auditd/auditd-2.1.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "auditd.log",
-        "title": "Auditd logs"
-      }
-    ]
-  },
-  {
-    "name": "auditd",
-    "title": "Auditd",
-    "version": "2.1.1",
-    "release": "ga",
-    "description": "Collect logs from Linux audit daemon with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/auditd/auditd-2.1.1.zip",
-    "path": "/package/auditd/2.1.1",
-    "icons": [
-      {
-        "src": "/img/linux.svg",
-        "path": "/package/auditd/2.1.1/img/linux.svg",
-        "title": "linux",
-        "size": "299x354",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "auditd",
-        "title": "Auditd logs",
-        "description": "Collect logs from Auditd instances"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.17.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "os_system"
-    ],
-    "signature_path": "/epr/auditd/auditd-2.1.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "auditd.log",
-        "title": "Auditd logs"
-      }
-    ]
-  },
-  {
-    "name": "auditd",
-    "title": "Auditd",
-    "version": "2.1.2",
-    "release": "ga",
-    "description": "Collect logs from Linux audit daemon with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/auditd/auditd-2.1.2.zip",
-    "path": "/package/auditd/2.1.2",
-    "icons": [
-      {
-        "src": "/img/linux.svg",
-        "path": "/package/auditd/2.1.2/img/linux.svg",
-        "title": "linux",
-        "size": "299x354",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "auditd",
-        "title": "Auditd logs",
-        "description": "Collect logs from Auditd instances"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.17.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "os_system"
-    ],
-    "signature_path": "/epr/auditd/auditd-2.1.2.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "auditd.log",
-        "title": "Auditd logs"
-      }
-    ]
-  },
-  {
-    "name": "auditd",
-    "title": "Auditd",
-    "version": "2.2.0",
-    "release": "ga",
-    "description": "Collect logs from Linux audit daemon with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/auditd/auditd-2.2.0.zip",
-    "path": "/package/auditd/2.2.0",
-    "icons": [
-      {
-        "src": "/img/linux.svg",
-        "path": "/package/auditd/2.2.0/img/linux.svg",
-        "title": "linux",
-        "size": "299x354",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "auditd",
-        "title": "Auditd logs",
-        "description": "Collect logs from Auditd instances"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.17.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "os_system"
-    ],
-    "signature_path": "/epr/auditd/auditd-2.2.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "auditd.log",
-        "title": "Auditd logs"
-      }
-    ]
-  },
-  {
-    "name": "auditd",
-    "title": "Auditd",
-    "version": "3.0.0",
-    "release": "ga",
-    "description": "Collect logs from Linux audit daemon with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/auditd/auditd-3.0.0.zip",
-    "path": "/package/auditd/3.0.0",
-    "icons": [
-      {
-        "src": "/img/linux.svg",
-        "path": "/package/auditd/3.0.0/img/linux.svg",
-        "title": "linux",
-        "size": "299x354",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "auditd",
-        "title": "Auditd logs",
-        "description": "Collect logs from Auditd instances"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "os_system"
-    ],
-    "signature_path": "/epr/auditd/auditd-3.0.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "auditd.log",
-        "title": "Auditd logs"
-      }
-    ]
-  },
-  {
-    "name": "auditd",
-    "title": "Auditd Logs",
-    "version": "3.1.0",
-    "release": "ga",
-    "description": "Collect logs from Linux audit daemon with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/auditd/auditd-3.1.0.zip",
-    "path": "/package/auditd/3.1.0",
-    "icons": [
-      {
-        "src": "/img/linux.svg",
-        "path": "/package/auditd/3.1.0/img/linux.svg",
-        "title": "linux",
-        "size": "299x354",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "auditd",
-        "title": "Auditd logs",
-        "description": "Collect logs from Auditd instances"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "os_system"
-    ],
-    "signature_path": "/epr/auditd/auditd-3.1.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "auditd.log",
-        "title": "Auditd logs"
-      }
-    ]
-  },
-  {
-    "name": "auditd_manager",
-    "title": "Auditd Manager",
-    "version": "1.0.0",
-    "release": "ga",
-    "description": "The Auditd Manager Integration receives audit events from the Linux Audit Framework that is a part of the Linux kernel.",
-    "type": "integration",
-    "download": "/epr/auditd_manager/auditd_manager-1.0.0.zip",
-    "path": "/package/auditd_manager/1.0.0",
-    "icons": [
-      {
-        "src": "/img/linux.svg",
-        "path": "/package/auditd_manager/1.0.0/img/linux.svg",
-        "title": "linux",
-        "size": "299x354",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "auditd",
-        "title": "Auditd",
-        "description": "Collect auditd events"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.2.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "os_system",
-      "security"
-    ],
-    "signature_path": "/epr/auditd_manager/auditd_manager-1.0.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "auditd_manager.auditd",
-        "title": "Auditd Manager"
-      }
-    ]
-  },
-  {
-    "name": "auth0",
-    "title": "Auth0 Log Streams Integration",
-    "version": "1.0.0",
-    "release": "ga",
-    "description": "Collect logs from Auth0 with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/auth0/auth0-1.0.0.zip",
-    "path": "/package/auth0/1.0.0",
-    "icons": [
-      {
-        "src": "/img/auth0-logo.svg",
-        "path": "/package/auth0/1.0.0/img/auth0-logo.svg",
-        "title": "Auth0 logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "auth0_events",
-        "title": "Auth0 log stream events via Webhooks",
-        "description": "Collect Auth0 log streams events via Webhooks."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "cloud",
-      "network",
-      "security"
-    ],
-    "signature_path": "/epr/auth0/auth0-1.0.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "auth0.logs",
-        "title": "Auth0 logs via Webhooks"
       }
     ]
   },
@@ -16188,554 +15645,6 @@
         "type": "logs",
         "dataset": "azure.signinlogs",
         "title": "Azure signinlogs logs"
-      }
-    ]
-  },
-  {
-    "name": "azure_application_insights",
-    "title": "Azure Application Insights Metrics Overview",
-    "version": "0.1.0",
-    "release": "beta",
-    "description": "Azure Application Insights",
-    "type": "integration",
-    "download": "/epr/azure_application_insights/azure_application_insights-0.1.0.zip",
-    "path": "/package/azure_application_insights/0.1.0",
-    "icons": [
-      {
-        "src": "/img/app_insights.png",
-        "path": "/package/azure_application_insights/0.1.0/img/app_insights.png",
-        "title": "logo docker",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "app_insights",
-        "title": "Azure Application Insights metrics",
-        "description": "Azure Application Insights Metrics Integration",
-        "icons": [
-          {
-            "src": "/img//app_insights.png",
-            "path": "/package/azure_application_insights/0.1.0/img/app_insights.png",
-            "title": "logo azure",
-            "size": "32x32",
-            "type": "image/svg+xml"
-          }
-        ],
-        "data_streams": [
-          "app_insights"
-        ]
-      },
-      {
-        "name": "app_state",
-        "title": "Azure Application State Insights metrics",
-        "description": "Azure Application State Insights Metrics Integration",
-        "icons": [
-          {
-            "src": "/img/application_insights_blue.png",
-            "path": "/package/azure_application_insights/0.1.0/img/application_insights_blue.png",
-            "title": "logo azure",
-            "size": "32x32",
-            "type": "image/svg+xml"
-          }
-        ],
-        "data_streams": [
-          "app_state"
-        ]
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "azure",
-      "web"
-    ],
-    "signature_path": "/epr/azure_application_insights/azure_application_insights-0.1.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "metrics",
-        "dataset": "azure.app_insights",
-        "title": "Azure Application Insights"
-      },
-      {
-        "type": "metrics",
-        "dataset": "azure.app_state",
-        "title": "Azure Application State"
-      }
-    ]
-  },
-  {
-    "name": "azure_application_insights",
-    "title": "Azure Application Insights Metrics Overview",
-    "version": "0.3.0",
-    "release": "beta",
-    "description": "Collect application insights metrics from Azure Monitor with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/azure_application_insights/azure_application_insights-0.3.0.zip",
-    "path": "/package/azure_application_insights/0.3.0",
-    "icons": [
-      {
-        "src": "/img/app_insights.png",
-        "path": "/package/azure_application_insights/0.3.0/img/app_insights.png",
-        "title": "logo docker",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "app_insights",
-        "title": "Azure Application Insights Metrics",
-        "description": "Collect application insights metrics from Azure Monitor with Elastic Agent.",
-        "icons": [
-          {
-            "src": "/img//app_insights.png",
-            "path": "/package/azure_application_insights/0.3.0/img/app_insights.png",
-            "title": "logo azure",
-            "size": "32x32",
-            "type": "image/svg+xml"
-          }
-        ],
-        "data_streams": [
-          "app_insights"
-        ]
-      },
-      {
-        "name": "app_state",
-        "title": "Azure Application State Insights Metrics",
-        "description": "Collect application state related metrics from Azure Monitor with Elastic Agent.",
-        "icons": [
-          {
-            "src": "/img/application_insights_blue.png",
-            "path": "/package/azure_application_insights/0.3.0/img/application_insights_blue.png",
-            "title": "logo azure",
-            "size": "32x32",
-            "type": "image/svg+xml"
-          }
-        ],
-        "data_streams": [
-          "app_state"
-        ]
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "azure",
-      "web"
-    ],
-    "signature_path": "/epr/azure_application_insights/azure_application_insights-0.3.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "metrics",
-        "dataset": "azure.app_insights",
-        "title": "Azure Application Insights"
-      },
-      {
-        "type": "metrics",
-        "dataset": "azure.app_state",
-        "title": "Azure Application State"
-      }
-    ]
-  },
-  {
-    "name": "azure_application_insights",
-    "title": "Azure Application Insights Metrics Overview",
-    "version": "1.0.0",
-    "release": "ga",
-    "description": "Collect application insights metrics from Azure Monitor with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/azure_application_insights/azure_application_insights-1.0.0.zip",
-    "path": "/package/azure_application_insights/1.0.0",
-    "icons": [
-      {
-        "src": "/img/app_insights.png",
-        "path": "/package/azure_application_insights/1.0.0/img/app_insights.png",
-        "title": "logo docker",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "app_insights",
-        "title": "Azure Application Insights Metrics",
-        "description": "Collect application insights metrics from Azure Monitor with Elastic Agent.",
-        "icons": [
-          {
-            "src": "/img//app_insights.png",
-            "path": "/package/azure_application_insights/1.0.0/img/app_insights.png",
-            "title": "logo azure",
-            "size": "32x32",
-            "type": "image/svg+xml"
-          }
-        ],
-        "data_streams": [
-          "app_insights"
-        ]
-      },
-      {
-        "name": "app_state",
-        "title": "Azure Application State Insights Metrics",
-        "description": "Collect application state related metrics from Azure Monitor with Elastic Agent.",
-        "icons": [
-          {
-            "src": "/img/application_insights_blue.png",
-            "path": "/package/azure_application_insights/1.0.0/img/application_insights_blue.png",
-            "title": "logo azure",
-            "size": "32x32",
-            "type": "image/svg+xml"
-          }
-        ],
-        "data_streams": [
-          "app_state"
-        ]
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "azure",
-      "web"
-    ],
-    "signature_path": "/epr/azure_application_insights/azure_application_insights-1.0.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "metrics",
-        "dataset": "azure.app_insights",
-        "title": "Azure Application Insights"
-      },
-      {
-        "type": "metrics",
-        "dataset": "azure.app_state",
-        "title": "Azure Application State"
-      }
-    ]
-  },
-  {
-    "name": "azure_application_insights",
-    "title": "Azure Application Insights Metrics Overview",
-    "version": "1.0.1",
-    "release": "ga",
-    "description": "Collect application insights metrics from Azure Monitor with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/azure_application_insights/azure_application_insights-1.0.1.zip",
-    "path": "/package/azure_application_insights/1.0.1",
-    "icons": [
-      {
-        "src": "/img/app_insights.png",
-        "path": "/package/azure_application_insights/1.0.1/img/app_insights.png",
-        "title": "logo docker",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "app_insights",
-        "title": "Azure Application Insights Metrics",
-        "description": "Collect application insights metrics from Azure Monitor with Elastic Agent.",
-        "icons": [
-          {
-            "src": "/img//app_insights.png",
-            "path": "/package/azure_application_insights/1.0.1/img/app_insights.png",
-            "title": "logo azure",
-            "size": "32x32",
-            "type": "image/svg+xml"
-          }
-        ],
-        "data_streams": [
-          "app_insights"
-        ]
-      },
-      {
-        "name": "app_state",
-        "title": "Azure Application State Insights Metrics",
-        "description": "Collect application state related metrics from Azure Monitor with Elastic Agent.",
-        "icons": [
-          {
-            "src": "/img/application_insights_blue.png",
-            "path": "/package/azure_application_insights/1.0.1/img/application_insights_blue.png",
-            "title": "logo azure",
-            "size": "32x32",
-            "type": "image/svg+xml"
-          }
-        ],
-        "data_streams": [
-          "app_state"
-        ]
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "azure",
-      "web"
-    ],
-    "signature_path": "/epr/azure_application_insights/azure_application_insights-1.0.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "metrics",
-        "dataset": "azure.app_insights",
-        "title": "Azure Application Insights"
-      },
-      {
-        "type": "metrics",
-        "dataset": "azure.app_state",
-        "title": "Azure Application State"
-      }
-    ]
-  },
-  {
-    "name": "azure_billing",
-    "title": "Azure Billing Metrics",
-    "version": "0.1.0",
-    "release": "beta",
-    "description": "Collect billing metrics with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/azure_billing/azure_billing-0.1.0.zip",
-    "path": "/package/azure_billing/0.1.0",
-    "icons": [
-      {
-        "src": "/img/billing.png",
-        "path": "/package/azure_billing/0.1.0/img/billing.png",
-        "title": "logo docker",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "billing",
-        "title": "Azure Billing Metrics",
-        "description": "Collect billing information with Elastic Agent.",
-        "icons": [
-          {
-            "src": "/img//billing.png",
-            "path": "/package/azure_billing/0.1.0/img/billing.png",
-            "title": "logo azure",
-            "size": "32x32",
-            "type": "image/svg+xml"
-          }
-        ],
-        "data_streams": [
-          "billing"
-        ]
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.15.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "azure"
-    ],
-    "signature_path": "/epr/azure_billing/azure_billing-0.1.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "metrics",
-        "dataset": "azure.billing",
-        "title": "Azure Billing Metrics"
-      }
-    ]
-  },
-  {
-    "name": "azure_billing",
-    "title": "Azure Billing Metrics",
-    "version": "0.2.0",
-    "release": "beta",
-    "description": "Collect billing metrics with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/azure_billing/azure_billing-0.2.0.zip",
-    "path": "/package/azure_billing/0.2.0",
-    "icons": [
-      {
-        "src": "/img/billing.png",
-        "path": "/package/azure_billing/0.2.0/img/billing.png",
-        "title": "logo docker",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "billing",
-        "title": "Azure Billing Metrics",
-        "description": "Collect billing information with Elastic Agent.",
-        "icons": [
-          {
-            "src": "/img//billing.png",
-            "path": "/package/azure_billing/0.2.0/img/billing.png",
-            "title": "logo azure",
-            "size": "32x32",
-            "type": "image/svg+xml"
-          }
-        ],
-        "data_streams": [
-          "billing"
-        ]
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.15.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "azure"
-    ],
-    "signature_path": "/epr/azure_billing/azure_billing-0.2.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "metrics",
-        "dataset": "azure.billing",
-        "title": "Azure Billing Metrics"
-      }
-    ]
-  },
-  {
-    "name": "azure_billing",
-    "title": "Azure Billing Metrics",
-    "version": "1.0.0",
-    "release": "ga",
-    "description": "Collect billing metrics with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/azure_billing/azure_billing-1.0.0.zip",
-    "path": "/package/azure_billing/1.0.0",
-    "icons": [
-      {
-        "src": "/img/billing.png",
-        "path": "/package/azure_billing/1.0.0/img/billing.png",
-        "title": "logo docker",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "billing",
-        "title": "Azure Billing Metrics",
-        "description": "Collect billing information with Elastic Agent.",
-        "icons": [
-          {
-            "src": "/img//billing.png",
-            "path": "/package/azure_billing/1.0.0/img/billing.png",
-            "title": "logo azure",
-            "size": "32x32",
-            "type": "image/svg+xml"
-          }
-        ],
-        "data_streams": [
-          "billing"
-        ]
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.15.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "azure"
-    ],
-    "signature_path": "/epr/azure_billing/azure_billing-1.0.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "metrics",
-        "dataset": "azure.billing",
-        "title": "Azure Billing Metrics"
-      }
-    ]
-  },
-  {
-    "name": "azure_billing",
-    "title": "Azure Billing Metrics",
-    "version": "1.0.1",
-    "release": "ga",
-    "description": "Collect billing metrics with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/azure_billing/azure_billing-1.0.1.zip",
-    "path": "/package/azure_billing/1.0.1",
-    "icons": [
-      {
-        "src": "/img/billing.png",
-        "path": "/package/azure_billing/1.0.1/img/billing.png",
-        "title": "logo docker",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "billing",
-        "title": "Azure Billing Metrics",
-        "description": "Collect billing information with Elastic Agent.",
-        "icons": [
-          {
-            "src": "/img//billing.png",
-            "path": "/package/azure_billing/1.0.1/img/billing.png",
-            "title": "logo azure",
-            "size": "32x32",
-            "type": "image/svg+xml"
-          }
-        ],
-        "data_streams": [
-          "billing"
-        ]
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.15.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "azure"
-    ],
-    "signature_path": "/epr/azure_billing/azure_billing-1.0.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "metrics",
-        "dataset": "azure.billing",
-        "title": "Azure Billing Metrics"
       }
     ]
   },
@@ -18236,6 +17145,978 @@
     ]
   },
   {
+    "name": "azure_application_insights",
+    "title": "Azure Application Insights Metrics Overview",
+    "version": "0.1.0",
+    "release": "beta",
+    "description": "Azure Application Insights",
+    "type": "integration",
+    "download": "/epr/azure_application_insights/azure_application_insights-0.1.0.zip",
+    "path": "/package/azure_application_insights/0.1.0",
+    "icons": [
+      {
+        "src": "/img/app_insights.png",
+        "path": "/package/azure_application_insights/0.1.0/img/app_insights.png",
+        "title": "logo docker",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "app_insights",
+        "title": "Azure Application Insights metrics",
+        "description": "Azure Application Insights Metrics Integration",
+        "icons": [
+          {
+            "src": "/img//app_insights.png",
+            "path": "/package/azure_application_insights/0.1.0/img/app_insights.png",
+            "title": "logo azure",
+            "size": "32x32",
+            "type": "image/svg+xml"
+          }
+        ],
+        "data_streams": [
+          "app_insights"
+        ]
+      },
+      {
+        "name": "app_state",
+        "title": "Azure Application State Insights metrics",
+        "description": "Azure Application State Insights Metrics Integration",
+        "icons": [
+          {
+            "src": "/img/application_insights_blue.png",
+            "path": "/package/azure_application_insights/0.1.0/img/application_insights_blue.png",
+            "title": "logo azure",
+            "size": "32x32",
+            "type": "image/svg+xml"
+          }
+        ],
+        "data_streams": [
+          "app_state"
+        ]
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "azure",
+      "web"
+    ],
+    "signature_path": "/epr/azure_application_insights/azure_application_insights-0.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "azure.app_insights",
+        "title": "Azure Application Insights"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.app_state",
+        "title": "Azure Application State"
+      }
+    ]
+  },
+  {
+    "name": "azure_application_insights",
+    "title": "Azure Application Insights Metrics Overview",
+    "version": "0.3.0",
+    "release": "beta",
+    "description": "Collect application insights metrics from Azure Monitor with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/azure_application_insights/azure_application_insights-0.3.0.zip",
+    "path": "/package/azure_application_insights/0.3.0",
+    "icons": [
+      {
+        "src": "/img/app_insights.png",
+        "path": "/package/azure_application_insights/0.3.0/img/app_insights.png",
+        "title": "logo docker",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "app_insights",
+        "title": "Azure Application Insights Metrics",
+        "description": "Collect application insights metrics from Azure Monitor with Elastic Agent.",
+        "icons": [
+          {
+            "src": "/img//app_insights.png",
+            "path": "/package/azure_application_insights/0.3.0/img/app_insights.png",
+            "title": "logo azure",
+            "size": "32x32",
+            "type": "image/svg+xml"
+          }
+        ],
+        "data_streams": [
+          "app_insights"
+        ]
+      },
+      {
+        "name": "app_state",
+        "title": "Azure Application State Insights Metrics",
+        "description": "Collect application state related metrics from Azure Monitor with Elastic Agent.",
+        "icons": [
+          {
+            "src": "/img/application_insights_blue.png",
+            "path": "/package/azure_application_insights/0.3.0/img/application_insights_blue.png",
+            "title": "logo azure",
+            "size": "32x32",
+            "type": "image/svg+xml"
+          }
+        ],
+        "data_streams": [
+          "app_state"
+        ]
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "azure",
+      "web"
+    ],
+    "signature_path": "/epr/azure_application_insights/azure_application_insights-0.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "azure.app_insights",
+        "title": "Azure Application Insights"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.app_state",
+        "title": "Azure Application State"
+      }
+    ]
+  },
+  {
+    "name": "azure_application_insights",
+    "title": "Azure Application Insights Metrics Overview",
+    "version": "1.0.0",
+    "release": "ga",
+    "description": "Collect application insights metrics from Azure Monitor with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/azure_application_insights/azure_application_insights-1.0.0.zip",
+    "path": "/package/azure_application_insights/1.0.0",
+    "icons": [
+      {
+        "src": "/img/app_insights.png",
+        "path": "/package/azure_application_insights/1.0.0/img/app_insights.png",
+        "title": "logo docker",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "app_insights",
+        "title": "Azure Application Insights Metrics",
+        "description": "Collect application insights metrics from Azure Monitor with Elastic Agent.",
+        "icons": [
+          {
+            "src": "/img//app_insights.png",
+            "path": "/package/azure_application_insights/1.0.0/img/app_insights.png",
+            "title": "logo azure",
+            "size": "32x32",
+            "type": "image/svg+xml"
+          }
+        ],
+        "data_streams": [
+          "app_insights"
+        ]
+      },
+      {
+        "name": "app_state",
+        "title": "Azure Application State Insights Metrics",
+        "description": "Collect application state related metrics from Azure Monitor with Elastic Agent.",
+        "icons": [
+          {
+            "src": "/img/application_insights_blue.png",
+            "path": "/package/azure_application_insights/1.0.0/img/application_insights_blue.png",
+            "title": "logo azure",
+            "size": "32x32",
+            "type": "image/svg+xml"
+          }
+        ],
+        "data_streams": [
+          "app_state"
+        ]
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "azure",
+      "web"
+    ],
+    "signature_path": "/epr/azure_application_insights/azure_application_insights-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "azure.app_insights",
+        "title": "Azure Application Insights"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.app_state",
+        "title": "Azure Application State"
+      }
+    ]
+  },
+  {
+    "name": "azure_application_insights",
+    "title": "Azure Application Insights Metrics Overview",
+    "version": "1.0.1",
+    "release": "ga",
+    "description": "Collect application insights metrics from Azure Monitor with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/azure_application_insights/azure_application_insights-1.0.1.zip",
+    "path": "/package/azure_application_insights/1.0.1",
+    "icons": [
+      {
+        "src": "/img/app_insights.png",
+        "path": "/package/azure_application_insights/1.0.1/img/app_insights.png",
+        "title": "logo docker",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "app_insights",
+        "title": "Azure Application Insights Metrics",
+        "description": "Collect application insights metrics from Azure Monitor with Elastic Agent.",
+        "icons": [
+          {
+            "src": "/img//app_insights.png",
+            "path": "/package/azure_application_insights/1.0.1/img/app_insights.png",
+            "title": "logo azure",
+            "size": "32x32",
+            "type": "image/svg+xml"
+          }
+        ],
+        "data_streams": [
+          "app_insights"
+        ]
+      },
+      {
+        "name": "app_state",
+        "title": "Azure Application State Insights Metrics",
+        "description": "Collect application state related metrics from Azure Monitor with Elastic Agent.",
+        "icons": [
+          {
+            "src": "/img/application_insights_blue.png",
+            "path": "/package/azure_application_insights/1.0.1/img/application_insights_blue.png",
+            "title": "logo azure",
+            "size": "32x32",
+            "type": "image/svg+xml"
+          }
+        ],
+        "data_streams": [
+          "app_state"
+        ]
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "azure",
+      "web"
+    ],
+    "signature_path": "/epr/azure_application_insights/azure_application_insights-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "azure.app_insights",
+        "title": "Azure Application Insights"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.app_state",
+        "title": "Azure Application State"
+      }
+    ]
+  },
+  {
+    "name": "azure_billing",
+    "title": "Azure Billing Metrics",
+    "version": "0.1.0",
+    "release": "beta",
+    "description": "Collect billing metrics with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/azure_billing/azure_billing-0.1.0.zip",
+    "path": "/package/azure_billing/0.1.0",
+    "icons": [
+      {
+        "src": "/img/billing.png",
+        "path": "/package/azure_billing/0.1.0/img/billing.png",
+        "title": "logo docker",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "billing",
+        "title": "Azure Billing Metrics",
+        "description": "Collect billing information with Elastic Agent.",
+        "icons": [
+          {
+            "src": "/img//billing.png",
+            "path": "/package/azure_billing/0.1.0/img/billing.png",
+            "title": "logo azure",
+            "size": "32x32",
+            "type": "image/svg+xml"
+          }
+        ],
+        "data_streams": [
+          "billing"
+        ]
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.15.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "azure"
+    ],
+    "signature_path": "/epr/azure_billing/azure_billing-0.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "azure.billing",
+        "title": "Azure Billing Metrics"
+      }
+    ]
+  },
+  {
+    "name": "azure_billing",
+    "title": "Azure Billing Metrics",
+    "version": "0.2.0",
+    "release": "beta",
+    "description": "Collect billing metrics with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/azure_billing/azure_billing-0.2.0.zip",
+    "path": "/package/azure_billing/0.2.0",
+    "icons": [
+      {
+        "src": "/img/billing.png",
+        "path": "/package/azure_billing/0.2.0/img/billing.png",
+        "title": "logo docker",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "billing",
+        "title": "Azure Billing Metrics",
+        "description": "Collect billing information with Elastic Agent.",
+        "icons": [
+          {
+            "src": "/img//billing.png",
+            "path": "/package/azure_billing/0.2.0/img/billing.png",
+            "title": "logo azure",
+            "size": "32x32",
+            "type": "image/svg+xml"
+          }
+        ],
+        "data_streams": [
+          "billing"
+        ]
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.15.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "azure"
+    ],
+    "signature_path": "/epr/azure_billing/azure_billing-0.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "azure.billing",
+        "title": "Azure Billing Metrics"
+      }
+    ]
+  },
+  {
+    "name": "azure_billing",
+    "title": "Azure Billing Metrics",
+    "version": "1.0.0",
+    "release": "ga",
+    "description": "Collect billing metrics with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/azure_billing/azure_billing-1.0.0.zip",
+    "path": "/package/azure_billing/1.0.0",
+    "icons": [
+      {
+        "src": "/img/billing.png",
+        "path": "/package/azure_billing/1.0.0/img/billing.png",
+        "title": "logo docker",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "billing",
+        "title": "Azure Billing Metrics",
+        "description": "Collect billing information with Elastic Agent.",
+        "icons": [
+          {
+            "src": "/img//billing.png",
+            "path": "/package/azure_billing/1.0.0/img/billing.png",
+            "title": "logo azure",
+            "size": "32x32",
+            "type": "image/svg+xml"
+          }
+        ],
+        "data_streams": [
+          "billing"
+        ]
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.15.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "azure"
+    ],
+    "signature_path": "/epr/azure_billing/azure_billing-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "azure.billing",
+        "title": "Azure Billing Metrics"
+      }
+    ]
+  },
+  {
+    "name": "azure_billing",
+    "title": "Azure Billing Metrics",
+    "version": "1.0.1",
+    "release": "ga",
+    "description": "Collect billing metrics with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/azure_billing/azure_billing-1.0.1.zip",
+    "path": "/package/azure_billing/1.0.1",
+    "icons": [
+      {
+        "src": "/img/billing.png",
+        "path": "/package/azure_billing/1.0.1/img/billing.png",
+        "title": "logo docker",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "billing",
+        "title": "Azure Billing Metrics",
+        "description": "Collect billing information with Elastic Agent.",
+        "icons": [
+          {
+            "src": "/img//billing.png",
+            "path": "/package/azure_billing/1.0.1/img/billing.png",
+            "title": "logo azure",
+            "size": "32x32",
+            "type": "image/svg+xml"
+          }
+        ],
+        "data_streams": [
+          "billing"
+        ]
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.15.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "azure"
+    ],
+    "signature_path": "/epr/azure_billing/azure_billing-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "azure.billing",
+        "title": "Azure Billing Metrics"
+      }
+    ]
+  },
+  {
+    "name": "azure_metrics",
+    "title": "Azure resource metrics",
+    "version": "0.3.1",
+    "release": "beta",
+    "description": "This Elastic integration collects and aggregates metrics from Azure resources",
+    "type": "integration",
+    "download": "/epr/azure_metrics/azure_metrics-0.3.1.zip",
+    "path": "/package/azure_metrics/0.3.1",
+    "icons": [
+      {
+        "src": "/img/azure_metrics_logo.png",
+        "path": "/package/azure_metrics/0.3.1/img/azure_metrics_logo.png",
+        "title": "logo docker",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "monitor",
+        "title": "Azure Monitor metrics",
+        "description": "Azure Monitor Metrics Integration",
+        "icons": [
+          {
+            "src": "/img/monitor_logo.png",
+            "path": "/package/azure_metrics/0.3.1/img/monitor_logo.png",
+            "title": "logo azure",
+            "size": "32x32",
+            "type": "image/svg+xml"
+          }
+        ],
+        "data_streams": [
+          "monitor"
+        ]
+      },
+      {
+        "name": "compute_vm",
+        "title": "Azure Virtual Machines metrics",
+        "description": "Azure Virtual Machines Metrics Integration",
+        "icons": [
+          {
+            "src": "/img/compute_vm_logo.png",
+            "path": "/package/azure_metrics/0.3.1/img/compute_vm_logo.png",
+            "title": "logo azure",
+            "size": "32x32",
+            "type": "image/svg+xml"
+          }
+        ],
+        "data_streams": [
+          "compute_vm"
+        ]
+      },
+      {
+        "name": "compute_vm_scaleset",
+        "title": "Azure Virtual Machines Scaleset metrics",
+        "description": "Azure Virtual Machines Scaleset Metrics Integration",
+        "icons": [
+          {
+            "src": "/img/compute_vm_scaleset_logo.png",
+            "path": "/package/azure_metrics/0.3.1/img/compute_vm_scaleset_logo.png",
+            "title": "logo azure",
+            "size": "32x32",
+            "type": "image/svg+xml"
+          }
+        ],
+        "data_streams": [
+          "compute_vm_scaleset"
+        ]
+      },
+      {
+        "name": "container_registry",
+        "title": "Azure Container Registry metrics",
+        "description": "Azure Container Registry Metrics Integration",
+        "icons": [
+          {
+            "src": "/img/container_registry_logo.png",
+            "path": "/package/azure_metrics/0.3.1/img/container_registry_logo.png",
+            "title": "logo azure",
+            "size": "32x32",
+            "type": "image/svg+xml"
+          }
+        ],
+        "data_streams": [
+          "container_registry"
+        ]
+      },
+      {
+        "name": "container_instance",
+        "title": "Azure Container Instance metrics",
+        "description": "Azure Container Instance Metrics Integration",
+        "icons": [
+          {
+            "src": "/img/container_instance_logo.png",
+            "path": "/package/azure_metrics/0.3.1/img/container_instance_logo.png",
+            "title": "logo azure",
+            "size": "32x32",
+            "type": "image/svg+xml"
+          }
+        ],
+        "data_streams": [
+          "container_instance"
+        ]
+      },
+      {
+        "name": "container_service",
+        "title": "Azure Container Service metrics",
+        "description": "Azure Container Service Metrics Integration",
+        "icons": [
+          {
+            "src": "/img/container_service_logo.png",
+            "path": "/package/azure_metrics/0.3.1/img/container_service_logo.png",
+            "title": "logo azure",
+            "size": "32x32",
+            "type": "image/svg+xml"
+          }
+        ],
+        "data_streams": [
+          "container_service"
+        ]
+      },
+      {
+        "name": "database_account",
+        "title": "Azure Database Account metrics",
+        "description": "Azure Database Account Metrics Integration",
+        "icons": [
+          {
+            "src": "/img/database_account_logo.png",
+            "path": "/package/azure_metrics/0.3.1/img/database_account_logo.png",
+            "title": "logo azure",
+            "size": "32x32",
+            "type": "image/svg+xml"
+          }
+        ],
+        "data_streams": [
+          "database_account"
+        ]
+      },
+      {
+        "name": "storage_account",
+        "title": "Azure Storage Account metrics",
+        "description": "Azure Storage Account Metrics Integration",
+        "icons": [
+          {
+            "src": "/img/storage_account_logo.png",
+            "path": "/package/azure_metrics/0.3.1/img/storage_account_logo.png",
+            "title": "logo azure",
+            "size": "32x32",
+            "type": "image/svg+xml"
+          }
+        ],
+        "data_streams": [
+          "storage_account"
+        ]
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "azure",
+      "web"
+    ],
+    "signature_path": "/epr/azure_metrics/azure_metrics-0.3.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "azure.compute_vm",
+        "title": "Compute VM"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.compute_vm_scaleset",
+        "title": "Compute VM Scaleset"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.container_instance",
+        "title": "Container Instance"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.container_registry",
+        "title": "Container Registry"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.container_service",
+        "title": "Container Service"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.database_account",
+        "title": "Database Account"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.monitor",
+        "title": "Monitor"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.storage_account",
+        "title": "Storage Account"
+      }
+    ]
+  },
+  {
+    "name": "azure_metrics",
+    "title": "Azure resource metrics",
+    "version": "0.3.2",
+    "release": "beta",
+    "description": "This Elastic integration collects and aggregates metrics from Azure resources",
+    "type": "integration",
+    "download": "/epr/azure_metrics/azure_metrics-0.3.2.zip",
+    "path": "/package/azure_metrics/0.3.2",
+    "icons": [
+      {
+        "src": "/img/azure_metrics_logo.png",
+        "path": "/package/azure_metrics/0.3.2/img/azure_metrics_logo.png",
+        "title": "logo docker",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "monitor",
+        "title": "Azure Monitor metrics",
+        "description": "Azure Monitor Metrics Integration",
+        "icons": [
+          {
+            "src": "/img/monitor_logo.png",
+            "path": "/package/azure_metrics/0.3.2/img/monitor_logo.png",
+            "title": "logo azure",
+            "size": "32x32",
+            "type": "image/svg+xml"
+          }
+        ],
+        "data_streams": [
+          "monitor"
+        ]
+      },
+      {
+        "name": "compute_vm",
+        "title": "Azure Virtual Machines metrics",
+        "description": "Azure Virtual Machines Metrics Integration",
+        "icons": [
+          {
+            "src": "/img/compute_vm_logo.png",
+            "path": "/package/azure_metrics/0.3.2/img/compute_vm_logo.png",
+            "title": "logo azure",
+            "size": "32x32",
+            "type": "image/svg+xml"
+          }
+        ],
+        "data_streams": [
+          "compute_vm"
+        ]
+      },
+      {
+        "name": "compute_vm_scaleset",
+        "title": "Azure Virtual Machines Scaleset metrics",
+        "description": "Azure Virtual Machines Scaleset Metrics Integration",
+        "icons": [
+          {
+            "src": "/img/compute_vm_scaleset_logo.png",
+            "path": "/package/azure_metrics/0.3.2/img/compute_vm_scaleset_logo.png",
+            "title": "logo azure",
+            "size": "32x32",
+            "type": "image/svg+xml"
+          }
+        ],
+        "data_streams": [
+          "compute_vm_scaleset"
+        ]
+      },
+      {
+        "name": "container_registry",
+        "title": "Azure Container Registry metrics",
+        "description": "Azure Container Registry Metrics Integration",
+        "icons": [
+          {
+            "src": "/img/container_registry_logo.png",
+            "path": "/package/azure_metrics/0.3.2/img/container_registry_logo.png",
+            "title": "logo azure",
+            "size": "32x32",
+            "type": "image/svg+xml"
+          }
+        ],
+        "data_streams": [
+          "container_registry"
+        ]
+      },
+      {
+        "name": "container_instance",
+        "title": "Azure Container Instance metrics",
+        "description": "Azure Container Instance Metrics Integration",
+        "icons": [
+          {
+            "src": "/img/container_instance_logo.png",
+            "path": "/package/azure_metrics/0.3.2/img/container_instance_logo.png",
+            "title": "logo azure",
+            "size": "32x32",
+            "type": "image/svg+xml"
+          }
+        ],
+        "data_streams": [
+          "container_instance"
+        ]
+      },
+      {
+        "name": "container_service",
+        "title": "Azure Container Service metrics",
+        "description": "Azure Container Service Metrics Integration",
+        "icons": [
+          {
+            "src": "/img/container_service_logo.png",
+            "path": "/package/azure_metrics/0.3.2/img/container_service_logo.png",
+            "title": "logo azure",
+            "size": "32x32",
+            "type": "image/svg+xml"
+          }
+        ],
+        "data_streams": [
+          "container_service"
+        ]
+      },
+      {
+        "name": "database_account",
+        "title": "Azure Database Account metrics",
+        "description": "Azure Database Account Metrics Integration",
+        "icons": [
+          {
+            "src": "/img/database_account_logo.png",
+            "path": "/package/azure_metrics/0.3.2/img/database_account_logo.png",
+            "title": "logo azure",
+            "size": "32x32",
+            "type": "image/svg+xml"
+          }
+        ],
+        "data_streams": [
+          "database_account"
+        ]
+      },
+      {
+        "name": "storage_account",
+        "title": "Azure Storage Account metrics",
+        "description": "Azure Storage Account Metrics Integration",
+        "icons": [
+          {
+            "src": "/img/storage_account_logo.png",
+            "path": "/package/azure_metrics/0.3.2/img/storage_account_logo.png",
+            "title": "logo azure",
+            "size": "32x32",
+            "type": "image/svg+xml"
+          }
+        ],
+        "data_streams": [
+          "storage_account"
+        ]
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "azure",
+      "web"
+    ],
+    "signature_path": "/epr/azure_metrics/azure_metrics-0.3.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "azure.compute_vm",
+        "title": "Compute VM"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.compute_vm_scaleset",
+        "title": "Compute VM Scaleset"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.container_instance",
+        "title": "Container Instance"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.container_registry",
+        "title": "Container Registry"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.container_service",
+        "title": "Container Service"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.database_account",
+        "title": "Database Account"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.monitor",
+        "title": "Monitor"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.storage_account",
+        "title": "Storage Account"
+      }
+    ]
+  },
+  {
     "name": "azure_metrics",
     "title": "Azure Resource Metrics",
     "version": "1.0.0",
@@ -18872,426 +18753,558 @@
     ]
   },
   {
-    "name": "azure_metrics",
-    "title": "Azure resource metrics",
-    "version": "0.3.1",
+    "name": "carbon_black_cloud",
+    "title": "Carbon Black Cloud",
+    "version": "0.1.0",
     "release": "beta",
-    "description": "This Elastic integration collects and aggregates metrics from Azure resources",
+    "description": "This Elastic integration collects logs from Carbon Black Cloud",
     "type": "integration",
-    "download": "/epr/azure_metrics/azure_metrics-0.3.1.zip",
-    "path": "/package/azure_metrics/0.3.1",
+    "download": "/epr/carbon_black_cloud/carbon_black_cloud-0.1.0.zip",
+    "path": "/package/carbon_black_cloud/0.1.0",
     "icons": [
       {
-        "src": "/img/azure_metrics_logo.png",
-        "path": "/package/azure_metrics/0.3.1/img/azure_metrics_logo.png",
-        "title": "logo docker",
+        "src": "/img/carbon_black_cloud-logo.svg",
+        "path": "/package/carbon_black_cloud/0.1.0/img/carbon_black_cloud-logo.svg",
+        "title": "Carbon Black Cloud logo",
         "size": "32x32",
         "type": "image/svg+xml"
       }
     ],
     "policy_templates": [
       {
-        "name": "monitor",
-        "title": "Azure Monitor metrics",
-        "description": "Azure Monitor Metrics Integration",
-        "icons": [
-          {
-            "src": "/img/monitor_logo.png",
-            "path": "/package/azure_metrics/0.3.1/img/monitor_logo.png",
-            "title": "logo azure",
-            "size": "32x32",
-            "type": "image/svg+xml"
-          }
-        ],
-        "data_streams": [
-          "monitor"
-        ]
-      },
-      {
-        "name": "compute_vm",
-        "title": "Azure Virtual Machines metrics",
-        "description": "Azure Virtual Machines Metrics Integration",
-        "icons": [
-          {
-            "src": "/img/compute_vm_logo.png",
-            "path": "/package/azure_metrics/0.3.1/img/compute_vm_logo.png",
-            "title": "logo azure",
-            "size": "32x32",
-            "type": "image/svg+xml"
-          }
-        ],
-        "data_streams": [
-          "compute_vm"
-        ]
-      },
-      {
-        "name": "compute_vm_scaleset",
-        "title": "Azure Virtual Machines Scaleset metrics",
-        "description": "Azure Virtual Machines Scaleset Metrics Integration",
-        "icons": [
-          {
-            "src": "/img/compute_vm_scaleset_logo.png",
-            "path": "/package/azure_metrics/0.3.1/img/compute_vm_scaleset_logo.png",
-            "title": "logo azure",
-            "size": "32x32",
-            "type": "image/svg+xml"
-          }
-        ],
-        "data_streams": [
-          "compute_vm_scaleset"
-        ]
-      },
-      {
-        "name": "container_registry",
-        "title": "Azure Container Registry metrics",
-        "description": "Azure Container Registry Metrics Integration",
-        "icons": [
-          {
-            "src": "/img/container_registry_logo.png",
-            "path": "/package/azure_metrics/0.3.1/img/container_registry_logo.png",
-            "title": "logo azure",
-            "size": "32x32",
-            "type": "image/svg+xml"
-          }
-        ],
-        "data_streams": [
-          "container_registry"
-        ]
-      },
-      {
-        "name": "container_instance",
-        "title": "Azure Container Instance metrics",
-        "description": "Azure Container Instance Metrics Integration",
-        "icons": [
-          {
-            "src": "/img/container_instance_logo.png",
-            "path": "/package/azure_metrics/0.3.1/img/container_instance_logo.png",
-            "title": "logo azure",
-            "size": "32x32",
-            "type": "image/svg+xml"
-          }
-        ],
-        "data_streams": [
-          "container_instance"
-        ]
-      },
-      {
-        "name": "container_service",
-        "title": "Azure Container Service metrics",
-        "description": "Azure Container Service Metrics Integration",
-        "icons": [
-          {
-            "src": "/img/container_service_logo.png",
-            "path": "/package/azure_metrics/0.3.1/img/container_service_logo.png",
-            "title": "logo azure",
-            "size": "32x32",
-            "type": "image/svg+xml"
-          }
-        ],
-        "data_streams": [
-          "container_service"
-        ]
-      },
-      {
-        "name": "database_account",
-        "title": "Azure Database Account metrics",
-        "description": "Azure Database Account Metrics Integration",
-        "icons": [
-          {
-            "src": "/img/database_account_logo.png",
-            "path": "/package/azure_metrics/0.3.1/img/database_account_logo.png",
-            "title": "logo azure",
-            "size": "32x32",
-            "type": "image/svg+xml"
-          }
-        ],
-        "data_streams": [
-          "database_account"
-        ]
-      },
-      {
-        "name": "storage_account",
-        "title": "Azure Storage Account metrics",
-        "description": "Azure Storage Account Metrics Integration",
-        "icons": [
-          {
-            "src": "/img/storage_account_logo.png",
-            "path": "/package/azure_metrics/0.3.1/img/storage_account_logo.png",
-            "title": "logo azure",
-            "size": "32x32",
-            "type": "image/svg+xml"
-          }
-        ],
-        "data_streams": [
-          "storage_account"
-        ]
+        "name": "carbon_black_cloud",
+        "title": "Carbon Black Cloud",
+        "description": "Collect Logs from Carbon Black Cloud"
       }
     ],
     "conditions": {
       "kibana": {
-        "version": "^7.14.0"
+        "version": "^7.17.0 || ^8.0.0"
       }
     },
     "owner": {
-      "github": "elastic/integrations"
+      "github": "elastic/security-external-integrations"
     },
     "categories": [
-      "azure",
-      "web"
+      "security"
     ],
-    "signature_path": "/epr/azure_metrics/azure_metrics-0.3.1.zip.sig",
+    "signature_path": "/epr/carbon_black_cloud/carbon_black_cloud-0.1.0.zip.sig",
     "data_streams": [
       {
-        "type": "metrics",
-        "dataset": "azure.compute_vm",
-        "title": "Compute VM"
+        "type": "logs",
+        "dataset": "carbon_black_cloud.alert",
+        "title": "Alert"
       },
       {
-        "type": "metrics",
-        "dataset": "azure.compute_vm_scaleset",
-        "title": "Compute VM Scaleset"
+        "type": "logs",
+        "dataset": "carbon_black_cloud.asset_vulnerability_summary",
+        "title": "Asset Vulnerability Summary"
       },
       {
-        "type": "metrics",
-        "dataset": "azure.container_instance",
-        "title": "Container Instance"
+        "type": "logs",
+        "dataset": "carbon_black_cloud.audit",
+        "title": "Audit"
       },
       {
-        "type": "metrics",
-        "dataset": "azure.container_registry",
-        "title": "Container Registry"
+        "type": "logs",
+        "dataset": "carbon_black_cloud.endpoint_event",
+        "title": "Endpoint Event"
       },
       {
-        "type": "metrics",
-        "dataset": "azure.container_service",
-        "title": "Container Service"
-      },
-      {
-        "type": "metrics",
-        "dataset": "azure.database_account",
-        "title": "Database Account"
-      },
-      {
-        "type": "metrics",
-        "dataset": "azure.monitor",
-        "title": "Monitor"
-      },
-      {
-        "type": "metrics",
-        "dataset": "azure.storage_account",
-        "title": "Storage Account"
+        "type": "logs",
+        "dataset": "carbon_black_cloud.watchlist_hit",
+        "title": "Watchlist Hit"
       }
     ]
   },
   {
-    "name": "azure_metrics",
-    "title": "Azure resource metrics",
-    "version": "0.3.2",
+    "name": "carbon_black_cloud",
+    "title": "Carbon Black Cloud",
+    "version": "0.1.1",
     "release": "beta",
-    "description": "This Elastic integration collects and aggregates metrics from Azure resources",
+    "description": "This Elastic integration collects logs from Carbon Black Cloud",
     "type": "integration",
-    "download": "/epr/azure_metrics/azure_metrics-0.3.2.zip",
-    "path": "/package/azure_metrics/0.3.2",
+    "download": "/epr/carbon_black_cloud/carbon_black_cloud-0.1.1.zip",
+    "path": "/package/carbon_black_cloud/0.1.1",
     "icons": [
       {
-        "src": "/img/azure_metrics_logo.png",
-        "path": "/package/azure_metrics/0.3.2/img/azure_metrics_logo.png",
-        "title": "logo docker",
+        "src": "/img/carbon_black_cloud-logo.svg",
+        "path": "/package/carbon_black_cloud/0.1.1/img/carbon_black_cloud-logo.svg",
+        "title": "Carbon Black Cloud logo",
         "size": "32x32",
         "type": "image/svg+xml"
       }
     ],
     "policy_templates": [
       {
-        "name": "monitor",
-        "title": "Azure Monitor metrics",
-        "description": "Azure Monitor Metrics Integration",
-        "icons": [
-          {
-            "src": "/img/monitor_logo.png",
-            "path": "/package/azure_metrics/0.3.2/img/monitor_logo.png",
-            "title": "logo azure",
-            "size": "32x32",
-            "type": "image/svg+xml"
-          }
-        ],
-        "data_streams": [
-          "monitor"
-        ]
-      },
-      {
-        "name": "compute_vm",
-        "title": "Azure Virtual Machines metrics",
-        "description": "Azure Virtual Machines Metrics Integration",
-        "icons": [
-          {
-            "src": "/img/compute_vm_logo.png",
-            "path": "/package/azure_metrics/0.3.2/img/compute_vm_logo.png",
-            "title": "logo azure",
-            "size": "32x32",
-            "type": "image/svg+xml"
-          }
-        ],
-        "data_streams": [
-          "compute_vm"
-        ]
-      },
-      {
-        "name": "compute_vm_scaleset",
-        "title": "Azure Virtual Machines Scaleset metrics",
-        "description": "Azure Virtual Machines Scaleset Metrics Integration",
-        "icons": [
-          {
-            "src": "/img/compute_vm_scaleset_logo.png",
-            "path": "/package/azure_metrics/0.3.2/img/compute_vm_scaleset_logo.png",
-            "title": "logo azure",
-            "size": "32x32",
-            "type": "image/svg+xml"
-          }
-        ],
-        "data_streams": [
-          "compute_vm_scaleset"
-        ]
-      },
-      {
-        "name": "container_registry",
-        "title": "Azure Container Registry metrics",
-        "description": "Azure Container Registry Metrics Integration",
-        "icons": [
-          {
-            "src": "/img/container_registry_logo.png",
-            "path": "/package/azure_metrics/0.3.2/img/container_registry_logo.png",
-            "title": "logo azure",
-            "size": "32x32",
-            "type": "image/svg+xml"
-          }
-        ],
-        "data_streams": [
-          "container_registry"
-        ]
-      },
-      {
-        "name": "container_instance",
-        "title": "Azure Container Instance metrics",
-        "description": "Azure Container Instance Metrics Integration",
-        "icons": [
-          {
-            "src": "/img/container_instance_logo.png",
-            "path": "/package/azure_metrics/0.3.2/img/container_instance_logo.png",
-            "title": "logo azure",
-            "size": "32x32",
-            "type": "image/svg+xml"
-          }
-        ],
-        "data_streams": [
-          "container_instance"
-        ]
-      },
-      {
-        "name": "container_service",
-        "title": "Azure Container Service metrics",
-        "description": "Azure Container Service Metrics Integration",
-        "icons": [
-          {
-            "src": "/img/container_service_logo.png",
-            "path": "/package/azure_metrics/0.3.2/img/container_service_logo.png",
-            "title": "logo azure",
-            "size": "32x32",
-            "type": "image/svg+xml"
-          }
-        ],
-        "data_streams": [
-          "container_service"
-        ]
-      },
-      {
-        "name": "database_account",
-        "title": "Azure Database Account metrics",
-        "description": "Azure Database Account Metrics Integration",
-        "icons": [
-          {
-            "src": "/img/database_account_logo.png",
-            "path": "/package/azure_metrics/0.3.2/img/database_account_logo.png",
-            "title": "logo azure",
-            "size": "32x32",
-            "type": "image/svg+xml"
-          }
-        ],
-        "data_streams": [
-          "database_account"
-        ]
-      },
-      {
-        "name": "storage_account",
-        "title": "Azure Storage Account metrics",
-        "description": "Azure Storage Account Metrics Integration",
-        "icons": [
-          {
-            "src": "/img/storage_account_logo.png",
-            "path": "/package/azure_metrics/0.3.2/img/storage_account_logo.png",
-            "title": "logo azure",
-            "size": "32x32",
-            "type": "image/svg+xml"
-          }
-        ],
-        "data_streams": [
-          "storage_account"
-        ]
+        "name": "carbon_black_cloud",
+        "title": "Carbon Black Cloud",
+        "description": "Collect Logs from Carbon Black Cloud"
       }
     ],
     "conditions": {
       "kibana": {
-        "version": "^7.14.0"
+        "version": "^7.17.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/carbon_black_cloud/carbon_black_cloud-0.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.alert",
+        "title": "Alert"
+      },
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.asset_vulnerability_summary",
+        "title": "Asset Vulnerability Summary"
+      },
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.audit",
+        "title": "Audit"
+      },
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.endpoint_event",
+        "title": "Endpoint Event"
+      },
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.watchlist_hit",
+        "title": "Watchlist Hit"
+      }
+    ]
+  },
+  {
+    "name": "carbon_black_cloud",
+    "title": "VMware Carbon Black Cloud",
+    "version": "0.1.2",
+    "release": "beta",
+    "description": "Collect logs from VMWare Carbon Black Cloud with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/carbon_black_cloud/carbon_black_cloud-0.1.2.zip",
+    "path": "/package/carbon_black_cloud/0.1.2",
+    "icons": [
+      {
+        "src": "/img/carbon_black_cloud-logo.svg",
+        "path": "/package/carbon_black_cloud/0.1.2/img/carbon_black_cloud-logo.svg",
+        "title": "Carbon Black Cloud logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "carbon_black_cloud",
+        "title": "Carbon Black Cloud",
+        "description": "Collect Logs from Carbon Black Cloud"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.17.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/carbon_black_cloud/carbon_black_cloud-0.1.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.alert",
+        "title": "Alert"
+      },
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.asset_vulnerability_summary",
+        "title": "Asset Vulnerability Summary"
+      },
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.audit",
+        "title": "Audit"
+      },
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.endpoint_event",
+        "title": "Endpoint Event"
+      },
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.watchlist_hit",
+        "title": "Watchlist Hit"
+      }
+    ]
+  },
+  {
+    "name": "carbon_black_cloud",
+    "title": "VMware Carbon Black Cloud",
+    "version": "1.0.1",
+    "release": "ga",
+    "description": "Collect logs from VMWare Carbon Black Cloud with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/carbon_black_cloud/carbon_black_cloud-1.0.1.zip",
+    "path": "/package/carbon_black_cloud/1.0.1",
+    "icons": [
+      {
+        "src": "/img/carbon_black_cloud-logo.svg",
+        "path": "/package/carbon_black_cloud/1.0.1/img/carbon_black_cloud-logo.svg",
+        "title": "Carbon Black Cloud logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "carbon_black_cloud",
+        "title": "Carbon Black Cloud",
+        "description": "Collect Logs from Carbon Black Cloud"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.17.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/carbon_black_cloud/carbon_black_cloud-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.alert",
+        "title": "Alert"
+      },
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.asset_vulnerability_summary",
+        "title": "Asset Vulnerability Summary"
+      },
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.audit",
+        "title": "Audit"
+      },
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.endpoint_event",
+        "title": "Endpoint Event"
+      },
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.watchlist_hit",
+        "title": "Watchlist Hit"
+      }
+    ]
+  },
+  {
+    "name": "carbon_black_cloud",
+    "title": "VMware Carbon Black Cloud",
+    "version": "1.0.2",
+    "release": "ga",
+    "description": "Collect logs from VMWare Carbon Black Cloud with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/carbon_black_cloud/carbon_black_cloud-1.0.2.zip",
+    "path": "/package/carbon_black_cloud/1.0.2",
+    "icons": [
+      {
+        "src": "/img/carbon_black_cloud-logo.svg",
+        "path": "/package/carbon_black_cloud/1.0.2/img/carbon_black_cloud-logo.svg",
+        "title": "Carbon Black Cloud logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "carbon_black_cloud",
+        "title": "Carbon Black Cloud",
+        "description": "Collect Logs from Carbon Black Cloud"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.17.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/carbon_black_cloud/carbon_black_cloud-1.0.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.alert",
+        "title": "Alert"
+      },
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.asset_vulnerability_summary",
+        "title": "Asset Vulnerability Summary"
+      },
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.audit",
+        "title": "Audit"
+      },
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.endpoint_event",
+        "title": "Endpoint Event"
+      },
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.watchlist_hit",
+        "title": "Watchlist Hit"
+      }
+    ]
+  },
+  {
+    "name": "carbonblack_edr",
+    "title": "VMware Carbon Black EDR",
+    "version": "1.0.0",
+    "release": "ga",
+    "description": "Collect logs from VMware Carbon Black EDR with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/carbonblack_edr/carbonblack_edr-1.0.0.zip",
+    "path": "/package/carbonblack_edr/1.0.0",
+    "icons": [
+      {
+        "src": "/img/carbon-black-logo.svg",
+        "path": "/package/carbonblack_edr/1.0.0/img/carbon-black-logo.svg",
+        "title": "VMWare Carbon Black",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "log",
+        "title": "Carbon Black EDR logs",
+        "description": "Collect logs from Carbon Black EDR"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/carbonblack_edr/carbonblack_edr-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "carbonblack_edr.log",
+        "title": "Carbon Black EDR logs"
+      }
+    ]
+  },
+  {
+    "name": "carbonblack_edr",
+    "title": "VMware Carbon Black EDR",
+    "version": "1.1.0",
+    "release": "ga",
+    "description": "Collect logs from VMware Carbon Black EDR with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/carbonblack_edr/carbonblack_edr-1.1.0.zip",
+    "path": "/package/carbonblack_edr/1.1.0",
+    "icons": [
+      {
+        "src": "/img/carbon-black-logo.svg",
+        "path": "/package/carbonblack_edr/1.1.0/img/carbon-black-logo.svg",
+        "title": "VMWare Carbon Black",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "log",
+        "title": "Carbon Black EDR logs",
+        "description": "Collect logs from Carbon Black EDR"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/carbonblack_edr/carbonblack_edr-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "carbonblack_edr.log",
+        "title": "Carbon Black EDR logs"
+      }
+    ]
+  },
+  {
+    "name": "carbonblack_edr",
+    "title": "VMware Carbon Black EDR",
+    "version": "1.1.1",
+    "release": "ga",
+    "description": "Collect logs from VMware Carbon Black EDR with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/carbonblack_edr/carbonblack_edr-1.1.1.zip",
+    "path": "/package/carbonblack_edr/1.1.1",
+    "icons": [
+      {
+        "src": "/img/carbon-black-logo.svg",
+        "path": "/package/carbonblack_edr/1.1.1/img/carbon-black-logo.svg",
+        "title": "VMWare Carbon Black",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "log",
+        "title": "Carbon Black EDR logs",
+        "description": "Collect logs from Carbon Black EDR"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/carbonblack_edr/carbonblack_edr-1.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "carbonblack_edr.log",
+        "title": "Carbon Black EDR logs"
+      }
+    ]
+  },
+  {
+    "name": "carbonblack_edr",
+    "title": "VMware Carbon Black EDR",
+    "version": "1.2.0",
+    "release": "ga",
+    "description": "Collect logs from VMware Carbon Black EDR with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/carbonblack_edr/carbonblack_edr-1.2.0.zip",
+    "path": "/package/carbonblack_edr/1.2.0",
+    "icons": [
+      {
+        "src": "/img/carbon-black-logo.svg",
+        "path": "/package/carbonblack_edr/1.2.0/img/carbon-black-logo.svg",
+        "title": "VMWare Carbon Black",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "log",
+        "title": "Carbon Black EDR logs",
+        "description": "Collect logs from Carbon Black EDR"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/carbonblack_edr/carbonblack_edr-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "carbonblack_edr.log",
+        "title": "Carbon Black EDR logs"
+      }
+    ]
+  },
+  {
+    "name": "cassandra",
+    "title": "Cassandra",
+    "version": "1.1.0",
+    "release": "ga",
+    "description": "This Elastic integration collects logs and metrics from cassandra.",
+    "type": "integration",
+    "download": "/epr/cassandra/cassandra-1.1.0.zip",
+    "path": "/package/cassandra/1.1.0",
+    "icons": [
+      {
+        "src": "/img/cassandra.svg",
+        "path": "/package/cassandra/1.1.0/img/cassandra.svg",
+        "title": "cassandra",
+        "size": "279x187",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "cassandra",
+        "title": "Cassandra logs and metrics",
+        "description": "Collect logs and metrics from Cassandra"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.15.0 || ^8.0.0"
       }
     },
     "owner": {
       "github": "elastic/integrations"
     },
     "categories": [
-      "azure",
-      "web"
+      "datastore",
+      "monitoring"
     ],
-    "signature_path": "/epr/azure_metrics/azure_metrics-0.3.2.zip.sig",
+    "signature_path": "/epr/cassandra/cassandra-1.1.0.zip.sig",
     "data_streams": [
       {
-        "type": "metrics",
-        "dataset": "azure.compute_vm",
-        "title": "Compute VM"
+        "type": "logs",
+        "dataset": "cassandra.log",
+        "title": "Cassandra System Logs"
       },
       {
         "type": "metrics",
-        "dataset": "azure.compute_vm_scaleset",
-        "title": "Compute VM Scaleset"
-      },
-      {
-        "type": "metrics",
-        "dataset": "azure.container_instance",
-        "title": "Container Instance"
-      },
-      {
-        "type": "metrics",
-        "dataset": "azure.container_registry",
-        "title": "Container Registry"
-      },
-      {
-        "type": "metrics",
-        "dataset": "azure.container_service",
-        "title": "Container Service"
-      },
-      {
-        "type": "metrics",
-        "dataset": "azure.database_account",
-        "title": "Database Account"
-      },
-      {
-        "type": "metrics",
-        "dataset": "azure.monitor",
-        "title": "Monitor"
-      },
-      {
-        "type": "metrics",
-        "dataset": "azure.storage_account",
-        "title": "Storage Account"
+        "dataset": "cassandra.metrics",
+        "title": "metrics"
       }
     ]
   },
@@ -19625,187 +19638,6 @@
         "type": "logs",
         "dataset": "cef.log",
         "title": "CEF log logs"
-      }
-    ]
-  },
-  {
-    "name": "carbon_black_cloud",
-    "title": "Carbon Black Cloud",
-    "version": "0.1.0",
-    "release": "beta",
-    "description": "This Elastic integration collects logs from Carbon Black Cloud",
-    "type": "integration",
-    "download": "/epr/carbon_black_cloud/carbon_black_cloud-0.1.0.zip",
-    "path": "/package/carbon_black_cloud/0.1.0",
-    "icons": [
-      {
-        "src": "/img/carbon_black_cloud-logo.svg",
-        "path": "/package/carbon_black_cloud/0.1.0/img/carbon_black_cloud-logo.svg",
-        "title": "Carbon Black Cloud logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "carbon_black_cloud",
-        "title": "Carbon Black Cloud",
-        "description": "Collect Logs from Carbon Black Cloud"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.17.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/carbon_black_cloud/carbon_black_cloud-0.1.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "carbon_black_cloud.alert",
-        "title": "Alert"
-      },
-      {
-        "type": "logs",
-        "dataset": "carbon_black_cloud.asset_vulnerability_summary",
-        "title": "Asset Vulnerability Summary"
-      },
-      {
-        "type": "logs",
-        "dataset": "carbon_black_cloud.audit",
-        "title": "Audit"
-      },
-      {
-        "type": "logs",
-        "dataset": "carbon_black_cloud.endpoint_event",
-        "title": "Endpoint Event"
-      },
-      {
-        "type": "logs",
-        "dataset": "carbon_black_cloud.watchlist_hit",
-        "title": "Watchlist Hit"
-      }
-    ]
-  },
-  {
-    "name": "carbon_black_cloud",
-    "title": "Carbon Black Cloud",
-    "version": "0.1.1",
-    "release": "beta",
-    "description": "This Elastic integration collects logs from Carbon Black Cloud",
-    "type": "integration",
-    "download": "/epr/carbon_black_cloud/carbon_black_cloud-0.1.1.zip",
-    "path": "/package/carbon_black_cloud/0.1.1",
-    "icons": [
-      {
-        "src": "/img/carbon_black_cloud-logo.svg",
-        "path": "/package/carbon_black_cloud/0.1.1/img/carbon_black_cloud-logo.svg",
-        "title": "Carbon Black Cloud logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "carbon_black_cloud",
-        "title": "Carbon Black Cloud",
-        "description": "Collect Logs from Carbon Black Cloud"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.17.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/carbon_black_cloud/carbon_black_cloud-0.1.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "carbon_black_cloud.alert",
-        "title": "Alert"
-      },
-      {
-        "type": "logs",
-        "dataset": "carbon_black_cloud.asset_vulnerability_summary",
-        "title": "Asset Vulnerability Summary"
-      },
-      {
-        "type": "logs",
-        "dataset": "carbon_black_cloud.audit",
-        "title": "Audit"
-      },
-      {
-        "type": "logs",
-        "dataset": "carbon_black_cloud.endpoint_event",
-        "title": "Endpoint Event"
-      },
-      {
-        "type": "logs",
-        "dataset": "carbon_black_cloud.watchlist_hit",
-        "title": "Watchlist Hit"
-      }
-    ]
-  },
-  {
-    "name": "cassandra",
-    "title": "Cassandra",
-    "version": "1.1.0",
-    "release": "ga",
-    "description": "This Elastic integration collects logs and metrics from cassandra.",
-    "type": "integration",
-    "download": "/epr/cassandra/cassandra-1.1.0.zip",
-    "path": "/package/cassandra/1.1.0",
-    "icons": [
-      {
-        "src": "/img/cassandra.svg",
-        "path": "/package/cassandra/1.1.0/img/cassandra.svg",
-        "title": "cassandra",
-        "size": "279x187",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "cassandra",
-        "title": "Cassandra logs and metrics",
-        "description": "Collect logs and metrics from Cassandra"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.15.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "datastore",
-      "monitoring"
-    ],
-    "signature_path": "/epr/cassandra/cassandra-1.1.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "cassandra.log",
-        "title": "Cassandra System Logs"
-      },
-      {
-        "type": "metrics",
-        "dataset": "cassandra.metrics",
-        "title": "metrics"
       }
     ]
   },
@@ -24111,674 +23943,6 @@
     ]
   },
   {
-    "name": "aws_logs",
-    "title": "Custom AWS Logs",
-    "version": "0.2.1",
-    "release": "beta",
-    "description": "Collect raw logs from AWS S3 or CloudWatch with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/aws_logs/aws_logs-0.2.1.zip",
-    "path": "/package/aws_logs/0.2.1",
-    "icons": [
-      {
-        "src": "/img/icon.svg",
-        "path": "/package/aws_logs/0.2.1/img/icon.svg",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "aws_logs",
-        "title": "Custom AWS Logs",
-        "description": "Collect raw logs from AWS S3 or CloudWatch with Elastic Agent."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/obs-cloud-monitoring"
-    },
-    "categories": [
-      "custom",
-      "cloud",
-      "aws"
-    ],
-    "signature_path": "/epr/aws_logs/aws_logs-0.2.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "aws_logs.generic",
-        "title": "Custom logs from AWS"
-      }
-    ]
-  },
-  {
-    "name": "gcp_pubsub",
-    "title": "Custom Google Pub/Sub Logs",
-    "version": "1.0.0",
-    "release": "ga",
-    "description": "Collect Logs from Google Pub/Sub topics",
-    "type": "integration",
-    "download": "/epr/gcp_pubsub/gcp_pubsub-1.0.0.zip",
-    "path": "/package/gcp_pubsub/1.0.0",
-    "icons": [
-      {
-        "src": "/img/logo_gcp.svg",
-        "path": "/package/gcp_pubsub/1.0.0/img/logo_gcp.svg",
-        "title": "logo gcp",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "gcp",
-        "title": "Custom Google Pub/Sub Logs",
-        "description": "Collect Logs from Google Pub/Sub topics"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "google_cloud",
-      "cloud",
-      "custom"
-    ],
-    "signature_path": "/epr/gcp_pubsub/gcp_pubsub-1.0.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "gcp_pubsub.generic",
-        "title": "Custom Google Pub/Sub Logs"
-      }
-    ]
-  },
-  {
-    "name": "http_endpoint",
-    "title": "Custom HTTP Endpoint Logs",
-    "version": "1.0.1",
-    "release": "ga",
-    "description": "Collect JSON data from listening HTTP port with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/http_endpoint/http_endpoint-1.0.1.zip",
-    "path": "/package/http_endpoint/1.0.1",
-    "icons": [
-      {
-        "src": "/img/icon.svg",
-        "path": "/package/http_endpoint/1.0.1/img/icon.svg",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "http_endpoint",
-        "title": "Custom HTTP Endpoint Logs",
-        "description": "Collect JSON data from listening HTTP port with Elastic Agent."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "signature_path": "/epr/http_endpoint/http_endpoint-1.0.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "http_endpoint.generic",
-        "title": "Custom HTTP Endpoint Logs"
-      }
-    ]
-  },
-  {
-    "name": "httpjson",
-    "title": "Custom HTTPJSON Input",
-    "version": "1.0.0",
-    "release": "ga",
-    "description": "Collect custom data from REST API's with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/httpjson/httpjson-1.0.0.zip",
-    "path": "/package/httpjson/1.0.0",
-    "policy_templates": [
-      {
-        "name": "generic",
-        "title": "Custom HTTPJSON Input",
-        "description": "Collect custom data from REST API's"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "signature_path": "/epr/httpjson/httpjson-1.0.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "httpjson.generic",
-        "title": "Custom HTTPJSON Input"
-      }
-    ]
-  },
-  {
-    "name": "httpjson",
-    "title": "Custom HTTPJSON Input",
-    "version": "1.1.0",
-    "release": "ga",
-    "description": "Collect custom data from REST API's with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/httpjson/httpjson-1.1.0.zip",
-    "path": "/package/httpjson/1.1.0",
-    "policy_templates": [
-      {
-        "name": "generic",
-        "title": "Custom HTTPJSON Input",
-        "description": "Collect custom data from REST API's"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "signature_path": "/epr/httpjson/httpjson-1.1.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "httpjson.generic",
-        "title": "Custom HTTPJSON Input"
-      }
-    ]
-  },
-  {
-    "name": "httpjson",
-    "title": "Custom HTTPJSON Input",
-    "version": "1.1.1",
-    "release": "ga",
-    "description": "Collect custom data from REST API's with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/httpjson/httpjson-1.1.1.zip",
-    "path": "/package/httpjson/1.1.1",
-    "policy_templates": [
-      {
-        "name": "generic",
-        "title": "Custom HTTPJSON Input",
-        "description": "Collect custom data from REST API's"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "signature_path": "/epr/httpjson/httpjson-1.1.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "httpjson.generic",
-        "title": "Custom HTTPJSON Input"
-      }
-    ]
-  },
-  {
-    "name": "log",
-    "title": "Custom Logs",
-    "version": "1.0.0",
-    "release": "ga",
-    "description": "Collect custom logs with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/log/log-1.0.0.zip",
-    "path": "/package/log/1.0.0",
-    "icons": [
-      {
-        "src": "/img/icon.svg",
-        "path": "/package/log/1.0.0/img/icon.svg",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "logs",
-        "title": "Custom logs",
-        "description": "Collect your custom log files."
-      }
-    ],
-    "owner": {
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "signature_path": "/epr/log/log-1.0.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "log.log",
-        "title": "Log Dataset"
-      }
-    ]
-  },
-  {
-    "name": "tcp",
-    "title": "Custom TCP Logs",
-    "version": "1.0.0",
-    "release": "ga",
-    "description": "Collect raw TCP data from listening TCP port with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/tcp/tcp-1.0.0.zip",
-    "path": "/package/tcp/1.0.0",
-    "icons": [
-      {
-        "src": "/img/icon.svg",
-        "path": "/package/tcp/1.0.0/img/icon.svg",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "tcp",
-        "title": "Custom TCP Logs",
-        "description": "Collect raw TCP data from listening TCP port with Elastic Agent."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "signature_path": "/epr/tcp/tcp-1.0.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "tcp.generic",
-        "title": "Custom TCP Logs"
-      }
-    ]
-  },
-  {
-    "name": "udp",
-    "title": "Custom UDP Logs",
-    "version": "1.0.0",
-    "release": "ga",
-    "description": "Collect raw UDP data from listening UDP port with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/udp/udp-1.0.0.zip",
-    "path": "/package/udp/1.0.0",
-    "icons": [
-      {
-        "src": "/img/icon.svg",
-        "path": "/package/udp/1.0.0/img/icon.svg",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "udp",
-        "title": "Custom UDP Logs",
-        "description": "Collect raw UDP data from listening UDP port with Elastic Agent."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "signature_path": "/epr/udp/udp-1.0.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "udp.generic",
-        "title": "Custom UDP Logs"
-      }
-    ]
-  },
-  {
-    "name": "udp",
-    "title": "Custom UDP Logs",
-    "version": "1.0.1",
-    "release": "ga",
-    "description": "Collect raw UDP data from listening UDP port with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/udp/udp-1.0.1.zip",
-    "path": "/package/udp/1.0.1",
-    "icons": [
-      {
-        "src": "/img/icon.svg",
-        "path": "/package/udp/1.0.1/img/icon.svg",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "udp",
-        "title": "Custom UDP Logs",
-        "description": "Collect raw UDP data from listening UDP port with Elastic Agent."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "signature_path": "/epr/udp/udp-1.0.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "udp.generic",
-        "title": "Custom UDP Logs"
-      }
-    ]
-  },
-  {
-    "name": "winlog",
-    "title": "Custom Windows Event Logs",
-    "version": "1.1.2",
-    "release": "ga",
-    "description": "Collect and parse logs from any Windows event log channel with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/winlog/winlog-1.1.2.zip",
-    "path": "/package/winlog/1.1.2",
-    "icons": [
-      {
-        "src": "/img/logo_windows.svg",
-        "path": "/package/winlog/1.1.2/img/logo_windows.svg",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "winlogs",
-        "title": "Custom Windows event logs",
-        "description": "Collect your custom Windows event logs."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "signature_path": "/epr/winlog/winlog-1.1.2.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "winlog.winlog",
-        "title": "Custom Windows Event Log Dataset"
-      }
-    ]
-  },
-  {
-    "name": "winlog",
-    "title": "Custom Windows Event Logs",
-    "version": "1.2.0",
-    "release": "ga",
-    "description": "Collect and parse logs from any Windows event log channel with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/winlog/winlog-1.2.0.zip",
-    "path": "/package/winlog/1.2.0",
-    "icons": [
-      {
-        "src": "/img/logo_windows.svg",
-        "path": "/package/winlog/1.2.0/img/logo_windows.svg",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "winlogs",
-        "title": "Custom Windows event logs",
-        "description": "Collect your custom Windows event logs."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "signature_path": "/epr/winlog/winlog-1.2.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "winlog.winlog",
-        "title": "Custom Windows Event Log Dataset"
-      }
-    ]
-  },
-  {
-    "name": "winlog",
-    "title": "Custom Windows Event Logs",
-    "version": "1.3.0",
-    "release": "ga",
-    "description": "Collect and parse logs from any Windows event log channel with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/winlog/winlog-1.3.0.zip",
-    "path": "/package/winlog/1.3.0",
-    "icons": [
-      {
-        "src": "/img/logo_windows.svg",
-        "path": "/package/winlog/1.3.0/img/logo_windows.svg",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "winlogs",
-        "title": "Custom Windows event logs",
-        "description": "Collect your custom Windows event logs."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "signature_path": "/epr/winlog/winlog-1.3.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "winlog.winlog",
-        "title": "Custom Windows Event Log Dataset"
-      }
-    ]
-  },
-  {
-    "name": "winlog",
-    "title": "Custom Windows Event Logs",
-    "version": "1.4.0",
-    "release": "ga",
-    "description": "Collect and parse logs from any Windows event log channel with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/winlog/winlog-1.4.0.zip",
-    "path": "/package/winlog/1.4.0",
-    "icons": [
-      {
-        "src": "/img/logo_windows.svg",
-        "path": "/package/winlog/1.4.0/img/logo_windows.svg",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "winlogs",
-        "title": "Custom Windows event logs",
-        "description": "Collect your custom Windows event logs."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "signature_path": "/epr/winlog/winlog-1.4.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "winlog.winlog",
-        "title": "Custom Windows Event Log Dataset"
-      }
-    ]
-  },
-  {
-    "name": "winlog",
-    "title": "Custom Windows event logs",
-    "version": "1.0.3",
-    "release": "ga",
-    "description": "Collect event logs from Windows with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/winlog/winlog-1.0.3.zip",
-    "path": "/package/winlog/1.0.3",
-    "icons": [
-      {
-        "src": "/img/logo_windows.svg",
-        "path": "/package/winlog/1.0.3/img/logo_windows.svg",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "winlogs",
-        "title": "Custom Windows event logs",
-        "description": "Collect your custom Windows event logs."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "signature_path": "/epr/winlog/winlog-1.0.3.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "winlog.winlog",
-        "title": "Custom Windows Event Log Dataset"
-      }
-    ]
-  },
-  {
-    "name": "winlog",
-    "title": "Custom Windows event logs",
-    "version": "1.1.0",
-    "release": "ga",
-    "description": "Collect event logs from Windows with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/winlog/winlog-1.1.0.zip",
-    "path": "/package/winlog/1.1.0",
-    "icons": [
-      {
-        "src": "/img/logo_windows.svg",
-        "path": "/package/winlog/1.1.0/img/logo_windows.svg",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "winlogs",
-        "title": "Custom Windows event logs",
-        "description": "Collect your custom Windows event logs."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "signature_path": "/epr/winlog/winlog-1.1.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "winlog.winlog",
-        "title": "Custom Windows Event Log Dataset"
-      }
-    ]
-  },
-  {
     "name": "cyberarkpas",
     "title": "CyberArk Privileged Access Security",
     "version": "1.0.0",
@@ -25274,282 +24438,6 @@
     ]
   },
   {
-    "name": "ti_cybersixgill",
-    "title": "Cybersixgill",
-    "version": "1.0.0",
-    "release": "ga",
-    "description": "This Elastic integration collects threat intelligence from Cybersixgill",
-    "type": "integration",
-    "download": "/epr/ti_cybersixgill/ti_cybersixgill-1.0.0.zip",
-    "path": "/package/ti_cybersixgill/1.0.0",
-    "icons": [
-      {
-        "src": "/img/cybersixgill.svg",
-        "path": "/package/ti_cybersixgill/1.0.0/img/cybersixgill.svg",
-        "title": "Zoom",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "cybersixgill",
-        "title": "Cybersixgill Threat Intel",
-        "description": "Collect Threat Intel from Cybersixgill"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security",
-      "productivity"
-    ],
-    "signature_path": "/epr/ti_cybersixgill/ti_cybersixgill-1.0.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ti_cybersixgill.threat",
-        "title": "Cybersixgill webhook logs"
-      }
-    ]
-  },
-  {
-    "name": "ti_cybersixgill",
-    "title": "Cybersixgill",
-    "version": "1.1.0",
-    "release": "ga",
-    "description": "This Elastic integration collects threat intelligence from Cybersixgill",
-    "type": "integration",
-    "download": "/epr/ti_cybersixgill/ti_cybersixgill-1.1.0.zip",
-    "path": "/package/ti_cybersixgill/1.1.0",
-    "icons": [
-      {
-        "src": "/img/cybersixgill.svg",
-        "path": "/package/ti_cybersixgill/1.1.0/img/cybersixgill.svg",
-        "title": "Zoom",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "cybersixgill",
-        "title": "Cybersixgill Threat Intel",
-        "description": "Collect Threat Intel from Cybersixgill"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security",
-      "productivity"
-    ],
-    "signature_path": "/epr/ti_cybersixgill/ti_cybersixgill-1.1.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ti_cybersixgill.threat",
-        "title": "Cybersixgill webhook logs"
-      }
-    ]
-  },
-  {
-    "name": "ti_cybersixgill",
-    "title": "Cybersixgill",
-    "version": "1.2.0",
-    "release": "ga",
-    "description": "This Elastic integration collects threat intelligence from Cybersixgill",
-    "type": "integration",
-    "download": "/epr/ti_cybersixgill/ti_cybersixgill-1.2.0.zip",
-    "path": "/package/ti_cybersixgill/1.2.0",
-    "icons": [
-      {
-        "src": "/img/cybersixgill.svg",
-        "path": "/package/ti_cybersixgill/1.2.0/img/cybersixgill.svg",
-        "title": "Zoom",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "cybersixgill",
-        "title": "Cybersixgill Threat Intel",
-        "description": "Collect Threat Intel from Cybersixgill"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security",
-      "productivity"
-    ],
-    "signature_path": "/epr/ti_cybersixgill/ti_cybersixgill-1.2.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ti_cybersixgill.threat",
-        "title": "Cybersixgill webhook logs"
-      }
-    ]
-  },
-  {
-    "name": "ti_cybersixgill",
-    "title": "Cybersixgill",
-    "version": "1.3.0",
-    "release": "ga",
-    "description": "This Elastic integration collects threat intelligence from Cybersixgill",
-    "type": "integration",
-    "download": "/epr/ti_cybersixgill/ti_cybersixgill-1.3.0.zip",
-    "path": "/package/ti_cybersixgill/1.3.0",
-    "icons": [
-      {
-        "src": "/img/cybersixgill.svg",
-        "path": "/package/ti_cybersixgill/1.3.0/img/cybersixgill.svg",
-        "title": "Cybersixgill",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "cybersixgill",
-        "title": "Cybersixgill Threat Intel",
-        "description": "Collect Threat Intel from Cybersixgill"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security",
-      "productivity"
-    ],
-    "signature_path": "/epr/ti_cybersixgill/ti_cybersixgill-1.3.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ti_cybersixgill.threat",
-        "title": "Cybersixgill Darkfeed Logs"
-      }
-    ]
-  },
-  {
-    "name": "ti_cybersixgill",
-    "title": "Cybersixgill",
-    "version": "1.3.1",
-    "release": "ga",
-    "description": "This Elastic integration collects threat intelligence from Cybersixgill",
-    "type": "integration",
-    "download": "/epr/ti_cybersixgill/ti_cybersixgill-1.3.1.zip",
-    "path": "/package/ti_cybersixgill/1.3.1",
-    "icons": [
-      {
-        "src": "/img/cybersixgill.svg",
-        "path": "/package/ti_cybersixgill/1.3.1/img/cybersixgill.svg",
-        "title": "Cybersixgill",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "cybersixgill",
-        "title": "Cybersixgill Threat Intel",
-        "description": "Collect Threat Intel from Cybersixgill"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security",
-      "productivity"
-    ],
-    "signature_path": "/epr/ti_cybersixgill/ti_cybersixgill-1.3.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ti_cybersixgill.threat",
-        "title": "Cybersixgill Darkfeed Logs"
-      }
-    ]
-  },
-  {
-    "name": "ti_cybersixgill",
-    "title": "Cybersixgill",
-    "version": "1.3.2",
-    "release": "ga",
-    "description": "This Elastic integration collects threat intelligence from Cybersixgill",
-    "type": "integration",
-    "download": "/epr/ti_cybersixgill/ti_cybersixgill-1.3.2.zip",
-    "path": "/package/ti_cybersixgill/1.3.2",
-    "icons": [
-      {
-        "src": "/img/cybersixgill.svg",
-        "path": "/package/ti_cybersixgill/1.3.2/img/cybersixgill.svg",
-        "title": "Cybersixgill",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "cybersixgill",
-        "title": "Cybersixgill Threat Intel",
-        "description": "Collect Threat Intel from Cybersixgill"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security",
-      "productivity"
-    ],
-    "signature_path": "/epr/ti_cybersixgill/ti_cybersixgill-1.3.2.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ti_cybersixgill.threat",
-        "title": "Cybersixgill Darkfeed Logs"
-      }
-    ]
-  },
-  {
     "name": "discovery_empty",
     "title": "Discovery Empty",
     "version": "0.1.0",
@@ -25807,695 +24695,6 @@
         "type": "metrics",
         "dataset": "docker.network",
         "title": "Docker network metrics"
-      }
-    ]
-  },
-  {
-    "name": "apm",
-    "title": "Elastic APM",
-    "version": "0.4.0",
-    "release": "beta",
-    "description": "Ingest APM data",
-    "type": "integration",
-    "download": "/epr/apm/apm-0.4.0.zip",
-    "path": "/package/apm/0.4.0",
-    "icons": [
-      {
-        "src": "/img/logo_apm.svg",
-        "path": "/package/apm/0.4.0/img/logo_apm.svg",
-        "title": "APM Logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "apmserver",
-        "title": "Elastic APM Integration",
-        "description": "Elastic APM Integration"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.13.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/apm-server"
-    },
-    "categories": [
-      "elastic_stack",
-      "monitoring"
-    ],
-    "signature_path": "/epr/apm/apm-0.4.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "metrics",
-        "dataset": "apm.app",
-        "title": "APM application metrics"
-      },
-      {
-        "type": "logs",
-        "dataset": "apm.error",
-        "title": "APM logs and errors"
-      },
-      {
-        "type": "metrics",
-        "dataset": "apm.internal",
-        "title": "APM internal metrics"
-      },
-      {
-        "type": "metrics",
-        "dataset": "apm.profiling",
-        "title": "APM profiles"
-      },
-      {
-        "type": "traces",
-        "dataset": "apm.sampled",
-        "title": "APM tail-sampled traces"
-      },
-      {
-        "type": "traces",
-        "dataset": "apm",
-        "title": "APM traces"
-      }
-    ]
-  },
-  {
-    "name": "apm",
-    "title": "Elastic APM",
-    "version": "7.16.0",
-    "release": "ga",
-    "description": "Ingest APM data",
-    "type": "integration",
-    "download": "/epr/apm/apm-7.16.0.zip",
-    "path": "/package/apm/7.16.0",
-    "icons": [
-      {
-        "src": "/img/logo_apm.svg",
-        "path": "/package/apm/7.16.0/img/logo_apm.svg",
-        "title": "APM Logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "apmserver",
-        "title": "Elastic APM Integration",
-        "description": "Elastic APM Integration"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/apm-server"
-    },
-    "categories": [
-      "elastic_stack",
-      "monitoring"
-    ],
-    "signature_path": "/epr/apm/apm-7.16.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "metrics",
-        "dataset": "apm.app",
-        "title": "APM application metrics"
-      },
-      {
-        "type": "logs",
-        "dataset": "apm.error",
-        "title": "APM logs and errors"
-      },
-      {
-        "type": "metrics",
-        "dataset": "apm.internal",
-        "title": "APM internal metrics"
-      },
-      {
-        "type": "metrics",
-        "dataset": "apm.profiling",
-        "title": "APM profiles"
-      },
-      {
-        "type": "traces",
-        "dataset": "apm.sampled",
-        "title": "APM tail-sampled traces"
-      },
-      {
-        "type": "traces",
-        "dataset": "apm",
-        "title": "APM traces"
-      }
-    ]
-  },
-  {
-    "name": "apm",
-    "title": "Elastic APM",
-    "version": "7.16.1",
-    "release": "ga",
-    "description": "Ingest APM data",
-    "type": "integration",
-    "download": "/epr/apm/apm-7.16.1.zip",
-    "path": "/package/apm/7.16.1",
-    "icons": [
-      {
-        "src": "/img/logo_apm.svg",
-        "path": "/package/apm/7.16.1/img/logo_apm.svg",
-        "title": "APM Logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "apmserver",
-        "title": "Elastic APM Integration",
-        "description": "Elastic APM Integration"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.1"
-      }
-    },
-    "owner": {
-      "github": "elastic/apm-server"
-    },
-    "categories": [
-      "elastic_stack",
-      "monitoring"
-    ],
-    "signature_path": "/epr/apm/apm-7.16.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "metrics",
-        "dataset": "apm.app",
-        "title": "APM application metrics"
-      },
-      {
-        "type": "logs",
-        "dataset": "apm.error",
-        "title": "APM logs and errors"
-      },
-      {
-        "type": "metrics",
-        "dataset": "apm.internal",
-        "title": "APM internal metrics"
-      },
-      {
-        "type": "metrics",
-        "dataset": "apm.profiling",
-        "title": "APM profiles"
-      },
-      {
-        "type": "traces",
-        "dataset": "apm.sampled",
-        "title": "APM tail-sampled traces"
-      },
-      {
-        "type": "traces",
-        "dataset": "apm",
-        "title": "APM traces"
-      }
-    ]
-  },
-  {
-    "name": "apm",
-    "title": "Elastic APM",
-    "version": "7.16.2",
-    "release": "ga",
-    "description": "Ingest APM data",
-    "type": "integration",
-    "download": "/epr/apm/apm-7.16.2.zip",
-    "path": "/package/apm/7.16.2",
-    "icons": [
-      {
-        "src": "/img/logo_apm.svg",
-        "path": "/package/apm/7.16.2/img/logo_apm.svg",
-        "title": "APM Logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "apmserver",
-        "title": "Elastic APM Integration",
-        "description": "Elastic APM Integration"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/apm-server"
-    },
-    "categories": [
-      "elastic_stack",
-      "monitoring"
-    ],
-    "signature_path": "/epr/apm/apm-7.16.2.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "apm.app",
-        "title": "APM application logs"
-      },
-      {
-        "type": "metrics",
-        "dataset": "apm.app",
-        "title": "APM application metrics"
-      },
-      {
-        "type": "logs",
-        "dataset": "apm.error",
-        "title": "APM logs and errors"
-      },
-      {
-        "type": "metrics",
-        "dataset": "apm.internal",
-        "title": "APM internal metrics"
-      },
-      {
-        "type": "metrics",
-        "dataset": "apm.profiling",
-        "title": "APM profiles"
-      },
-      {
-        "type": "traces",
-        "dataset": "apm.sampled",
-        "title": "APM tail-sampled traces"
-      },
-      {
-        "type": "traces",
-        "dataset": "apm",
-        "title": "APM traces"
-      }
-    ]
-  },
-  {
-    "name": "apm",
-    "title": "Elastic APM",
-    "version": "7.17.0",
-    "release": "ga",
-    "description": "Ingest APM data",
-    "type": "integration",
-    "download": "/epr/apm/apm-7.17.0.zip",
-    "path": "/package/apm/7.17.0",
-    "icons": [
-      {
-        "src": "/img/logo_apm.svg",
-        "path": "/package/apm/7.17.0/img/logo_apm.svg",
-        "title": "APM Logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "apmserver",
-        "title": "Elastic APM Integration",
-        "description": "Elastic APM Integration"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.17.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/apm-server"
-    },
-    "categories": [
-      "elastic_stack",
-      "monitoring"
-    ],
-    "signature_path": "/epr/apm/apm-7.17.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "apm.app",
-        "title": "APM application logs"
-      },
-      {
-        "type": "metrics",
-        "dataset": "apm.app",
-        "title": "APM application metrics"
-      },
-      {
-        "type": "logs",
-        "dataset": "apm.error",
-        "title": "APM logs and errors"
-      },
-      {
-        "type": "metrics",
-        "dataset": "apm.internal",
-        "title": "APM internal metrics"
-      },
-      {
-        "type": "metrics",
-        "dataset": "apm.profiling",
-        "title": "APM profiles"
-      },
-      {
-        "type": "traces",
-        "dataset": "apm.sampled",
-        "title": "APM tail-sampled traces"
-      },
-      {
-        "type": "traces",
-        "dataset": "apm",
-        "title": "APM traces"
-      }
-    ]
-  },
-  {
-    "name": "apm",
-    "title": "Elastic APM",
-    "version": "8.0.0",
-    "release": "ga",
-    "description": "Ingest APM data",
-    "type": "integration",
-    "download": "/epr/apm/apm-8.0.0.zip",
-    "path": "/package/apm/8.0.0",
-    "icons": [
-      {
-        "src": "/img/logo_apm.svg",
-        "path": "/package/apm/8.0.0/img/logo_apm.svg",
-        "title": "APM Logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "apmserver",
-        "title": "Elastic APM Integration",
-        "description": "Elastic APM Integration"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/apm-server"
-    },
-    "categories": [
-      "elastic_stack",
-      "monitoring"
-    ],
-    "signature_path": "/epr/apm/apm-8.0.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "apm.app",
-        "title": "APM application logs"
-      },
-      {
-        "type": "metrics",
-        "dataset": "apm.app",
-        "title": "APM application metrics"
-      },
-      {
-        "type": "logs",
-        "dataset": "apm.error",
-        "title": "APM errors"
-      },
-      {
-        "type": "metrics",
-        "dataset": "apm.internal",
-        "title": "APM internal metrics"
-      },
-      {
-        "type": "metrics",
-        "dataset": "apm.profiling",
-        "title": "APM profiles"
-      },
-      {
-        "type": "traces",
-        "dataset": "apm.rum",
-        "title": "APM RUM traces"
-      },
-      {
-        "type": "traces",
-        "dataset": "apm.sampled",
-        "title": "APM tail-sampled traces"
-      },
-      {
-        "type": "traces",
-        "dataset": "apm",
-        "title": "APM traces"
-      }
-    ]
-  },
-  {
-    "name": "apm",
-    "title": "Elastic APM",
-    "version": "8.1.0",
-    "release": "ga",
-    "description": "Ingest APM data",
-    "type": "integration",
-    "download": "/epr/apm/apm-8.1.0.zip",
-    "path": "/package/apm/8.1.0",
-    "icons": [
-      {
-        "src": "/img/logo_apm.svg",
-        "path": "/package/apm/8.1.0/img/logo_apm.svg",
-        "title": "APM Logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "apmserver",
-        "title": "Elastic APM Integration",
-        "description": "Elastic APM Integration"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.1.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/apm-server"
-    },
-    "categories": [
-      "elastic_stack",
-      "monitoring"
-    ],
-    "signature_path": "/epr/apm/apm-8.1.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "apm.app",
-        "title": "APM application logs"
-      },
-      {
-        "type": "metrics",
-        "dataset": "apm.app",
-        "title": "APM application metrics"
-      },
-      {
-        "type": "logs",
-        "dataset": "apm.error",
-        "title": "APM errors"
-      },
-      {
-        "type": "metrics",
-        "dataset": "apm.internal",
-        "title": "APM internal metrics"
-      },
-      {
-        "type": "metrics",
-        "dataset": "apm.profiling",
-        "title": "APM profiles"
-      },
-      {
-        "type": "traces",
-        "dataset": "apm.rum",
-        "title": "APM RUM traces"
-      },
-      {
-        "type": "traces",
-        "dataset": "apm.sampled",
-        "title": "APM tail-sampled traces"
-      },
-      {
-        "type": "traces",
-        "dataset": "apm",
-        "title": "APM traces"
-      }
-    ]
-  },
-  {
-    "name": "apm",
-    "title": "Elastic APM",
-    "version": "8.1.2",
-    "release": "ga",
-    "description": "Ingest APM data",
-    "type": "integration",
-    "download": "/epr/apm/apm-8.1.2.zip",
-    "path": "/package/apm/8.1.2",
-    "icons": [
-      {
-        "src": "/img/logo_apm.svg",
-        "path": "/package/apm/8.1.2/img/logo_apm.svg",
-        "title": "APM Logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "apmserver",
-        "title": "Elastic APM Integration",
-        "description": "Elastic APM Integration"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.1.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/apm-server"
-    },
-    "categories": [
-      "elastic_stack",
-      "monitoring"
-    ],
-    "signature_path": "/epr/apm/apm-8.1.2.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "apm.app",
-        "title": "APM application logs"
-      },
-      {
-        "type": "metrics",
-        "dataset": "apm.app",
-        "title": "APM application metrics"
-      },
-      {
-        "type": "logs",
-        "dataset": "apm.error",
-        "title": "APM errors"
-      },
-      {
-        "type": "metrics",
-        "dataset": "apm.internal",
-        "title": "APM internal metrics"
-      },
-      {
-        "type": "metrics",
-        "dataset": "apm.profiling",
-        "title": "APM profiles"
-      },
-      {
-        "type": "traces",
-        "dataset": "apm.rum",
-        "title": "APM RUM traces"
-      },
-      {
-        "type": "traces",
-        "dataset": "apm.sampled",
-        "title": "APM tail-sampled traces"
-      },
-      {
-        "type": "traces",
-        "dataset": "apm",
-        "title": "APM traces"
-      }
-    ]
-  },
-  {
-    "name": "apm",
-    "title": "Elastic APM",
-    "version": "8.2.0",
-    "release": "ga",
-    "description": "Ingest APM data",
-    "type": "integration",
-    "download": "/epr/apm/apm-8.2.0.zip",
-    "path": "/package/apm/8.2.0",
-    "icons": [
-      {
-        "src": "/img/logo_apm.svg",
-        "path": "/package/apm/8.2.0/img/logo_apm.svg",
-        "title": "APM Logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "apmserver",
-        "title": "Elastic APM Integration",
-        "description": "Elastic APM Integration"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.2.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/apm-server"
-    },
-    "categories": [
-      "elastic_stack",
-      "monitoring"
-    ],
-    "signature_path": "/epr/apm/apm-8.2.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "apm.app",
-        "title": "APM application logs"
-      },
-      {
-        "type": "metrics",
-        "dataset": "apm.app",
-        "title": "APM application metrics"
-      },
-      {
-        "type": "logs",
-        "dataset": "apm.error",
-        "title": "APM errors"
-      },
-      {
-        "type": "metrics",
-        "dataset": "apm.internal",
-        "title": "APM internal metrics"
-      },
-      {
-        "type": "metrics",
-        "dataset": "apm.profiling",
-        "title": "APM profiles"
-      },
-      {
-        "type": "traces",
-        "dataset": "apm.rum",
-        "title": "APM RUM traces"
-      },
-      {
-        "type": "traces",
-        "dataset": "apm.sampled",
-        "title": "APM tail-sampled traces"
-      },
-      {
-        "type": "traces",
-        "dataset": "apm",
-        "title": "APM traces"
       }
     ]
   },
@@ -27371,594 +25570,6 @@
         "type": "logs",
         "dataset": "endpoint.security",
         "title": "Endpoint Security Events"
-      }
-    ]
-  },
-  {
-    "name": "synthetics",
-    "title": "Elastic Synthetics",
-    "version": "0.0.6",
-    "release": "beta",
-    "description": "Monitor services availability.",
-    "type": "integration",
-    "download": "/epr/synthetics/synthetics-0.0.6.zip",
-    "path": "/package/synthetics/0.0.6",
-    "icons": [
-      {
-        "src": "/img/uptime-logo-color-64px.svg",
-        "path": "/package/synthetics/0.0.6/img/uptime-logo-color-64px.svg",
-        "size": "16x16",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "synthetics",
-        "title": "Elastic Synthetics",
-        "description": "Perform synthetic health checks on network endpoints."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.13.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/uptime"
-    },
-    "categories": [
-      "custom"
-    ],
-    "signature_path": "/epr/synthetics/synthetics-0.0.6.zip.sig",
-    "data_streams": [
-      {
-        "type": "synthetics",
-        "dataset": "http",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "icmp",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "tcp",
-        "title": "synthetic monitor check"
-      }
-    ]
-  },
-  {
-    "name": "synthetics",
-    "title": "Elastic Synthetics",
-    "version": "0.1.0",
-    "release": "beta",
-    "description": "Monitor services availability.",
-    "type": "integration",
-    "download": "/epr/synthetics/synthetics-0.1.0.zip",
-    "path": "/package/synthetics/0.1.0",
-    "icons": [
-      {
-        "src": "/img/uptime-logo-color-64px.svg",
-        "path": "/package/synthetics/0.1.0/img/uptime-logo-color-64px.svg",
-        "size": "16x16",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "synthetics",
-        "title": "Elastic Synthetics",
-        "description": "Perform synthetic health checks on network endpoints."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.13.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/uptime"
-    },
-    "categories": [
-      "custom"
-    ],
-    "signature_path": "/epr/synthetics/synthetics-0.1.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "synthetics",
-        "dataset": "http",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "icmp",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "tcp",
-        "title": "synthetic monitor check"
-      }
-    ]
-  },
-  {
-    "name": "synthetics",
-    "title": "Elastic Synthetics",
-    "version": "0.2.1",
-    "release": "beta",
-    "description": "This Elastic integration allows you to monitor the availability of your services",
-    "type": "integration",
-    "download": "/epr/synthetics/synthetics-0.2.1.zip",
-    "path": "/package/synthetics/0.2.1",
-    "icons": [
-      {
-        "src": "/img/uptime-logo-color-64px.svg",
-        "path": "/package/synthetics/0.2.1/img/uptime-logo-color-64px.svg",
-        "size": "16x16",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "synthetics",
-        "title": "Elastic Synthetics",
-        "description": "Perform synthetic health checks on network endpoints."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.13.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/uptime"
-    },
-    "categories": [
-      "elastic_stack"
-    ],
-    "signature_path": "/epr/synthetics/synthetics-0.2.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "synthetics",
-        "dataset": "http",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "icmp",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "tcp",
-        "title": "synthetic monitor check"
-      }
-    ]
-  },
-  {
-    "name": "synthetics",
-    "title": "Elastic Synthetics",
-    "version": "0.3.0",
-    "release": "beta",
-    "description": "This Elastic integration allows you to monitor the availability of your services",
-    "type": "integration",
-    "download": "/epr/synthetics/synthetics-0.3.0.zip",
-    "path": "/package/synthetics/0.3.0",
-    "icons": [
-      {
-        "src": "/img/uptime-logo-color-64px.svg",
-        "path": "/package/synthetics/0.3.0/img/uptime-logo-color-64px.svg",
-        "size": "16x16",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "synthetics",
-        "title": "Elastic Synthetics",
-        "description": "Perform synthetic health checks on network endpoints."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.13.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/uptime"
-    },
-    "categories": [
-      "elastic_stack",
-      "monitoring",
-      "web"
-    ],
-    "signature_path": "/epr/synthetics/synthetics-0.3.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "synthetics",
-        "dataset": "browser",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "browser.network",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "browser.screenshot",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "http",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "icmp",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "tcp",
-        "title": "synthetic monitor check"
-      }
-    ]
-  },
-  {
-    "name": "synthetics",
-    "title": "Elastic Synthetics",
-    "version": "0.5.0",
-    "release": "beta",
-    "description": "Monitor the availability of your services with Elastic Synthetics.",
-    "type": "integration",
-    "download": "/epr/synthetics/synthetics-0.5.0.zip",
-    "path": "/package/synthetics/0.5.0",
-    "icons": [
-      {
-        "src": "/img/uptime-logo-color-64px.svg",
-        "path": "/package/synthetics/0.5.0/img/uptime-logo-color-64px.svg",
-        "size": "16x16",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "synthetics",
-        "title": "Elastic Synthetics",
-        "description": "Perform synthetic health checks on network endpoints."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/uptime"
-    },
-    "categories": [
-      "elastic_stack",
-      "monitoring",
-      "web"
-    ],
-    "signature_path": "/epr/synthetics/synthetics-0.5.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "synthetics",
-        "dataset": "browser",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "browser.network",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "browser.screenshot",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "http",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "icmp",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "tcp",
-        "title": "synthetic monitor check"
-      }
-    ]
-  },
-  {
-    "name": "synthetics",
-    "title": "Elastic Synthetics",
-    "version": "0.7.0",
-    "release": "beta",
-    "description": "Monitor the availability of your services with Elastic Synthetics.",
-    "type": "integration",
-    "download": "/epr/synthetics/synthetics-0.7.0.zip",
-    "path": "/package/synthetics/0.7.0",
-    "icons": [
-      {
-        "src": "/img/uptime-logo-color-64px.svg",
-        "path": "/package/synthetics/0.7.0/img/uptime-logo-color-64px.svg",
-        "size": "16x16",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "synthetics",
-        "title": "Elastic Synthetics",
-        "description": "Perform synthetic health checks on network endpoints."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/uptime"
-    },
-    "categories": [
-      "elastic_stack",
-      "monitoring",
-      "web"
-    ],
-    "signature_path": "/epr/synthetics/synthetics-0.7.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "synthetics",
-        "dataset": "browser",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "browser.network",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "browser.screenshot",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "http",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "icmp",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "tcp",
-        "title": "synthetic monitor check"
-      }
-    ]
-  },
-  {
-    "name": "synthetics",
-    "title": "Elastic Synthetics",
-    "version": "0.8.1",
-    "release": "beta",
-    "description": "Monitor the availability of your services with Elastic Synthetics.",
-    "type": "integration",
-    "download": "/epr/synthetics/synthetics-0.8.1.zip",
-    "path": "/package/synthetics/0.8.1",
-    "icons": [
-      {
-        "src": "/img/uptime-logo-color-64px.svg",
-        "path": "/package/synthetics/0.8.1/img/uptime-logo-color-64px.svg",
-        "size": "16x16",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "synthetics",
-        "title": "Elastic Synthetics",
-        "description": "Perform synthetic health checks on network endpoints."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/uptime"
-    },
-    "categories": [
-      "elastic_stack",
-      "monitoring",
-      "web"
-    ],
-    "signature_path": "/epr/synthetics/synthetics-0.8.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "synthetics",
-        "dataset": "browser",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "browser.network",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "browser.screenshot",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "http",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "icmp",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "tcp",
-        "title": "synthetic monitor check"
-      }
-    ]
-  },
-  {
-    "name": "synthetics",
-    "title": "Elastic Synthetics",
-    "version": "0.9.0",
-    "release": "beta",
-    "description": "Monitor the availability of your services with Elastic Synthetics.",
-    "type": "integration",
-    "download": "/epr/synthetics/synthetics-0.9.0.zip",
-    "path": "/package/synthetics/0.9.0",
-    "icons": [
-      {
-        "src": "/img/uptime-logo-color-64px.svg",
-        "path": "/package/synthetics/0.9.0/img/uptime-logo-color-64px.svg",
-        "size": "16x16",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "synthetics",
-        "title": "Elastic Synthetics",
-        "description": "Perform synthetic health checks on network endpoints."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.1.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/uptime"
-    },
-    "categories": [
-      "elastic_stack",
-      "monitoring",
-      "web"
-    ],
-    "signature_path": "/epr/synthetics/synthetics-0.9.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "synthetics",
-        "dataset": "browser",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "browser.network",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "browser.screenshot",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "http",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "icmp",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "tcp",
-        "title": "synthetic monitor check"
-      }
-    ]
-  },
-  {
-    "name": "synthetics",
-    "title": "Elastic Synthetics",
-    "version": "0.9.2",
-    "release": "beta",
-    "description": "Monitor the availability of your services with Elastic Synthetics.",
-    "type": "integration",
-    "download": "/epr/synthetics/synthetics-0.9.2.zip",
-    "path": "/package/synthetics/0.9.2",
-    "icons": [
-      {
-        "src": "/img/uptime-logo-color-64px.svg",
-        "path": "/package/synthetics/0.9.2/img/uptime-logo-color-64px.svg",
-        "size": "16x16",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "synthetics",
-        "title": "Elastic Synthetics",
-        "description": "Perform synthetic health checks on network endpoints."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.1.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/uptime"
-    },
-    "categories": [
-      "elastic_stack",
-      "monitoring",
-      "web"
-    ],
-    "signature_path": "/epr/synthetics/synthetics-0.9.2.zip.sig",
-    "data_streams": [
-      {
-        "type": "synthetics",
-        "dataset": "browser",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "browser.network",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "browser.screenshot",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "http",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "icmp",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "tcp",
-        "title": "synthetic monitor check"
       }
     ]
   },
@@ -31203,47 +28814,60 @@
     ]
   },
   {
-    "name": "github",
-    "title": "GitHub",
-    "version": "1.0.0",
+    "name": "gcp",
+    "title": "Google Cloud Platform (GCP)",
+    "version": "1.1.0",
     "release": "ga",
-    "description": "Collect events from GitHub with Elastic Agent.",
+    "description": "This Elastic integration collects logs from various Google Cloud Platform (GCP) services",
     "type": "integration",
-    "download": "/epr/github/github-1.0.0.zip",
-    "path": "/package/github/1.0.0",
+    "download": "/epr/gcp/gcp-1.1.0.zip",
+    "path": "/package/gcp/1.1.0",
     "icons": [
       {
-        "src": "/img/github.svg",
-        "path": "/package/github/1.0.0/img/github.svg",
-        "title": "GitHub",
-        "size": "1024x1024",
+        "src": "/img/logo_gcp.svg",
+        "path": "/package/gcp/1.1.0/img/logo_gcp.svg",
+        "title": "logo gcp",
+        "size": "32x32",
         "type": "image/svg+xml"
       }
     ],
     "policy_templates": [
       {
-        "name": "github",
-        "title": "GitHub logs",
-        "description": "Collect logs from GitHub"
+        "name": "gcp",
+        "title": "Google Cloud Platform (GCP) logs",
+        "description": "Collect logs from Google Cloud Platform (GCP) instances"
       }
     ],
     "conditions": {
       "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
+        "version": "^7.15.0"
       }
     },
     "owner": {
       "github": "elastic/security-external-integrations"
     },
     "categories": [
+      "google_cloud",
+      "cloud",
+      "network",
       "security"
     ],
-    "signature_path": "/epr/github/github-1.0.0.zip.sig",
+    "signature_path": "/epr/gcp/gcp-1.1.0.zip.sig",
     "data_streams": [
       {
         "type": "logs",
-        "dataset": "github.audit",
-        "title": "GitHub Audit Logs"
+        "dataset": "gcp.audit",
+        "title": "Google Cloud Platform (GCP) audit logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "gcp.firewall",
+        "title": "Google Cloud Platform (GCP) firewall logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "gcp.vpcflow",
+        "title": "Google Cloud Platform (GCP) vpcflow logs"
       }
     ]
   },
@@ -31979,18 +29603,18 @@
     ]
   },
   {
-    "name": "gcp",
-    "title": "Google Cloud Platform (GCP)",
-    "version": "1.1.0",
+    "name": "gcp_pubsub",
+    "title": "Custom Google Pub/Sub Logs",
+    "version": "1.0.0",
     "release": "ga",
-    "description": "This Elastic integration collects logs from various Google Cloud Platform (GCP) services",
+    "description": "Collect Logs from Google Pub/Sub topics",
     "type": "integration",
-    "download": "/epr/gcp/gcp-1.1.0.zip",
-    "path": "/package/gcp/1.1.0",
+    "download": "/epr/gcp_pubsub/gcp_pubsub-1.0.0.zip",
+    "path": "/package/gcp_pubsub/1.0.0",
     "icons": [
       {
         "src": "/img/logo_gcp.svg",
-        "path": "/package/gcp/1.1.0/img/logo_gcp.svg",
+        "path": "/package/gcp_pubsub/1.0.0/img/logo_gcp.svg",
         "title": "logo gcp",
         "size": "32x32",
         "type": "image/svg+xml"
@@ -31999,155 +29623,8 @@
     "policy_templates": [
       {
         "name": "gcp",
-        "title": "Google Cloud Platform (GCP) logs",
-        "description": "Collect logs from Google Cloud Platform (GCP) instances"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.15.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "google_cloud",
-      "cloud",
-      "network",
-      "security"
-    ],
-    "signature_path": "/epr/gcp/gcp-1.1.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "gcp.audit",
-        "title": "Google Cloud Platform (GCP) audit logs"
-      },
-      {
-        "type": "logs",
-        "dataset": "gcp.firewall",
-        "title": "Google Cloud Platform (GCP) firewall logs"
-      },
-      {
-        "type": "logs",
-        "dataset": "gcp.vpcflow",
-        "title": "Google Cloud Platform (GCP) vpcflow logs"
-      }
-    ]
-  },
-  {
-    "name": "santa",
-    "title": "Google Santa",
-    "version": "1.0.2",
-    "release": "ga",
-    "description": "Collect logs from Google Santa with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/santa/santa-1.0.2.zip",
-    "path": "/package/santa/1.0.2",
-    "icons": [
-      {
-        "src": "/img/icon.svg",
-        "path": "/package/santa/1.0.2/img/icon.svg",
-        "title": "Google Santa",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "santa",
-        "title": "Google Santa logs",
-        "description": "Collect logs from Google Santa instances"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security",
-      "os_system"
-    ],
-    "signature_path": "/epr/santa/santa-1.0.2.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "santa.log",
-        "title": "Google Santa log logs"
-      }
-    ]
-  },
-  {
-    "name": "santa",
-    "title": "Google Santa Logs",
-    "version": "1.0.3",
-    "release": "ga",
-    "description": "Collect and parse logs from Google Santa instances with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/santa/santa-1.0.3.zip",
-    "path": "/package/santa/1.0.3",
-    "icons": [
-      {
-        "src": "/img/icon.svg",
-        "path": "/package/santa/1.0.3/img/icon.svg",
-        "title": "Google Santa",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "santa",
-        "title": "Google Santa logs",
-        "description": "Collect logs from Google Santa instances"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security",
-      "os_system"
-    ],
-    "signature_path": "/epr/santa/santa-1.0.3.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "santa.log",
-        "title": "Google Santa log logs"
-      }
-    ]
-  },
-  {
-    "name": "santa",
-    "title": "Google Santa Logs",
-    "version": "1.1.0",
-    "release": "ga",
-    "description": "Collect and parse logs from Google Santa instances with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/santa/santa-1.1.0.zip",
-    "path": "/package/santa/1.1.0",
-    "icons": [
-      {
-        "src": "/img/icon.svg",
-        "path": "/package/santa/1.1.0/img/icon.svg",
-        "title": "Google Santa",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "santa",
-        "title": "Google Santa logs",
-        "description": "Collect logs from Google Santa instances"
+        "title": "Custom Google Pub/Sub Logs",
+        "description": "Collect Logs from Google Pub/Sub topics"
       }
     ],
     "conditions": {
@@ -32159,105 +29636,61 @@
       "github": "elastic/security-external-integrations"
     },
     "categories": [
-      "security",
-      "os_system"
+      "google_cloud",
+      "cloud",
+      "custom"
     ],
-    "signature_path": "/epr/santa/santa-1.1.0.zip.sig",
+    "signature_path": "/epr/gcp_pubsub/gcp_pubsub-1.0.0.zip.sig",
     "data_streams": [
       {
         "type": "logs",
-        "dataset": "santa.log",
-        "title": "Google Santa log logs"
+        "dataset": "gcp_pubsub.generic",
+        "title": "Custom Google Pub/Sub Logs"
       }
     ]
   },
   {
-    "name": "santa",
-    "title": "Google Santa Logs",
-    "version": "2.0.0",
+    "name": "github",
+    "title": "GitHub",
+    "version": "1.0.0",
     "release": "ga",
-    "description": "Collect and parse logs from Google Santa instances with Elastic Agent.",
+    "description": "Collect events from GitHub with Elastic Agent.",
     "type": "integration",
-    "download": "/epr/santa/santa-2.0.0.zip",
-    "path": "/package/santa/2.0.0",
+    "download": "/epr/github/github-1.0.0.zip",
+    "path": "/package/github/1.0.0",
     "icons": [
       {
-        "src": "/img/icon.svg",
-        "path": "/package/santa/2.0.0/img/icon.svg",
-        "title": "Google Santa",
+        "src": "/img/github.svg",
+        "path": "/package/github/1.0.0/img/github.svg",
+        "title": "GitHub",
+        "size": "1024x1024",
         "type": "image/svg+xml"
       }
     ],
     "policy_templates": [
       {
-        "name": "santa",
-        "title": "Google Santa logs",
-        "description": "Collect logs from Google Santa instances"
+        "name": "github",
+        "title": "GitHub logs",
+        "description": "Collect logs from GitHub"
       }
     ],
     "conditions": {
       "kibana": {
-        "version": "^7.17.0 || ^8.0.0"
+        "version": "^7.16.0 || ^8.0.0"
       }
     },
     "owner": {
       "github": "elastic/security-external-integrations"
     },
     "categories": [
-      "security",
-      "os_system"
+      "security"
     ],
-    "signature_path": "/epr/santa/santa-2.0.0.zip.sig",
+    "signature_path": "/epr/github/github-1.0.0.zip.sig",
     "data_streams": [
       {
         "type": "logs",
-        "dataset": "santa.log",
-        "title": "Google Santa log logs"
-      }
-    ]
-  },
-  {
-    "name": "santa",
-    "title": "Google Santa Logs",
-    "version": "2.0.1",
-    "release": "ga",
-    "description": "Collect and parse logs from Google Santa instances with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/santa/santa-2.0.1.zip",
-    "path": "/package/santa/2.0.1",
-    "icons": [
-      {
-        "src": "/img/icon.svg",
-        "path": "/package/santa/2.0.1/img/icon.svg",
-        "title": "Google Santa",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "santa",
-        "title": "Google Santa logs",
-        "description": "Collect logs from Google Santa instances"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.17.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security",
-      "os_system"
-    ],
-    "signature_path": "/epr/santa/santa-2.0.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "santa.log",
-        "title": "Google Santa log logs"
+        "dataset": "github.audit",
+        "title": "GitHub Audit Logs"
       }
     ]
   },
@@ -33438,6 +30871,157 @@
         "type": "logs",
         "dataset": "hid_bravura_monitor.winlog",
         "title": "Hitachi ID Security Fabric logs"
+      }
+    ]
+  },
+  {
+    "name": "http_endpoint",
+    "title": "Custom HTTP Endpoint Logs",
+    "version": "1.0.1",
+    "release": "ga",
+    "description": "Collect JSON data from listening HTTP port with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/http_endpoint/http_endpoint-1.0.1.zip",
+    "path": "/package/http_endpoint/1.0.1",
+    "icons": [
+      {
+        "src": "/img/icon.svg",
+        "path": "/package/http_endpoint/1.0.1/img/icon.svg",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "http_endpoint",
+        "title": "Custom HTTP Endpoint Logs",
+        "description": "Collect JSON data from listening HTTP port with Elastic Agent."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "signature_path": "/epr/http_endpoint/http_endpoint-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "http_endpoint.generic",
+        "title": "Custom HTTP Endpoint Logs"
+      }
+    ]
+  },
+  {
+    "name": "httpjson",
+    "title": "Custom HTTPJSON Input",
+    "version": "1.0.0",
+    "release": "ga",
+    "description": "Collect custom data from REST API's with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/httpjson/httpjson-1.0.0.zip",
+    "path": "/package/httpjson/1.0.0",
+    "policy_templates": [
+      {
+        "name": "generic",
+        "title": "Custom HTTPJSON Input",
+        "description": "Collect custom data from REST API's"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "signature_path": "/epr/httpjson/httpjson-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "httpjson.generic",
+        "title": "Custom HTTPJSON Input"
+      }
+    ]
+  },
+  {
+    "name": "httpjson",
+    "title": "Custom HTTPJSON Input",
+    "version": "1.1.0",
+    "release": "ga",
+    "description": "Collect custom data from REST API's with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/httpjson/httpjson-1.1.0.zip",
+    "path": "/package/httpjson/1.1.0",
+    "policy_templates": [
+      {
+        "name": "generic",
+        "title": "Custom HTTPJSON Input",
+        "description": "Collect custom data from REST API's"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "signature_path": "/epr/httpjson/httpjson-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "httpjson.generic",
+        "title": "Custom HTTPJSON Input"
+      }
+    ]
+  },
+  {
+    "name": "httpjson",
+    "title": "Custom HTTPJSON Input",
+    "version": "1.1.1",
+    "release": "ga",
+    "description": "Collect custom data from REST API's with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/httpjson/httpjson-1.1.1.zip",
+    "path": "/package/httpjson/1.1.1",
+    "policy_templates": [
+      {
+        "name": "generic",
+        "title": "Custom HTTPJSON Input",
+        "description": "Collect custom data from REST API's"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "signature_path": "/epr/httpjson/httpjson-1.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "httpjson.generic",
+        "title": "Custom HTTPJSON Input"
       }
     ]
   },
@@ -38645,6 +36229,44 @@
     ]
   },
   {
+    "name": "log",
+    "title": "Custom Logs",
+    "version": "1.0.0",
+    "release": "ga",
+    "description": "Collect custom logs with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/log/log-1.0.0.zip",
+    "path": "/package/log/1.0.0",
+    "icons": [
+      {
+        "src": "/img/icon.svg",
+        "path": "/package/log/1.0.0/img/icon.svg",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "logs",
+        "title": "Custom logs",
+        "description": "Collect your custom log files."
+      }
+    ],
+    "owner": {
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "signature_path": "/epr/log/log-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "log.log",
+        "title": "Log Dataset"
+      }
+    ]
+  },
+  {
     "name": "logstash",
     "title": "Logstash",
     "version": "1.0.0",
@@ -38795,276 +36417,6 @@
         "type": "logs",
         "dataset": "m365_defender.log",
         "title": "M365 Defender Logs"
-      }
-    ]
-  },
-  {
-    "name": "ti_misp",
-    "title": "MISP",
-    "version": "1.0.1",
-    "release": "ga",
-    "description": "This Elastic integration collects events from MISP",
-    "type": "integration",
-    "download": "/epr/ti_misp/ti_misp-1.0.1.zip",
-    "path": "/package/ti_misp/1.0.1",
-    "icons": [
-      {
-        "src": "/img/misp.svg",
-        "path": "/package/ti_misp/1.0.1/img/misp.svg",
-        "title": "MISP",
-        "size": "216x216",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "ti_misp",
-        "title": "MISP",
-        "description": "Collect threat intelligence from the MISP API."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/ti_misp/ti_misp-1.0.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ti_misp.threat",
-        "title": "MISP"
-      }
-    ]
-  },
-  {
-    "name": "ti_misp",
-    "title": "MISP",
-    "version": "1.0.2",
-    "release": "ga",
-    "description": "This Elastic integration collects events from MISP",
-    "type": "integration",
-    "download": "/epr/ti_misp/ti_misp-1.0.2.zip",
-    "path": "/package/ti_misp/1.0.2",
-    "icons": [
-      {
-        "src": "/img/misp.svg",
-        "path": "/package/ti_misp/1.0.2/img/misp.svg",
-        "title": "MISP",
-        "size": "216x216",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "ti_misp",
-        "title": "MISP",
-        "description": "Collect threat intelligence from the MISP API."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/ti_misp/ti_misp-1.0.2.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ti_misp.threat",
-        "title": "MISP"
-      }
-    ]
-  },
-  {
-    "name": "ti_misp",
-    "title": "MISP",
-    "version": "1.1.0",
-    "release": "ga",
-    "description": "This Elastic integration collects events from MISP",
-    "type": "integration",
-    "download": "/epr/ti_misp/ti_misp-1.1.0.zip",
-    "path": "/package/ti_misp/1.1.0",
-    "icons": [
-      {
-        "src": "/img/misp.svg",
-        "path": "/package/ti_misp/1.1.0/img/misp.svg",
-        "title": "MISP",
-        "size": "216x216",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "ti_misp",
-        "title": "MISP",
-        "description": "Collect threat intelligence from the MISP API."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/ti_misp/ti_misp-1.1.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ti_misp.threat",
-        "title": "MISP"
-      }
-    ]
-  },
-  {
-    "name": "ti_misp",
-    "title": "MISP",
-    "version": "1.2.0",
-    "release": "ga",
-    "description": "This Elastic integration collects events from MISP",
-    "type": "integration",
-    "download": "/epr/ti_misp/ti_misp-1.2.0.zip",
-    "path": "/package/ti_misp/1.2.0",
-    "icons": [
-      {
-        "src": "/img/misp.svg",
-        "path": "/package/ti_misp/1.2.0/img/misp.svg",
-        "title": "MISP",
-        "size": "216x216",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "ti_misp",
-        "title": "MISP",
-        "description": "Collect threat intelligence from the MISP API."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/ti_misp/ti_misp-1.2.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ti_misp.threat",
-        "title": "MISP"
-      }
-    ]
-  },
-  {
-    "name": "ti_misp",
-    "title": "MISP",
-    "version": "1.2.1",
-    "release": "ga",
-    "description": "This Elastic integration collects events from MISP",
-    "type": "integration",
-    "download": "/epr/ti_misp/ti_misp-1.2.1.zip",
-    "path": "/package/ti_misp/1.2.1",
-    "icons": [
-      {
-        "src": "/img/misp.svg",
-        "path": "/package/ti_misp/1.2.1/img/misp.svg",
-        "title": "MISP",
-        "size": "216x216",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "ti_misp",
-        "title": "MISP",
-        "description": "Collect threat intelligence from the MISP API."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/ti_misp/ti_misp-1.2.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ti_misp.threat",
-        "title": "MISP"
-      }
-    ]
-  },
-  {
-    "name": "ti_misp",
-    "title": "MISP",
-    "version": "1.2.2",
-    "release": "ga",
-    "description": "This Elastic integration collects events from MISP",
-    "type": "integration",
-    "download": "/epr/ti_misp/ti_misp-1.2.2.zip",
-    "path": "/package/ti_misp/1.2.2",
-    "icons": [
-      {
-        "src": "/img/misp.svg",
-        "path": "/package/ti_misp/1.2.2/img/misp.svg",
-        "title": "MISP",
-        "size": "216x216",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "ti_misp",
-        "title": "MISP",
-        "description": "Collect threat intelligence from the MISP API."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/ti_misp/ti_misp-1.2.2.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ti_misp.threat",
-        "title": "MISP"
       }
     ]
   },
@@ -39255,231 +36607,6 @@
         "type": "logs",
         "dataset": "microsoft.dhcp",
         "title": "Microsoft DHCP logs"
-      }
-    ]
-  },
-  {
-    "name": "microsoft_dhcp",
-    "title": "Microsoft DHCP",
-    "version": "0.1.1",
-    "release": "beta",
-    "description": "Collect logs from Microsoft DHCP with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/microsoft_dhcp/microsoft_dhcp-0.1.1.zip",
-    "path": "/package/microsoft_dhcp/0.1.1",
-    "icons": [
-      {
-        "src": "/img/logo.svg",
-        "path": "/package/microsoft_dhcp/0.1.1/img/logo.svg",
-        "title": "Microsoft logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "microsoft_dhcp",
-        "title": "Microsoft DHCP",
-        "description": "Collect Microsoft DHCP logs."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "network"
-    ],
-    "signature_path": "/epr/microsoft_dhcp/microsoft_dhcp-0.1.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "microsoft_dhcp.log",
-        "title": "Microsoft DHCP Logs"
-      }
-    ]
-  },
-  {
-    "name": "microsoft_dhcp",
-    "title": "Microsoft DHCP",
-    "version": "0.2.0",
-    "release": "beta",
-    "description": "Collect logs from Microsoft DHCP with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/microsoft_dhcp/microsoft_dhcp-0.2.0.zip",
-    "path": "/package/microsoft_dhcp/0.2.0",
-    "icons": [
-      {
-        "src": "/img/logo.svg",
-        "path": "/package/microsoft_dhcp/0.2.0/img/logo.svg",
-        "title": "Microsoft logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "microsoft_dhcp",
-        "title": "Microsoft DHCP",
-        "description": "Collect Microsoft DHCP logs."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "network"
-    ],
-    "signature_path": "/epr/microsoft_dhcp/microsoft_dhcp-0.2.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "microsoft_dhcp.log",
-        "title": "Microsoft DHCP Logs"
-      }
-    ]
-  },
-  {
-    "name": "microsoft_dhcp",
-    "title": "Microsoft DHCP",
-    "version": "1.1.0",
-    "release": "ga",
-    "description": "Collect logs from Microsoft DHCP with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/microsoft_dhcp/microsoft_dhcp-1.1.0.zip",
-    "path": "/package/microsoft_dhcp/1.1.0",
-    "icons": [
-      {
-        "src": "/img/logo.svg",
-        "path": "/package/microsoft_dhcp/1.1.0/img/logo.svg",
-        "title": "Microsoft logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "microsoft_dhcp",
-        "title": "Microsoft DHCP",
-        "description": "Collect Microsoft DHCP logs."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "network"
-    ],
-    "signature_path": "/epr/microsoft_dhcp/microsoft_dhcp-1.1.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "microsoft_dhcp.log",
-        "title": "Microsoft DHCP Logs"
-      }
-    ]
-  },
-  {
-    "name": "microsoft_dhcp",
-    "title": "Microsoft DHCP",
-    "version": "1.3.0",
-    "release": "ga",
-    "description": "Collect logs from Microsoft DHCP with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/microsoft_dhcp/microsoft_dhcp-1.3.0.zip",
-    "path": "/package/microsoft_dhcp/1.3.0",
-    "icons": [
-      {
-        "src": "/img/logo.svg",
-        "path": "/package/microsoft_dhcp/1.3.0/img/logo.svg",
-        "title": "Microsoft logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "microsoft_dhcp",
-        "title": "Microsoft DHCP",
-        "description": "Collect Microsoft DHCP logs."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "network"
-    ],
-    "signature_path": "/epr/microsoft_dhcp/microsoft_dhcp-1.3.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "microsoft_dhcp.log",
-        "title": "Microsoft DHCP Logs"
-      }
-    ]
-  },
-  {
-    "name": "microsoft_dhcp",
-    "title": "Microsoft DHCP",
-    "version": "1.3.1",
-    "release": "ga",
-    "description": "Collect logs from Microsoft DHCP with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/microsoft_dhcp/microsoft_dhcp-1.3.1.zip",
-    "path": "/package/microsoft_dhcp/1.3.1",
-    "icons": [
-      {
-        "src": "/img/logo.svg",
-        "path": "/package/microsoft_dhcp/1.3.1/img/logo.svg",
-        "title": "Microsoft logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "microsoft_dhcp",
-        "title": "Microsoft DHCP",
-        "description": "Collect Microsoft DHCP logs."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "network"
-    ],
-    "signature_path": "/epr/microsoft_dhcp/microsoft_dhcp-1.3.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "microsoft_dhcp.log",
-        "title": "Microsoft DHCP Logs"
       }
     ]
   },
@@ -39715,6 +36842,231 @@
         "type": "logs",
         "dataset": "microsoft_defender_endpoint.log",
         "title": "Microsoft Defender for Endpoint logs"
+      }
+    ]
+  },
+  {
+    "name": "microsoft_dhcp",
+    "title": "Microsoft DHCP",
+    "version": "0.1.1",
+    "release": "beta",
+    "description": "Collect logs from Microsoft DHCP with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/microsoft_dhcp/microsoft_dhcp-0.1.1.zip",
+    "path": "/package/microsoft_dhcp/0.1.1",
+    "icons": [
+      {
+        "src": "/img/logo.svg",
+        "path": "/package/microsoft_dhcp/0.1.1/img/logo.svg",
+        "title": "Microsoft logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "microsoft_dhcp",
+        "title": "Microsoft DHCP",
+        "description": "Collect Microsoft DHCP logs."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "network"
+    ],
+    "signature_path": "/epr/microsoft_dhcp/microsoft_dhcp-0.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "microsoft_dhcp.log",
+        "title": "Microsoft DHCP Logs"
+      }
+    ]
+  },
+  {
+    "name": "microsoft_dhcp",
+    "title": "Microsoft DHCP",
+    "version": "0.2.0",
+    "release": "beta",
+    "description": "Collect logs from Microsoft DHCP with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/microsoft_dhcp/microsoft_dhcp-0.2.0.zip",
+    "path": "/package/microsoft_dhcp/0.2.0",
+    "icons": [
+      {
+        "src": "/img/logo.svg",
+        "path": "/package/microsoft_dhcp/0.2.0/img/logo.svg",
+        "title": "Microsoft logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "microsoft_dhcp",
+        "title": "Microsoft DHCP",
+        "description": "Collect Microsoft DHCP logs."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "network"
+    ],
+    "signature_path": "/epr/microsoft_dhcp/microsoft_dhcp-0.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "microsoft_dhcp.log",
+        "title": "Microsoft DHCP Logs"
+      }
+    ]
+  },
+  {
+    "name": "microsoft_dhcp",
+    "title": "Microsoft DHCP",
+    "version": "1.1.0",
+    "release": "ga",
+    "description": "Collect logs from Microsoft DHCP with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/microsoft_dhcp/microsoft_dhcp-1.1.0.zip",
+    "path": "/package/microsoft_dhcp/1.1.0",
+    "icons": [
+      {
+        "src": "/img/logo.svg",
+        "path": "/package/microsoft_dhcp/1.1.0/img/logo.svg",
+        "title": "Microsoft logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "microsoft_dhcp",
+        "title": "Microsoft DHCP",
+        "description": "Collect Microsoft DHCP logs."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "network"
+    ],
+    "signature_path": "/epr/microsoft_dhcp/microsoft_dhcp-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "microsoft_dhcp.log",
+        "title": "Microsoft DHCP Logs"
+      }
+    ]
+  },
+  {
+    "name": "microsoft_dhcp",
+    "title": "Microsoft DHCP",
+    "version": "1.3.0",
+    "release": "ga",
+    "description": "Collect logs from Microsoft DHCP with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/microsoft_dhcp/microsoft_dhcp-1.3.0.zip",
+    "path": "/package/microsoft_dhcp/1.3.0",
+    "icons": [
+      {
+        "src": "/img/logo.svg",
+        "path": "/package/microsoft_dhcp/1.3.0/img/logo.svg",
+        "title": "Microsoft logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "microsoft_dhcp",
+        "title": "Microsoft DHCP",
+        "description": "Collect Microsoft DHCP logs."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "network"
+    ],
+    "signature_path": "/epr/microsoft_dhcp/microsoft_dhcp-1.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "microsoft_dhcp.log",
+        "title": "Microsoft DHCP Logs"
+      }
+    ]
+  },
+  {
+    "name": "microsoft_dhcp",
+    "title": "Microsoft DHCP",
+    "version": "1.3.1",
+    "release": "ga",
+    "description": "Collect logs from Microsoft DHCP with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/microsoft_dhcp/microsoft_dhcp-1.3.1.zip",
+    "path": "/package/microsoft_dhcp/1.3.1",
+    "icons": [
+      {
+        "src": "/img/logo.svg",
+        "path": "/package/microsoft_dhcp/1.3.1/img/logo.svg",
+        "title": "Microsoft logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "microsoft_dhcp",
+        "title": "Microsoft DHCP",
+        "description": "Collect Microsoft DHCP logs."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "network"
+    ],
+    "signature_path": "/epr/microsoft_dhcp/microsoft_dhcp-1.3.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "microsoft_dhcp.log",
+        "title": "Microsoft DHCP Logs"
       }
     ]
   },
@@ -43276,321 +40628,6 @@
     ]
   },
   {
-    "name": "panw_cortex_xdr",
-    "title": "Palo Alto Cortex XDR",
-    "version": "0.1.0",
-    "release": "beta",
-    "description": "Palo Alto Cortex XDR Integration",
-    "type": "integration",
-    "download": "/epr/panw_cortex_xdr/panw_cortex_xdr-0.1.0.zip",
-    "path": "/package/panw_cortex_xdr/0.1.0",
-    "icons": [
-      {
-        "src": "/img/icon-cortex.svg",
-        "path": "/package/panw_cortex_xdr/0.1.0/img/icon-cortex.svg",
-        "title": "Palo Alto",
-        "size": "216x216",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "alerts",
-        "title": "Palo Alto Cortex XDR API",
-        "description": "Collect logs from Palo Alto Cortex XDR API"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.15.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/panw_cortex_xdr/panw_cortex_xdr-0.1.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "panw_cortex_xdr.alerts",
-        "title": "Palo Alto Cortex XDR API"
-      }
-    ]
-  },
-  {
-    "name": "panw_cortex_xdr",
-    "title": "Palo Alto Cortex XDR",
-    "version": "0.2.0",
-    "release": "beta",
-    "description": "Palo Alto Cortex XDR Integration",
-    "type": "integration",
-    "download": "/epr/panw_cortex_xdr/panw_cortex_xdr-0.2.0.zip",
-    "path": "/package/panw_cortex_xdr/0.2.0",
-    "icons": [
-      {
-        "src": "/img/icon-cortex.svg",
-        "path": "/package/panw_cortex_xdr/0.2.0/img/icon-cortex.svg",
-        "title": "Palo Alto",
-        "size": "216x216",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "alerts",
-        "title": "Palo Alto Cortex XDR API",
-        "description": "Collect logs from Palo Alto Cortex XDR API"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.15.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/panw_cortex_xdr/panw_cortex_xdr-0.2.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "panw_cortex_xdr.alerts",
-        "title": "Palo Alto Cortex XDR API"
-      }
-    ]
-  },
-  {
-    "name": "panw_cortex_xdr",
-    "title": "Palo Alto Cortex XDR",
-    "version": "0.2.2",
-    "release": "beta",
-    "description": "Palo Alto Cortex XDR Integration",
-    "type": "integration",
-    "download": "/epr/panw_cortex_xdr/panw_cortex_xdr-0.2.2.zip",
-    "path": "/package/panw_cortex_xdr/0.2.2",
-    "icons": [
-      {
-        "src": "/img/icon-cortex.svg",
-        "path": "/package/panw_cortex_xdr/0.2.2/img/icon-cortex.svg",
-        "title": "Palo Alto",
-        "size": "216x216",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "alerts",
-        "title": "Palo Alto Cortex XDR API",
-        "description": "Collect logs from Palo Alto Cortex XDR API"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.15.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/panw_cortex_xdr/panw_cortex_xdr-0.2.2.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "panw_cortex_xdr.alerts",
-        "title": "Palo Alto Cortex XDR API"
-      }
-    ]
-  },
-  {
-    "name": "panw_cortex_xdr",
-    "title": "Palo Alto Cortex XDR Logs",
-    "version": "0.2.4",
-    "release": "beta",
-    "description": "Collect and parse logs from Palo Alto Cortex XDR API with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/panw_cortex_xdr/panw_cortex_xdr-0.2.4.zip",
-    "path": "/package/panw_cortex_xdr/0.2.4",
-    "icons": [
-      {
-        "src": "/img/icon-cortex.svg",
-        "path": "/package/panw_cortex_xdr/0.2.4/img/icon-cortex.svg",
-        "title": "Palo Alto",
-        "size": "216x216",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "alerts",
-        "title": "Palo Alto Cortex XDR API",
-        "description": "Collect logs from Palo Alto Cortex XDR API"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.15.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/panw_cortex_xdr/panw_cortex_xdr-0.2.4.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "panw_cortex_xdr.alerts",
-        "title": "Palo Alto Cortex XDR API"
-      }
-    ]
-  },
-  {
-    "name": "panw_cortex_xdr",
-    "title": "Palo Alto Cortex XDR Logs",
-    "version": "1.0.0",
-    "release": "ga",
-    "description": "Collect and parse logs from Palo Alto Cortex XDR API with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/panw_cortex_xdr/panw_cortex_xdr-1.0.0.zip",
-    "path": "/package/panw_cortex_xdr/1.0.0",
-    "icons": [
-      {
-        "src": "/img/icon-cortex.svg",
-        "path": "/package/panw_cortex_xdr/1.0.0/img/icon-cortex.svg",
-        "title": "Palo Alto",
-        "size": "216x216",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "alerts",
-        "title": "Palo Alto Cortex XDR API",
-        "description": "Collect logs from Palo Alto Cortex XDR API"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.15.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/panw_cortex_xdr/panw_cortex_xdr-1.0.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "panw_cortex_xdr.alerts",
-        "title": "Palo Alto Cortex XDR API"
-      }
-    ]
-  },
-  {
-    "name": "panw_cortex_xdr",
-    "title": "Palo Alto Cortex XDR Logs",
-    "version": "1.1.0",
-    "release": "ga",
-    "description": "Collect and parse logs from Palo Alto Cortex XDR API with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/panw_cortex_xdr/panw_cortex_xdr-1.1.0.zip",
-    "path": "/package/panw_cortex_xdr/1.1.0",
-    "icons": [
-      {
-        "src": "/img/icon-cortex.svg",
-        "path": "/package/panw_cortex_xdr/1.1.0/img/icon-cortex.svg",
-        "title": "Palo Alto",
-        "size": "216x216",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "alerts",
-        "title": "Palo Alto Cortex XDR API",
-        "description": "Collect logs from Palo Alto Cortex XDR API"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.15.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/panw_cortex_xdr/panw_cortex_xdr-1.1.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "panw_cortex_xdr.alerts",
-        "title": "Palo Alto Cortex XDR API"
-      }
-    ]
-  },
-  {
-    "name": "panw_cortex_xdr",
-    "title": "Palo Alto Cortex XDR Logs",
-    "version": "1.1.1",
-    "release": "ga",
-    "description": "Collect and parse logs from Palo Alto Cortex XDR API with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/panw_cortex_xdr/panw_cortex_xdr-1.1.1.zip",
-    "path": "/package/panw_cortex_xdr/1.1.1",
-    "icons": [
-      {
-        "src": "/img/icon-cortex.svg",
-        "path": "/package/panw_cortex_xdr/1.1.1/img/icon-cortex.svg",
-        "title": "Palo Alto",
-        "size": "216x216",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "alerts",
-        "title": "Palo Alto Cortex XDR API",
-        "description": "Collect logs from Palo Alto Cortex XDR API"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.15.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/panw_cortex_xdr/panw_cortex_xdr-1.1.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "panw_cortex_xdr.alerts",
-        "title": "Palo Alto Cortex XDR API"
-      }
-    ]
-  },
-  {
     "name": "panw",
     "title": "Palo Alto Networks",
     "version": "1.0.0",
@@ -43996,6 +41033,321 @@
     ]
   },
   {
+    "name": "panw_cortex_xdr",
+    "title": "Palo Alto Cortex XDR",
+    "version": "0.1.0",
+    "release": "beta",
+    "description": "Palo Alto Cortex XDR Integration",
+    "type": "integration",
+    "download": "/epr/panw_cortex_xdr/panw_cortex_xdr-0.1.0.zip",
+    "path": "/package/panw_cortex_xdr/0.1.0",
+    "icons": [
+      {
+        "src": "/img/icon-cortex.svg",
+        "path": "/package/panw_cortex_xdr/0.1.0/img/icon-cortex.svg",
+        "title": "Palo Alto",
+        "size": "216x216",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "alerts",
+        "title": "Palo Alto Cortex XDR API",
+        "description": "Collect logs from Palo Alto Cortex XDR API"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.15.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/panw_cortex_xdr/panw_cortex_xdr-0.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "panw_cortex_xdr.alerts",
+        "title": "Palo Alto Cortex XDR API"
+      }
+    ]
+  },
+  {
+    "name": "panw_cortex_xdr",
+    "title": "Palo Alto Cortex XDR",
+    "version": "0.2.0",
+    "release": "beta",
+    "description": "Palo Alto Cortex XDR Integration",
+    "type": "integration",
+    "download": "/epr/panw_cortex_xdr/panw_cortex_xdr-0.2.0.zip",
+    "path": "/package/panw_cortex_xdr/0.2.0",
+    "icons": [
+      {
+        "src": "/img/icon-cortex.svg",
+        "path": "/package/panw_cortex_xdr/0.2.0/img/icon-cortex.svg",
+        "title": "Palo Alto",
+        "size": "216x216",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "alerts",
+        "title": "Palo Alto Cortex XDR API",
+        "description": "Collect logs from Palo Alto Cortex XDR API"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.15.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/panw_cortex_xdr/panw_cortex_xdr-0.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "panw_cortex_xdr.alerts",
+        "title": "Palo Alto Cortex XDR API"
+      }
+    ]
+  },
+  {
+    "name": "panw_cortex_xdr",
+    "title": "Palo Alto Cortex XDR",
+    "version": "0.2.2",
+    "release": "beta",
+    "description": "Palo Alto Cortex XDR Integration",
+    "type": "integration",
+    "download": "/epr/panw_cortex_xdr/panw_cortex_xdr-0.2.2.zip",
+    "path": "/package/panw_cortex_xdr/0.2.2",
+    "icons": [
+      {
+        "src": "/img/icon-cortex.svg",
+        "path": "/package/panw_cortex_xdr/0.2.2/img/icon-cortex.svg",
+        "title": "Palo Alto",
+        "size": "216x216",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "alerts",
+        "title": "Palo Alto Cortex XDR API",
+        "description": "Collect logs from Palo Alto Cortex XDR API"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.15.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/panw_cortex_xdr/panw_cortex_xdr-0.2.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "panw_cortex_xdr.alerts",
+        "title": "Palo Alto Cortex XDR API"
+      }
+    ]
+  },
+  {
+    "name": "panw_cortex_xdr",
+    "title": "Palo Alto Cortex XDR Logs",
+    "version": "0.2.4",
+    "release": "beta",
+    "description": "Collect and parse logs from Palo Alto Cortex XDR API with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/panw_cortex_xdr/panw_cortex_xdr-0.2.4.zip",
+    "path": "/package/panw_cortex_xdr/0.2.4",
+    "icons": [
+      {
+        "src": "/img/icon-cortex.svg",
+        "path": "/package/panw_cortex_xdr/0.2.4/img/icon-cortex.svg",
+        "title": "Palo Alto",
+        "size": "216x216",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "alerts",
+        "title": "Palo Alto Cortex XDR API",
+        "description": "Collect logs from Palo Alto Cortex XDR API"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.15.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/panw_cortex_xdr/panw_cortex_xdr-0.2.4.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "panw_cortex_xdr.alerts",
+        "title": "Palo Alto Cortex XDR API"
+      }
+    ]
+  },
+  {
+    "name": "panw_cortex_xdr",
+    "title": "Palo Alto Cortex XDR Logs",
+    "version": "1.0.0",
+    "release": "ga",
+    "description": "Collect and parse logs from Palo Alto Cortex XDR API with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/panw_cortex_xdr/panw_cortex_xdr-1.0.0.zip",
+    "path": "/package/panw_cortex_xdr/1.0.0",
+    "icons": [
+      {
+        "src": "/img/icon-cortex.svg",
+        "path": "/package/panw_cortex_xdr/1.0.0/img/icon-cortex.svg",
+        "title": "Palo Alto",
+        "size": "216x216",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "alerts",
+        "title": "Palo Alto Cortex XDR API",
+        "description": "Collect logs from Palo Alto Cortex XDR API"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.15.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/panw_cortex_xdr/panw_cortex_xdr-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "panw_cortex_xdr.alerts",
+        "title": "Palo Alto Cortex XDR API"
+      }
+    ]
+  },
+  {
+    "name": "panw_cortex_xdr",
+    "title": "Palo Alto Cortex XDR Logs",
+    "version": "1.1.0",
+    "release": "ga",
+    "description": "Collect and parse logs from Palo Alto Cortex XDR API with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/panw_cortex_xdr/panw_cortex_xdr-1.1.0.zip",
+    "path": "/package/panw_cortex_xdr/1.1.0",
+    "icons": [
+      {
+        "src": "/img/icon-cortex.svg",
+        "path": "/package/panw_cortex_xdr/1.1.0/img/icon-cortex.svg",
+        "title": "Palo Alto",
+        "size": "216x216",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "alerts",
+        "title": "Palo Alto Cortex XDR API",
+        "description": "Collect logs from Palo Alto Cortex XDR API"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.15.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/panw_cortex_xdr/panw_cortex_xdr-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "panw_cortex_xdr.alerts",
+        "title": "Palo Alto Cortex XDR API"
+      }
+    ]
+  },
+  {
+    "name": "panw_cortex_xdr",
+    "title": "Palo Alto Cortex XDR Logs",
+    "version": "1.1.1",
+    "release": "ga",
+    "description": "Collect and parse logs from Palo Alto Cortex XDR API with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/panw_cortex_xdr/panw_cortex_xdr-1.1.1.zip",
+    "path": "/package/panw_cortex_xdr/1.1.1",
+    "icons": [
+      {
+        "src": "/img/icon-cortex.svg",
+        "path": "/package/panw_cortex_xdr/1.1.1/img/icon-cortex.svg",
+        "title": "Palo Alto",
+        "size": "216x216",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "alerts",
+        "title": "Palo Alto Cortex XDR API",
+        "description": "Collect logs from Palo Alto Cortex XDR API"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.15.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/panw_cortex_xdr/panw_cortex_xdr-1.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "panw_cortex_xdr.alerts",
+        "title": "Palo Alto Cortex XDR API"
+      }
+    ]
+  },
+  {
     "name": "postgresql",
     "title": "PostgreSQL",
     "version": "1.1.0",
@@ -44122,6 +41474,628 @@
         "type": "metrics",
         "dataset": "postgresql.statement",
         "title": "PostgreSQL statement metrics"
+      }
+    ]
+  },
+  {
+    "name": "qnap_nas",
+    "title": "QNAP NAS",
+    "version": "1.0.1",
+    "release": "ga",
+    "description": "Collect logs from QNAP NAS devices with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/qnap_nas/qnap_nas-1.0.1.zip",
+    "path": "/package/qnap_nas/1.0.1",
+    "icons": [
+      {
+        "src": "/img/logo.svg",
+        "path": "/package/qnap_nas/1.0.1/img/logo.svg",
+        "title": "QNAP logo",
+        "size": "643x121",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "qnap",
+        "title": "QNAP NAS Event & Access logs",
+        "description": "Collect logs from QNAP NAS"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/qnap_nas/qnap_nas-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "qnap_nas.log",
+        "title": "QNAP NAS logs"
+      }
+    ]
+  },
+  {
+    "name": "qnap_nas",
+    "title": "QNAP NAS",
+    "version": "1.1.0",
+    "release": "ga",
+    "description": "Collect logs from QNAP NAS devices with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/qnap_nas/qnap_nas-1.1.0.zip",
+    "path": "/package/qnap_nas/1.1.0",
+    "icons": [
+      {
+        "src": "/img/logo.svg",
+        "path": "/package/qnap_nas/1.1.0/img/logo.svg",
+        "title": "QNAP logo",
+        "size": "643x121",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "qnap",
+        "title": "QNAP NAS Event & Access logs",
+        "description": "Collect logs from QNAP NAS"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/qnap_nas/qnap_nas-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "qnap_nas.log",
+        "title": "QNAP NAS logs"
+      }
+    ]
+  },
+  {
+    "name": "qnap_nas",
+    "title": "QNAP NAS",
+    "version": "1.1.1",
+    "release": "ga",
+    "description": "Collect logs from QNAP NAS devices with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/qnap_nas/qnap_nas-1.1.1.zip",
+    "path": "/package/qnap_nas/1.1.1",
+    "icons": [
+      {
+        "src": "/img/logo.svg",
+        "path": "/package/qnap_nas/1.1.1/img/logo.svg",
+        "title": "QNAP logo",
+        "size": "643x121",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "qnap",
+        "title": "QNAP NAS Event & Access logs",
+        "description": "Collect logs from QNAP NAS"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/qnap_nas/qnap_nas-1.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "qnap_nas.log",
+        "title": "QNAP NAS logs"
+      }
+    ]
+  },
+  {
+    "name": "rabbitmq",
+    "title": "RabbitMQ",
+    "version": "1.0.0",
+    "release": "ga",
+    "description": "This Elastic integration collects logs and metrics from RabbitMQ instances",
+    "type": "integration",
+    "download": "/epr/rabbitmq/rabbitmq-1.0.0.zip",
+    "path": "/package/rabbitmq/1.0.0",
+    "icons": [
+      {
+        "src": "/img/logo_rabbitmq.svg",
+        "path": "/package/rabbitmq/1.0.0/img/logo_rabbitmq.svg",
+        "title": "RabbitMQ Logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "rabbitmq",
+        "title": "RabbitMQ logs and metrics",
+        "description": "Collect logs and metrics from RabbitMQ instances"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "message_queue"
+    ],
+    "signature_path": "/epr/rabbitmq/rabbitmq-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "rabbitmq.connection",
+        "title": "RabbitMQ connection metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "rabbitmq.exchange",
+        "title": "RabbitMQ exchange metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "rabbitmq.log",
+        "title": "RabbitMQ application logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "rabbitmq.node",
+        "title": "RabbitMQ node metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "rabbitmq.queue",
+        "title": "RabbitMQ queue metrics"
+      }
+    ]
+  },
+  {
+    "name": "rabbitmq",
+    "title": "RabbitMQ Logs",
+    "version": "1.2.0",
+    "release": "ga",
+    "description": "Collect and parse logs from RabbitMQ servers with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/rabbitmq/rabbitmq-1.2.0.zip",
+    "path": "/package/rabbitmq/1.2.0",
+    "icons": [
+      {
+        "src": "/img/logo_rabbitmq.svg",
+        "path": "/package/rabbitmq/1.2.0/img/logo_rabbitmq.svg",
+        "title": "RabbitMQ Logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "rabbitmq",
+        "title": "RabbitMQ logs and metrics",
+        "description": "Collect logs and metrics from RabbitMQ instances"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "message_queue"
+    ],
+    "signature_path": "/epr/rabbitmq/rabbitmq-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "rabbitmq.connection",
+        "title": "RabbitMQ connection metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "rabbitmq.exchange",
+        "title": "RabbitMQ exchange metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "rabbitmq.log",
+        "title": "RabbitMQ application logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "rabbitmq.node",
+        "title": "RabbitMQ node metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "rabbitmq.queue",
+        "title": "RabbitMQ queue metrics"
+      }
+    ]
+  },
+  {
+    "name": "redis",
+    "title": "Redis",
+    "version": "1.1.0",
+    "release": "ga",
+    "description": "This integration collects logs and metrics from Redis instances",
+    "type": "integration",
+    "download": "/epr/redis/redis-1.1.0.zip",
+    "path": "/package/redis/1.1.0",
+    "icons": [
+      {
+        "src": "/img/logo_redis.svg",
+        "path": "/package/redis/1.1.0/img/logo_redis.svg",
+        "title": "logo redis",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "redis",
+        "title": "Redis logs and metrics",
+        "description": "Collect logs and metrics from Redis instances"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "datastore",
+      "message_queue"
+    ],
+    "signature_path": "/epr/redis/redis-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "redis.info",
+        "title": "Redis info metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "redis.key",
+        "title": "Redis key metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "redis.keyspace",
+        "title": "Redis keyspace metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "redis.log",
+        "title": "Redis application logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "redis.slowlog",
+        "title": "Redis slow logs"
+      }
+    ]
+  },
+  {
+    "name": "redis",
+    "title": "Redis",
+    "version": "1.2.0",
+    "release": "ga",
+    "description": "Collect logs and metrics from Redis servers with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/redis/redis-1.2.0.zip",
+    "path": "/package/redis/1.2.0",
+    "icons": [
+      {
+        "src": "/img/logo_redis.svg",
+        "path": "/package/redis/1.2.0/img/logo_redis.svg",
+        "title": "logo redis",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "redis",
+        "title": "Redis logs and metrics",
+        "description": "Collect logs and metrics from Redis instances"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "datastore",
+      "message_queue"
+    ],
+    "signature_path": "/epr/redis/redis-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "redis.info",
+        "title": "Redis info metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "redis.key",
+        "title": "Redis key metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "redis.keyspace",
+        "title": "Redis keyspace metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "redis.log",
+        "title": "Redis application logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "redis.slowlog",
+        "title": "Redis slow logs"
+      }
+    ]
+  },
+  {
+    "name": "santa",
+    "title": "Google Santa",
+    "version": "1.0.2",
+    "release": "ga",
+    "description": "Collect logs from Google Santa with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/santa/santa-1.0.2.zip",
+    "path": "/package/santa/1.0.2",
+    "icons": [
+      {
+        "src": "/img/icon.svg",
+        "path": "/package/santa/1.0.2/img/icon.svg",
+        "title": "Google Santa",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "santa",
+        "title": "Google Santa logs",
+        "description": "Collect logs from Google Santa instances"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security",
+      "os_system"
+    ],
+    "signature_path": "/epr/santa/santa-1.0.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "santa.log",
+        "title": "Google Santa log logs"
+      }
+    ]
+  },
+  {
+    "name": "santa",
+    "title": "Google Santa Logs",
+    "version": "1.0.3",
+    "release": "ga",
+    "description": "Collect and parse logs from Google Santa instances with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/santa/santa-1.0.3.zip",
+    "path": "/package/santa/1.0.3",
+    "icons": [
+      {
+        "src": "/img/icon.svg",
+        "path": "/package/santa/1.0.3/img/icon.svg",
+        "title": "Google Santa",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "santa",
+        "title": "Google Santa logs",
+        "description": "Collect logs from Google Santa instances"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security",
+      "os_system"
+    ],
+    "signature_path": "/epr/santa/santa-1.0.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "santa.log",
+        "title": "Google Santa log logs"
+      }
+    ]
+  },
+  {
+    "name": "santa",
+    "title": "Google Santa Logs",
+    "version": "1.1.0",
+    "release": "ga",
+    "description": "Collect and parse logs from Google Santa instances with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/santa/santa-1.1.0.zip",
+    "path": "/package/santa/1.1.0",
+    "icons": [
+      {
+        "src": "/img/icon.svg",
+        "path": "/package/santa/1.1.0/img/icon.svg",
+        "title": "Google Santa",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "santa",
+        "title": "Google Santa logs",
+        "description": "Collect logs from Google Santa instances"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security",
+      "os_system"
+    ],
+    "signature_path": "/epr/santa/santa-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "santa.log",
+        "title": "Google Santa log logs"
+      }
+    ]
+  },
+  {
+    "name": "santa",
+    "title": "Google Santa Logs",
+    "version": "2.0.0",
+    "release": "ga",
+    "description": "Collect and parse logs from Google Santa instances with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/santa/santa-2.0.0.zip",
+    "path": "/package/santa/2.0.0",
+    "icons": [
+      {
+        "src": "/img/icon.svg",
+        "path": "/package/santa/2.0.0/img/icon.svg",
+        "title": "Google Santa",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "santa",
+        "title": "Google Santa logs",
+        "description": "Collect logs from Google Santa instances"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.17.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security",
+      "os_system"
+    ],
+    "signature_path": "/epr/santa/santa-2.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "santa.log",
+        "title": "Google Santa log logs"
+      }
+    ]
+  },
+  {
+    "name": "santa",
+    "title": "Google Santa Logs",
+    "version": "2.0.1",
+    "release": "ga",
+    "description": "Collect and parse logs from Google Santa instances with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/santa/santa-2.0.1.zip",
+    "path": "/package/santa/2.0.1",
+    "icons": [
+      {
+        "src": "/img/icon.svg",
+        "path": "/package/santa/2.0.1/img/icon.svg",
+        "title": "Google Santa",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "santa",
+        "title": "Google Santa logs",
+        "description": "Collect logs from Google Santa instances"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.17.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security",
+      "os_system"
+    ],
+    "signature_path": "/epr/santa/santa-2.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "santa.log",
+        "title": "Google Santa log logs"
       }
     ]
   },
@@ -44468,298 +42442,33 @@
     "signature_path": "/epr/security_detection_engine/security_detection_engine-1.0.2.zip.sig"
   },
   {
-    "name": "qnap_nas",
-    "title": "QNAP NAS",
-    "version": "1.0.1",
-    "release": "ga",
-    "description": "Collect logs from QNAP NAS devices with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/qnap_nas/qnap_nas-1.0.1.zip",
-    "path": "/package/qnap_nas/1.0.1",
-    "icons": [
-      {
-        "src": "/img/logo.svg",
-        "path": "/package/qnap_nas/1.0.1/img/logo.svg",
-        "title": "QNAP logo",
-        "size": "643x121",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "qnap",
-        "title": "QNAP NAS Event & Access logs",
-        "description": "Collect logs from QNAP NAS"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/qnap_nas/qnap_nas-1.0.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "qnap_nas.log",
-        "title": "QNAP NAS logs"
-      }
-    ]
-  },
-  {
-    "name": "qnap_nas",
-    "title": "QNAP NAS",
-    "version": "1.1.0",
-    "release": "ga",
-    "description": "Collect logs from QNAP NAS devices with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/qnap_nas/qnap_nas-1.1.0.zip",
-    "path": "/package/qnap_nas/1.1.0",
-    "icons": [
-      {
-        "src": "/img/logo.svg",
-        "path": "/package/qnap_nas/1.1.0/img/logo.svg",
-        "title": "QNAP logo",
-        "size": "643x121",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "qnap",
-        "title": "QNAP NAS Event & Access logs",
-        "description": "Collect logs from QNAP NAS"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/qnap_nas/qnap_nas-1.1.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "qnap_nas.log",
-        "title": "QNAP NAS logs"
-      }
-    ]
-  },
-  {
-    "name": "qnap_nas",
-    "title": "QNAP NAS",
-    "version": "1.1.1",
-    "release": "ga",
-    "description": "Collect logs from QNAP NAS devices with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/qnap_nas/qnap_nas-1.1.1.zip",
-    "path": "/package/qnap_nas/1.1.1",
-    "icons": [
-      {
-        "src": "/img/logo.svg",
-        "path": "/package/qnap_nas/1.1.1/img/logo.svg",
-        "title": "QNAP logo",
-        "size": "643x121",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "qnap",
-        "title": "QNAP NAS Event & Access logs",
-        "description": "Collect logs from QNAP NAS"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/qnap_nas/qnap_nas-1.1.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "qnap_nas.log",
-        "title": "QNAP NAS logs"
-      }
-    ]
-  },
-  {
-    "name": "rabbitmq",
-    "title": "RabbitMQ",
+    "name": "snyk",
+    "title": "Snyk",
     "version": "1.0.0",
     "release": "ga",
-    "description": "This Elastic integration collects logs and metrics from RabbitMQ instances",
+    "description": "Collect logs from Snyk API with Elastic Agent.",
     "type": "integration",
-    "download": "/epr/rabbitmq/rabbitmq-1.0.0.zip",
-    "path": "/package/rabbitmq/1.0.0",
+    "download": "/epr/snyk/snyk-1.0.0.zip",
+    "path": "/package/snyk/1.0.0",
     "icons": [
       {
-        "src": "/img/logo_rabbitmq.svg",
-        "path": "/package/rabbitmq/1.0.0/img/logo_rabbitmq.svg",
-        "title": "RabbitMQ Logo",
-        "size": "32x32",
+        "src": "/img/snyk-logo.svg",
+        "path": "/package/snyk/1.0.0/img/snyk-logo.svg",
+        "title": "Snyk logo",
+        "size": "382x625",
         "type": "image/svg+xml"
       }
     ],
     "policy_templates": [
       {
-        "name": "rabbitmq",
-        "title": "RabbitMQ logs and metrics",
-        "description": "Collect logs and metrics from RabbitMQ instances"
+        "name": "snyk",
+        "title": "Snyk Events",
+        "description": "Collect data from Snyk API"
       }
     ],
     "conditions": {
       "kibana": {
-        "version": "^7.14.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "message_queue"
-    ],
-    "signature_path": "/epr/rabbitmq/rabbitmq-1.0.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "metrics",
-        "dataset": "rabbitmq.connection",
-        "title": "RabbitMQ connection metrics"
-      },
-      {
-        "type": "metrics",
-        "dataset": "rabbitmq.exchange",
-        "title": "RabbitMQ exchange metrics"
-      },
-      {
-        "type": "logs",
-        "dataset": "rabbitmq.log",
-        "title": "RabbitMQ application logs"
-      },
-      {
-        "type": "metrics",
-        "dataset": "rabbitmq.node",
-        "title": "RabbitMQ node metrics"
-      },
-      {
-        "type": "metrics",
-        "dataset": "rabbitmq.queue",
-        "title": "RabbitMQ queue metrics"
-      }
-    ]
-  },
-  {
-    "name": "rabbitmq",
-    "title": "RabbitMQ Logs",
-    "version": "1.2.0",
-    "release": "ga",
-    "description": "Collect and parse logs from RabbitMQ servers with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/rabbitmq/rabbitmq-1.2.0.zip",
-    "path": "/package/rabbitmq/1.2.0",
-    "icons": [
-      {
-        "src": "/img/logo_rabbitmq.svg",
-        "path": "/package/rabbitmq/1.2.0/img/logo_rabbitmq.svg",
-        "title": "RabbitMQ Logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "rabbitmq",
-        "title": "RabbitMQ logs and metrics",
-        "description": "Collect logs and metrics from RabbitMQ instances"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "message_queue"
-    ],
-    "signature_path": "/epr/rabbitmq/rabbitmq-1.2.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "metrics",
-        "dataset": "rabbitmq.connection",
-        "title": "RabbitMQ connection metrics"
-      },
-      {
-        "type": "metrics",
-        "dataset": "rabbitmq.exchange",
-        "title": "RabbitMQ exchange metrics"
-      },
-      {
-        "type": "logs",
-        "dataset": "rabbitmq.log",
-        "title": "RabbitMQ application logs"
-      },
-      {
-        "type": "metrics",
-        "dataset": "rabbitmq.node",
-        "title": "RabbitMQ node metrics"
-      },
-      {
-        "type": "metrics",
-        "dataset": "rabbitmq.queue",
-        "title": "RabbitMQ queue metrics"
-      }
-    ]
-  },
-  {
-    "name": "ti_recordedfuture",
-    "title": "Recorded Future",
-    "version": "0.1.0",
-    "release": "beta",
-    "description": "Collect threat intelligence from Recorded Future with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/ti_recordedfuture/ti_recordedfuture-0.1.0.zip",
-    "path": "/package/ti_recordedfuture/0.1.0",
-    "icons": [
-      {
-        "src": "/img/logo.svg",
-        "path": "/package/ti_recordedfuture/0.1.0/img/logo.svg",
-        "title": "Recorded Future",
-        "size": "216x216",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "ti_recordedfuture",
-        "title": "Recorded Future",
-        "description": "Collect threat intelligence from Recorded Future."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
+        "version": "^7.16.0 || ^8.0.0"
       }
     },
     "owner": {
@@ -44768,234 +42477,467 @@
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/ti_recordedfuture/ti_recordedfuture-0.1.0.zip.sig",
+    "signature_path": "/epr/snyk/snyk-1.0.0.zip.sig",
     "data_streams": [
       {
         "type": "logs",
-        "dataset": "ti_recordedfuture.threat",
-        "title": "Recorded Future"
+        "dataset": "snyk.audit",
+        "title": "Collect Snyk Audit Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "snyk.vulnerabilities",
+        "title": "Collect Snyk Vulnerability Data"
       }
     ]
   },
   {
-    "name": "ti_recordedfuture",
-    "title": "Recorded Future",
-    "version": "0.1.1",
-    "release": "beta",
-    "description": "Collect threat intelligence from Recorded Future with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/ti_recordedfuture/ti_recordedfuture-0.1.1.zip",
-    "path": "/package/ti_recordedfuture/0.1.1",
-    "icons": [
-      {
-        "src": "/img/logo.svg",
-        "path": "/package/ti_recordedfuture/0.1.1/img/logo.svg",
-        "title": "Recorded Future",
-        "size": "216x216",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "ti_recordedfuture",
-        "title": "Recorded Future",
-        "description": "Collect threat intelligence from Recorded Future."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/ti_recordedfuture/ti_recordedfuture-0.1.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ti_recordedfuture.threat",
-        "title": "Recorded Future"
-      }
-    ]
-  },
-  {
-    "name": "ti_recordedfuture",
-    "title": "Recorded Future",
-    "version": "0.1.2",
-    "release": "beta",
-    "description": "Collect threat intelligence from Recorded Future with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/ti_recordedfuture/ti_recordedfuture-0.1.2.zip",
-    "path": "/package/ti_recordedfuture/0.1.2",
-    "icons": [
-      {
-        "src": "/img/logo.svg",
-        "path": "/package/ti_recordedfuture/0.1.2/img/logo.svg",
-        "title": "Recorded Future",
-        "size": "216x216",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "ti_recordedfuture",
-        "title": "Recorded Future",
-        "description": "Collect threat intelligence from Recorded Future."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/ti_recordedfuture/ti_recordedfuture-0.1.2.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ti_recordedfuture.threat",
-        "title": "Recorded Future"
-      }
-    ]
-  },
-  {
-    "name": "redis",
-    "title": "Redis",
+    "name": "snyk",
+    "title": "Snyk",
     "version": "1.1.0",
     "release": "ga",
-    "description": "This integration collects logs and metrics from Redis instances",
+    "description": "Collect logs from Snyk API with Elastic Agent.",
     "type": "integration",
-    "download": "/epr/redis/redis-1.1.0.zip",
-    "path": "/package/redis/1.1.0",
+    "download": "/epr/snyk/snyk-1.1.0.zip",
+    "path": "/package/snyk/1.1.0",
     "icons": [
       {
-        "src": "/img/logo_redis.svg",
-        "path": "/package/redis/1.1.0/img/logo_redis.svg",
-        "title": "logo redis",
-        "size": "32x32",
+        "src": "/img/snyk-logo.svg",
+        "path": "/package/snyk/1.1.0/img/snyk-logo.svg",
+        "title": "Snyk logo",
+        "size": "382x625",
         "type": "image/svg+xml"
       }
     ],
     "policy_templates": [
       {
-        "name": "redis",
-        "title": "Redis logs and metrics",
-        "description": "Collect logs and metrics from Redis instances"
+        "name": "snyk",
+        "title": "Snyk Events",
+        "description": "Collect data from Snyk API"
       }
     ],
     "conditions": {
       "kibana": {
-        "version": "^7.14.0"
+        "version": "^7.16.0 || ^8.0.0"
       }
     },
     "owner": {
-      "github": "elastic/integrations"
+      "github": "elastic/security-external-integrations"
     },
     "categories": [
-      "datastore",
-      "message_queue"
+      "security"
     ],
-    "signature_path": "/epr/redis/redis-1.1.0.zip.sig",
+    "signature_path": "/epr/snyk/snyk-1.1.0.zip.sig",
     "data_streams": [
       {
-        "type": "metrics",
-        "dataset": "redis.info",
-        "title": "Redis info metrics"
-      },
-      {
-        "type": "metrics",
-        "dataset": "redis.key",
-        "title": "Redis key metrics"
-      },
-      {
-        "type": "metrics",
-        "dataset": "redis.keyspace",
-        "title": "Redis keyspace metrics"
+        "type": "logs",
+        "dataset": "snyk.audit",
+        "title": "Collect Snyk Audit Logs"
       },
       {
         "type": "logs",
-        "dataset": "redis.log",
-        "title": "Redis application logs"
-      },
-      {
-        "type": "logs",
-        "dataset": "redis.slowlog",
-        "title": "Redis slow logs"
+        "dataset": "snyk.vulnerabilities",
+        "title": "Collect Snyk Vulnerability Data"
       }
     ]
   },
   {
-    "name": "redis",
-    "title": "Redis",
-    "version": "1.2.0",
+    "name": "snyk",
+    "title": "Snyk",
+    "version": "1.1.1",
     "release": "ga",
-    "description": "Collect logs and metrics from Redis servers with Elastic Agent.",
+    "description": "Collect logs from Snyk API with Elastic Agent.",
     "type": "integration",
-    "download": "/epr/redis/redis-1.2.0.zip",
-    "path": "/package/redis/1.2.0",
+    "download": "/epr/snyk/snyk-1.1.1.zip",
+    "path": "/package/snyk/1.1.1",
     "icons": [
       {
-        "src": "/img/logo_redis.svg",
-        "path": "/package/redis/1.2.0/img/logo_redis.svg",
-        "title": "logo redis",
+        "src": "/img/snyk-logo.svg",
+        "path": "/package/snyk/1.1.1/img/snyk-logo.svg",
+        "title": "Snyk logo",
+        "size": "382x625",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "snyk",
+        "title": "Snyk Events",
+        "description": "Collect data from Snyk API"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/snyk/snyk-1.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "snyk.audit",
+        "title": "Collect Snyk Audit Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "snyk.vulnerabilities",
+        "title": "Collect Snyk Vulnerability Data"
+      }
+    ]
+  },
+  {
+    "name": "snyk",
+    "title": "Snyk",
+    "version": "1.1.2",
+    "release": "ga",
+    "description": "Collect logs from Snyk API with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/snyk/snyk-1.1.2.zip",
+    "path": "/package/snyk/1.1.2",
+    "icons": [
+      {
+        "src": "/img/snyk-logo.svg",
+        "path": "/package/snyk/1.1.2/img/snyk-logo.svg",
+        "title": "Snyk logo",
+        "size": "382x625",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "snyk",
+        "title": "Snyk Events",
+        "description": "Collect data from Snyk API"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/snyk/snyk-1.1.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "snyk.audit",
+        "title": "Collect Snyk Audit Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "snyk.vulnerabilities",
+        "title": "Collect Snyk Vulnerability Data"
+      }
+    ]
+  },
+  {
+    "name": "sophos",
+    "title": "Sophos Logs",
+    "version": "1.0.6",
+    "release": "ga",
+    "description": "Collect and parse logs from Sophos Products with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/sophos/sophos-1.0.6.zip",
+    "path": "/package/sophos/1.0.6",
+    "icons": [
+      {
+        "src": "/img/logo.svg",
+        "path": "/package/sophos/1.0.6/img/logo.svg",
+        "title": "Sophos logo",
         "size": "32x32",
         "type": "image/svg+xml"
       }
     ],
     "policy_templates": [
       {
-        "name": "redis",
-        "title": "Redis logs and metrics",
-        "description": "Collect logs and metrics from Redis instances"
+        "name": "sophos",
+        "title": "Sophos logs",
+        "description": "Collect Sophos logs from syslog or a file."
       }
     ],
     "conditions": {
       "kibana": {
-        "version": "^7.14.0 || ^8.0.0"
+        "version": "^7.14.1"
       }
     },
     "owner": {
-      "github": "elastic/integrations"
+      "github": "elastic/security-external-integrations"
     },
     "categories": [
-      "datastore",
-      "message_queue"
+      "security"
     ],
-    "signature_path": "/epr/redis/redis-1.2.0.zip.sig",
+    "signature_path": "/epr/sophos/sophos-1.0.6.zip.sig",
     "data_streams": [
       {
-        "type": "metrics",
-        "dataset": "redis.info",
-        "title": "Redis info metrics"
-      },
-      {
-        "type": "metrics",
-        "dataset": "redis.key",
-        "title": "Redis key metrics"
-      },
-      {
-        "type": "metrics",
-        "dataset": "redis.keyspace",
-        "title": "Redis keyspace metrics"
+        "type": "logs",
+        "dataset": "sophos.utm",
+        "title": "Sophos UTM logs"
       },
       {
         "type": "logs",
-        "dataset": "redis.log",
-        "title": "Redis application logs"
+        "dataset": "sophos.xg",
+        "title": "Sophos XG logs"
+      }
+    ]
+  },
+  {
+    "name": "sophos",
+    "title": "Sophos Logs",
+    "version": "1.1.0",
+    "release": "ga",
+    "description": "Collect and parse logs from Sophos Products with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/sophos/sophos-1.1.0.zip",
+    "path": "/package/sophos/1.1.0",
+    "icons": [
+      {
+        "src": "/img/logo.svg",
+        "path": "/package/sophos/1.1.0/img/logo.svg",
+        "title": "Sophos logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "sophos",
+        "title": "Sophos logs",
+        "description": "Collect Sophos logs from syslog or a file."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.1 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/sophos/sophos-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "sophos.utm",
+        "title": "Sophos UTM logs"
       },
       {
         "type": "logs",
-        "dataset": "redis.slowlog",
-        "title": "Redis slow logs"
+        "dataset": "sophos.xg",
+        "title": "Sophos XG logs"
+      }
+    ]
+  },
+  {
+    "name": "sophos",
+    "title": "Sophos Logs",
+    "version": "1.1.3",
+    "release": "ga",
+    "description": "Collect and parse logs from Sophos Products with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/sophos/sophos-1.1.3.zip",
+    "path": "/package/sophos/1.1.3",
+    "icons": [
+      {
+        "src": "/img/logo.svg",
+        "path": "/package/sophos/1.1.3/img/logo.svg",
+        "title": "Sophos logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "sophos",
+        "title": "Sophos logs",
+        "description": "Collect Sophos logs from syslog or a file."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.1 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/sophos/sophos-1.1.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "sophos.utm",
+        "title": "Sophos UTM logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "sophos.xg",
+        "title": "Sophos XG logs"
+      }
+    ]
+  },
+  {
+    "name": "sophos",
+    "title": "Sophos Logs",
+    "version": "1.2.0",
+    "release": "ga",
+    "description": "Collect and parse logs from Sophos Products with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/sophos/sophos-1.2.0.zip",
+    "path": "/package/sophos/1.2.0",
+    "icons": [
+      {
+        "src": "/img/logo.svg",
+        "path": "/package/sophos/1.2.0/img/logo.svg",
+        "title": "Sophos logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "sophos",
+        "title": "Sophos logs",
+        "description": "Collect Sophos logs from syslog or a file."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.1 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/sophos/sophos-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "sophos.utm",
+        "title": "Sophos UTM logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "sophos.xg",
+        "title": "Sophos XG logs"
+      }
+    ]
+  },
+  {
+    "name": "sophos",
+    "title": "Sophos Logs",
+    "version": "1.2.1",
+    "release": "ga",
+    "description": "Collect and parse logs from Sophos Products with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/sophos/sophos-1.2.1.zip",
+    "path": "/package/sophos/1.2.1",
+    "icons": [
+      {
+        "src": "/img/logo.svg",
+        "path": "/package/sophos/1.2.1/img/logo.svg",
+        "title": "Sophos logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "sophos",
+        "title": "Sophos logs",
+        "description": "Collect Sophos logs from syslog or a file."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.1 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/sophos/sophos-1.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "sophos.utm",
+        "title": "Sophos UTM logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "sophos.xg",
+        "title": "Sophos XG logs"
+      }
+    ]
+  },
+  {
+    "name": "sophos",
+    "title": "Sophos Logs",
+    "version": "1.2.2",
+    "release": "ga",
+    "description": "Collect and parse logs from Sophos Products with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/sophos/sophos-1.2.2.zip",
+    "path": "/package/sophos/1.2.2",
+    "icons": [
+      {
+        "src": "/img/logo.svg",
+        "path": "/package/sophos/1.2.2/img/logo.svg",
+        "title": "Sophos logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "sophos",
+        "title": "Sophos logs",
+        "description": "Collect Sophos logs from syslog or a file."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.1 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/sophos/sophos-1.2.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "sophos.utm",
+        "title": "Sophos UTM logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "sophos.xg",
+        "title": "Sophos XG logs"
       }
     ]
   },
@@ -45519,506 +43461,6 @@
     ]
   },
   {
-    "name": "snyk",
-    "title": "Snyk",
-    "version": "1.0.0",
-    "release": "ga",
-    "description": "Collect logs from Snyk API with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/snyk/snyk-1.0.0.zip",
-    "path": "/package/snyk/1.0.0",
-    "icons": [
-      {
-        "src": "/img/snyk-logo.svg",
-        "path": "/package/snyk/1.0.0/img/snyk-logo.svg",
-        "title": "Snyk logo",
-        "size": "382x625",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "snyk",
-        "title": "Snyk Events",
-        "description": "Collect data from Snyk API"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/snyk/snyk-1.0.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "snyk.audit",
-        "title": "Collect Snyk Audit Logs"
-      },
-      {
-        "type": "logs",
-        "dataset": "snyk.vulnerabilities",
-        "title": "Collect Snyk Vulnerability Data"
-      }
-    ]
-  },
-  {
-    "name": "snyk",
-    "title": "Snyk",
-    "version": "1.1.0",
-    "release": "ga",
-    "description": "Collect logs from Snyk API with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/snyk/snyk-1.1.0.zip",
-    "path": "/package/snyk/1.1.0",
-    "icons": [
-      {
-        "src": "/img/snyk-logo.svg",
-        "path": "/package/snyk/1.1.0/img/snyk-logo.svg",
-        "title": "Snyk logo",
-        "size": "382x625",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "snyk",
-        "title": "Snyk Events",
-        "description": "Collect data from Snyk API"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/snyk/snyk-1.1.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "snyk.audit",
-        "title": "Collect Snyk Audit Logs"
-      },
-      {
-        "type": "logs",
-        "dataset": "snyk.vulnerabilities",
-        "title": "Collect Snyk Vulnerability Data"
-      }
-    ]
-  },
-  {
-    "name": "snyk",
-    "title": "Snyk",
-    "version": "1.1.1",
-    "release": "ga",
-    "description": "Collect logs from Snyk API with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/snyk/snyk-1.1.1.zip",
-    "path": "/package/snyk/1.1.1",
-    "icons": [
-      {
-        "src": "/img/snyk-logo.svg",
-        "path": "/package/snyk/1.1.1/img/snyk-logo.svg",
-        "title": "Snyk logo",
-        "size": "382x625",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "snyk",
-        "title": "Snyk Events",
-        "description": "Collect data from Snyk API"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/snyk/snyk-1.1.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "snyk.audit",
-        "title": "Collect Snyk Audit Logs"
-      },
-      {
-        "type": "logs",
-        "dataset": "snyk.vulnerabilities",
-        "title": "Collect Snyk Vulnerability Data"
-      }
-    ]
-  },
-  {
-    "name": "snyk",
-    "title": "Snyk",
-    "version": "1.1.2",
-    "release": "ga",
-    "description": "Collect logs from Snyk API with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/snyk/snyk-1.1.2.zip",
-    "path": "/package/snyk/1.1.2",
-    "icons": [
-      {
-        "src": "/img/snyk-logo.svg",
-        "path": "/package/snyk/1.1.2/img/snyk-logo.svg",
-        "title": "Snyk logo",
-        "size": "382x625",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "snyk",
-        "title": "Snyk Events",
-        "description": "Collect data from Snyk API"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/snyk/snyk-1.1.2.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "snyk.audit",
-        "title": "Collect Snyk Audit Logs"
-      },
-      {
-        "type": "logs",
-        "dataset": "snyk.vulnerabilities",
-        "title": "Collect Snyk Vulnerability Data"
-      }
-    ]
-  },
-  {
-    "name": "sophos",
-    "title": "Sophos Logs",
-    "version": "1.0.6",
-    "release": "ga",
-    "description": "Collect and parse logs from Sophos Products with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/sophos/sophos-1.0.6.zip",
-    "path": "/package/sophos/1.0.6",
-    "icons": [
-      {
-        "src": "/img/logo.svg",
-        "path": "/package/sophos/1.0.6/img/logo.svg",
-        "title": "Sophos logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "sophos",
-        "title": "Sophos logs",
-        "description": "Collect Sophos logs from syslog or a file."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.1"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/sophos/sophos-1.0.6.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "sophos.utm",
-        "title": "Sophos UTM logs"
-      },
-      {
-        "type": "logs",
-        "dataset": "sophos.xg",
-        "title": "Sophos XG logs"
-      }
-    ]
-  },
-  {
-    "name": "sophos",
-    "title": "Sophos Logs",
-    "version": "1.1.0",
-    "release": "ga",
-    "description": "Collect and parse logs from Sophos Products with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/sophos/sophos-1.1.0.zip",
-    "path": "/package/sophos/1.1.0",
-    "icons": [
-      {
-        "src": "/img/logo.svg",
-        "path": "/package/sophos/1.1.0/img/logo.svg",
-        "title": "Sophos logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "sophos",
-        "title": "Sophos logs",
-        "description": "Collect Sophos logs from syslog or a file."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.1 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/sophos/sophos-1.1.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "sophos.utm",
-        "title": "Sophos UTM logs"
-      },
-      {
-        "type": "logs",
-        "dataset": "sophos.xg",
-        "title": "Sophos XG logs"
-      }
-    ]
-  },
-  {
-    "name": "sophos",
-    "title": "Sophos Logs",
-    "version": "1.1.3",
-    "release": "ga",
-    "description": "Collect and parse logs from Sophos Products with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/sophos/sophos-1.1.3.zip",
-    "path": "/package/sophos/1.1.3",
-    "icons": [
-      {
-        "src": "/img/logo.svg",
-        "path": "/package/sophos/1.1.3/img/logo.svg",
-        "title": "Sophos logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "sophos",
-        "title": "Sophos logs",
-        "description": "Collect Sophos logs from syslog or a file."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.1 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/sophos/sophos-1.1.3.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "sophos.utm",
-        "title": "Sophos UTM logs"
-      },
-      {
-        "type": "logs",
-        "dataset": "sophos.xg",
-        "title": "Sophos XG logs"
-      }
-    ]
-  },
-  {
-    "name": "sophos",
-    "title": "Sophos Logs",
-    "version": "1.2.0",
-    "release": "ga",
-    "description": "Collect and parse logs from Sophos Products with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/sophos/sophos-1.2.0.zip",
-    "path": "/package/sophos/1.2.0",
-    "icons": [
-      {
-        "src": "/img/logo.svg",
-        "path": "/package/sophos/1.2.0/img/logo.svg",
-        "title": "Sophos logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "sophos",
-        "title": "Sophos logs",
-        "description": "Collect Sophos logs from syslog or a file."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.1 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/sophos/sophos-1.2.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "sophos.utm",
-        "title": "Sophos UTM logs"
-      },
-      {
-        "type": "logs",
-        "dataset": "sophos.xg",
-        "title": "Sophos XG logs"
-      }
-    ]
-  },
-  {
-    "name": "sophos",
-    "title": "Sophos Logs",
-    "version": "1.2.1",
-    "release": "ga",
-    "description": "Collect and parse logs from Sophos Products with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/sophos/sophos-1.2.1.zip",
-    "path": "/package/sophos/1.2.1",
-    "icons": [
-      {
-        "src": "/img/logo.svg",
-        "path": "/package/sophos/1.2.1/img/logo.svg",
-        "title": "Sophos logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "sophos",
-        "title": "Sophos logs",
-        "description": "Collect Sophos logs from syslog or a file."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.1 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/sophos/sophos-1.2.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "sophos.utm",
-        "title": "Sophos UTM logs"
-      },
-      {
-        "type": "logs",
-        "dataset": "sophos.xg",
-        "title": "Sophos XG logs"
-      }
-    ]
-  },
-  {
-    "name": "sophos",
-    "title": "Sophos Logs",
-    "version": "1.2.2",
-    "release": "ga",
-    "description": "Collect and parse logs from Sophos Products with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/sophos/sophos-1.2.2.zip",
-    "path": "/package/sophos/1.2.2",
-    "icons": [
-      {
-        "src": "/img/logo.svg",
-        "path": "/package/sophos/1.2.2/img/logo.svg",
-        "title": "Sophos logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "sophos",
-        "title": "Sophos logs",
-        "description": "Collect Sophos logs from syslog or a file."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.1 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/sophos/sophos-1.2.2.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "sophos.utm",
-        "title": "Sophos UTM logs"
-      },
-      {
-        "type": "logs",
-        "dataset": "sophos.xg",
-        "title": "Sophos XG logs"
-      }
-    ]
-  },
-  {
     "name": "suricata",
     "title": "Suricata",
     "version": "1.0.0",
@@ -46473,6 +43915,594 @@
         "type": "logs",
         "dataset": "symantec_endpoint.log",
         "title": "Symantec Endpoint Protection (SEP) Logs"
+      }
+    ]
+  },
+  {
+    "name": "synthetics",
+    "title": "Elastic Synthetics",
+    "version": "0.0.6",
+    "release": "beta",
+    "description": "Monitor services availability.",
+    "type": "integration",
+    "download": "/epr/synthetics/synthetics-0.0.6.zip",
+    "path": "/package/synthetics/0.0.6",
+    "icons": [
+      {
+        "src": "/img/uptime-logo-color-64px.svg",
+        "path": "/package/synthetics/0.0.6/img/uptime-logo-color-64px.svg",
+        "size": "16x16",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "synthetics",
+        "title": "Elastic Synthetics",
+        "description": "Perform synthetic health checks on network endpoints."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.13.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/uptime"
+    },
+    "categories": [
+      "custom"
+    ],
+    "signature_path": "/epr/synthetics/synthetics-0.0.6.zip.sig",
+    "data_streams": [
+      {
+        "type": "synthetics",
+        "dataset": "http",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "icmp",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "tcp",
+        "title": "synthetic monitor check"
+      }
+    ]
+  },
+  {
+    "name": "synthetics",
+    "title": "Elastic Synthetics",
+    "version": "0.1.0",
+    "release": "beta",
+    "description": "Monitor services availability.",
+    "type": "integration",
+    "download": "/epr/synthetics/synthetics-0.1.0.zip",
+    "path": "/package/synthetics/0.1.0",
+    "icons": [
+      {
+        "src": "/img/uptime-logo-color-64px.svg",
+        "path": "/package/synthetics/0.1.0/img/uptime-logo-color-64px.svg",
+        "size": "16x16",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "synthetics",
+        "title": "Elastic Synthetics",
+        "description": "Perform synthetic health checks on network endpoints."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.13.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/uptime"
+    },
+    "categories": [
+      "custom"
+    ],
+    "signature_path": "/epr/synthetics/synthetics-0.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "synthetics",
+        "dataset": "http",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "icmp",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "tcp",
+        "title": "synthetic monitor check"
+      }
+    ]
+  },
+  {
+    "name": "synthetics",
+    "title": "Elastic Synthetics",
+    "version": "0.2.1",
+    "release": "beta",
+    "description": "This Elastic integration allows you to monitor the availability of your services",
+    "type": "integration",
+    "download": "/epr/synthetics/synthetics-0.2.1.zip",
+    "path": "/package/synthetics/0.2.1",
+    "icons": [
+      {
+        "src": "/img/uptime-logo-color-64px.svg",
+        "path": "/package/synthetics/0.2.1/img/uptime-logo-color-64px.svg",
+        "size": "16x16",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "synthetics",
+        "title": "Elastic Synthetics",
+        "description": "Perform synthetic health checks on network endpoints."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.13.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/uptime"
+    },
+    "categories": [
+      "elastic_stack"
+    ],
+    "signature_path": "/epr/synthetics/synthetics-0.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "synthetics",
+        "dataset": "http",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "icmp",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "tcp",
+        "title": "synthetic monitor check"
+      }
+    ]
+  },
+  {
+    "name": "synthetics",
+    "title": "Elastic Synthetics",
+    "version": "0.3.0",
+    "release": "beta",
+    "description": "This Elastic integration allows you to monitor the availability of your services",
+    "type": "integration",
+    "download": "/epr/synthetics/synthetics-0.3.0.zip",
+    "path": "/package/synthetics/0.3.0",
+    "icons": [
+      {
+        "src": "/img/uptime-logo-color-64px.svg",
+        "path": "/package/synthetics/0.3.0/img/uptime-logo-color-64px.svg",
+        "size": "16x16",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "synthetics",
+        "title": "Elastic Synthetics",
+        "description": "Perform synthetic health checks on network endpoints."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.13.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/uptime"
+    },
+    "categories": [
+      "elastic_stack",
+      "monitoring",
+      "web"
+    ],
+    "signature_path": "/epr/synthetics/synthetics-0.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "synthetics",
+        "dataset": "browser",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "browser.network",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "browser.screenshot",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "http",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "icmp",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "tcp",
+        "title": "synthetic monitor check"
+      }
+    ]
+  },
+  {
+    "name": "synthetics",
+    "title": "Elastic Synthetics",
+    "version": "0.5.0",
+    "release": "beta",
+    "description": "Monitor the availability of your services with Elastic Synthetics.",
+    "type": "integration",
+    "download": "/epr/synthetics/synthetics-0.5.0.zip",
+    "path": "/package/synthetics/0.5.0",
+    "icons": [
+      {
+        "src": "/img/uptime-logo-color-64px.svg",
+        "path": "/package/synthetics/0.5.0/img/uptime-logo-color-64px.svg",
+        "size": "16x16",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "synthetics",
+        "title": "Elastic Synthetics",
+        "description": "Perform synthetic health checks on network endpoints."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/uptime"
+    },
+    "categories": [
+      "elastic_stack",
+      "monitoring",
+      "web"
+    ],
+    "signature_path": "/epr/synthetics/synthetics-0.5.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "synthetics",
+        "dataset": "browser",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "browser.network",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "browser.screenshot",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "http",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "icmp",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "tcp",
+        "title": "synthetic monitor check"
+      }
+    ]
+  },
+  {
+    "name": "synthetics",
+    "title": "Elastic Synthetics",
+    "version": "0.7.0",
+    "release": "beta",
+    "description": "Monitor the availability of your services with Elastic Synthetics.",
+    "type": "integration",
+    "download": "/epr/synthetics/synthetics-0.7.0.zip",
+    "path": "/package/synthetics/0.7.0",
+    "icons": [
+      {
+        "src": "/img/uptime-logo-color-64px.svg",
+        "path": "/package/synthetics/0.7.0/img/uptime-logo-color-64px.svg",
+        "size": "16x16",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "synthetics",
+        "title": "Elastic Synthetics",
+        "description": "Perform synthetic health checks on network endpoints."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/uptime"
+    },
+    "categories": [
+      "elastic_stack",
+      "monitoring",
+      "web"
+    ],
+    "signature_path": "/epr/synthetics/synthetics-0.7.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "synthetics",
+        "dataset": "browser",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "browser.network",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "browser.screenshot",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "http",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "icmp",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "tcp",
+        "title": "synthetic monitor check"
+      }
+    ]
+  },
+  {
+    "name": "synthetics",
+    "title": "Elastic Synthetics",
+    "version": "0.8.1",
+    "release": "beta",
+    "description": "Monitor the availability of your services with Elastic Synthetics.",
+    "type": "integration",
+    "download": "/epr/synthetics/synthetics-0.8.1.zip",
+    "path": "/package/synthetics/0.8.1",
+    "icons": [
+      {
+        "src": "/img/uptime-logo-color-64px.svg",
+        "path": "/package/synthetics/0.8.1/img/uptime-logo-color-64px.svg",
+        "size": "16x16",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "synthetics",
+        "title": "Elastic Synthetics",
+        "description": "Perform synthetic health checks on network endpoints."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/uptime"
+    },
+    "categories": [
+      "elastic_stack",
+      "monitoring",
+      "web"
+    ],
+    "signature_path": "/epr/synthetics/synthetics-0.8.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "synthetics",
+        "dataset": "browser",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "browser.network",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "browser.screenshot",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "http",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "icmp",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "tcp",
+        "title": "synthetic monitor check"
+      }
+    ]
+  },
+  {
+    "name": "synthetics",
+    "title": "Elastic Synthetics",
+    "version": "0.9.0",
+    "release": "beta",
+    "description": "Monitor the availability of your services with Elastic Synthetics.",
+    "type": "integration",
+    "download": "/epr/synthetics/synthetics-0.9.0.zip",
+    "path": "/package/synthetics/0.9.0",
+    "icons": [
+      {
+        "src": "/img/uptime-logo-color-64px.svg",
+        "path": "/package/synthetics/0.9.0/img/uptime-logo-color-64px.svg",
+        "size": "16x16",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "synthetics",
+        "title": "Elastic Synthetics",
+        "description": "Perform synthetic health checks on network endpoints."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.1.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/uptime"
+    },
+    "categories": [
+      "elastic_stack",
+      "monitoring",
+      "web"
+    ],
+    "signature_path": "/epr/synthetics/synthetics-0.9.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "synthetics",
+        "dataset": "browser",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "browser.network",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "browser.screenshot",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "http",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "icmp",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "tcp",
+        "title": "synthetic monitor check"
+      }
+    ]
+  },
+  {
+    "name": "synthetics",
+    "title": "Elastic Synthetics",
+    "version": "0.9.2",
+    "release": "beta",
+    "description": "Monitor the availability of your services with Elastic Synthetics.",
+    "type": "integration",
+    "download": "/epr/synthetics/synthetics-0.9.2.zip",
+    "path": "/package/synthetics/0.9.2",
+    "icons": [
+      {
+        "src": "/img/uptime-logo-color-64px.svg",
+        "path": "/package/synthetics/0.9.2/img/uptime-logo-color-64px.svg",
+        "size": "16x16",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "synthetics",
+        "title": "Elastic Synthetics",
+        "description": "Perform synthetic health checks on network endpoints."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.1.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/uptime"
+    },
+    "categories": [
+      "elastic_stack",
+      "monitoring",
+      "web"
+    ],
+    "signature_path": "/epr/synthetics/synthetics-0.9.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "synthetics",
+        "dataset": "browser",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "browser.network",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "browser.screenshot",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "http",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "icmp",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "tcp",
+        "title": "synthetic monitor check"
       }
     ]
   },
@@ -48937,6 +46967,49 @@
     ]
   },
   {
+    "name": "tcp",
+    "title": "Custom TCP Logs",
+    "version": "1.0.0",
+    "release": "ga",
+    "description": "Collect raw TCP data from listening TCP port with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/tcp/tcp-1.0.0.zip",
+    "path": "/package/tcp/1.0.0",
+    "icons": [
+      {
+        "src": "/img/icon.svg",
+        "path": "/package/tcp/1.0.0/img/icon.svg",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "tcp",
+        "title": "Custom TCP Logs",
+        "description": "Collect raw TCP data from listening TCP port with Elastic Agent."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "signature_path": "/epr/tcp/tcp-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "tcp.generic",
+        "title": "Custom TCP Logs"
+      }
+    ]
+  },
+  {
     "name": "tenable_sc",
     "title": "Tenable.sc",
     "version": "0.1.0",
@@ -49153,6 +47226,1642 @@
         "type": "logs",
         "dataset": "tenable_sc.vulnerability",
         "title": "Tenable.sc vulnerability logs"
+      }
+    ]
+  },
+  {
+    "name": "ti_abusech",
+    "title": "AbuseCH",
+    "version": "1.0.4",
+    "release": "ga",
+    "description": "Collect threat intelligence from AbuseCH API with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/ti_abusech/ti_abusech-1.0.4.zip",
+    "path": "/package/ti_abusech/1.0.4",
+    "icons": [
+      {
+        "src": "/img/abusech2.svg",
+        "path": "/package/ti_abusech/1.0.4/img/abusech2.svg",
+        "title": "AbuseCH",
+        "size": "512x512",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "ti_abusech",
+        "title": "AbuseCH API",
+        "description": "Collect threat intelligence from the AbuseCH API"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/ti_abusech/ti_abusech-1.0.4.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_abusech.malware",
+        "title": "AbuseCH Malware logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "ti_abusech.malwarebazaar",
+        "title": "AbuseCH MalwareBazaar logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "ti_abusech.url",
+        "title": "AbuseCH URL logs"
+      }
+    ]
+  },
+  {
+    "name": "ti_abusech",
+    "title": "AbuseCH",
+    "version": "1.1.0",
+    "release": "ga",
+    "description": "Collect threat intelligence from AbuseCH API with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/ti_abusech/ti_abusech-1.1.0.zip",
+    "path": "/package/ti_abusech/1.1.0",
+    "icons": [
+      {
+        "src": "/img/abusech2.svg",
+        "path": "/package/ti_abusech/1.1.0/img/abusech2.svg",
+        "title": "AbuseCH",
+        "size": "512x512",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "ti_abusech",
+        "title": "AbuseCH API",
+        "description": "Collect threat intelligence from the AbuseCH API"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/ti_abusech/ti_abusech-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_abusech.malware",
+        "title": "AbuseCH Malware logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "ti_abusech.malwarebazaar",
+        "title": "AbuseCH MalwareBazaar logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "ti_abusech.url",
+        "title": "AbuseCH URL logs"
+      }
+    ]
+  },
+  {
+    "name": "ti_abusech",
+    "title": "AbuseCH",
+    "version": "1.1.4",
+    "release": "ga",
+    "description": "Collect threat intelligence from AbuseCH API with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/ti_abusech/ti_abusech-1.1.4.zip",
+    "path": "/package/ti_abusech/1.1.4",
+    "icons": [
+      {
+        "src": "/img/abusech2.svg",
+        "path": "/package/ti_abusech/1.1.4/img/abusech2.svg",
+        "title": "AbuseCH",
+        "size": "512x512",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "ti_abusech",
+        "title": "AbuseCH API",
+        "description": "Collect threat intelligence from the AbuseCH API"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/ti_abusech/ti_abusech-1.1.4.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_abusech.malware",
+        "title": "AbuseCH Malware logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "ti_abusech.malwarebazaar",
+        "title": "AbuseCH MalwareBazaar logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "ti_abusech.url",
+        "title": "AbuseCH URL logs"
+      }
+    ]
+  },
+  {
+    "name": "ti_abusech",
+    "title": "AbuseCH",
+    "version": "1.1.5",
+    "release": "ga",
+    "description": "Collect threat intelligence from AbuseCH API with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/ti_abusech/ti_abusech-1.1.5.zip",
+    "path": "/package/ti_abusech/1.1.5",
+    "icons": [
+      {
+        "src": "/img/abusech2.svg",
+        "path": "/package/ti_abusech/1.1.5/img/abusech2.svg",
+        "title": "AbuseCH",
+        "size": "512x512",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "ti_abusech",
+        "title": "AbuseCH API",
+        "description": "Collect threat intelligence from the AbuseCH API"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/ti_abusech/ti_abusech-1.1.5.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_abusech.malware",
+        "title": "AbuseCH Malware logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "ti_abusech.malwarebazaar",
+        "title": "AbuseCH MalwareBazaar logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "ti_abusech.url",
+        "title": "AbuseCH URL logs"
+      }
+    ]
+  },
+  {
+    "name": "ti_abusech",
+    "title": "AbuseCH",
+    "version": "1.2.0",
+    "release": "ga",
+    "description": "Collect threat intelligence from AbuseCH API with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/ti_abusech/ti_abusech-1.2.0.zip",
+    "path": "/package/ti_abusech/1.2.0",
+    "icons": [
+      {
+        "src": "/img/abusech2.svg",
+        "path": "/package/ti_abusech/1.2.0/img/abusech2.svg",
+        "title": "AbuseCH",
+        "size": "512x512",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "ti_abusech",
+        "title": "AbuseCH API",
+        "description": "Collect threat intelligence from the AbuseCH API"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/ti_abusech/ti_abusech-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_abusech.malware",
+        "title": "AbuseCH Malware logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "ti_abusech.malwarebazaar",
+        "title": "AbuseCH MalwareBazaar logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "ti_abusech.url",
+        "title": "AbuseCH URL logs"
+      }
+    ]
+  },
+  {
+    "name": "ti_abusech",
+    "title": "AbuseCH",
+    "version": "1.2.2",
+    "release": "ga",
+    "description": "Collect threat intelligence from AbuseCH API with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/ti_abusech/ti_abusech-1.2.2.zip",
+    "path": "/package/ti_abusech/1.2.2",
+    "icons": [
+      {
+        "src": "/img/abusech2.svg",
+        "path": "/package/ti_abusech/1.2.2/img/abusech2.svg",
+        "title": "AbuseCH",
+        "size": "512x512",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "ti_abusech",
+        "title": "AbuseCH API",
+        "description": "Collect threat intelligence from the AbuseCH API"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/ti_abusech/ti_abusech-1.2.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_abusech.malware",
+        "title": "AbuseCH Malware logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "ti_abusech.malwarebazaar",
+        "title": "AbuseCH MalwareBazaar logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "ti_abusech.url",
+        "title": "AbuseCH URL logs"
+      }
+    ]
+  },
+  {
+    "name": "ti_abusech",
+    "title": "AbuseCH",
+    "version": "1.2.3",
+    "release": "ga",
+    "description": "Collect threat intelligence from AbuseCH API with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/ti_abusech/ti_abusech-1.2.3.zip",
+    "path": "/package/ti_abusech/1.2.3",
+    "icons": [
+      {
+        "src": "/img/abusech2.svg",
+        "path": "/package/ti_abusech/1.2.3/img/abusech2.svg",
+        "title": "AbuseCH",
+        "size": "512x512",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "ti_abusech",
+        "title": "AbuseCH API",
+        "description": "Collect threat intelligence from the AbuseCH API"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/ti_abusech/ti_abusech-1.2.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_abusech.malware",
+        "title": "AbuseCH Malware logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "ti_abusech.malwarebazaar",
+        "title": "AbuseCH MalwareBazaar logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "ti_abusech.url",
+        "title": "AbuseCH URL logs"
+      }
+    ]
+  },
+  {
+    "name": "ti_anomali",
+    "title": "Anomali",
+    "version": "1.0.2",
+    "release": "ga",
+    "description": "Collect threat intelligence from Anomali APIs with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/ti_anomali/ti_anomali-1.0.2.zip",
+    "path": "/package/ti_anomali/1.0.2",
+    "icons": [
+      {
+        "src": "/img/anomali.svg",
+        "path": "/package/ti_anomali/1.0.2/img/anomali.svg",
+        "title": "Anomali",
+        "size": "216x216",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "ti_anomali",
+        "title": "Anomali",
+        "description": "Collect threat intelligence from the Anomali Limo API and Anomali Threatstream."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/ti_anomali/ti_anomali-1.0.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_anomali.limo",
+        "title": "Anomali Limo"
+      },
+      {
+        "type": "logs",
+        "dataset": "ti_anomali.threatstream",
+        "title": "Anomali Threatstream"
+      }
+    ]
+  },
+  {
+    "name": "ti_anomali",
+    "title": "Anomali",
+    "version": "1.1.3",
+    "release": "ga",
+    "description": "Collect threat intelligence from Anomali APIs with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/ti_anomali/ti_anomali-1.1.3.zip",
+    "path": "/package/ti_anomali/1.1.3",
+    "icons": [
+      {
+        "src": "/img/anomali.svg",
+        "path": "/package/ti_anomali/1.1.3/img/anomali.svg",
+        "title": "Anomali",
+        "size": "216x216",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "ti_anomali",
+        "title": "Anomali",
+        "description": "Collect threat intelligence from the Anomali Limo API and Anomali Threatstream."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/ti_anomali/ti_anomali-1.1.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_anomali.limo",
+        "title": "Anomali Limo"
+      },
+      {
+        "type": "logs",
+        "dataset": "ti_anomali.threatstream",
+        "title": "Anomali Threatstream"
+      }
+    ]
+  },
+  {
+    "name": "ti_anomali",
+    "title": "Anomali",
+    "version": "1.2.0",
+    "release": "ga",
+    "description": "Collect threat intelligence from Anomali APIs with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/ti_anomali/ti_anomali-1.2.0.zip",
+    "path": "/package/ti_anomali/1.2.0",
+    "icons": [
+      {
+        "src": "/img/anomali.svg",
+        "path": "/package/ti_anomali/1.2.0/img/anomali.svg",
+        "title": "Anomali",
+        "size": "216x216",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "ti_anomali",
+        "title": "Anomali",
+        "description": "Collect threat intelligence from the Anomali Limo API and Anomali Threatstream."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/ti_anomali/ti_anomali-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_anomali.limo",
+        "title": "Anomali Limo"
+      },
+      {
+        "type": "logs",
+        "dataset": "ti_anomali.threatstream",
+        "title": "Anomali Threatstream"
+      }
+    ]
+  },
+  {
+    "name": "ti_anomali",
+    "title": "Anomali",
+    "version": "1.2.1",
+    "release": "ga",
+    "description": "Collect threat intelligence from Anomali APIs with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/ti_anomali/ti_anomali-1.2.1.zip",
+    "path": "/package/ti_anomali/1.2.1",
+    "icons": [
+      {
+        "src": "/img/anomali.svg",
+        "path": "/package/ti_anomali/1.2.1/img/anomali.svg",
+        "title": "Anomali",
+        "size": "216x216",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "ti_anomali",
+        "title": "Anomali",
+        "description": "Collect threat intelligence from the Anomali Limo API and Anomali Threatstream."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/ti_anomali/ti_anomali-1.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_anomali.limo",
+        "title": "Anomali Limo"
+      },
+      {
+        "type": "logs",
+        "dataset": "ti_anomali.threatstream",
+        "title": "Anomali Threatstream"
+      }
+    ]
+  },
+  {
+    "name": "ti_anomali",
+    "title": "Anomali",
+    "version": "1.2.2",
+    "release": "ga",
+    "description": "Collect threat intelligence from Anomali APIs with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/ti_anomali/ti_anomali-1.2.2.zip",
+    "path": "/package/ti_anomali/1.2.2",
+    "icons": [
+      {
+        "src": "/img/anomali.svg",
+        "path": "/package/ti_anomali/1.2.2/img/anomali.svg",
+        "title": "Anomali",
+        "size": "216x216",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "ti_anomali",
+        "title": "Anomali",
+        "description": "Collect threat intelligence from the Anomali Limo API and Anomali Threatstream."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/ti_anomali/ti_anomali-1.2.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_anomali.limo",
+        "title": "Anomali Limo"
+      },
+      {
+        "type": "logs",
+        "dataset": "ti_anomali.threatstream",
+        "title": "Anomali Threatstream"
+      }
+    ]
+  },
+  {
+    "name": "ti_anomali",
+    "title": "Anomali",
+    "version": "1.2.3",
+    "release": "ga",
+    "description": "Collect threat intelligence from Anomali APIs with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/ti_anomali/ti_anomali-1.2.3.zip",
+    "path": "/package/ti_anomali/1.2.3",
+    "icons": [
+      {
+        "src": "/img/anomali.svg",
+        "path": "/package/ti_anomali/1.2.3/img/anomali.svg",
+        "title": "Anomali",
+        "size": "216x216",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "ti_anomali",
+        "title": "Anomali",
+        "description": "Collect threat intelligence from the Anomali Limo API and Anomali Threatstream."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/ti_anomali/ti_anomali-1.2.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_anomali.limo",
+        "title": "Anomali Limo"
+      },
+      {
+        "type": "logs",
+        "dataset": "ti_anomali.threatstream",
+        "title": "Anomali Threatstream"
+      }
+    ]
+  },
+  {
+    "name": "ti_cybersixgill",
+    "title": "Cybersixgill",
+    "version": "1.0.0",
+    "release": "ga",
+    "description": "This Elastic integration collects threat intelligence from Cybersixgill",
+    "type": "integration",
+    "download": "/epr/ti_cybersixgill/ti_cybersixgill-1.0.0.zip",
+    "path": "/package/ti_cybersixgill/1.0.0",
+    "icons": [
+      {
+        "src": "/img/cybersixgill.svg",
+        "path": "/package/ti_cybersixgill/1.0.0/img/cybersixgill.svg",
+        "title": "Zoom",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "cybersixgill",
+        "title": "Cybersixgill Threat Intel",
+        "description": "Collect Threat Intel from Cybersixgill"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security",
+      "productivity"
+    ],
+    "signature_path": "/epr/ti_cybersixgill/ti_cybersixgill-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_cybersixgill.threat",
+        "title": "Cybersixgill webhook logs"
+      }
+    ]
+  },
+  {
+    "name": "ti_cybersixgill",
+    "title": "Cybersixgill",
+    "version": "1.1.0",
+    "release": "ga",
+    "description": "This Elastic integration collects threat intelligence from Cybersixgill",
+    "type": "integration",
+    "download": "/epr/ti_cybersixgill/ti_cybersixgill-1.1.0.zip",
+    "path": "/package/ti_cybersixgill/1.1.0",
+    "icons": [
+      {
+        "src": "/img/cybersixgill.svg",
+        "path": "/package/ti_cybersixgill/1.1.0/img/cybersixgill.svg",
+        "title": "Zoom",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "cybersixgill",
+        "title": "Cybersixgill Threat Intel",
+        "description": "Collect Threat Intel from Cybersixgill"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security",
+      "productivity"
+    ],
+    "signature_path": "/epr/ti_cybersixgill/ti_cybersixgill-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_cybersixgill.threat",
+        "title": "Cybersixgill webhook logs"
+      }
+    ]
+  },
+  {
+    "name": "ti_cybersixgill",
+    "title": "Cybersixgill",
+    "version": "1.2.0",
+    "release": "ga",
+    "description": "This Elastic integration collects threat intelligence from Cybersixgill",
+    "type": "integration",
+    "download": "/epr/ti_cybersixgill/ti_cybersixgill-1.2.0.zip",
+    "path": "/package/ti_cybersixgill/1.2.0",
+    "icons": [
+      {
+        "src": "/img/cybersixgill.svg",
+        "path": "/package/ti_cybersixgill/1.2.0/img/cybersixgill.svg",
+        "title": "Zoom",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "cybersixgill",
+        "title": "Cybersixgill Threat Intel",
+        "description": "Collect Threat Intel from Cybersixgill"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security",
+      "productivity"
+    ],
+    "signature_path": "/epr/ti_cybersixgill/ti_cybersixgill-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_cybersixgill.threat",
+        "title": "Cybersixgill webhook logs"
+      }
+    ]
+  },
+  {
+    "name": "ti_cybersixgill",
+    "title": "Cybersixgill",
+    "version": "1.3.0",
+    "release": "ga",
+    "description": "This Elastic integration collects threat intelligence from Cybersixgill",
+    "type": "integration",
+    "download": "/epr/ti_cybersixgill/ti_cybersixgill-1.3.0.zip",
+    "path": "/package/ti_cybersixgill/1.3.0",
+    "icons": [
+      {
+        "src": "/img/cybersixgill.svg",
+        "path": "/package/ti_cybersixgill/1.3.0/img/cybersixgill.svg",
+        "title": "Cybersixgill",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "cybersixgill",
+        "title": "Cybersixgill Threat Intel",
+        "description": "Collect Threat Intel from Cybersixgill"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security",
+      "productivity"
+    ],
+    "signature_path": "/epr/ti_cybersixgill/ti_cybersixgill-1.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_cybersixgill.threat",
+        "title": "Cybersixgill Darkfeed Logs"
+      }
+    ]
+  },
+  {
+    "name": "ti_cybersixgill",
+    "title": "Cybersixgill",
+    "version": "1.3.1",
+    "release": "ga",
+    "description": "This Elastic integration collects threat intelligence from Cybersixgill",
+    "type": "integration",
+    "download": "/epr/ti_cybersixgill/ti_cybersixgill-1.3.1.zip",
+    "path": "/package/ti_cybersixgill/1.3.1",
+    "icons": [
+      {
+        "src": "/img/cybersixgill.svg",
+        "path": "/package/ti_cybersixgill/1.3.1/img/cybersixgill.svg",
+        "title": "Cybersixgill",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "cybersixgill",
+        "title": "Cybersixgill Threat Intel",
+        "description": "Collect Threat Intel from Cybersixgill"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security",
+      "productivity"
+    ],
+    "signature_path": "/epr/ti_cybersixgill/ti_cybersixgill-1.3.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_cybersixgill.threat",
+        "title": "Cybersixgill Darkfeed Logs"
+      }
+    ]
+  },
+  {
+    "name": "ti_cybersixgill",
+    "title": "Cybersixgill",
+    "version": "1.3.2",
+    "release": "ga",
+    "description": "This Elastic integration collects threat intelligence from Cybersixgill",
+    "type": "integration",
+    "download": "/epr/ti_cybersixgill/ti_cybersixgill-1.3.2.zip",
+    "path": "/package/ti_cybersixgill/1.3.2",
+    "icons": [
+      {
+        "src": "/img/cybersixgill.svg",
+        "path": "/package/ti_cybersixgill/1.3.2/img/cybersixgill.svg",
+        "title": "Cybersixgill",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "cybersixgill",
+        "title": "Cybersixgill Threat Intel",
+        "description": "Collect Threat Intel from Cybersixgill"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security",
+      "productivity"
+    ],
+    "signature_path": "/epr/ti_cybersixgill/ti_cybersixgill-1.3.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_cybersixgill.threat",
+        "title": "Cybersixgill Darkfeed Logs"
+      }
+    ]
+  },
+  {
+    "name": "ti_misp",
+    "title": "MISP",
+    "version": "1.0.1",
+    "release": "ga",
+    "description": "This Elastic integration collects events from MISP",
+    "type": "integration",
+    "download": "/epr/ti_misp/ti_misp-1.0.1.zip",
+    "path": "/package/ti_misp/1.0.1",
+    "icons": [
+      {
+        "src": "/img/misp.svg",
+        "path": "/package/ti_misp/1.0.1/img/misp.svg",
+        "title": "MISP",
+        "size": "216x216",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "ti_misp",
+        "title": "MISP",
+        "description": "Collect threat intelligence from the MISP API."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/ti_misp/ti_misp-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_misp.threat",
+        "title": "MISP"
+      }
+    ]
+  },
+  {
+    "name": "ti_misp",
+    "title": "MISP",
+    "version": "1.0.2",
+    "release": "ga",
+    "description": "This Elastic integration collects events from MISP",
+    "type": "integration",
+    "download": "/epr/ti_misp/ti_misp-1.0.2.zip",
+    "path": "/package/ti_misp/1.0.2",
+    "icons": [
+      {
+        "src": "/img/misp.svg",
+        "path": "/package/ti_misp/1.0.2/img/misp.svg",
+        "title": "MISP",
+        "size": "216x216",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "ti_misp",
+        "title": "MISP",
+        "description": "Collect threat intelligence from the MISP API."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/ti_misp/ti_misp-1.0.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_misp.threat",
+        "title": "MISP"
+      }
+    ]
+  },
+  {
+    "name": "ti_misp",
+    "title": "MISP",
+    "version": "1.1.0",
+    "release": "ga",
+    "description": "This Elastic integration collects events from MISP",
+    "type": "integration",
+    "download": "/epr/ti_misp/ti_misp-1.1.0.zip",
+    "path": "/package/ti_misp/1.1.0",
+    "icons": [
+      {
+        "src": "/img/misp.svg",
+        "path": "/package/ti_misp/1.1.0/img/misp.svg",
+        "title": "MISP",
+        "size": "216x216",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "ti_misp",
+        "title": "MISP",
+        "description": "Collect threat intelligence from the MISP API."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/ti_misp/ti_misp-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_misp.threat",
+        "title": "MISP"
+      }
+    ]
+  },
+  {
+    "name": "ti_misp",
+    "title": "MISP",
+    "version": "1.2.0",
+    "release": "ga",
+    "description": "This Elastic integration collects events from MISP",
+    "type": "integration",
+    "download": "/epr/ti_misp/ti_misp-1.2.0.zip",
+    "path": "/package/ti_misp/1.2.0",
+    "icons": [
+      {
+        "src": "/img/misp.svg",
+        "path": "/package/ti_misp/1.2.0/img/misp.svg",
+        "title": "MISP",
+        "size": "216x216",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "ti_misp",
+        "title": "MISP",
+        "description": "Collect threat intelligence from the MISP API."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/ti_misp/ti_misp-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_misp.threat",
+        "title": "MISP"
+      }
+    ]
+  },
+  {
+    "name": "ti_misp",
+    "title": "MISP",
+    "version": "1.2.1",
+    "release": "ga",
+    "description": "This Elastic integration collects events from MISP",
+    "type": "integration",
+    "download": "/epr/ti_misp/ti_misp-1.2.1.zip",
+    "path": "/package/ti_misp/1.2.1",
+    "icons": [
+      {
+        "src": "/img/misp.svg",
+        "path": "/package/ti_misp/1.2.1/img/misp.svg",
+        "title": "MISP",
+        "size": "216x216",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "ti_misp",
+        "title": "MISP",
+        "description": "Collect threat intelligence from the MISP API."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/ti_misp/ti_misp-1.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_misp.threat",
+        "title": "MISP"
+      }
+    ]
+  },
+  {
+    "name": "ti_misp",
+    "title": "MISP",
+    "version": "1.2.2",
+    "release": "ga",
+    "description": "This Elastic integration collects events from MISP",
+    "type": "integration",
+    "download": "/epr/ti_misp/ti_misp-1.2.2.zip",
+    "path": "/package/ti_misp/1.2.2",
+    "icons": [
+      {
+        "src": "/img/misp.svg",
+        "path": "/package/ti_misp/1.2.2/img/misp.svg",
+        "title": "MISP",
+        "size": "216x216",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "ti_misp",
+        "title": "MISP",
+        "description": "Collect threat intelligence from the MISP API."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/ti_misp/ti_misp-1.2.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_misp.threat",
+        "title": "MISP"
+      }
+    ]
+  },
+  {
+    "name": "ti_otx",
+    "title": "AlienVault OTX",
+    "version": "1.0.2",
+    "release": "ga",
+    "description": "Collect threat intelligence from AlienVault OTX with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/ti_otx/ti_otx-1.0.2.zip",
+    "path": "/package/ti_otx/1.0.2",
+    "icons": [
+      {
+        "src": "/img/otx.svg",
+        "path": "/package/ti_otx/1.0.2/img/otx.svg",
+        "title": "Alienvault OTX",
+        "size": "216x216",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "ti_otx",
+        "title": "Alienvault OTX",
+        "description": "Collect threat intelligence from the Alienvault OTX"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/ti_otx/ti_otx-1.0.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_otx.threat",
+        "title": "Alienvault OTX logs"
+      }
+    ]
+  },
+  {
+    "name": "ti_otx",
+    "title": "AlienVault OTX",
+    "version": "1.0.3",
+    "release": "ga",
+    "description": "Collect threat intelligence from AlienVault OTX with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/ti_otx/ti_otx-1.0.3.zip",
+    "path": "/package/ti_otx/1.0.3",
+    "icons": [
+      {
+        "src": "/img/otx.svg",
+        "path": "/package/ti_otx/1.0.3/img/otx.svg",
+        "title": "Alienvault OTX",
+        "size": "216x216",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "ti_otx",
+        "title": "Alienvault OTX",
+        "description": "Collect threat intelligence from the Alienvault OTX"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/ti_otx/ti_otx-1.0.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_otx.threat",
+        "title": "Alienvault OTX logs"
+      }
+    ]
+  },
+  {
+    "name": "ti_otx",
+    "title": "AlienVault OTX",
+    "version": "1.1.0",
+    "release": "ga",
+    "description": "Collect threat intelligence from AlienVault OTX with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/ti_otx/ti_otx-1.1.0.zip",
+    "path": "/package/ti_otx/1.1.0",
+    "icons": [
+      {
+        "src": "/img/otx.svg",
+        "path": "/package/ti_otx/1.1.0/img/otx.svg",
+        "title": "Alienvault OTX",
+        "size": "216x216",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "ti_otx",
+        "title": "Alienvault OTX",
+        "description": "Collect threat intelligence from the Alienvault OTX"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/ti_otx/ti_otx-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_otx.threat",
+        "title": "Alienvault OTX logs"
+      }
+    ]
+  },
+  {
+    "name": "ti_otx",
+    "title": "AlienVault OTX",
+    "version": "1.2.0",
+    "release": "ga",
+    "description": "Collect threat intelligence from AlienVault OTX with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/ti_otx/ti_otx-1.2.0.zip",
+    "path": "/package/ti_otx/1.2.0",
+    "icons": [
+      {
+        "src": "/img/otx.svg",
+        "path": "/package/ti_otx/1.2.0/img/otx.svg",
+        "title": "Alienvault OTX",
+        "size": "216x216",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "ti_otx",
+        "title": "Alienvault OTX",
+        "description": "Collect threat intelligence from the Alienvault OTX"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/ti_otx/ti_otx-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_otx.threat",
+        "title": "Alienvault OTX logs"
+      }
+    ]
+  },
+  {
+    "name": "ti_otx",
+    "title": "AlienVault OTX",
+    "version": "1.2.1",
+    "release": "ga",
+    "description": "Collect threat intelligence from AlienVault OTX with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/ti_otx/ti_otx-1.2.1.zip",
+    "path": "/package/ti_otx/1.2.1",
+    "icons": [
+      {
+        "src": "/img/otx.svg",
+        "path": "/package/ti_otx/1.2.1/img/otx.svg",
+        "title": "Alienvault OTX",
+        "size": "216x216",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "ti_otx",
+        "title": "Alienvault OTX",
+        "description": "Collect threat intelligence from the Alienvault OTX"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/ti_otx/ti_otx-1.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_otx.threat",
+        "title": "Alienvault OTX logs"
+      }
+    ]
+  },
+  {
+    "name": "ti_otx",
+    "title": "AlienVault OTX",
+    "version": "1.2.2",
+    "release": "ga",
+    "description": "Collect threat intelligence from AlienVault OTX with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/ti_otx/ti_otx-1.2.2.zip",
+    "path": "/package/ti_otx/1.2.2",
+    "icons": [
+      {
+        "src": "/img/otx.svg",
+        "path": "/package/ti_otx/1.2.2/img/otx.svg",
+        "title": "Alienvault OTX",
+        "size": "216x216",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "ti_otx",
+        "title": "Alienvault OTX",
+        "description": "Collect threat intelligence from the Alienvault OTX"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/ti_otx/ti_otx-1.2.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_otx.threat",
+        "title": "Alienvault OTX logs"
+      }
+    ]
+  },
+  {
+    "name": "ti_recordedfuture",
+    "title": "Recorded Future",
+    "version": "0.1.0",
+    "release": "beta",
+    "description": "Collect threat intelligence from Recorded Future with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/ti_recordedfuture/ti_recordedfuture-0.1.0.zip",
+    "path": "/package/ti_recordedfuture/0.1.0",
+    "icons": [
+      {
+        "src": "/img/logo.svg",
+        "path": "/package/ti_recordedfuture/0.1.0/img/logo.svg",
+        "title": "Recorded Future",
+        "size": "216x216",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "ti_recordedfuture",
+        "title": "Recorded Future",
+        "description": "Collect threat intelligence from Recorded Future."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/ti_recordedfuture/ti_recordedfuture-0.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_recordedfuture.threat",
+        "title": "Recorded Future"
+      }
+    ]
+  },
+  {
+    "name": "ti_recordedfuture",
+    "title": "Recorded Future",
+    "version": "0.1.1",
+    "release": "beta",
+    "description": "Collect threat intelligence from Recorded Future with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/ti_recordedfuture/ti_recordedfuture-0.1.1.zip",
+    "path": "/package/ti_recordedfuture/0.1.1",
+    "icons": [
+      {
+        "src": "/img/logo.svg",
+        "path": "/package/ti_recordedfuture/0.1.1/img/logo.svg",
+        "title": "Recorded Future",
+        "size": "216x216",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "ti_recordedfuture",
+        "title": "Recorded Future",
+        "description": "Collect threat intelligence from Recorded Future."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/ti_recordedfuture/ti_recordedfuture-0.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_recordedfuture.threat",
+        "title": "Recorded Future"
+      }
+    ]
+  },
+  {
+    "name": "ti_recordedfuture",
+    "title": "Recorded Future",
+    "version": "0.1.2",
+    "release": "beta",
+    "description": "Collect threat intelligence from Recorded Future with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/ti_recordedfuture/ti_recordedfuture-0.1.2.zip",
+    "path": "/package/ti_recordedfuture/0.1.2",
+    "icons": [
+      {
+        "src": "/img/logo.svg",
+        "path": "/package/ti_recordedfuture/0.1.2/img/logo.svg",
+        "title": "Recorded Future",
+        "size": "216x216",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "ti_recordedfuture",
+        "title": "Recorded Future",
+        "description": "Collect threat intelligence from Recorded Future."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/ti_recordedfuture/ti_recordedfuture-0.1.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_recordedfuture.threat",
+        "title": "Recorded Future"
       }
     ]
   },
@@ -49427,6 +49136,328 @@
     ]
   },
   {
+    "name": "tomcat",
+    "title": "Apache Tomcat",
+    "version": "1.0.0",
+    "release": "ga",
+    "description": "This Elastic integration collects logs from Apache Tomcat",
+    "type": "integration",
+    "download": "/epr/tomcat/tomcat-1.0.0.zip",
+    "path": "/package/tomcat/1.0.0",
+    "icons": [
+      {
+        "src": "/img/logo.svg",
+        "path": "/package/tomcat/1.0.0/img/logo.svg",
+        "title": "Apache Tomcat logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "log",
+        "title": "Apache Tomcat",
+        "description": "Collect Apache Tomcat logs from syslog or a file."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.1"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "web",
+      "security"
+    ],
+    "signature_path": "/epr/tomcat/tomcat-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "tomcat.log",
+        "title": "Apache Tomcat logs"
+      }
+    ]
+  },
+  {
+    "name": "tomcat",
+    "title": "Apache Tomcat",
+    "version": "1.1.0",
+    "release": "ga",
+    "description": "This Elastic integration collects logs from Apache Tomcat",
+    "type": "integration",
+    "download": "/epr/tomcat/tomcat-1.1.0.zip",
+    "path": "/package/tomcat/1.1.0",
+    "icons": [
+      {
+        "src": "/img/logo.svg",
+        "path": "/package/tomcat/1.1.0/img/logo.svg",
+        "title": "Apache Tomcat logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "log",
+        "title": "Apache Tomcat",
+        "description": "Collect Apache Tomcat logs from syslog or a file."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.1"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "web",
+      "security"
+    ],
+    "signature_path": "/epr/tomcat/tomcat-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "tomcat.log",
+        "title": "Apache Tomcat logs"
+      }
+    ]
+  },
+  {
+    "name": "tomcat",
+    "title": "Apache Tomcat",
+    "version": "1.1.4",
+    "release": "ga",
+    "description": "Collect and parse logs from Apache Tomcat servers with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/tomcat/tomcat-1.1.4.zip",
+    "path": "/package/tomcat/1.1.4",
+    "icons": [
+      {
+        "src": "/img/logo.svg",
+        "path": "/package/tomcat/1.1.4/img/logo.svg",
+        "title": "Apache Tomcat logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "log",
+        "title": "Apache Tomcat",
+        "description": "Collect Apache Tomcat logs from syslog or a file."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.1"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "web",
+      "security"
+    ],
+    "signature_path": "/epr/tomcat/tomcat-1.1.4.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "tomcat.log",
+        "title": "Apache Tomcat logs"
+      }
+    ]
+  },
+  {
+    "name": "tomcat",
+    "title": "Apache Tomcat",
+    "version": "1.2.0",
+    "release": "ga",
+    "description": "Collect and parse logs from Apache Tomcat servers with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/tomcat/tomcat-1.2.0.zip",
+    "path": "/package/tomcat/1.2.0",
+    "icons": [
+      {
+        "src": "/img/logo.svg",
+        "path": "/package/tomcat/1.2.0/img/logo.svg",
+        "title": "Apache Tomcat logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "log",
+        "title": "Apache Tomcat",
+        "description": "Collect Apache Tomcat logs from syslog or a file."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.1 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "web",
+      "security"
+    ],
+    "signature_path": "/epr/tomcat/tomcat-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "tomcat.log",
+        "title": "Apache Tomcat logs"
+      }
+    ]
+  },
+  {
+    "name": "tomcat",
+    "title": "Apache Tomcat",
+    "version": "1.2.1",
+    "release": "ga",
+    "description": "Collect and parse logs from Apache Tomcat servers with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/tomcat/tomcat-1.2.1.zip",
+    "path": "/package/tomcat/1.2.1",
+    "icons": [
+      {
+        "src": "/img/logo.svg",
+        "path": "/package/tomcat/1.2.1/img/logo.svg",
+        "title": "Apache Tomcat logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "log",
+        "title": "Apache Tomcat",
+        "description": "Collect Apache Tomcat logs from syslog or a file."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.1 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "web",
+      "security"
+    ],
+    "signature_path": "/epr/tomcat/tomcat-1.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "tomcat.log",
+        "title": "Apache Tomcat logs"
+      }
+    ]
+  },
+  {
+    "name": "tomcat",
+    "title": "Apache Tomcat",
+    "version": "1.3.0",
+    "release": "ga",
+    "description": "Collect and parse logs from Apache Tomcat servers with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/tomcat/tomcat-1.3.0.zip",
+    "path": "/package/tomcat/1.3.0",
+    "icons": [
+      {
+        "src": "/img/logo.svg",
+        "path": "/package/tomcat/1.3.0/img/logo.svg",
+        "title": "Apache Tomcat logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "log",
+        "title": "Apache Tomcat",
+        "description": "Collect Apache Tomcat logs from syslog or a file."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.1 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "web",
+      "security"
+    ],
+    "signature_path": "/epr/tomcat/tomcat-1.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "tomcat.log",
+        "title": "Apache Tomcat logs"
+      }
+    ]
+  },
+  {
+    "name": "tomcat",
+    "title": "Apache Tomcat",
+    "version": "1.3.1",
+    "release": "ga",
+    "description": "Collect and parse logs from Apache Tomcat servers with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/tomcat/tomcat-1.3.1.zip",
+    "path": "/package/tomcat/1.3.1",
+    "icons": [
+      {
+        "src": "/img/logo.svg",
+        "path": "/package/tomcat/1.3.1/img/logo.svg",
+        "title": "Apache Tomcat logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "log",
+        "title": "Apache Tomcat",
+        "description": "Collect Apache Tomcat logs from syslog or a file."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.1 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "web",
+      "security"
+    ],
+    "signature_path": "/epr/tomcat/tomcat-1.3.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "tomcat.log",
+        "title": "Apache Tomcat logs"
+      }
+    ]
+  },
+  {
     "name": "traefik",
     "title": "Traefik",
     "version": "1.1.0",
@@ -49529,377 +49560,88 @@
     ]
   },
   {
-    "name": "carbon_black_cloud",
-    "title": "VMware Carbon Black Cloud",
-    "version": "0.1.2",
-    "release": "beta",
-    "description": "Collect logs from VMWare Carbon Black Cloud with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/carbon_black_cloud/carbon_black_cloud-0.1.2.zip",
-    "path": "/package/carbon_black_cloud/0.1.2",
-    "icons": [
-      {
-        "src": "/img/carbon_black_cloud-logo.svg",
-        "path": "/package/carbon_black_cloud/0.1.2/img/carbon_black_cloud-logo.svg",
-        "title": "Carbon Black Cloud logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "carbon_black_cloud",
-        "title": "Carbon Black Cloud",
-        "description": "Collect Logs from Carbon Black Cloud"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.17.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/carbon_black_cloud/carbon_black_cloud-0.1.2.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "carbon_black_cloud.alert",
-        "title": "Alert"
-      },
-      {
-        "type": "logs",
-        "dataset": "carbon_black_cloud.asset_vulnerability_summary",
-        "title": "Asset Vulnerability Summary"
-      },
-      {
-        "type": "logs",
-        "dataset": "carbon_black_cloud.audit",
-        "title": "Audit"
-      },
-      {
-        "type": "logs",
-        "dataset": "carbon_black_cloud.endpoint_event",
-        "title": "Endpoint Event"
-      },
-      {
-        "type": "logs",
-        "dataset": "carbon_black_cloud.watchlist_hit",
-        "title": "Watchlist Hit"
-      }
-    ]
-  },
-  {
-    "name": "carbon_black_cloud",
-    "title": "VMware Carbon Black Cloud",
-    "version": "1.0.1",
-    "release": "ga",
-    "description": "Collect logs from VMWare Carbon Black Cloud with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/carbon_black_cloud/carbon_black_cloud-1.0.1.zip",
-    "path": "/package/carbon_black_cloud/1.0.1",
-    "icons": [
-      {
-        "src": "/img/carbon_black_cloud-logo.svg",
-        "path": "/package/carbon_black_cloud/1.0.1/img/carbon_black_cloud-logo.svg",
-        "title": "Carbon Black Cloud logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "carbon_black_cloud",
-        "title": "Carbon Black Cloud",
-        "description": "Collect Logs from Carbon Black Cloud"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.17.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/carbon_black_cloud/carbon_black_cloud-1.0.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "carbon_black_cloud.alert",
-        "title": "Alert"
-      },
-      {
-        "type": "logs",
-        "dataset": "carbon_black_cloud.asset_vulnerability_summary",
-        "title": "Asset Vulnerability Summary"
-      },
-      {
-        "type": "logs",
-        "dataset": "carbon_black_cloud.audit",
-        "title": "Audit"
-      },
-      {
-        "type": "logs",
-        "dataset": "carbon_black_cloud.endpoint_event",
-        "title": "Endpoint Event"
-      },
-      {
-        "type": "logs",
-        "dataset": "carbon_black_cloud.watchlist_hit",
-        "title": "Watchlist Hit"
-      }
-    ]
-  },
-  {
-    "name": "carbon_black_cloud",
-    "title": "VMware Carbon Black Cloud",
-    "version": "1.0.2",
-    "release": "ga",
-    "description": "Collect logs from VMWare Carbon Black Cloud with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/carbon_black_cloud/carbon_black_cloud-1.0.2.zip",
-    "path": "/package/carbon_black_cloud/1.0.2",
-    "icons": [
-      {
-        "src": "/img/carbon_black_cloud-logo.svg",
-        "path": "/package/carbon_black_cloud/1.0.2/img/carbon_black_cloud-logo.svg",
-        "title": "Carbon Black Cloud logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "carbon_black_cloud",
-        "title": "Carbon Black Cloud",
-        "description": "Collect Logs from Carbon Black Cloud"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.17.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/carbon_black_cloud/carbon_black_cloud-1.0.2.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "carbon_black_cloud.alert",
-        "title": "Alert"
-      },
-      {
-        "type": "logs",
-        "dataset": "carbon_black_cloud.asset_vulnerability_summary",
-        "title": "Asset Vulnerability Summary"
-      },
-      {
-        "type": "logs",
-        "dataset": "carbon_black_cloud.audit",
-        "title": "Audit"
-      },
-      {
-        "type": "logs",
-        "dataset": "carbon_black_cloud.endpoint_event",
-        "title": "Endpoint Event"
-      },
-      {
-        "type": "logs",
-        "dataset": "carbon_black_cloud.watchlist_hit",
-        "title": "Watchlist Hit"
-      }
-    ]
-  },
-  {
-    "name": "carbonblack_edr",
-    "title": "VMware Carbon Black EDR",
+    "name": "udp",
+    "title": "Custom UDP Logs",
     "version": "1.0.0",
     "release": "ga",
-    "description": "Collect logs from VMware Carbon Black EDR with Elastic Agent.",
+    "description": "Collect raw UDP data from listening UDP port with Elastic Agent.",
     "type": "integration",
-    "download": "/epr/carbonblack_edr/carbonblack_edr-1.0.0.zip",
-    "path": "/package/carbonblack_edr/1.0.0",
+    "download": "/epr/udp/udp-1.0.0.zip",
+    "path": "/package/udp/1.0.0",
     "icons": [
       {
-        "src": "/img/carbon-black-logo.svg",
-        "path": "/package/carbonblack_edr/1.0.0/img/carbon-black-logo.svg",
-        "title": "VMWare Carbon Black",
-        "size": "32x32",
+        "src": "/img/icon.svg",
+        "path": "/package/udp/1.0.0/img/icon.svg",
         "type": "image/svg+xml"
       }
     ],
     "policy_templates": [
       {
-        "name": "log",
-        "title": "Carbon Black EDR logs",
-        "description": "Collect logs from Carbon Black EDR"
+        "name": "udp",
+        "title": "Custom UDP Logs",
+        "description": "Collect raw UDP data from listening UDP port with Elastic Agent."
       }
     ],
     "conditions": {
       "kibana": {
-        "version": "^7.14.0 || ^8.0.0"
+        "version": "^7.16.0 || ^8.0.0"
       }
     },
     "owner": {
       "github": "elastic/security-external-integrations"
     },
     "categories": [
-      "security"
+      "custom"
     ],
-    "signature_path": "/epr/carbonblack_edr/carbonblack_edr-1.0.0.zip.sig",
+    "signature_path": "/epr/udp/udp-1.0.0.zip.sig",
     "data_streams": [
       {
         "type": "logs",
-        "dataset": "carbonblack_edr.log",
-        "title": "Carbon Black EDR logs"
+        "dataset": "udp.generic",
+        "title": "Custom UDP Logs"
       }
     ]
   },
   {
-    "name": "carbonblack_edr",
-    "title": "VMware Carbon Black EDR",
-    "version": "1.1.0",
+    "name": "udp",
+    "title": "Custom UDP Logs",
+    "version": "1.0.1",
     "release": "ga",
-    "description": "Collect logs from VMware Carbon Black EDR with Elastic Agent.",
+    "description": "Collect raw UDP data from listening UDP port with Elastic Agent.",
     "type": "integration",
-    "download": "/epr/carbonblack_edr/carbonblack_edr-1.1.0.zip",
-    "path": "/package/carbonblack_edr/1.1.0",
+    "download": "/epr/udp/udp-1.0.1.zip",
+    "path": "/package/udp/1.0.1",
     "icons": [
       {
-        "src": "/img/carbon-black-logo.svg",
-        "path": "/package/carbonblack_edr/1.1.0/img/carbon-black-logo.svg",
-        "title": "VMWare Carbon Black",
-        "size": "32x32",
+        "src": "/img/icon.svg",
+        "path": "/package/udp/1.0.1/img/icon.svg",
         "type": "image/svg+xml"
       }
     ],
     "policy_templates": [
       {
-        "name": "log",
-        "title": "Carbon Black EDR logs",
-        "description": "Collect logs from Carbon Black EDR"
+        "name": "udp",
+        "title": "Custom UDP Logs",
+        "description": "Collect raw UDP data from listening UDP port with Elastic Agent."
       }
     ],
     "conditions": {
       "kibana": {
-        "version": "^7.14.0 || ^8.0.0"
+        "version": "^7.16.0 || ^8.0.0"
       }
     },
     "owner": {
       "github": "elastic/security-external-integrations"
     },
     "categories": [
-      "security"
+      "custom"
     ],
-    "signature_path": "/epr/carbonblack_edr/carbonblack_edr-1.1.0.zip.sig",
+    "signature_path": "/epr/udp/udp-1.0.1.zip.sig",
     "data_streams": [
       {
         "type": "logs",
-        "dataset": "carbonblack_edr.log",
-        "title": "Carbon Black EDR logs"
-      }
-    ]
-  },
-  {
-    "name": "carbonblack_edr",
-    "title": "VMware Carbon Black EDR",
-    "version": "1.1.1",
-    "release": "ga",
-    "description": "Collect logs from VMware Carbon Black EDR with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/carbonblack_edr/carbonblack_edr-1.1.1.zip",
-    "path": "/package/carbonblack_edr/1.1.1",
-    "icons": [
-      {
-        "src": "/img/carbon-black-logo.svg",
-        "path": "/package/carbonblack_edr/1.1.1/img/carbon-black-logo.svg",
-        "title": "VMWare Carbon Black",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "log",
-        "title": "Carbon Black EDR logs",
-        "description": "Collect logs from Carbon Black EDR"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/carbonblack_edr/carbonblack_edr-1.1.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "carbonblack_edr.log",
-        "title": "Carbon Black EDR logs"
-      }
-    ]
-  },
-  {
-    "name": "carbonblack_edr",
-    "title": "VMware Carbon Black EDR",
-    "version": "1.2.0",
-    "release": "ga",
-    "description": "Collect logs from VMware Carbon Black EDR with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/carbonblack_edr/carbonblack_edr-1.2.0.zip",
-    "path": "/package/carbonblack_edr/1.2.0",
-    "icons": [
-      {
-        "src": "/img/carbon-black-logo.svg",
-        "path": "/package/carbonblack_edr/1.2.0/img/carbon-black-logo.svg",
-        "title": "VMWare Carbon Black",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "log",
-        "title": "Carbon Black EDR logs",
-        "description": "Collect logs from Carbon Black EDR"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/carbonblack_edr/carbonblack_edr-1.2.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "carbonblack_edr.log",
-        "title": "Carbon Black EDR logs"
+        "dataset": "udp.generic",
+        "title": "Custom UDP Logs"
       }
     ]
   },
@@ -50174,6 +49916,264 @@
         "type": "logs",
         "dataset": "windows.sysmon_operational",
         "title": "Windows Sysmon/Operational events"
+      }
+    ]
+  },
+  {
+    "name": "winlog",
+    "title": "Custom Windows event logs",
+    "version": "1.0.3",
+    "release": "ga",
+    "description": "Collect event logs from Windows with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/winlog/winlog-1.0.3.zip",
+    "path": "/package/winlog/1.0.3",
+    "icons": [
+      {
+        "src": "/img/logo_windows.svg",
+        "path": "/package/winlog/1.0.3/img/logo_windows.svg",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "winlogs",
+        "title": "Custom Windows event logs",
+        "description": "Collect your custom Windows event logs."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "signature_path": "/epr/winlog/winlog-1.0.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "winlog.winlog",
+        "title": "Custom Windows Event Log Dataset"
+      }
+    ]
+  },
+  {
+    "name": "winlog",
+    "title": "Custom Windows event logs",
+    "version": "1.1.0",
+    "release": "ga",
+    "description": "Collect event logs from Windows with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/winlog/winlog-1.1.0.zip",
+    "path": "/package/winlog/1.1.0",
+    "icons": [
+      {
+        "src": "/img/logo_windows.svg",
+        "path": "/package/winlog/1.1.0/img/logo_windows.svg",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "winlogs",
+        "title": "Custom Windows event logs",
+        "description": "Collect your custom Windows event logs."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "signature_path": "/epr/winlog/winlog-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "winlog.winlog",
+        "title": "Custom Windows Event Log Dataset"
+      }
+    ]
+  },
+  {
+    "name": "winlog",
+    "title": "Custom Windows Event Logs",
+    "version": "1.1.2",
+    "release": "ga",
+    "description": "Collect and parse logs from any Windows event log channel with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/winlog/winlog-1.1.2.zip",
+    "path": "/package/winlog/1.1.2",
+    "icons": [
+      {
+        "src": "/img/logo_windows.svg",
+        "path": "/package/winlog/1.1.2/img/logo_windows.svg",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "winlogs",
+        "title": "Custom Windows event logs",
+        "description": "Collect your custom Windows event logs."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "signature_path": "/epr/winlog/winlog-1.1.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "winlog.winlog",
+        "title": "Custom Windows Event Log Dataset"
+      }
+    ]
+  },
+  {
+    "name": "winlog",
+    "title": "Custom Windows Event Logs",
+    "version": "1.2.0",
+    "release": "ga",
+    "description": "Collect and parse logs from any Windows event log channel with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/winlog/winlog-1.2.0.zip",
+    "path": "/package/winlog/1.2.0",
+    "icons": [
+      {
+        "src": "/img/logo_windows.svg",
+        "path": "/package/winlog/1.2.0/img/logo_windows.svg",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "winlogs",
+        "title": "Custom Windows event logs",
+        "description": "Collect your custom Windows event logs."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "signature_path": "/epr/winlog/winlog-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "winlog.winlog",
+        "title": "Custom Windows Event Log Dataset"
+      }
+    ]
+  },
+  {
+    "name": "winlog",
+    "title": "Custom Windows Event Logs",
+    "version": "1.3.0",
+    "release": "ga",
+    "description": "Collect and parse logs from any Windows event log channel with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/winlog/winlog-1.3.0.zip",
+    "path": "/package/winlog/1.3.0",
+    "icons": [
+      {
+        "src": "/img/logo_windows.svg",
+        "path": "/package/winlog/1.3.0/img/logo_windows.svg",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "winlogs",
+        "title": "Custom Windows event logs",
+        "description": "Collect your custom Windows event logs."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "signature_path": "/epr/winlog/winlog-1.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "winlog.winlog",
+        "title": "Custom Windows Event Log Dataset"
+      }
+    ]
+  },
+  {
+    "name": "winlog",
+    "title": "Custom Windows Event Logs",
+    "version": "1.4.0",
+    "release": "ga",
+    "description": "Collect and parse logs from any Windows event log channel with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/winlog/winlog-1.4.0.zip",
+    "path": "/package/winlog/1.4.0",
+    "icons": [
+      {
+        "src": "/img/logo_windows.svg",
+        "path": "/package/winlog/1.4.0/img/logo_windows.svg",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "winlogs",
+        "title": "Custom Windows event logs",
+        "description": "Collect your custom Windows event logs."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "signature_path": "/epr/winlog/winlog-1.4.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "winlog.winlog",
+        "title": "Custom Windows Event Log Dataset"
       }
     ]
   },

--- a/testdata/generated/storage-indexer/search-category-custom.json
+++ b/testdata/generated/storage-indexer/search-category-custom.json
@@ -209,6 +209,55 @@
     ]
   },
   {
+    "name": "sql",
+    "title": "SQL Input",
+    "version": "0.5.0",
+    "release": "beta",
+    "description": "Collects Metrics by Quering on SQL Databases",
+    "type": "input",
+    "download": "/epr/sql/sql-0.5.0.zip",
+    "path": "/package/sql/0.5.0",
+    "icons": [
+      {
+        "src": "/img/sql-server-icon.svg",
+        "path": "/package/sql/0.5.0/img/sql-server-icon.svg",
+        "title": "SQL logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "sql",
+        "title": "SQL Metrics",
+        "description": "Collects Metrics by Quering on SQL Databases",
+        "deprecated": {
+          "since": "0.5.0",
+          "description": "This policy is deprecated"
+        }
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.13.0"
+      },
+      "elastic": {
+        "subscription": "basic"
+      }
+    },
+    "owner": {
+      "github": "elastic/obs-infraobs-integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "signature_path": "/epr/sql/sql-0.5.0.zip.sig",
+    "deprecated": {
+      "since": "0.5.0",
+      "description": "This package is deprecated"
+    }
+  },
+  {
     "name": "tcp",
     "title": "Custom TCP Logs",
     "version": "1.0.0",
@@ -336,54 +385,5 @@
         "title": "Custom Windows Event Log Dataset"
       }
     ]
-  },
-  {
-    "name": "sql",
-    "title": "SQL Input",
-    "version": "0.5.0",
-    "release": "beta",
-    "description": "Collects Metrics by Quering on SQL Databases",
-    "type": "input",
-    "download": "/epr/sql/sql-0.5.0.zip",
-    "path": "/package/sql/0.5.0",
-    "icons": [
-      {
-        "src": "/img/sql-server-icon.svg",
-        "path": "/package/sql/0.5.0/img/sql-server-icon.svg",
-        "title": "SQL logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "sql",
-        "title": "SQL Metrics",
-        "description": "Collects Metrics by Quering on SQL Databases",
-        "deprecated": {
-          "since": "0.5.0",
-          "description": "This policy is deprecated"
-        }
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.13.0"
-      },
-      "elastic": {
-        "subscription": "basic"
-      }
-    },
-    "owner": {
-      "github": "elastic/obs-infraobs-integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "signature_path": "/epr/sql/sql-0.5.0.zip.sig",
-    "deprecated": {
-      "since": "0.5.0",
-      "description": "This package is deprecated"
-    }
   }
 ]

--- a/testdata/generated/storage-indexer/search-category-observability-subcategories.json
+++ b/testdata/generated/storage-indexer/search-category-observability-subcategories.json
@@ -128,48 +128,83 @@
     }
   },
   {
-    "name": "tomcat",
-    "title": "Apache Tomcat",
-    "version": "1.3.1",
+    "name": "apm",
+    "title": "Elastic APM",
+    "version": "8.2.0",
     "release": "ga",
-    "description": "Collect and parse logs from Apache Tomcat servers with Elastic Agent.",
+    "description": "Ingest APM data",
     "type": "integration",
-    "download": "/epr/tomcat/tomcat-1.3.1.zip",
-    "path": "/package/tomcat/1.3.1",
+    "download": "/epr/apm/apm-8.2.0.zip",
+    "path": "/package/apm/8.2.0",
     "icons": [
       {
-        "src": "/img/logo.svg",
-        "path": "/package/tomcat/1.3.1/img/logo.svg",
-        "title": "Apache Tomcat logo",
+        "src": "/img/logo_apm.svg",
+        "path": "/package/apm/8.2.0/img/logo_apm.svg",
+        "title": "APM Logo",
         "size": "32x32",
         "type": "image/svg+xml"
       }
     ],
     "policy_templates": [
       {
-        "name": "log",
-        "title": "Apache Tomcat",
-        "description": "Collect Apache Tomcat logs from syslog or a file."
+        "name": "apmserver",
+        "title": "Elastic APM Integration",
+        "description": "Elastic APM Integration"
       }
     ],
     "conditions": {
       "kibana": {
-        "version": "^7.14.1 || ^8.0.0"
+        "version": "^8.2.0"
       }
     },
     "owner": {
-      "github": "elastic/security-external-integrations"
+      "github": "elastic/apm-server"
     },
     "categories": [
-      "web",
-      "security"
+      "elastic_stack",
+      "monitoring"
     ],
-    "signature_path": "/epr/tomcat/tomcat-1.3.1.zip.sig",
+    "signature_path": "/epr/apm/apm-8.2.0.zip.sig",
     "data_streams": [
       {
         "type": "logs",
-        "dataset": "tomcat.log",
-        "title": "Apache Tomcat logs"
+        "dataset": "apm.app",
+        "title": "APM application logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.app",
+        "title": "APM application metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "apm.error",
+        "title": "APM errors"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.internal",
+        "title": "APM internal metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.profiling",
+        "title": "APM profiles"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm.rum",
+        "title": "APM RUM traces"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm.sampled",
+        "title": "APM tail-sampled traces"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm",
+        "title": "APM traces"
       }
     ]
   },
@@ -704,158 +739,6 @@
         "type": "logs",
         "dataset": "cloudflare.logpull",
         "title": "Cloudflare Logpull"
-      }
-    ]
-  },
-  {
-    "name": "apm",
-    "title": "Elastic APM",
-    "version": "8.2.0",
-    "release": "ga",
-    "description": "Ingest APM data",
-    "type": "integration",
-    "download": "/epr/apm/apm-8.2.0.zip",
-    "path": "/package/apm/8.2.0",
-    "icons": [
-      {
-        "src": "/img/logo_apm.svg",
-        "path": "/package/apm/8.2.0/img/logo_apm.svg",
-        "title": "APM Logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "apmserver",
-        "title": "Elastic APM Integration",
-        "description": "Elastic APM Integration"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.2.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/apm-server"
-    },
-    "categories": [
-      "elastic_stack",
-      "monitoring"
-    ],
-    "signature_path": "/epr/apm/apm-8.2.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "apm.app",
-        "title": "APM application logs"
-      },
-      {
-        "type": "metrics",
-        "dataset": "apm.app",
-        "title": "APM application metrics"
-      },
-      {
-        "type": "logs",
-        "dataset": "apm.error",
-        "title": "APM errors"
-      },
-      {
-        "type": "metrics",
-        "dataset": "apm.internal",
-        "title": "APM internal metrics"
-      },
-      {
-        "type": "metrics",
-        "dataset": "apm.profiling",
-        "title": "APM profiles"
-      },
-      {
-        "type": "traces",
-        "dataset": "apm.rum",
-        "title": "APM RUM traces"
-      },
-      {
-        "type": "traces",
-        "dataset": "apm.sampled",
-        "title": "APM tail-sampled traces"
-      },
-      {
-        "type": "traces",
-        "dataset": "apm",
-        "title": "APM traces"
-      }
-    ]
-  },
-  {
-    "name": "synthetics",
-    "title": "Elastic Synthetics",
-    "version": "0.9.2",
-    "release": "beta",
-    "description": "Monitor the availability of your services with Elastic Synthetics.",
-    "type": "integration",
-    "download": "/epr/synthetics/synthetics-0.9.2.zip",
-    "path": "/package/synthetics/0.9.2",
-    "icons": [
-      {
-        "src": "/img/uptime-logo-color-64px.svg",
-        "path": "/package/synthetics/0.9.2/img/uptime-logo-color-64px.svg",
-        "size": "16x16",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "synthetics",
-        "title": "Elastic Synthetics",
-        "description": "Perform synthetic health checks on network endpoints."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.1.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/uptime"
-    },
-    "categories": [
-      "elastic_stack",
-      "monitoring",
-      "web"
-    ],
-    "signature_path": "/epr/synthetics/synthetics-0.9.2.zip.sig",
-    "data_streams": [
-      {
-        "type": "synthetics",
-        "dataset": "browser",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "browser.network",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "browser.screenshot",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "http",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "icmp",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "tcp",
-        "title": "synthetic monitor check"
       }
     ]
   },
@@ -2023,6 +1906,123 @@
         "type": "metrics",
         "dataset": "stan.subscriptions",
         "title": "Stan subscriptions metrics"
+      }
+    ]
+  },
+  {
+    "name": "synthetics",
+    "title": "Elastic Synthetics",
+    "version": "0.9.2",
+    "release": "beta",
+    "description": "Monitor the availability of your services with Elastic Synthetics.",
+    "type": "integration",
+    "download": "/epr/synthetics/synthetics-0.9.2.zip",
+    "path": "/package/synthetics/0.9.2",
+    "icons": [
+      {
+        "src": "/img/uptime-logo-color-64px.svg",
+        "path": "/package/synthetics/0.9.2/img/uptime-logo-color-64px.svg",
+        "size": "16x16",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "synthetics",
+        "title": "Elastic Synthetics",
+        "description": "Perform synthetic health checks on network endpoints."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.1.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/uptime"
+    },
+    "categories": [
+      "elastic_stack",
+      "monitoring",
+      "web"
+    ],
+    "signature_path": "/epr/synthetics/synthetics-0.9.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "synthetics",
+        "dataset": "browser",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "browser.network",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "browser.screenshot",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "http",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "icmp",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "tcp",
+        "title": "synthetic monitor check"
+      }
+    ]
+  },
+  {
+    "name": "tomcat",
+    "title": "Apache Tomcat",
+    "version": "1.3.1",
+    "release": "ga",
+    "description": "Collect and parse logs from Apache Tomcat servers with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/tomcat/tomcat-1.3.1.zip",
+    "path": "/package/tomcat/1.3.1",
+    "icons": [
+      {
+        "src": "/img/logo.svg",
+        "path": "/package/tomcat/1.3.1/img/logo.svg",
+        "title": "Apache Tomcat logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "log",
+        "title": "Apache Tomcat",
+        "description": "Collect Apache Tomcat logs from syslog or a file."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.1 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "web",
+      "security"
+    ],
+    "signature_path": "/epr/tomcat/tomcat-1.3.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "tomcat.log",
+        "title": "Apache Tomcat logs"
       }
     ]
   },

--- a/testdata/generated/storage-indexer/search-category-web-all.json
+++ b/testdata/generated/storage-indexer/search-category-web-all.json
@@ -658,328 +658,6 @@
     }
   },
   {
-    "name": "tomcat",
-    "title": "Apache Tomcat",
-    "version": "1.0.0",
-    "release": "ga",
-    "description": "This Elastic integration collects logs from Apache Tomcat",
-    "type": "integration",
-    "download": "/epr/tomcat/tomcat-1.0.0.zip",
-    "path": "/package/tomcat/1.0.0",
-    "icons": [
-      {
-        "src": "/img/logo.svg",
-        "path": "/package/tomcat/1.0.0/img/logo.svg",
-        "title": "Apache Tomcat logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "log",
-        "title": "Apache Tomcat",
-        "description": "Collect Apache Tomcat logs from syslog or a file."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.1"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "web",
-      "security"
-    ],
-    "signature_path": "/epr/tomcat/tomcat-1.0.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "tomcat.log",
-        "title": "Apache Tomcat logs"
-      }
-    ]
-  },
-  {
-    "name": "tomcat",
-    "title": "Apache Tomcat",
-    "version": "1.1.0",
-    "release": "ga",
-    "description": "This Elastic integration collects logs from Apache Tomcat",
-    "type": "integration",
-    "download": "/epr/tomcat/tomcat-1.1.0.zip",
-    "path": "/package/tomcat/1.1.0",
-    "icons": [
-      {
-        "src": "/img/logo.svg",
-        "path": "/package/tomcat/1.1.0/img/logo.svg",
-        "title": "Apache Tomcat logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "log",
-        "title": "Apache Tomcat",
-        "description": "Collect Apache Tomcat logs from syslog or a file."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.1"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "web",
-      "security"
-    ],
-    "signature_path": "/epr/tomcat/tomcat-1.1.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "tomcat.log",
-        "title": "Apache Tomcat logs"
-      }
-    ]
-  },
-  {
-    "name": "tomcat",
-    "title": "Apache Tomcat",
-    "version": "1.1.4",
-    "release": "ga",
-    "description": "Collect and parse logs from Apache Tomcat servers with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/tomcat/tomcat-1.1.4.zip",
-    "path": "/package/tomcat/1.1.4",
-    "icons": [
-      {
-        "src": "/img/logo.svg",
-        "path": "/package/tomcat/1.1.4/img/logo.svg",
-        "title": "Apache Tomcat logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "log",
-        "title": "Apache Tomcat",
-        "description": "Collect Apache Tomcat logs from syslog or a file."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.1"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "web",
-      "security"
-    ],
-    "signature_path": "/epr/tomcat/tomcat-1.1.4.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "tomcat.log",
-        "title": "Apache Tomcat logs"
-      }
-    ]
-  },
-  {
-    "name": "tomcat",
-    "title": "Apache Tomcat",
-    "version": "1.2.0",
-    "release": "ga",
-    "description": "Collect and parse logs from Apache Tomcat servers with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/tomcat/tomcat-1.2.0.zip",
-    "path": "/package/tomcat/1.2.0",
-    "icons": [
-      {
-        "src": "/img/logo.svg",
-        "path": "/package/tomcat/1.2.0/img/logo.svg",
-        "title": "Apache Tomcat logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "log",
-        "title": "Apache Tomcat",
-        "description": "Collect Apache Tomcat logs from syslog or a file."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.1 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "web",
-      "security"
-    ],
-    "signature_path": "/epr/tomcat/tomcat-1.2.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "tomcat.log",
-        "title": "Apache Tomcat logs"
-      }
-    ]
-  },
-  {
-    "name": "tomcat",
-    "title": "Apache Tomcat",
-    "version": "1.2.1",
-    "release": "ga",
-    "description": "Collect and parse logs from Apache Tomcat servers with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/tomcat/tomcat-1.2.1.zip",
-    "path": "/package/tomcat/1.2.1",
-    "icons": [
-      {
-        "src": "/img/logo.svg",
-        "path": "/package/tomcat/1.2.1/img/logo.svg",
-        "title": "Apache Tomcat logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "log",
-        "title": "Apache Tomcat",
-        "description": "Collect Apache Tomcat logs from syslog or a file."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.1 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "web",
-      "security"
-    ],
-    "signature_path": "/epr/tomcat/tomcat-1.2.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "tomcat.log",
-        "title": "Apache Tomcat logs"
-      }
-    ]
-  },
-  {
-    "name": "tomcat",
-    "title": "Apache Tomcat",
-    "version": "1.3.0",
-    "release": "ga",
-    "description": "Collect and parse logs from Apache Tomcat servers with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/tomcat/tomcat-1.3.0.zip",
-    "path": "/package/tomcat/1.3.0",
-    "icons": [
-      {
-        "src": "/img/logo.svg",
-        "path": "/package/tomcat/1.3.0/img/logo.svg",
-        "title": "Apache Tomcat logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "log",
-        "title": "Apache Tomcat",
-        "description": "Collect Apache Tomcat logs from syslog or a file."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.1 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "web",
-      "security"
-    ],
-    "signature_path": "/epr/tomcat/tomcat-1.3.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "tomcat.log",
-        "title": "Apache Tomcat logs"
-      }
-    ]
-  },
-  {
-    "name": "tomcat",
-    "title": "Apache Tomcat",
-    "version": "1.3.1",
-    "release": "ga",
-    "description": "Collect and parse logs from Apache Tomcat servers with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/tomcat/tomcat-1.3.1.zip",
-    "path": "/package/tomcat/1.3.1",
-    "icons": [
-      {
-        "src": "/img/logo.svg",
-        "path": "/package/tomcat/1.3.1/img/logo.svg",
-        "title": "Apache Tomcat logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "log",
-        "title": "Apache Tomcat",
-        "description": "Collect Apache Tomcat logs from syslog or a file."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.1 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "web",
-      "security"
-    ],
-    "signature_path": "/epr/tomcat/tomcat-1.3.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "tomcat.log",
-        "title": "Apache Tomcat logs"
-      }
-    ]
-  },
-  {
     "name": "atlassian_bitbucket",
     "title": "Atlassian Bitbucket",
     "version": "1.0.0",
@@ -2083,6 +1761,430 @@
   },
   {
     "name": "azure_metrics",
+    "title": "Azure resource metrics",
+    "version": "0.3.1",
+    "release": "beta",
+    "description": "This Elastic integration collects and aggregates metrics from Azure resources",
+    "type": "integration",
+    "download": "/epr/azure_metrics/azure_metrics-0.3.1.zip",
+    "path": "/package/azure_metrics/0.3.1",
+    "icons": [
+      {
+        "src": "/img/azure_metrics_logo.png",
+        "path": "/package/azure_metrics/0.3.1/img/azure_metrics_logo.png",
+        "title": "logo docker",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "monitor",
+        "title": "Azure Monitor metrics",
+        "description": "Azure Monitor Metrics Integration",
+        "icons": [
+          {
+            "src": "/img/monitor_logo.png",
+            "path": "/package/azure_metrics/0.3.1/img/monitor_logo.png",
+            "title": "logo azure",
+            "size": "32x32",
+            "type": "image/svg+xml"
+          }
+        ],
+        "data_streams": [
+          "monitor"
+        ]
+      },
+      {
+        "name": "compute_vm",
+        "title": "Azure Virtual Machines metrics",
+        "description": "Azure Virtual Machines Metrics Integration",
+        "icons": [
+          {
+            "src": "/img/compute_vm_logo.png",
+            "path": "/package/azure_metrics/0.3.1/img/compute_vm_logo.png",
+            "title": "logo azure",
+            "size": "32x32",
+            "type": "image/svg+xml"
+          }
+        ],
+        "data_streams": [
+          "compute_vm"
+        ]
+      },
+      {
+        "name": "compute_vm_scaleset",
+        "title": "Azure Virtual Machines Scaleset metrics",
+        "description": "Azure Virtual Machines Scaleset Metrics Integration",
+        "icons": [
+          {
+            "src": "/img/compute_vm_scaleset_logo.png",
+            "path": "/package/azure_metrics/0.3.1/img/compute_vm_scaleset_logo.png",
+            "title": "logo azure",
+            "size": "32x32",
+            "type": "image/svg+xml"
+          }
+        ],
+        "data_streams": [
+          "compute_vm_scaleset"
+        ]
+      },
+      {
+        "name": "container_registry",
+        "title": "Azure Container Registry metrics",
+        "description": "Azure Container Registry Metrics Integration",
+        "icons": [
+          {
+            "src": "/img/container_registry_logo.png",
+            "path": "/package/azure_metrics/0.3.1/img/container_registry_logo.png",
+            "title": "logo azure",
+            "size": "32x32",
+            "type": "image/svg+xml"
+          }
+        ],
+        "data_streams": [
+          "container_registry"
+        ]
+      },
+      {
+        "name": "container_instance",
+        "title": "Azure Container Instance metrics",
+        "description": "Azure Container Instance Metrics Integration",
+        "icons": [
+          {
+            "src": "/img/container_instance_logo.png",
+            "path": "/package/azure_metrics/0.3.1/img/container_instance_logo.png",
+            "title": "logo azure",
+            "size": "32x32",
+            "type": "image/svg+xml"
+          }
+        ],
+        "data_streams": [
+          "container_instance"
+        ]
+      },
+      {
+        "name": "container_service",
+        "title": "Azure Container Service metrics",
+        "description": "Azure Container Service Metrics Integration",
+        "icons": [
+          {
+            "src": "/img/container_service_logo.png",
+            "path": "/package/azure_metrics/0.3.1/img/container_service_logo.png",
+            "title": "logo azure",
+            "size": "32x32",
+            "type": "image/svg+xml"
+          }
+        ],
+        "data_streams": [
+          "container_service"
+        ]
+      },
+      {
+        "name": "database_account",
+        "title": "Azure Database Account metrics",
+        "description": "Azure Database Account Metrics Integration",
+        "icons": [
+          {
+            "src": "/img/database_account_logo.png",
+            "path": "/package/azure_metrics/0.3.1/img/database_account_logo.png",
+            "title": "logo azure",
+            "size": "32x32",
+            "type": "image/svg+xml"
+          }
+        ],
+        "data_streams": [
+          "database_account"
+        ]
+      },
+      {
+        "name": "storage_account",
+        "title": "Azure Storage Account metrics",
+        "description": "Azure Storage Account Metrics Integration",
+        "icons": [
+          {
+            "src": "/img/storage_account_logo.png",
+            "path": "/package/azure_metrics/0.3.1/img/storage_account_logo.png",
+            "title": "logo azure",
+            "size": "32x32",
+            "type": "image/svg+xml"
+          }
+        ],
+        "data_streams": [
+          "storage_account"
+        ]
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "azure",
+      "web"
+    ],
+    "signature_path": "/epr/azure_metrics/azure_metrics-0.3.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "azure.compute_vm",
+        "title": "Compute VM"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.compute_vm_scaleset",
+        "title": "Compute VM Scaleset"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.container_instance",
+        "title": "Container Instance"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.container_registry",
+        "title": "Container Registry"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.container_service",
+        "title": "Container Service"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.database_account",
+        "title": "Database Account"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.monitor",
+        "title": "Monitor"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.storage_account",
+        "title": "Storage Account"
+      }
+    ]
+  },
+  {
+    "name": "azure_metrics",
+    "title": "Azure resource metrics",
+    "version": "0.3.2",
+    "release": "beta",
+    "description": "This Elastic integration collects and aggregates metrics from Azure resources",
+    "type": "integration",
+    "download": "/epr/azure_metrics/azure_metrics-0.3.2.zip",
+    "path": "/package/azure_metrics/0.3.2",
+    "icons": [
+      {
+        "src": "/img/azure_metrics_logo.png",
+        "path": "/package/azure_metrics/0.3.2/img/azure_metrics_logo.png",
+        "title": "logo docker",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "monitor",
+        "title": "Azure Monitor metrics",
+        "description": "Azure Monitor Metrics Integration",
+        "icons": [
+          {
+            "src": "/img/monitor_logo.png",
+            "path": "/package/azure_metrics/0.3.2/img/monitor_logo.png",
+            "title": "logo azure",
+            "size": "32x32",
+            "type": "image/svg+xml"
+          }
+        ],
+        "data_streams": [
+          "monitor"
+        ]
+      },
+      {
+        "name": "compute_vm",
+        "title": "Azure Virtual Machines metrics",
+        "description": "Azure Virtual Machines Metrics Integration",
+        "icons": [
+          {
+            "src": "/img/compute_vm_logo.png",
+            "path": "/package/azure_metrics/0.3.2/img/compute_vm_logo.png",
+            "title": "logo azure",
+            "size": "32x32",
+            "type": "image/svg+xml"
+          }
+        ],
+        "data_streams": [
+          "compute_vm"
+        ]
+      },
+      {
+        "name": "compute_vm_scaleset",
+        "title": "Azure Virtual Machines Scaleset metrics",
+        "description": "Azure Virtual Machines Scaleset Metrics Integration",
+        "icons": [
+          {
+            "src": "/img/compute_vm_scaleset_logo.png",
+            "path": "/package/azure_metrics/0.3.2/img/compute_vm_scaleset_logo.png",
+            "title": "logo azure",
+            "size": "32x32",
+            "type": "image/svg+xml"
+          }
+        ],
+        "data_streams": [
+          "compute_vm_scaleset"
+        ]
+      },
+      {
+        "name": "container_registry",
+        "title": "Azure Container Registry metrics",
+        "description": "Azure Container Registry Metrics Integration",
+        "icons": [
+          {
+            "src": "/img/container_registry_logo.png",
+            "path": "/package/azure_metrics/0.3.2/img/container_registry_logo.png",
+            "title": "logo azure",
+            "size": "32x32",
+            "type": "image/svg+xml"
+          }
+        ],
+        "data_streams": [
+          "container_registry"
+        ]
+      },
+      {
+        "name": "container_instance",
+        "title": "Azure Container Instance metrics",
+        "description": "Azure Container Instance Metrics Integration",
+        "icons": [
+          {
+            "src": "/img/container_instance_logo.png",
+            "path": "/package/azure_metrics/0.3.2/img/container_instance_logo.png",
+            "title": "logo azure",
+            "size": "32x32",
+            "type": "image/svg+xml"
+          }
+        ],
+        "data_streams": [
+          "container_instance"
+        ]
+      },
+      {
+        "name": "container_service",
+        "title": "Azure Container Service metrics",
+        "description": "Azure Container Service Metrics Integration",
+        "icons": [
+          {
+            "src": "/img/container_service_logo.png",
+            "path": "/package/azure_metrics/0.3.2/img/container_service_logo.png",
+            "title": "logo azure",
+            "size": "32x32",
+            "type": "image/svg+xml"
+          }
+        ],
+        "data_streams": [
+          "container_service"
+        ]
+      },
+      {
+        "name": "database_account",
+        "title": "Azure Database Account metrics",
+        "description": "Azure Database Account Metrics Integration",
+        "icons": [
+          {
+            "src": "/img/database_account_logo.png",
+            "path": "/package/azure_metrics/0.3.2/img/database_account_logo.png",
+            "title": "logo azure",
+            "size": "32x32",
+            "type": "image/svg+xml"
+          }
+        ],
+        "data_streams": [
+          "database_account"
+        ]
+      },
+      {
+        "name": "storage_account",
+        "title": "Azure Storage Account metrics",
+        "description": "Azure Storage Account Metrics Integration",
+        "icons": [
+          {
+            "src": "/img/storage_account_logo.png",
+            "path": "/package/azure_metrics/0.3.2/img/storage_account_logo.png",
+            "title": "logo azure",
+            "size": "32x32",
+            "type": "image/svg+xml"
+          }
+        ],
+        "data_streams": [
+          "storage_account"
+        ]
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "azure",
+      "web"
+    ],
+    "signature_path": "/epr/azure_metrics/azure_metrics-0.3.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "azure.compute_vm",
+        "title": "Compute VM"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.compute_vm_scaleset",
+        "title": "Compute VM Scaleset"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.container_instance",
+        "title": "Container Instance"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.container_registry",
+        "title": "Container Registry"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.container_service",
+        "title": "Container Service"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.database_account",
+        "title": "Database Account"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.monitor",
+        "title": "Monitor"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.storage_account",
+        "title": "Storage Account"
+      }
+    ]
+  },
+  {
+    "name": "azure_metrics",
     "title": "Azure Resource Metrics",
     "version": "1.0.0",
     "release": "beta",
@@ -2718,430 +2820,6 @@
     ]
   },
   {
-    "name": "azure_metrics",
-    "title": "Azure resource metrics",
-    "version": "0.3.1",
-    "release": "beta",
-    "description": "This Elastic integration collects and aggregates metrics from Azure resources",
-    "type": "integration",
-    "download": "/epr/azure_metrics/azure_metrics-0.3.1.zip",
-    "path": "/package/azure_metrics/0.3.1",
-    "icons": [
-      {
-        "src": "/img/azure_metrics_logo.png",
-        "path": "/package/azure_metrics/0.3.1/img/azure_metrics_logo.png",
-        "title": "logo docker",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "monitor",
-        "title": "Azure Monitor metrics",
-        "description": "Azure Monitor Metrics Integration",
-        "icons": [
-          {
-            "src": "/img/monitor_logo.png",
-            "path": "/package/azure_metrics/0.3.1/img/monitor_logo.png",
-            "title": "logo azure",
-            "size": "32x32",
-            "type": "image/svg+xml"
-          }
-        ],
-        "data_streams": [
-          "monitor"
-        ]
-      },
-      {
-        "name": "compute_vm",
-        "title": "Azure Virtual Machines metrics",
-        "description": "Azure Virtual Machines Metrics Integration",
-        "icons": [
-          {
-            "src": "/img/compute_vm_logo.png",
-            "path": "/package/azure_metrics/0.3.1/img/compute_vm_logo.png",
-            "title": "logo azure",
-            "size": "32x32",
-            "type": "image/svg+xml"
-          }
-        ],
-        "data_streams": [
-          "compute_vm"
-        ]
-      },
-      {
-        "name": "compute_vm_scaleset",
-        "title": "Azure Virtual Machines Scaleset metrics",
-        "description": "Azure Virtual Machines Scaleset Metrics Integration",
-        "icons": [
-          {
-            "src": "/img/compute_vm_scaleset_logo.png",
-            "path": "/package/azure_metrics/0.3.1/img/compute_vm_scaleset_logo.png",
-            "title": "logo azure",
-            "size": "32x32",
-            "type": "image/svg+xml"
-          }
-        ],
-        "data_streams": [
-          "compute_vm_scaleset"
-        ]
-      },
-      {
-        "name": "container_registry",
-        "title": "Azure Container Registry metrics",
-        "description": "Azure Container Registry Metrics Integration",
-        "icons": [
-          {
-            "src": "/img/container_registry_logo.png",
-            "path": "/package/azure_metrics/0.3.1/img/container_registry_logo.png",
-            "title": "logo azure",
-            "size": "32x32",
-            "type": "image/svg+xml"
-          }
-        ],
-        "data_streams": [
-          "container_registry"
-        ]
-      },
-      {
-        "name": "container_instance",
-        "title": "Azure Container Instance metrics",
-        "description": "Azure Container Instance Metrics Integration",
-        "icons": [
-          {
-            "src": "/img/container_instance_logo.png",
-            "path": "/package/azure_metrics/0.3.1/img/container_instance_logo.png",
-            "title": "logo azure",
-            "size": "32x32",
-            "type": "image/svg+xml"
-          }
-        ],
-        "data_streams": [
-          "container_instance"
-        ]
-      },
-      {
-        "name": "container_service",
-        "title": "Azure Container Service metrics",
-        "description": "Azure Container Service Metrics Integration",
-        "icons": [
-          {
-            "src": "/img/container_service_logo.png",
-            "path": "/package/azure_metrics/0.3.1/img/container_service_logo.png",
-            "title": "logo azure",
-            "size": "32x32",
-            "type": "image/svg+xml"
-          }
-        ],
-        "data_streams": [
-          "container_service"
-        ]
-      },
-      {
-        "name": "database_account",
-        "title": "Azure Database Account metrics",
-        "description": "Azure Database Account Metrics Integration",
-        "icons": [
-          {
-            "src": "/img/database_account_logo.png",
-            "path": "/package/azure_metrics/0.3.1/img/database_account_logo.png",
-            "title": "logo azure",
-            "size": "32x32",
-            "type": "image/svg+xml"
-          }
-        ],
-        "data_streams": [
-          "database_account"
-        ]
-      },
-      {
-        "name": "storage_account",
-        "title": "Azure Storage Account metrics",
-        "description": "Azure Storage Account Metrics Integration",
-        "icons": [
-          {
-            "src": "/img/storage_account_logo.png",
-            "path": "/package/azure_metrics/0.3.1/img/storage_account_logo.png",
-            "title": "logo azure",
-            "size": "32x32",
-            "type": "image/svg+xml"
-          }
-        ],
-        "data_streams": [
-          "storage_account"
-        ]
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "azure",
-      "web"
-    ],
-    "signature_path": "/epr/azure_metrics/azure_metrics-0.3.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "metrics",
-        "dataset": "azure.compute_vm",
-        "title": "Compute VM"
-      },
-      {
-        "type": "metrics",
-        "dataset": "azure.compute_vm_scaleset",
-        "title": "Compute VM Scaleset"
-      },
-      {
-        "type": "metrics",
-        "dataset": "azure.container_instance",
-        "title": "Container Instance"
-      },
-      {
-        "type": "metrics",
-        "dataset": "azure.container_registry",
-        "title": "Container Registry"
-      },
-      {
-        "type": "metrics",
-        "dataset": "azure.container_service",
-        "title": "Container Service"
-      },
-      {
-        "type": "metrics",
-        "dataset": "azure.database_account",
-        "title": "Database Account"
-      },
-      {
-        "type": "metrics",
-        "dataset": "azure.monitor",
-        "title": "Monitor"
-      },
-      {
-        "type": "metrics",
-        "dataset": "azure.storage_account",
-        "title": "Storage Account"
-      }
-    ]
-  },
-  {
-    "name": "azure_metrics",
-    "title": "Azure resource metrics",
-    "version": "0.3.2",
-    "release": "beta",
-    "description": "This Elastic integration collects and aggregates metrics from Azure resources",
-    "type": "integration",
-    "download": "/epr/azure_metrics/azure_metrics-0.3.2.zip",
-    "path": "/package/azure_metrics/0.3.2",
-    "icons": [
-      {
-        "src": "/img/azure_metrics_logo.png",
-        "path": "/package/azure_metrics/0.3.2/img/azure_metrics_logo.png",
-        "title": "logo docker",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "monitor",
-        "title": "Azure Monitor metrics",
-        "description": "Azure Monitor Metrics Integration",
-        "icons": [
-          {
-            "src": "/img/monitor_logo.png",
-            "path": "/package/azure_metrics/0.3.2/img/monitor_logo.png",
-            "title": "logo azure",
-            "size": "32x32",
-            "type": "image/svg+xml"
-          }
-        ],
-        "data_streams": [
-          "monitor"
-        ]
-      },
-      {
-        "name": "compute_vm",
-        "title": "Azure Virtual Machines metrics",
-        "description": "Azure Virtual Machines Metrics Integration",
-        "icons": [
-          {
-            "src": "/img/compute_vm_logo.png",
-            "path": "/package/azure_metrics/0.3.2/img/compute_vm_logo.png",
-            "title": "logo azure",
-            "size": "32x32",
-            "type": "image/svg+xml"
-          }
-        ],
-        "data_streams": [
-          "compute_vm"
-        ]
-      },
-      {
-        "name": "compute_vm_scaleset",
-        "title": "Azure Virtual Machines Scaleset metrics",
-        "description": "Azure Virtual Machines Scaleset Metrics Integration",
-        "icons": [
-          {
-            "src": "/img/compute_vm_scaleset_logo.png",
-            "path": "/package/azure_metrics/0.3.2/img/compute_vm_scaleset_logo.png",
-            "title": "logo azure",
-            "size": "32x32",
-            "type": "image/svg+xml"
-          }
-        ],
-        "data_streams": [
-          "compute_vm_scaleset"
-        ]
-      },
-      {
-        "name": "container_registry",
-        "title": "Azure Container Registry metrics",
-        "description": "Azure Container Registry Metrics Integration",
-        "icons": [
-          {
-            "src": "/img/container_registry_logo.png",
-            "path": "/package/azure_metrics/0.3.2/img/container_registry_logo.png",
-            "title": "logo azure",
-            "size": "32x32",
-            "type": "image/svg+xml"
-          }
-        ],
-        "data_streams": [
-          "container_registry"
-        ]
-      },
-      {
-        "name": "container_instance",
-        "title": "Azure Container Instance metrics",
-        "description": "Azure Container Instance Metrics Integration",
-        "icons": [
-          {
-            "src": "/img/container_instance_logo.png",
-            "path": "/package/azure_metrics/0.3.2/img/container_instance_logo.png",
-            "title": "logo azure",
-            "size": "32x32",
-            "type": "image/svg+xml"
-          }
-        ],
-        "data_streams": [
-          "container_instance"
-        ]
-      },
-      {
-        "name": "container_service",
-        "title": "Azure Container Service metrics",
-        "description": "Azure Container Service Metrics Integration",
-        "icons": [
-          {
-            "src": "/img/container_service_logo.png",
-            "path": "/package/azure_metrics/0.3.2/img/container_service_logo.png",
-            "title": "logo azure",
-            "size": "32x32",
-            "type": "image/svg+xml"
-          }
-        ],
-        "data_streams": [
-          "container_service"
-        ]
-      },
-      {
-        "name": "database_account",
-        "title": "Azure Database Account metrics",
-        "description": "Azure Database Account Metrics Integration",
-        "icons": [
-          {
-            "src": "/img/database_account_logo.png",
-            "path": "/package/azure_metrics/0.3.2/img/database_account_logo.png",
-            "title": "logo azure",
-            "size": "32x32",
-            "type": "image/svg+xml"
-          }
-        ],
-        "data_streams": [
-          "database_account"
-        ]
-      },
-      {
-        "name": "storage_account",
-        "title": "Azure Storage Account metrics",
-        "description": "Azure Storage Account Metrics Integration",
-        "icons": [
-          {
-            "src": "/img/storage_account_logo.png",
-            "path": "/package/azure_metrics/0.3.2/img/storage_account_logo.png",
-            "title": "logo azure",
-            "size": "32x32",
-            "type": "image/svg+xml"
-          }
-        ],
-        "data_streams": [
-          "storage_account"
-        ]
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "azure",
-      "web"
-    ],
-    "signature_path": "/epr/azure_metrics/azure_metrics-0.3.2.zip.sig",
-    "data_streams": [
-      {
-        "type": "metrics",
-        "dataset": "azure.compute_vm",
-        "title": "Compute VM"
-      },
-      {
-        "type": "metrics",
-        "dataset": "azure.compute_vm_scaleset",
-        "title": "Compute VM Scaleset"
-      },
-      {
-        "type": "metrics",
-        "dataset": "azure.container_instance",
-        "title": "Container Instance"
-      },
-      {
-        "type": "metrics",
-        "dataset": "azure.container_registry",
-        "title": "Container Registry"
-      },
-      {
-        "type": "metrics",
-        "dataset": "azure.container_service",
-        "title": "Container Service"
-      },
-      {
-        "type": "metrics",
-        "dataset": "azure.database_account",
-        "title": "Database Account"
-      },
-      {
-        "type": "metrics",
-        "dataset": "azure.monitor",
-        "title": "Monitor"
-      },
-      {
-        "type": "metrics",
-        "dataset": "azure.storage_account",
-        "title": "Storage Account"
-      }
-    ]
-  },
-  {
     "name": "cloudflare",
     "title": "Cloudflare",
     "version": "1.0.2",
@@ -3597,432 +3275,6 @@
         "type": "logs",
         "dataset": "cloudflare.logpull",
         "title": "Cloudflare Logpull"
-      }
-    ]
-  },
-  {
-    "name": "synthetics",
-    "title": "Elastic Synthetics",
-    "version": "0.3.0",
-    "release": "beta",
-    "description": "This Elastic integration allows you to monitor the availability of your services",
-    "type": "integration",
-    "download": "/epr/synthetics/synthetics-0.3.0.zip",
-    "path": "/package/synthetics/0.3.0",
-    "icons": [
-      {
-        "src": "/img/uptime-logo-color-64px.svg",
-        "path": "/package/synthetics/0.3.0/img/uptime-logo-color-64px.svg",
-        "size": "16x16",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "synthetics",
-        "title": "Elastic Synthetics",
-        "description": "Perform synthetic health checks on network endpoints."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.13.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/uptime"
-    },
-    "categories": [
-      "elastic_stack",
-      "monitoring",
-      "web"
-    ],
-    "signature_path": "/epr/synthetics/synthetics-0.3.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "synthetics",
-        "dataset": "browser",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "browser.network",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "browser.screenshot",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "http",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "icmp",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "tcp",
-        "title": "synthetic monitor check"
-      }
-    ]
-  },
-  {
-    "name": "synthetics",
-    "title": "Elastic Synthetics",
-    "version": "0.5.0",
-    "release": "beta",
-    "description": "Monitor the availability of your services with Elastic Synthetics.",
-    "type": "integration",
-    "download": "/epr/synthetics/synthetics-0.5.0.zip",
-    "path": "/package/synthetics/0.5.0",
-    "icons": [
-      {
-        "src": "/img/uptime-logo-color-64px.svg",
-        "path": "/package/synthetics/0.5.0/img/uptime-logo-color-64px.svg",
-        "size": "16x16",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "synthetics",
-        "title": "Elastic Synthetics",
-        "description": "Perform synthetic health checks on network endpoints."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/uptime"
-    },
-    "categories": [
-      "elastic_stack",
-      "monitoring",
-      "web"
-    ],
-    "signature_path": "/epr/synthetics/synthetics-0.5.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "synthetics",
-        "dataset": "browser",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "browser.network",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "browser.screenshot",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "http",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "icmp",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "tcp",
-        "title": "synthetic monitor check"
-      }
-    ]
-  },
-  {
-    "name": "synthetics",
-    "title": "Elastic Synthetics",
-    "version": "0.7.0",
-    "release": "beta",
-    "description": "Monitor the availability of your services with Elastic Synthetics.",
-    "type": "integration",
-    "download": "/epr/synthetics/synthetics-0.7.0.zip",
-    "path": "/package/synthetics/0.7.0",
-    "icons": [
-      {
-        "src": "/img/uptime-logo-color-64px.svg",
-        "path": "/package/synthetics/0.7.0/img/uptime-logo-color-64px.svg",
-        "size": "16x16",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "synthetics",
-        "title": "Elastic Synthetics",
-        "description": "Perform synthetic health checks on network endpoints."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/uptime"
-    },
-    "categories": [
-      "elastic_stack",
-      "monitoring",
-      "web"
-    ],
-    "signature_path": "/epr/synthetics/synthetics-0.7.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "synthetics",
-        "dataset": "browser",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "browser.network",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "browser.screenshot",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "http",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "icmp",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "tcp",
-        "title": "synthetic monitor check"
-      }
-    ]
-  },
-  {
-    "name": "synthetics",
-    "title": "Elastic Synthetics",
-    "version": "0.8.1",
-    "release": "beta",
-    "description": "Monitor the availability of your services with Elastic Synthetics.",
-    "type": "integration",
-    "download": "/epr/synthetics/synthetics-0.8.1.zip",
-    "path": "/package/synthetics/0.8.1",
-    "icons": [
-      {
-        "src": "/img/uptime-logo-color-64px.svg",
-        "path": "/package/synthetics/0.8.1/img/uptime-logo-color-64px.svg",
-        "size": "16x16",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "synthetics",
-        "title": "Elastic Synthetics",
-        "description": "Perform synthetic health checks on network endpoints."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/uptime"
-    },
-    "categories": [
-      "elastic_stack",
-      "monitoring",
-      "web"
-    ],
-    "signature_path": "/epr/synthetics/synthetics-0.8.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "synthetics",
-        "dataset": "browser",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "browser.network",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "browser.screenshot",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "http",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "icmp",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "tcp",
-        "title": "synthetic monitor check"
-      }
-    ]
-  },
-  {
-    "name": "synthetics",
-    "title": "Elastic Synthetics",
-    "version": "0.9.0",
-    "release": "beta",
-    "description": "Monitor the availability of your services with Elastic Synthetics.",
-    "type": "integration",
-    "download": "/epr/synthetics/synthetics-0.9.0.zip",
-    "path": "/package/synthetics/0.9.0",
-    "icons": [
-      {
-        "src": "/img/uptime-logo-color-64px.svg",
-        "path": "/package/synthetics/0.9.0/img/uptime-logo-color-64px.svg",
-        "size": "16x16",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "synthetics",
-        "title": "Elastic Synthetics",
-        "description": "Perform synthetic health checks on network endpoints."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.1.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/uptime"
-    },
-    "categories": [
-      "elastic_stack",
-      "monitoring",
-      "web"
-    ],
-    "signature_path": "/epr/synthetics/synthetics-0.9.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "synthetics",
-        "dataset": "browser",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "browser.network",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "browser.screenshot",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "http",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "icmp",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "tcp",
-        "title": "synthetic monitor check"
-      }
-    ]
-  },
-  {
-    "name": "synthetics",
-    "title": "Elastic Synthetics",
-    "version": "0.9.2",
-    "release": "beta",
-    "description": "Monitor the availability of your services with Elastic Synthetics.",
-    "type": "integration",
-    "download": "/epr/synthetics/synthetics-0.9.2.zip",
-    "path": "/package/synthetics/0.9.2",
-    "icons": [
-      {
-        "src": "/img/uptime-logo-color-64px.svg",
-        "path": "/package/synthetics/0.9.2/img/uptime-logo-color-64px.svg",
-        "size": "16x16",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "synthetics",
-        "title": "Elastic Synthetics",
-        "description": "Perform synthetic health checks on network endpoints."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.1.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/uptime"
-    },
-    "categories": [
-      "elastic_stack",
-      "monitoring",
-      "web"
-    ],
-    "signature_path": "/epr/synthetics/synthetics-0.9.2.zip.sig",
-    "data_streams": [
-      {
-        "type": "synthetics",
-        "dataset": "browser",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "browser.network",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "browser.screenshot",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "http",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "icmp",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "tcp",
-        "title": "synthetic monitor check"
       }
     ]
   },
@@ -4981,6 +4233,754 @@
         "type": "logs",
         "dataset": "nginx_ingress_controller.error",
         "title": "Nginx Ingress Controller error logs"
+      }
+    ]
+  },
+  {
+    "name": "synthetics",
+    "title": "Elastic Synthetics",
+    "version": "0.3.0",
+    "release": "beta",
+    "description": "This Elastic integration allows you to monitor the availability of your services",
+    "type": "integration",
+    "download": "/epr/synthetics/synthetics-0.3.0.zip",
+    "path": "/package/synthetics/0.3.0",
+    "icons": [
+      {
+        "src": "/img/uptime-logo-color-64px.svg",
+        "path": "/package/synthetics/0.3.0/img/uptime-logo-color-64px.svg",
+        "size": "16x16",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "synthetics",
+        "title": "Elastic Synthetics",
+        "description": "Perform synthetic health checks on network endpoints."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.13.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/uptime"
+    },
+    "categories": [
+      "elastic_stack",
+      "monitoring",
+      "web"
+    ],
+    "signature_path": "/epr/synthetics/synthetics-0.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "synthetics",
+        "dataset": "browser",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "browser.network",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "browser.screenshot",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "http",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "icmp",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "tcp",
+        "title": "synthetic monitor check"
+      }
+    ]
+  },
+  {
+    "name": "synthetics",
+    "title": "Elastic Synthetics",
+    "version": "0.5.0",
+    "release": "beta",
+    "description": "Monitor the availability of your services with Elastic Synthetics.",
+    "type": "integration",
+    "download": "/epr/synthetics/synthetics-0.5.0.zip",
+    "path": "/package/synthetics/0.5.0",
+    "icons": [
+      {
+        "src": "/img/uptime-logo-color-64px.svg",
+        "path": "/package/synthetics/0.5.0/img/uptime-logo-color-64px.svg",
+        "size": "16x16",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "synthetics",
+        "title": "Elastic Synthetics",
+        "description": "Perform synthetic health checks on network endpoints."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/uptime"
+    },
+    "categories": [
+      "elastic_stack",
+      "monitoring",
+      "web"
+    ],
+    "signature_path": "/epr/synthetics/synthetics-0.5.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "synthetics",
+        "dataset": "browser",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "browser.network",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "browser.screenshot",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "http",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "icmp",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "tcp",
+        "title": "synthetic monitor check"
+      }
+    ]
+  },
+  {
+    "name": "synthetics",
+    "title": "Elastic Synthetics",
+    "version": "0.7.0",
+    "release": "beta",
+    "description": "Monitor the availability of your services with Elastic Synthetics.",
+    "type": "integration",
+    "download": "/epr/synthetics/synthetics-0.7.0.zip",
+    "path": "/package/synthetics/0.7.0",
+    "icons": [
+      {
+        "src": "/img/uptime-logo-color-64px.svg",
+        "path": "/package/synthetics/0.7.0/img/uptime-logo-color-64px.svg",
+        "size": "16x16",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "synthetics",
+        "title": "Elastic Synthetics",
+        "description": "Perform synthetic health checks on network endpoints."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/uptime"
+    },
+    "categories": [
+      "elastic_stack",
+      "monitoring",
+      "web"
+    ],
+    "signature_path": "/epr/synthetics/synthetics-0.7.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "synthetics",
+        "dataset": "browser",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "browser.network",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "browser.screenshot",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "http",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "icmp",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "tcp",
+        "title": "synthetic monitor check"
+      }
+    ]
+  },
+  {
+    "name": "synthetics",
+    "title": "Elastic Synthetics",
+    "version": "0.8.1",
+    "release": "beta",
+    "description": "Monitor the availability of your services with Elastic Synthetics.",
+    "type": "integration",
+    "download": "/epr/synthetics/synthetics-0.8.1.zip",
+    "path": "/package/synthetics/0.8.1",
+    "icons": [
+      {
+        "src": "/img/uptime-logo-color-64px.svg",
+        "path": "/package/synthetics/0.8.1/img/uptime-logo-color-64px.svg",
+        "size": "16x16",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "synthetics",
+        "title": "Elastic Synthetics",
+        "description": "Perform synthetic health checks on network endpoints."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/uptime"
+    },
+    "categories": [
+      "elastic_stack",
+      "monitoring",
+      "web"
+    ],
+    "signature_path": "/epr/synthetics/synthetics-0.8.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "synthetics",
+        "dataset": "browser",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "browser.network",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "browser.screenshot",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "http",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "icmp",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "tcp",
+        "title": "synthetic monitor check"
+      }
+    ]
+  },
+  {
+    "name": "synthetics",
+    "title": "Elastic Synthetics",
+    "version": "0.9.0",
+    "release": "beta",
+    "description": "Monitor the availability of your services with Elastic Synthetics.",
+    "type": "integration",
+    "download": "/epr/synthetics/synthetics-0.9.0.zip",
+    "path": "/package/synthetics/0.9.0",
+    "icons": [
+      {
+        "src": "/img/uptime-logo-color-64px.svg",
+        "path": "/package/synthetics/0.9.0/img/uptime-logo-color-64px.svg",
+        "size": "16x16",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "synthetics",
+        "title": "Elastic Synthetics",
+        "description": "Perform synthetic health checks on network endpoints."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.1.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/uptime"
+    },
+    "categories": [
+      "elastic_stack",
+      "monitoring",
+      "web"
+    ],
+    "signature_path": "/epr/synthetics/synthetics-0.9.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "synthetics",
+        "dataset": "browser",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "browser.network",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "browser.screenshot",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "http",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "icmp",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "tcp",
+        "title": "synthetic monitor check"
+      }
+    ]
+  },
+  {
+    "name": "synthetics",
+    "title": "Elastic Synthetics",
+    "version": "0.9.2",
+    "release": "beta",
+    "description": "Monitor the availability of your services with Elastic Synthetics.",
+    "type": "integration",
+    "download": "/epr/synthetics/synthetics-0.9.2.zip",
+    "path": "/package/synthetics/0.9.2",
+    "icons": [
+      {
+        "src": "/img/uptime-logo-color-64px.svg",
+        "path": "/package/synthetics/0.9.2/img/uptime-logo-color-64px.svg",
+        "size": "16x16",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "synthetics",
+        "title": "Elastic Synthetics",
+        "description": "Perform synthetic health checks on network endpoints."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.1.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/uptime"
+    },
+    "categories": [
+      "elastic_stack",
+      "monitoring",
+      "web"
+    ],
+    "signature_path": "/epr/synthetics/synthetics-0.9.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "synthetics",
+        "dataset": "browser",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "browser.network",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "browser.screenshot",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "http",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "icmp",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "tcp",
+        "title": "synthetic monitor check"
+      }
+    ]
+  },
+  {
+    "name": "tomcat",
+    "title": "Apache Tomcat",
+    "version": "1.0.0",
+    "release": "ga",
+    "description": "This Elastic integration collects logs from Apache Tomcat",
+    "type": "integration",
+    "download": "/epr/tomcat/tomcat-1.0.0.zip",
+    "path": "/package/tomcat/1.0.0",
+    "icons": [
+      {
+        "src": "/img/logo.svg",
+        "path": "/package/tomcat/1.0.0/img/logo.svg",
+        "title": "Apache Tomcat logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "log",
+        "title": "Apache Tomcat",
+        "description": "Collect Apache Tomcat logs from syslog or a file."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.1"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "web",
+      "security"
+    ],
+    "signature_path": "/epr/tomcat/tomcat-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "tomcat.log",
+        "title": "Apache Tomcat logs"
+      }
+    ]
+  },
+  {
+    "name": "tomcat",
+    "title": "Apache Tomcat",
+    "version": "1.1.0",
+    "release": "ga",
+    "description": "This Elastic integration collects logs from Apache Tomcat",
+    "type": "integration",
+    "download": "/epr/tomcat/tomcat-1.1.0.zip",
+    "path": "/package/tomcat/1.1.0",
+    "icons": [
+      {
+        "src": "/img/logo.svg",
+        "path": "/package/tomcat/1.1.0/img/logo.svg",
+        "title": "Apache Tomcat logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "log",
+        "title": "Apache Tomcat",
+        "description": "Collect Apache Tomcat logs from syslog or a file."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.1"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "web",
+      "security"
+    ],
+    "signature_path": "/epr/tomcat/tomcat-1.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "tomcat.log",
+        "title": "Apache Tomcat logs"
+      }
+    ]
+  },
+  {
+    "name": "tomcat",
+    "title": "Apache Tomcat",
+    "version": "1.1.4",
+    "release": "ga",
+    "description": "Collect and parse logs from Apache Tomcat servers with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/tomcat/tomcat-1.1.4.zip",
+    "path": "/package/tomcat/1.1.4",
+    "icons": [
+      {
+        "src": "/img/logo.svg",
+        "path": "/package/tomcat/1.1.4/img/logo.svg",
+        "title": "Apache Tomcat logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "log",
+        "title": "Apache Tomcat",
+        "description": "Collect Apache Tomcat logs from syslog or a file."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.1"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "web",
+      "security"
+    ],
+    "signature_path": "/epr/tomcat/tomcat-1.1.4.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "tomcat.log",
+        "title": "Apache Tomcat logs"
+      }
+    ]
+  },
+  {
+    "name": "tomcat",
+    "title": "Apache Tomcat",
+    "version": "1.2.0",
+    "release": "ga",
+    "description": "Collect and parse logs from Apache Tomcat servers with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/tomcat/tomcat-1.2.0.zip",
+    "path": "/package/tomcat/1.2.0",
+    "icons": [
+      {
+        "src": "/img/logo.svg",
+        "path": "/package/tomcat/1.2.0/img/logo.svg",
+        "title": "Apache Tomcat logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "log",
+        "title": "Apache Tomcat",
+        "description": "Collect Apache Tomcat logs from syslog or a file."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.1 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "web",
+      "security"
+    ],
+    "signature_path": "/epr/tomcat/tomcat-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "tomcat.log",
+        "title": "Apache Tomcat logs"
+      }
+    ]
+  },
+  {
+    "name": "tomcat",
+    "title": "Apache Tomcat",
+    "version": "1.2.1",
+    "release": "ga",
+    "description": "Collect and parse logs from Apache Tomcat servers with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/tomcat/tomcat-1.2.1.zip",
+    "path": "/package/tomcat/1.2.1",
+    "icons": [
+      {
+        "src": "/img/logo.svg",
+        "path": "/package/tomcat/1.2.1/img/logo.svg",
+        "title": "Apache Tomcat logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "log",
+        "title": "Apache Tomcat",
+        "description": "Collect Apache Tomcat logs from syslog or a file."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.1 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "web",
+      "security"
+    ],
+    "signature_path": "/epr/tomcat/tomcat-1.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "tomcat.log",
+        "title": "Apache Tomcat logs"
+      }
+    ]
+  },
+  {
+    "name": "tomcat",
+    "title": "Apache Tomcat",
+    "version": "1.3.0",
+    "release": "ga",
+    "description": "Collect and parse logs from Apache Tomcat servers with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/tomcat/tomcat-1.3.0.zip",
+    "path": "/package/tomcat/1.3.0",
+    "icons": [
+      {
+        "src": "/img/logo.svg",
+        "path": "/package/tomcat/1.3.0/img/logo.svg",
+        "title": "Apache Tomcat logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "log",
+        "title": "Apache Tomcat",
+        "description": "Collect Apache Tomcat logs from syslog or a file."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.1 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "web",
+      "security"
+    ],
+    "signature_path": "/epr/tomcat/tomcat-1.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "tomcat.log",
+        "title": "Apache Tomcat logs"
+      }
+    ]
+  },
+  {
+    "name": "tomcat",
+    "title": "Apache Tomcat",
+    "version": "1.3.1",
+    "release": "ga",
+    "description": "Collect and parse logs from Apache Tomcat servers with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/tomcat/tomcat-1.3.1.zip",
+    "path": "/package/tomcat/1.3.1",
+    "icons": [
+      {
+        "src": "/img/logo.svg",
+        "path": "/package/tomcat/1.3.1/img/logo.svg",
+        "title": "Apache Tomcat logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "log",
+        "title": "Apache Tomcat",
+        "description": "Collect Apache Tomcat logs from syslog or a file."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.1 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "web",
+      "security"
+    ],
+    "signature_path": "/epr/tomcat/tomcat-1.3.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "tomcat.log",
+        "title": "Apache Tomcat logs"
       }
     ]
   },

--- a/testdata/generated/storage-indexer/search-category-web.json
+++ b/testdata/generated/storage-indexer/search-category-web.json
@@ -128,52 +128,6 @@
     }
   },
   {
-    "name": "tomcat",
-    "title": "Apache Tomcat",
-    "version": "1.3.1",
-    "release": "ga",
-    "description": "Collect and parse logs from Apache Tomcat servers with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/tomcat/tomcat-1.3.1.zip",
-    "path": "/package/tomcat/1.3.1",
-    "icons": [
-      {
-        "src": "/img/logo.svg",
-        "path": "/package/tomcat/1.3.1/img/logo.svg",
-        "title": "Apache Tomcat logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "log",
-        "title": "Apache Tomcat",
-        "description": "Collect Apache Tomcat logs from syslog or a file."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.1 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "web",
-      "security"
-    ],
-    "signature_path": "/epr/tomcat/tomcat-1.3.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "tomcat.log",
-        "title": "Apache Tomcat logs"
-      }
-    ]
-  },
-  {
     "name": "atlassian_bitbucket",
     "title": "Atlassian Bitbucket",
     "version": "1.2.1",
@@ -657,77 +611,6 @@
     ]
   },
   {
-    "name": "synthetics",
-    "title": "Elastic Synthetics",
-    "version": "0.9.2",
-    "release": "beta",
-    "description": "Monitor the availability of your services with Elastic Synthetics.",
-    "type": "integration",
-    "download": "/epr/synthetics/synthetics-0.9.2.zip",
-    "path": "/package/synthetics/0.9.2",
-    "icons": [
-      {
-        "src": "/img/uptime-logo-color-64px.svg",
-        "path": "/package/synthetics/0.9.2/img/uptime-logo-color-64px.svg",
-        "size": "16x16",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "synthetics",
-        "title": "Elastic Synthetics",
-        "description": "Perform synthetic health checks on network endpoints."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.1.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/uptime"
-    },
-    "categories": [
-      "elastic_stack",
-      "monitoring",
-      "web"
-    ],
-    "signature_path": "/epr/synthetics/synthetics-0.9.2.zip.sig",
-    "data_streams": [
-      {
-        "type": "synthetics",
-        "dataset": "browser",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "browser.network",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "browser.screenshot",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "http",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "icmp",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "tcp",
-        "title": "synthetic monitor check"
-      }
-    ]
-  },
-  {
     "name": "iis",
     "title": "IIS",
     "version": "0.8.0",
@@ -1100,6 +983,123 @@
         "type": "logs",
         "dataset": "nginx_ingress_controller.error",
         "title": "Nginx Ingress Controller error logs"
+      }
+    ]
+  },
+  {
+    "name": "synthetics",
+    "title": "Elastic Synthetics",
+    "version": "0.9.2",
+    "release": "beta",
+    "description": "Monitor the availability of your services with Elastic Synthetics.",
+    "type": "integration",
+    "download": "/epr/synthetics/synthetics-0.9.2.zip",
+    "path": "/package/synthetics/0.9.2",
+    "icons": [
+      {
+        "src": "/img/uptime-logo-color-64px.svg",
+        "path": "/package/synthetics/0.9.2/img/uptime-logo-color-64px.svg",
+        "size": "16x16",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "synthetics",
+        "title": "Elastic Synthetics",
+        "description": "Perform synthetic health checks on network endpoints."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.1.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/uptime"
+    },
+    "categories": [
+      "elastic_stack",
+      "monitoring",
+      "web"
+    ],
+    "signature_path": "/epr/synthetics/synthetics-0.9.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "synthetics",
+        "dataset": "browser",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "browser.network",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "browser.screenshot",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "http",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "icmp",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "tcp",
+        "title": "synthetic monitor check"
+      }
+    ]
+  },
+  {
+    "name": "tomcat",
+    "title": "Apache Tomcat",
+    "version": "1.3.1",
+    "release": "ga",
+    "description": "Collect and parse logs from Apache Tomcat servers with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/tomcat/tomcat-1.3.1.zip",
+    "path": "/package/tomcat/1.3.1",
+    "icons": [
+      {
+        "src": "/img/logo.svg",
+        "path": "/package/tomcat/1.3.1/img/logo.svg",
+        "title": "Apache Tomcat logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "log",
+        "title": "Apache Tomcat",
+        "description": "Collect Apache Tomcat logs from syslog or a file."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.1 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "web",
+      "security"
+    ],
+    "signature_path": "/epr/tomcat/tomcat-1.3.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "tomcat.log",
+        "title": "Apache Tomcat logs"
       }
     ]
   },

--- a/testdata/generated/storage-indexer/search-kibana800.json
+++ b/testdata/generated/storage-indexer/search-kibana800.json
@@ -54,6 +54,493 @@
     ]
   },
   {
+    "name": "activemq",
+    "title": "ActiveMQ",
+    "version": "0.3.0",
+    "release": "beta",
+    "description": "Collect logs and metrics from ActiveMQ instances with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/activemq/activemq-0.3.0.zip",
+    "path": "/package/activemq/0.3.0",
+    "icons": [
+      {
+        "src": "/img/activemq.svg",
+        "path": "/package/activemq/0.3.0/img/activemq.svg",
+        "title": "activemq",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "activemq",
+        "title": "ActiveMQ logs and metrics",
+        "description": "Collect logs and metrics from ActiveMQ instances"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "web"
+    ],
+    "signature_path": "/epr/activemq/activemq-0.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "activemq.audit",
+        "title": "ActiveMQ audit logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "activemq.broker",
+        "title": "ActiveMQ broker metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "activemq.log",
+        "title": "ActiveMQ log logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "activemq.queue",
+        "title": "ActiveMQ queue metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "activemq.topic",
+        "title": "ActiveMQ topic metrics"
+      }
+    ]
+  },
+  {
+    "name": "akamai",
+    "title": "Akamai",
+    "version": "1.0.0",
+    "release": "ga",
+    "description": "Akamai Integration",
+    "type": "integration",
+    "download": "/epr/akamai/akamai-1.0.0.zip",
+    "path": "/package/akamai/1.0.0",
+    "icons": [
+      {
+        "src": "/img/akamai_logo.svg",
+        "path": "/package/akamai/1.0.0/img/akamai_logo.svg",
+        "title": "Akamai",
+        "size": "409×167",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "akamai",
+        "title": "Akamai logs",
+        "description": "Collect SIEM logs from Akamai"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security",
+      "network",
+      "web",
+      "cloud"
+    ],
+    "signature_path": "/epr/akamai/akamai-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "akamai.siem",
+        "title": "Akamai SIEM Logs"
+      }
+    ]
+  },
+  {
+    "name": "apache",
+    "title": "Apache HTTP Server",
+    "version": "1.3.5",
+    "release": "ga",
+    "description": "Collect logs and metrics from Apache servers with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/apache/apache-1.3.5.zip",
+    "path": "/package/apache/1.3.5",
+    "icons": [
+      {
+        "src": "/img/logo_apache.svg",
+        "path": "/package/apache/1.3.5/img/logo_apache.svg",
+        "title": "Apache Logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "apache",
+        "title": "Apache logs and metrics",
+        "description": "Collect logs and metrics from Apache instances"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "web"
+    ],
+    "signature_path": "/epr/apache/apache-1.3.5.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "apache.access",
+        "title": "Apache access logs",
+        "deprecated": {
+          "since": "1.3.5",
+          "description": "This data stream is deprecated"
+        }
+      },
+      {
+        "type": "logs",
+        "dataset": "apache.error",
+        "title": "Apache error logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apache.status",
+        "title": "Apache status metrics"
+      }
+    ],
+    "deprecated": {
+      "since": "1.3.0",
+      "description": "This package is deprecated"
+    }
+  },
+  {
+    "name": "apm",
+    "title": "Elastic APM",
+    "version": "8.0.0",
+    "release": "ga",
+    "description": "Ingest APM data",
+    "type": "integration",
+    "download": "/epr/apm/apm-8.0.0.zip",
+    "path": "/package/apm/8.0.0",
+    "icons": [
+      {
+        "src": "/img/logo_apm.svg",
+        "path": "/package/apm/8.0.0/img/logo_apm.svg",
+        "title": "APM Logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "apmserver",
+        "title": "Elastic APM Integration",
+        "description": "Elastic APM Integration"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/apm-server"
+    },
+    "categories": [
+      "elastic_stack",
+      "monitoring"
+    ],
+    "signature_path": "/epr/apm/apm-8.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "apm.app",
+        "title": "APM application logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.app",
+        "title": "APM application metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "apm.error",
+        "title": "APM errors"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.internal",
+        "title": "APM internal metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.profiling",
+        "title": "APM profiles"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm.rum",
+        "title": "APM RUM traces"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm.sampled",
+        "title": "APM tail-sampled traces"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm",
+        "title": "APM traces"
+      }
+    ]
+  },
+  {
+    "name": "atlassian_bitbucket",
+    "title": "Atlassian Bitbucket",
+    "version": "1.2.1",
+    "release": "ga",
+    "description": "Collect logs from Atlassian Bitbucket with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.2.1.zip",
+    "path": "/package/atlassian_bitbucket/1.2.1",
+    "icons": [
+      {
+        "src": "/img/bitbucket-logo.svg",
+        "path": "/package/atlassian_bitbucket/1.2.1/img/bitbucket-logo.svg",
+        "title": "Bitbucket Logo",
+        "size": "625x564",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "audit",
+        "title": "Audit Logs",
+        "description": "Collect audit logs from Atlassian Bitbucket with Elastic Agent."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security",
+      "web"
+    ],
+    "signature_path": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_bitbucket.audit",
+        "title": "Bitbucket Audit Logs"
+      }
+    ]
+  },
+  {
+    "name": "atlassian_confluence",
+    "title": "Atlassian Confluence",
+    "version": "1.3.0",
+    "release": "ga",
+    "description": "Collect logs from Atlassian Confluence with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/atlassian_confluence/atlassian_confluence-1.3.0.zip",
+    "path": "/package/atlassian_confluence/1.3.0",
+    "icons": [
+      {
+        "src": "/img/confluence-logo.svg",
+        "path": "/package/atlassian_confluence/1.3.0/img/confluence-logo.svg",
+        "title": "Confluence Logo",
+        "size": "400x400",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "audit",
+        "title": "Audit Logs",
+        "description": "Collect audit logs from Atlassian Confluence with Elastic Agent."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security",
+      "web"
+    ],
+    "signature_path": "/epr/atlassian_confluence/atlassian_confluence-1.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_confluence.audit",
+        "title": "Confluence Audit Logs"
+      }
+    ]
+  },
+  {
+    "name": "atlassian_jira",
+    "title": "Atlassian Jira",
+    "version": "1.3.0",
+    "release": "ga",
+    "description": "Collect logs from Atlassian Jira with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/atlassian_jira/atlassian_jira-1.3.0.zip",
+    "path": "/package/atlassian_jira/1.3.0",
+    "icons": [
+      {
+        "src": "/img/jira-software-logo.svg",
+        "path": "/package/atlassian_jira/1.3.0/img/jira-software-logo.svg",
+        "title": "Jira Software Logo",
+        "size": "590x625",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "audit",
+        "title": "Audit Logs",
+        "description": "Collect audit logs from Atlassian Jira with Elastic Agent."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security",
+      "web"
+    ],
+    "signature_path": "/epr/atlassian_jira/atlassian_jira-1.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_jira.audit",
+        "title": "Jira Audit Logs"
+      }
+    ]
+  },
+  {
+    "name": "auditd",
+    "title": "Auditd Logs",
+    "version": "3.1.0",
+    "release": "ga",
+    "description": "Collect logs from Linux audit daemon with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/auditd/auditd-3.1.0.zip",
+    "path": "/package/auditd/3.1.0",
+    "icons": [
+      {
+        "src": "/img/linux.svg",
+        "path": "/package/auditd/3.1.0/img/linux.svg",
+        "title": "linux",
+        "size": "299x354",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "auditd",
+        "title": "Auditd logs",
+        "description": "Collect logs from Auditd instances"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "os_system"
+    ],
+    "signature_path": "/epr/auditd/auditd-3.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "auditd.log",
+        "title": "Auditd logs"
+      }
+    ]
+  },
+  {
+    "name": "auth0",
+    "title": "Auth0 Log Streams Integration",
+    "version": "1.0.0",
+    "release": "ga",
+    "description": "Collect logs from Auth0 with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/auth0/auth0-1.0.0.zip",
+    "path": "/package/auth0/1.0.0",
+    "icons": [
+      {
+        "src": "/img/auth0-logo.svg",
+        "path": "/package/auth0/1.0.0/img/auth0-logo.svg",
+        "title": "Auth0 logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "auth0_events",
+        "title": "Auth0 log stream events via Webhooks",
+        "description": "Collect Auth0 log streams events via Webhooks."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "cloud",
+      "network",
+      "security"
+    ],
+    "signature_path": "/epr/auth0/auth0-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "auth0.logs",
+        "title": "Auth0 logs via Webhooks"
+      }
+    ]
+  },
+  {
     "name": "aws",
     "title": "AWS",
     "version": "1.16.4",
@@ -649,6 +1136,51 @@
     ]
   },
   {
+    "name": "aws_logs",
+    "title": "Custom AWS Logs",
+    "version": "0.2.1",
+    "release": "beta",
+    "description": "Collect raw logs from AWS S3 or CloudWatch with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/aws_logs/aws_logs-0.2.1.zip",
+    "path": "/package/aws_logs/0.2.1",
+    "icons": [
+      {
+        "src": "/img/icon.svg",
+        "path": "/package/aws_logs/0.2.1/img/icon.svg",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "aws_logs",
+        "title": "Custom AWS Logs",
+        "description": "Collect raw logs from AWS S3 or CloudWatch with Elastic Agent."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/obs-cloud-monitoring"
+    },
+    "categories": [
+      "custom",
+      "cloud",
+      "aws"
+    ],
+    "signature_path": "/epr/aws_logs/aws_logs-0.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "aws_logs.generic",
+        "title": "Custom logs from AWS"
+      }
+    ]
+  },
+  {
     "name": "awsfargate",
     "title": "AWS Fargate",
     "version": "0.1.1",
@@ -692,745 +1224,6 @@
         "type": "metrics",
         "dataset": "awsfargate.task_stats",
         "title": "AWS Fargate task_stats metrics"
-      }
-    ]
-  },
-  {
-    "name": "ti_abusech",
-    "title": "AbuseCH",
-    "version": "1.2.3",
-    "release": "ga",
-    "description": "Collect threat intelligence from AbuseCH API with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/ti_abusech/ti_abusech-1.2.3.zip",
-    "path": "/package/ti_abusech/1.2.3",
-    "icons": [
-      {
-        "src": "/img/abusech2.svg",
-        "path": "/package/ti_abusech/1.2.3/img/abusech2.svg",
-        "title": "AbuseCH",
-        "size": "512x512",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "ti_abusech",
-        "title": "AbuseCH API",
-        "description": "Collect threat intelligence from the AbuseCH API"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/ti_abusech/ti_abusech-1.2.3.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ti_abusech.malware",
-        "title": "AbuseCH Malware logs"
-      },
-      {
-        "type": "logs",
-        "dataset": "ti_abusech.malwarebazaar",
-        "title": "AbuseCH MalwareBazaar logs"
-      },
-      {
-        "type": "logs",
-        "dataset": "ti_abusech.url",
-        "title": "AbuseCH URL logs"
-      }
-    ]
-  },
-  {
-    "name": "activemq",
-    "title": "ActiveMQ",
-    "version": "0.3.0",
-    "release": "beta",
-    "description": "Collect logs and metrics from ActiveMQ instances with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/activemq/activemq-0.3.0.zip",
-    "path": "/package/activemq/0.3.0",
-    "icons": [
-      {
-        "src": "/img/activemq.svg",
-        "path": "/package/activemq/0.3.0/img/activemq.svg",
-        "title": "activemq",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "activemq",
-        "title": "ActiveMQ logs and metrics",
-        "description": "Collect logs and metrics from ActiveMQ instances"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "web"
-    ],
-    "signature_path": "/epr/activemq/activemq-0.3.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "activemq.audit",
-        "title": "ActiveMQ audit logs"
-      },
-      {
-        "type": "metrics",
-        "dataset": "activemq.broker",
-        "title": "ActiveMQ broker metrics"
-      },
-      {
-        "type": "logs",
-        "dataset": "activemq.log",
-        "title": "ActiveMQ log logs"
-      },
-      {
-        "type": "metrics",
-        "dataset": "activemq.queue",
-        "title": "ActiveMQ queue metrics"
-      },
-      {
-        "type": "metrics",
-        "dataset": "activemq.topic",
-        "title": "ActiveMQ topic metrics"
-      }
-    ]
-  },
-  {
-    "name": "akamai",
-    "title": "Akamai",
-    "version": "1.0.0",
-    "release": "ga",
-    "description": "Akamai Integration",
-    "type": "integration",
-    "download": "/epr/akamai/akamai-1.0.0.zip",
-    "path": "/package/akamai/1.0.0",
-    "icons": [
-      {
-        "src": "/img/akamai_logo.svg",
-        "path": "/package/akamai/1.0.0/img/akamai_logo.svg",
-        "title": "Akamai",
-        "size": "409×167",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "akamai",
-        "title": "Akamai logs",
-        "description": "Collect SIEM logs from Akamai"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security",
-      "network",
-      "web",
-      "cloud"
-    ],
-    "signature_path": "/epr/akamai/akamai-1.0.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "akamai.siem",
-        "title": "Akamai SIEM Logs"
-      }
-    ]
-  },
-  {
-    "name": "ti_otx",
-    "title": "AlienVault OTX",
-    "version": "1.2.2",
-    "release": "ga",
-    "description": "Collect threat intelligence from AlienVault OTX with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/ti_otx/ti_otx-1.2.2.zip",
-    "path": "/package/ti_otx/1.2.2",
-    "icons": [
-      {
-        "src": "/img/otx.svg",
-        "path": "/package/ti_otx/1.2.2/img/otx.svg",
-        "title": "Alienvault OTX",
-        "size": "216x216",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "ti_otx",
-        "title": "Alienvault OTX",
-        "description": "Collect threat intelligence from the Alienvault OTX"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/ti_otx/ti_otx-1.2.2.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ti_otx.threat",
-        "title": "Alienvault OTX logs"
-      }
-    ]
-  },
-  {
-    "name": "ti_anomali",
-    "title": "Anomali",
-    "version": "1.2.3",
-    "release": "ga",
-    "description": "Collect threat intelligence from Anomali APIs with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/ti_anomali/ti_anomali-1.2.3.zip",
-    "path": "/package/ti_anomali/1.2.3",
-    "icons": [
-      {
-        "src": "/img/anomali.svg",
-        "path": "/package/ti_anomali/1.2.3/img/anomali.svg",
-        "title": "Anomali",
-        "size": "216x216",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "ti_anomali",
-        "title": "Anomali",
-        "description": "Collect threat intelligence from the Anomali Limo API and Anomali Threatstream."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/ti_anomali/ti_anomali-1.2.3.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ti_anomali.limo",
-        "title": "Anomali Limo"
-      },
-      {
-        "type": "logs",
-        "dataset": "ti_anomali.threatstream",
-        "title": "Anomali Threatstream"
-      }
-    ]
-  },
-  {
-    "name": "apache",
-    "title": "Apache HTTP Server",
-    "version": "1.3.5",
-    "release": "ga",
-    "description": "Collect logs and metrics from Apache servers with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/apache/apache-1.3.5.zip",
-    "path": "/package/apache/1.3.5",
-    "icons": [
-      {
-        "src": "/img/logo_apache.svg",
-        "path": "/package/apache/1.3.5/img/logo_apache.svg",
-        "title": "Apache Logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "apache",
-        "title": "Apache logs and metrics",
-        "description": "Collect logs and metrics from Apache instances"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "web"
-    ],
-    "signature_path": "/epr/apache/apache-1.3.5.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "apache.access",
-        "title": "Apache access logs",
-        "deprecated": {
-          "since": "1.3.5",
-          "description": "This data stream is deprecated"
-        }
-      },
-      {
-        "type": "logs",
-        "dataset": "apache.error",
-        "title": "Apache error logs"
-      },
-      {
-        "type": "metrics",
-        "dataset": "apache.status",
-        "title": "Apache status metrics"
-      }
-    ],
-    "deprecated": {
-      "since": "1.3.0",
-      "description": "This package is deprecated"
-    }
-  },
-  {
-    "name": "tomcat",
-    "title": "Apache Tomcat",
-    "version": "1.3.1",
-    "release": "ga",
-    "description": "Collect and parse logs from Apache Tomcat servers with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/tomcat/tomcat-1.3.1.zip",
-    "path": "/package/tomcat/1.3.1",
-    "icons": [
-      {
-        "src": "/img/logo.svg",
-        "path": "/package/tomcat/1.3.1/img/logo.svg",
-        "title": "Apache Tomcat logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "log",
-        "title": "Apache Tomcat",
-        "description": "Collect Apache Tomcat logs from syslog or a file."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.1 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "web",
-      "security"
-    ],
-    "signature_path": "/epr/tomcat/tomcat-1.3.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "tomcat.log",
-        "title": "Apache Tomcat logs"
-      }
-    ]
-  },
-  {
-    "name": "atlassian_bitbucket",
-    "title": "Atlassian Bitbucket",
-    "version": "1.2.1",
-    "release": "ga",
-    "description": "Collect logs from Atlassian Bitbucket with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.2.1.zip",
-    "path": "/package/atlassian_bitbucket/1.2.1",
-    "icons": [
-      {
-        "src": "/img/bitbucket-logo.svg",
-        "path": "/package/atlassian_bitbucket/1.2.1/img/bitbucket-logo.svg",
-        "title": "Bitbucket Logo",
-        "size": "625x564",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "audit",
-        "title": "Audit Logs",
-        "description": "Collect audit logs from Atlassian Bitbucket with Elastic Agent."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security",
-      "web"
-    ],
-    "signature_path": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.2.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "atlassian_bitbucket.audit",
-        "title": "Bitbucket Audit Logs"
-      }
-    ]
-  },
-  {
-    "name": "atlassian_confluence",
-    "title": "Atlassian Confluence",
-    "version": "1.3.0",
-    "release": "ga",
-    "description": "Collect logs from Atlassian Confluence with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/atlassian_confluence/atlassian_confluence-1.3.0.zip",
-    "path": "/package/atlassian_confluence/1.3.0",
-    "icons": [
-      {
-        "src": "/img/confluence-logo.svg",
-        "path": "/package/atlassian_confluence/1.3.0/img/confluence-logo.svg",
-        "title": "Confluence Logo",
-        "size": "400x400",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "audit",
-        "title": "Audit Logs",
-        "description": "Collect audit logs from Atlassian Confluence with Elastic Agent."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security",
-      "web"
-    ],
-    "signature_path": "/epr/atlassian_confluence/atlassian_confluence-1.3.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "atlassian_confluence.audit",
-        "title": "Confluence Audit Logs"
-      }
-    ]
-  },
-  {
-    "name": "atlassian_jira",
-    "title": "Atlassian Jira",
-    "version": "1.3.0",
-    "release": "ga",
-    "description": "Collect logs from Atlassian Jira with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/atlassian_jira/atlassian_jira-1.3.0.zip",
-    "path": "/package/atlassian_jira/1.3.0",
-    "icons": [
-      {
-        "src": "/img/jira-software-logo.svg",
-        "path": "/package/atlassian_jira/1.3.0/img/jira-software-logo.svg",
-        "title": "Jira Software Logo",
-        "size": "590x625",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "audit",
-        "title": "Audit Logs",
-        "description": "Collect audit logs from Atlassian Jira with Elastic Agent."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security",
-      "web"
-    ],
-    "signature_path": "/epr/atlassian_jira/atlassian_jira-1.3.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "atlassian_jira.audit",
-        "title": "Jira Audit Logs"
-      }
-    ]
-  },
-  {
-    "name": "auditd",
-    "title": "Auditd Logs",
-    "version": "3.1.0",
-    "release": "ga",
-    "description": "Collect logs from Linux audit daemon with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/auditd/auditd-3.1.0.zip",
-    "path": "/package/auditd/3.1.0",
-    "icons": [
-      {
-        "src": "/img/linux.svg",
-        "path": "/package/auditd/3.1.0/img/linux.svg",
-        "title": "linux",
-        "size": "299x354",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "auditd",
-        "title": "Auditd logs",
-        "description": "Collect logs from Auditd instances"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "os_system"
-    ],
-    "signature_path": "/epr/auditd/auditd-3.1.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "auditd.log",
-        "title": "Auditd logs"
-      }
-    ]
-  },
-  {
-    "name": "auth0",
-    "title": "Auth0 Log Streams Integration",
-    "version": "1.0.0",
-    "release": "ga",
-    "description": "Collect logs from Auth0 with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/auth0/auth0-1.0.0.zip",
-    "path": "/package/auth0/1.0.0",
-    "icons": [
-      {
-        "src": "/img/auth0-logo.svg",
-        "path": "/package/auth0/1.0.0/img/auth0-logo.svg",
-        "title": "Auth0 logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "auth0_events",
-        "title": "Auth0 log stream events via Webhooks",
-        "description": "Collect Auth0 log streams events via Webhooks."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "cloud",
-      "network",
-      "security"
-    ],
-    "signature_path": "/epr/auth0/auth0-1.0.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "auth0.logs",
-        "title": "Auth0 logs via Webhooks"
-      }
-    ]
-  },
-  {
-    "name": "azure_application_insights",
-    "title": "Azure Application Insights Metrics Overview",
-    "version": "1.0.1",
-    "release": "ga",
-    "description": "Collect application insights metrics from Azure Monitor with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/azure_application_insights/azure_application_insights-1.0.1.zip",
-    "path": "/package/azure_application_insights/1.0.1",
-    "icons": [
-      {
-        "src": "/img/app_insights.png",
-        "path": "/package/azure_application_insights/1.0.1/img/app_insights.png",
-        "title": "logo docker",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "app_insights",
-        "title": "Azure Application Insights Metrics",
-        "description": "Collect application insights metrics from Azure Monitor with Elastic Agent.",
-        "icons": [
-          {
-            "src": "/img//app_insights.png",
-            "path": "/package/azure_application_insights/1.0.1/img/app_insights.png",
-            "title": "logo azure",
-            "size": "32x32",
-            "type": "image/svg+xml"
-          }
-        ],
-        "data_streams": [
-          "app_insights"
-        ]
-      },
-      {
-        "name": "app_state",
-        "title": "Azure Application State Insights Metrics",
-        "description": "Collect application state related metrics from Azure Monitor with Elastic Agent.",
-        "icons": [
-          {
-            "src": "/img/application_insights_blue.png",
-            "path": "/package/azure_application_insights/1.0.1/img/application_insights_blue.png",
-            "title": "logo azure",
-            "size": "32x32",
-            "type": "image/svg+xml"
-          }
-        ],
-        "data_streams": [
-          "app_state"
-        ]
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "azure",
-      "web"
-    ],
-    "signature_path": "/epr/azure_application_insights/azure_application_insights-1.0.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "metrics",
-        "dataset": "azure.app_insights",
-        "title": "Azure Application Insights"
-      },
-      {
-        "type": "metrics",
-        "dataset": "azure.app_state",
-        "title": "Azure Application State"
-      }
-    ]
-  },
-  {
-    "name": "azure_billing",
-    "title": "Azure Billing Metrics",
-    "version": "1.0.1",
-    "release": "ga",
-    "description": "Collect billing metrics with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/azure_billing/azure_billing-1.0.1.zip",
-    "path": "/package/azure_billing/1.0.1",
-    "icons": [
-      {
-        "src": "/img/billing.png",
-        "path": "/package/azure_billing/1.0.1/img/billing.png",
-        "title": "logo docker",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "billing",
-        "title": "Azure Billing Metrics",
-        "description": "Collect billing information with Elastic Agent.",
-        "icons": [
-          {
-            "src": "/img//billing.png",
-            "path": "/package/azure_billing/1.0.1/img/billing.png",
-            "title": "logo azure",
-            "size": "32x32",
-            "type": "image/svg+xml"
-          }
-        ],
-        "data_streams": [
-          "billing"
-        ]
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.15.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "azure"
-    ],
-    "signature_path": "/epr/azure_billing/azure_billing-1.0.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "metrics",
-        "dataset": "azure.billing",
-        "title": "Azure Billing Metrics"
       }
     ]
   },
@@ -1585,6 +1378,143 @@
         "type": "logs",
         "dataset": "azure.springcloudlogs",
         "title": "Azure Spring Cloud Logs"
+      }
+    ]
+  },
+  {
+    "name": "azure_application_insights",
+    "title": "Azure Application Insights Metrics Overview",
+    "version": "1.0.1",
+    "release": "ga",
+    "description": "Collect application insights metrics from Azure Monitor with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/azure_application_insights/azure_application_insights-1.0.1.zip",
+    "path": "/package/azure_application_insights/1.0.1",
+    "icons": [
+      {
+        "src": "/img/app_insights.png",
+        "path": "/package/azure_application_insights/1.0.1/img/app_insights.png",
+        "title": "logo docker",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "app_insights",
+        "title": "Azure Application Insights Metrics",
+        "description": "Collect application insights metrics from Azure Monitor with Elastic Agent.",
+        "icons": [
+          {
+            "src": "/img//app_insights.png",
+            "path": "/package/azure_application_insights/1.0.1/img/app_insights.png",
+            "title": "logo azure",
+            "size": "32x32",
+            "type": "image/svg+xml"
+          }
+        ],
+        "data_streams": [
+          "app_insights"
+        ]
+      },
+      {
+        "name": "app_state",
+        "title": "Azure Application State Insights Metrics",
+        "description": "Collect application state related metrics from Azure Monitor with Elastic Agent.",
+        "icons": [
+          {
+            "src": "/img/application_insights_blue.png",
+            "path": "/package/azure_application_insights/1.0.1/img/application_insights_blue.png",
+            "title": "logo azure",
+            "size": "32x32",
+            "type": "image/svg+xml"
+          }
+        ],
+        "data_streams": [
+          "app_state"
+        ]
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "azure",
+      "web"
+    ],
+    "signature_path": "/epr/azure_application_insights/azure_application_insights-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "azure.app_insights",
+        "title": "Azure Application Insights"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.app_state",
+        "title": "Azure Application State"
+      }
+    ]
+  },
+  {
+    "name": "azure_billing",
+    "title": "Azure Billing Metrics",
+    "version": "1.0.1",
+    "release": "ga",
+    "description": "Collect billing metrics with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/azure_billing/azure_billing-1.0.1.zip",
+    "path": "/package/azure_billing/1.0.1",
+    "icons": [
+      {
+        "src": "/img/billing.png",
+        "path": "/package/azure_billing/1.0.1/img/billing.png",
+        "title": "logo docker",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "billing",
+        "title": "Azure Billing Metrics",
+        "description": "Collect billing information with Elastic Agent.",
+        "icons": [
+          {
+            "src": "/img//billing.png",
+            "path": "/package/azure_billing/1.0.1/img/billing.png",
+            "title": "logo azure",
+            "size": "32x32",
+            "type": "image/svg+xml"
+          }
+        ],
+        "data_streams": [
+          "billing"
+        ]
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.15.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "azure"
+    ],
+    "signature_path": "/epr/azure_billing/azure_billing-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "azure.billing",
+        "title": "Azure Billing Metrics"
       }
     ]
   },
@@ -1801,39 +1731,112 @@
     ]
   },
   {
-    "name": "cef",
-    "title": "CEF Logs",
-    "version": "2.0.0",
+    "name": "carbon_black_cloud",
+    "title": "VMware Carbon Black Cloud",
+    "version": "1.0.2",
     "release": "ga",
-    "description": "Collect logs from CEF Logs with Elastic Agent.",
+    "description": "Collect logs from VMWare Carbon Black Cloud with Elastic Agent.",
     "type": "integration",
-    "download": "/epr/cef/cef-2.0.0.zip",
-    "path": "/package/cef/2.0.0",
+    "download": "/epr/carbon_black_cloud/carbon_black_cloud-1.0.2.zip",
+    "path": "/package/carbon_black_cloud/1.0.2",
+    "icons": [
+      {
+        "src": "/img/carbon_black_cloud-logo.svg",
+        "path": "/package/carbon_black_cloud/1.0.2/img/carbon_black_cloud-logo.svg",
+        "title": "Carbon Black Cloud logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
     "policy_templates": [
       {
-        "name": "cef",
-        "title": "CEF logs",
-        "description": "Collect logs from CEF instances"
+        "name": "carbon_black_cloud",
+        "title": "Carbon Black Cloud",
+        "description": "Collect Logs from Carbon Black Cloud"
       }
     ],
     "conditions": {
       "kibana": {
-        "version": "^8.0.0"
+        "version": "^7.17.0 || ^8.0.0"
       }
     },
     "owner": {
       "github": "elastic/security-external-integrations"
     },
     "categories": [
-      "network",
       "security"
     ],
-    "signature_path": "/epr/cef/cef-2.0.0.zip.sig",
+    "signature_path": "/epr/carbon_black_cloud/carbon_black_cloud-1.0.2.zip.sig",
     "data_streams": [
       {
         "type": "logs",
-        "dataset": "cef.log",
-        "title": "CEF log logs"
+        "dataset": "carbon_black_cloud.alert",
+        "title": "Alert"
+      },
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.asset_vulnerability_summary",
+        "title": "Asset Vulnerability Summary"
+      },
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.audit",
+        "title": "Audit"
+      },
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.endpoint_event",
+        "title": "Endpoint Event"
+      },
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.watchlist_hit",
+        "title": "Watchlist Hit"
+      }
+    ]
+  },
+  {
+    "name": "carbonblack_edr",
+    "title": "VMware Carbon Black EDR",
+    "version": "1.2.0",
+    "release": "ga",
+    "description": "Collect logs from VMware Carbon Black EDR with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/carbonblack_edr/carbonblack_edr-1.2.0.zip",
+    "path": "/package/carbonblack_edr/1.2.0",
+    "icons": [
+      {
+        "src": "/img/carbon-black-logo.svg",
+        "path": "/package/carbonblack_edr/1.2.0/img/carbon-black-logo.svg",
+        "title": "VMWare Carbon Black",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "log",
+        "title": "Carbon Black EDR logs",
+        "description": "Collect logs from Carbon Black EDR"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/carbonblack_edr/carbonblack_edr-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "carbonblack_edr.log",
+        "title": "Carbon Black EDR logs"
       }
     ]
   },
@@ -1885,6 +1888,43 @@
         "type": "metrics",
         "dataset": "cassandra.metrics",
         "title": "metrics"
+      }
+    ]
+  },
+  {
+    "name": "cef",
+    "title": "CEF Logs",
+    "version": "2.0.0",
+    "release": "ga",
+    "description": "Collect logs from CEF Logs with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/cef/cef-2.0.0.zip",
+    "path": "/package/cef/2.0.0",
+    "policy_templates": [
+      {
+        "name": "cef",
+        "title": "CEF logs",
+        "description": "Collect logs from CEF instances"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "network",
+      "security"
+    ],
+    "signature_path": "/epr/cef/cef-2.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cef.log",
+        "title": "CEF log logs"
       }
     ]
   },
@@ -2479,344 +2519,6 @@
     ]
   },
   {
-    "name": "aws_logs",
-    "title": "Custom AWS Logs",
-    "version": "0.2.1",
-    "release": "beta",
-    "description": "Collect raw logs from AWS S3 or CloudWatch with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/aws_logs/aws_logs-0.2.1.zip",
-    "path": "/package/aws_logs/0.2.1",
-    "icons": [
-      {
-        "src": "/img/icon.svg",
-        "path": "/package/aws_logs/0.2.1/img/icon.svg",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "aws_logs",
-        "title": "Custom AWS Logs",
-        "description": "Collect raw logs from AWS S3 or CloudWatch with Elastic Agent."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/obs-cloud-monitoring"
-    },
-    "categories": [
-      "custom",
-      "cloud",
-      "aws"
-    ],
-    "signature_path": "/epr/aws_logs/aws_logs-0.2.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "aws_logs.generic",
-        "title": "Custom logs from AWS"
-      }
-    ]
-  },
-  {
-    "name": "gcp_pubsub",
-    "title": "Custom Google Pub/Sub Logs",
-    "version": "1.0.0",
-    "release": "ga",
-    "description": "Collect Logs from Google Pub/Sub topics",
-    "type": "integration",
-    "download": "/epr/gcp_pubsub/gcp_pubsub-1.0.0.zip",
-    "path": "/package/gcp_pubsub/1.0.0",
-    "icons": [
-      {
-        "src": "/img/logo_gcp.svg",
-        "path": "/package/gcp_pubsub/1.0.0/img/logo_gcp.svg",
-        "title": "logo gcp",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "gcp",
-        "title": "Custom Google Pub/Sub Logs",
-        "description": "Collect Logs from Google Pub/Sub topics"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "google_cloud",
-      "cloud",
-      "custom"
-    ],
-    "signature_path": "/epr/gcp_pubsub/gcp_pubsub-1.0.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "gcp_pubsub.generic",
-        "title": "Custom Google Pub/Sub Logs"
-      }
-    ]
-  },
-  {
-    "name": "http_endpoint",
-    "title": "Custom HTTP Endpoint Logs",
-    "version": "1.0.1",
-    "release": "ga",
-    "description": "Collect JSON data from listening HTTP port with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/http_endpoint/http_endpoint-1.0.1.zip",
-    "path": "/package/http_endpoint/1.0.1",
-    "icons": [
-      {
-        "src": "/img/icon.svg",
-        "path": "/package/http_endpoint/1.0.1/img/icon.svg",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "http_endpoint",
-        "title": "Custom HTTP Endpoint Logs",
-        "description": "Collect JSON data from listening HTTP port with Elastic Agent."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "signature_path": "/epr/http_endpoint/http_endpoint-1.0.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "http_endpoint.generic",
-        "title": "Custom HTTP Endpoint Logs"
-      }
-    ]
-  },
-  {
-    "name": "httpjson",
-    "title": "Custom HTTPJSON Input",
-    "version": "1.1.1",
-    "release": "ga",
-    "description": "Collect custom data from REST API's with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/httpjson/httpjson-1.1.1.zip",
-    "path": "/package/httpjson/1.1.1",
-    "policy_templates": [
-      {
-        "name": "generic",
-        "title": "Custom HTTPJSON Input",
-        "description": "Collect custom data from REST API's"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "signature_path": "/epr/httpjson/httpjson-1.1.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "httpjson.generic",
-        "title": "Custom HTTPJSON Input"
-      }
-    ]
-  },
-  {
-    "name": "log",
-    "title": "Custom Logs",
-    "version": "1.0.0",
-    "release": "ga",
-    "description": "Collect custom logs with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/log/log-1.0.0.zip",
-    "path": "/package/log/1.0.0",
-    "icons": [
-      {
-        "src": "/img/icon.svg",
-        "path": "/package/log/1.0.0/img/icon.svg",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "logs",
-        "title": "Custom logs",
-        "description": "Collect your custom log files."
-      }
-    ],
-    "owner": {
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "signature_path": "/epr/log/log-1.0.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "log.log",
-        "title": "Log Dataset"
-      }
-    ]
-  },
-  {
-    "name": "tcp",
-    "title": "Custom TCP Logs",
-    "version": "1.0.0",
-    "release": "ga",
-    "description": "Collect raw TCP data from listening TCP port with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/tcp/tcp-1.0.0.zip",
-    "path": "/package/tcp/1.0.0",
-    "icons": [
-      {
-        "src": "/img/icon.svg",
-        "path": "/package/tcp/1.0.0/img/icon.svg",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "tcp",
-        "title": "Custom TCP Logs",
-        "description": "Collect raw TCP data from listening TCP port with Elastic Agent."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "signature_path": "/epr/tcp/tcp-1.0.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "tcp.generic",
-        "title": "Custom TCP Logs"
-      }
-    ]
-  },
-  {
-    "name": "udp",
-    "title": "Custom UDP Logs",
-    "version": "1.0.1",
-    "release": "ga",
-    "description": "Collect raw UDP data from listening UDP port with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/udp/udp-1.0.1.zip",
-    "path": "/package/udp/1.0.1",
-    "icons": [
-      {
-        "src": "/img/icon.svg",
-        "path": "/package/udp/1.0.1/img/icon.svg",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "udp",
-        "title": "Custom UDP Logs",
-        "description": "Collect raw UDP data from listening UDP port with Elastic Agent."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "signature_path": "/epr/udp/udp-1.0.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "udp.generic",
-        "title": "Custom UDP Logs"
-      }
-    ]
-  },
-  {
-    "name": "winlog",
-    "title": "Custom Windows Event Logs",
-    "version": "1.4.0",
-    "release": "ga",
-    "description": "Collect and parse logs from any Windows event log channel with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/winlog/winlog-1.4.0.zip",
-    "path": "/package/winlog/1.4.0",
-    "icons": [
-      {
-        "src": "/img/logo_windows.svg",
-        "path": "/package/winlog/1.4.0/img/logo_windows.svg",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "winlogs",
-        "title": "Custom Windows event logs",
-        "description": "Collect your custom Windows event logs."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "signature_path": "/epr/winlog/winlog-1.4.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "winlog.winlog",
-        "title": "Custom Windows Event Log Dataset"
-      }
-    ]
-  },
-  {
     "name": "cyberarkpas",
     "title": "CyberArk Privileged Access Security Logs",
     "version": "2.4.2",
@@ -2858,52 +2560,6 @@
         "type": "logs",
         "dataset": "cyberarkpas.audit",
         "title": "CyberArk PAS audit logs"
-      }
-    ]
-  },
-  {
-    "name": "ti_cybersixgill",
-    "title": "Cybersixgill",
-    "version": "1.3.2",
-    "release": "ga",
-    "description": "This Elastic integration collects threat intelligence from Cybersixgill",
-    "type": "integration",
-    "download": "/epr/ti_cybersixgill/ti_cybersixgill-1.3.2.zip",
-    "path": "/package/ti_cybersixgill/1.3.2",
-    "icons": [
-      {
-        "src": "/img/cybersixgill.svg",
-        "path": "/package/ti_cybersixgill/1.3.2/img/cybersixgill.svg",
-        "title": "Cybersixgill",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "cybersixgill",
-        "title": "Cybersixgill Threat Intel",
-        "description": "Collect Threat Intel from Cybersixgill"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security",
-      "productivity"
-    ],
-    "signature_path": "/epr/ti_cybersixgill/ti_cybersixgill-1.3.2.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ti_cybersixgill.threat",
-        "title": "Cybersixgill Darkfeed Logs"
       }
     ]
   },
@@ -2990,87 +2646,6 @@
         "type": "metrics",
         "dataset": "docker.network",
         "title": "Docker network metrics"
-      }
-    ]
-  },
-  {
-    "name": "apm",
-    "title": "Elastic APM",
-    "version": "8.0.0",
-    "release": "ga",
-    "description": "Ingest APM data",
-    "type": "integration",
-    "download": "/epr/apm/apm-8.0.0.zip",
-    "path": "/package/apm/8.0.0",
-    "icons": [
-      {
-        "src": "/img/logo_apm.svg",
-        "path": "/package/apm/8.0.0/img/logo_apm.svg",
-        "title": "APM Logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "apmserver",
-        "title": "Elastic APM Integration",
-        "description": "Elastic APM Integration"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/apm-server"
-    },
-    "categories": [
-      "elastic_stack",
-      "monitoring"
-    ],
-    "signature_path": "/epr/apm/apm-8.0.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "apm.app",
-        "title": "APM application logs"
-      },
-      {
-        "type": "metrics",
-        "dataset": "apm.app",
-        "title": "APM application metrics"
-      },
-      {
-        "type": "logs",
-        "dataset": "apm.error",
-        "title": "APM errors"
-      },
-      {
-        "type": "metrics",
-        "dataset": "apm.internal",
-        "title": "APM internal metrics"
-      },
-      {
-        "type": "metrics",
-        "dataset": "apm.profiling",
-        "title": "APM profiles"
-      },
-      {
-        "type": "traces",
-        "dataset": "apm.rum",
-        "title": "APM RUM traces"
-      },
-      {
-        "type": "traces",
-        "dataset": "apm.sampled",
-        "title": "APM tail-sampled traces"
-      },
-      {
-        "type": "traces",
-        "dataset": "apm",
-        "title": "APM traces"
       }
     ]
   },
@@ -3204,77 +2779,6 @@
         "type": "metrics",
         "dataset": "elastic_agent.packetbeat",
         "title": "Elastic Agent"
-      }
-    ]
-  },
-  {
-    "name": "synthetics",
-    "title": "Elastic Synthetics",
-    "version": "0.8.1",
-    "release": "beta",
-    "description": "Monitor the availability of your services with Elastic Synthetics.",
-    "type": "integration",
-    "download": "/epr/synthetics/synthetics-0.8.1.zip",
-    "path": "/package/synthetics/0.8.1",
-    "icons": [
-      {
-        "src": "/img/uptime-logo-color-64px.svg",
-        "path": "/package/synthetics/0.8.1/img/uptime-logo-color-64px.svg",
-        "size": "16x16",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "synthetics",
-        "title": "Elastic Synthetics",
-        "description": "Perform synthetic health checks on network endpoints."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/uptime"
-    },
-    "categories": [
-      "elastic_stack",
-      "monitoring",
-      "web"
-    ],
-    "signature_path": "/epr/synthetics/synthetics-0.8.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "synthetics",
-        "dataset": "browser",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "browser.network",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "browser.screenshot",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "http",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "icmp",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "tcp",
-        "title": "synthetic monitor check"
       }
     ]
   },
@@ -3528,51 +3032,6 @@
     ]
   },
   {
-    "name": "github",
-    "title": "GitHub",
-    "version": "1.0.0",
-    "release": "ga",
-    "description": "Collect events from GitHub with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/github/github-1.0.0.zip",
-    "path": "/package/github/1.0.0",
-    "icons": [
-      {
-        "src": "/img/github.svg",
-        "path": "/package/github/1.0.0/img/github.svg",
-        "title": "GitHub",
-        "size": "1024x1024",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "github",
-        "title": "GitHub logs",
-        "description": "Collect logs from GitHub"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/github/github-1.0.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "github.audit",
-        "title": "GitHub Audit Logs"
-      }
-    ]
-  },
-  {
     "name": "gcp",
     "title": "Google Cloud Platform",
     "version": "1.9.0",
@@ -3636,47 +3095,94 @@
     ]
   },
   {
-    "name": "santa",
-    "title": "Google Santa Logs",
-    "version": "2.0.1",
+    "name": "gcp_pubsub",
+    "title": "Custom Google Pub/Sub Logs",
+    "version": "1.0.0",
     "release": "ga",
-    "description": "Collect and parse logs from Google Santa instances with Elastic Agent.",
+    "description": "Collect Logs from Google Pub/Sub topics",
     "type": "integration",
-    "download": "/epr/santa/santa-2.0.1.zip",
-    "path": "/package/santa/2.0.1",
+    "download": "/epr/gcp_pubsub/gcp_pubsub-1.0.0.zip",
+    "path": "/package/gcp_pubsub/1.0.0",
     "icons": [
       {
-        "src": "/img/icon.svg",
-        "path": "/package/santa/2.0.1/img/icon.svg",
-        "title": "Google Santa",
+        "src": "/img/logo_gcp.svg",
+        "path": "/package/gcp_pubsub/1.0.0/img/logo_gcp.svg",
+        "title": "logo gcp",
+        "size": "32x32",
         "type": "image/svg+xml"
       }
     ],
     "policy_templates": [
       {
-        "name": "santa",
-        "title": "Google Santa logs",
-        "description": "Collect logs from Google Santa instances"
+        "name": "gcp",
+        "title": "Custom Google Pub/Sub Logs",
+        "description": "Collect Logs from Google Pub/Sub topics"
       }
     ],
     "conditions": {
       "kibana": {
-        "version": "^7.17.0 || ^8.0.0"
+        "version": "^7.16.0 || ^8.0.0"
       }
     },
     "owner": {
       "github": "elastic/security-external-integrations"
     },
     "categories": [
-      "security",
-      "os_system"
+      "google_cloud",
+      "cloud",
+      "custom"
     ],
-    "signature_path": "/epr/santa/santa-2.0.1.zip.sig",
+    "signature_path": "/epr/gcp_pubsub/gcp_pubsub-1.0.0.zip.sig",
     "data_streams": [
       {
         "type": "logs",
-        "dataset": "santa.log",
-        "title": "Google Santa log logs"
+        "dataset": "gcp_pubsub.generic",
+        "title": "Custom Google Pub/Sub Logs"
+      }
+    ]
+  },
+  {
+    "name": "github",
+    "title": "GitHub",
+    "version": "1.0.0",
+    "release": "ga",
+    "description": "Collect events from GitHub with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/github/github-1.0.0.zip",
+    "path": "/package/github/1.0.0",
+    "icons": [
+      {
+        "src": "/img/github.svg",
+        "path": "/package/github/1.0.0/img/github.svg",
+        "title": "GitHub",
+        "size": "1024x1024",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "github",
+        "title": "GitHub logs",
+        "description": "Collect logs from GitHub"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/github/github-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "github.audit",
+        "title": "GitHub Audit Logs"
       }
     ]
   },
@@ -3852,6 +3358,85 @@
         "type": "logs",
         "dataset": "hid_bravura_monitor.winlog",
         "title": "Hitachi ID Security Fabric logs"
+      }
+    ]
+  },
+  {
+    "name": "http_endpoint",
+    "title": "Custom HTTP Endpoint Logs",
+    "version": "1.0.1",
+    "release": "ga",
+    "description": "Collect JSON data from listening HTTP port with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/http_endpoint/http_endpoint-1.0.1.zip",
+    "path": "/package/http_endpoint/1.0.1",
+    "icons": [
+      {
+        "src": "/img/icon.svg",
+        "path": "/package/http_endpoint/1.0.1/img/icon.svg",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "http_endpoint",
+        "title": "Custom HTTP Endpoint Logs",
+        "description": "Collect JSON data from listening HTTP port with Elastic Agent."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "signature_path": "/epr/http_endpoint/http_endpoint-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "http_endpoint.generic",
+        "title": "Custom HTTP Endpoint Logs"
+      }
+    ]
+  },
+  {
+    "name": "httpjson",
+    "title": "Custom HTTPJSON Input",
+    "version": "1.1.1",
+    "release": "ga",
+    "description": "Collect custom data from REST API's with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/httpjson/httpjson-1.1.1.zip",
+    "path": "/package/httpjson/1.1.1",
+    "policy_templates": [
+      {
+        "name": "generic",
+        "title": "Custom HTTPJSON Input",
+        "description": "Collect custom data from REST API's"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "signature_path": "/epr/httpjson/httpjson-1.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "httpjson.generic",
+        "title": "Custom HTTPJSON Input"
       }
     ]
   },
@@ -4598,6 +4183,44 @@
     ]
   },
   {
+    "name": "log",
+    "title": "Custom Logs",
+    "version": "1.0.0",
+    "release": "ga",
+    "description": "Collect custom logs with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/log/log-1.0.0.zip",
+    "path": "/package/log/1.0.0",
+    "icons": [
+      {
+        "src": "/img/icon.svg",
+        "path": "/package/log/1.0.0/img/icon.svg",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "logs",
+        "title": "Custom logs",
+        "description": "Collect your custom log files."
+      }
+    ],
+    "owner": {
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "signature_path": "/epr/log/log-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "log.log",
+        "title": "Log Dataset"
+      }
+    ]
+  },
+  {
     "name": "m365_defender",
     "title": "M365 Defender Logs",
     "version": "1.0.3",
@@ -4641,51 +4264,6 @@
         "type": "logs",
         "dataset": "m365_defender.log",
         "title": "M365 Defender Logs"
-      }
-    ]
-  },
-  {
-    "name": "ti_misp",
-    "title": "MISP",
-    "version": "1.2.2",
-    "release": "ga",
-    "description": "This Elastic integration collects events from MISP",
-    "type": "integration",
-    "download": "/epr/ti_misp/ti_misp-1.2.2.zip",
-    "path": "/package/ti_misp/1.2.2",
-    "icons": [
-      {
-        "src": "/img/misp.svg",
-        "path": "/package/ti_misp/1.2.2/img/misp.svg",
-        "title": "MISP",
-        "size": "216x216",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "ti_misp",
-        "title": "MISP",
-        "description": "Collect threat intelligence from the MISP API."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/ti_misp/ti_misp-1.2.2.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ti_misp.threat",
-        "title": "MISP"
       }
     ]
   },
@@ -4736,51 +4314,6 @@
     ]
   },
   {
-    "name": "microsoft_dhcp",
-    "title": "Microsoft DHCP",
-    "version": "1.3.1",
-    "release": "ga",
-    "description": "Collect logs from Microsoft DHCP with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/microsoft_dhcp/microsoft_dhcp-1.3.1.zip",
-    "path": "/package/microsoft_dhcp/1.3.1",
-    "icons": [
-      {
-        "src": "/img/logo.svg",
-        "path": "/package/microsoft_dhcp/1.3.1/img/logo.svg",
-        "title": "Microsoft logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "microsoft_dhcp",
-        "title": "Microsoft DHCP",
-        "description": "Collect Microsoft DHCP logs."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "network"
-    ],
-    "signature_path": "/epr/microsoft_dhcp/microsoft_dhcp-1.3.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "microsoft_dhcp.log",
-        "title": "Microsoft DHCP Logs"
-      }
-    ]
-  },
-  {
     "name": "microsoft_defender_endpoint",
     "title": "Microsoft Defender for Endpoint",
     "version": "2.1.0",
@@ -4824,6 +4357,51 @@
         "type": "logs",
         "dataset": "microsoft_defender_endpoint.log",
         "title": "Microsoft Defender for Endpoint logs"
+      }
+    ]
+  },
+  {
+    "name": "microsoft_dhcp",
+    "title": "Microsoft DHCP",
+    "version": "1.3.1",
+    "release": "ga",
+    "description": "Collect logs from Microsoft DHCP with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/microsoft_dhcp/microsoft_dhcp-1.3.1.zip",
+    "path": "/package/microsoft_dhcp/1.3.1",
+    "icons": [
+      {
+        "src": "/img/logo.svg",
+        "path": "/package/microsoft_dhcp/1.3.1/img/logo.svg",
+        "title": "Microsoft logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "microsoft_dhcp",
+        "title": "Microsoft DHCP",
+        "description": "Collect Microsoft DHCP logs."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "network"
+    ],
+    "signature_path": "/epr/microsoft_dhcp/microsoft_dhcp-1.3.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "microsoft_dhcp.log",
+        "title": "Microsoft DHCP Logs"
       }
     ]
   },
@@ -5664,51 +5242,6 @@
     ]
   },
   {
-    "name": "panw_cortex_xdr",
-    "title": "Palo Alto Cortex XDR Logs",
-    "version": "1.1.1",
-    "release": "ga",
-    "description": "Collect and parse logs from Palo Alto Cortex XDR API with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/panw_cortex_xdr/panw_cortex_xdr-1.1.1.zip",
-    "path": "/package/panw_cortex_xdr/1.1.1",
-    "icons": [
-      {
-        "src": "/img/icon-cortex.svg",
-        "path": "/package/panw_cortex_xdr/1.1.1/img/icon-cortex.svg",
-        "title": "Palo Alto",
-        "size": "216x216",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "alerts",
-        "title": "Palo Alto Cortex XDR API",
-        "description": "Collect logs from Palo Alto Cortex XDR API"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.15.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/panw_cortex_xdr/panw_cortex_xdr-1.1.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "panw_cortex_xdr.alerts",
-        "title": "Palo Alto Cortex XDR API"
-      }
-    ]
-  },
-  {
     "name": "panw",
     "title": "Palo Alto Networks Logs",
     "version": "1.5.3",
@@ -5750,6 +5283,51 @@
         "type": "logs",
         "dataset": "panw.panos",
         "title": "Palo Alto Networks PAN-OS firewall logs"
+      }
+    ]
+  },
+  {
+    "name": "panw_cortex_xdr",
+    "title": "Palo Alto Cortex XDR Logs",
+    "version": "1.1.1",
+    "release": "ga",
+    "description": "Collect and parse logs from Palo Alto Cortex XDR API with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/panw_cortex_xdr/panw_cortex_xdr-1.1.1.zip",
+    "path": "/package/panw_cortex_xdr/1.1.1",
+    "icons": [
+      {
+        "src": "/img/icon-cortex.svg",
+        "path": "/package/panw_cortex_xdr/1.1.1/img/icon-cortex.svg",
+        "title": "Palo Alto",
+        "size": "216x216",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "alerts",
+        "title": "Palo Alto Cortex XDR API",
+        "description": "Collect logs from Palo Alto Cortex XDR API"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.15.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/panw_cortex_xdr/panw_cortex_xdr-1.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "panw_cortex_xdr.alerts",
+        "title": "Palo Alto Cortex XDR API"
       }
     ]
   },
@@ -5817,42 +5395,6 @@
         "title": "PostgreSQL statement metrics"
       }
     ]
-  },
-  {
-    "name": "security_detection_engine",
-    "title": "Prebuilt Security Detection Rules",
-    "version": "1.0.2",
-    "release": "ga",
-    "description": "Prebuilt detection rules for Elastic Security",
-    "type": "integration",
-    "download": "/epr/security_detection_engine/security_detection_engine-1.0.2.zip",
-    "path": "/package/security_detection_engine/1.0.2",
-    "icons": [
-      {
-        "src": "/img/security-logo-color-64px.svg",
-        "path": "/package/security_detection_engine/1.0.2/img/security-logo-color-64px.svg",
-        "size": "16x16",
-        "type": "image/svg+xml"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      },
-      "elastic": {
-        "subscription": "basic",
-        "capabilities": [
-          "security"
-        ]
-      }
-    },
-    "owner": {
-      "github": "elastic/protections"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/security_detection_engine/security_detection_engine-1.0.2.zip.sig"
   },
   {
     "name": "qnap_nas",
@@ -5965,51 +5507,6 @@
     ]
   },
   {
-    "name": "ti_recordedfuture",
-    "title": "Recorded Future",
-    "version": "0.1.2",
-    "release": "beta",
-    "description": "Collect threat intelligence from Recorded Future with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/ti_recordedfuture/ti_recordedfuture-0.1.2.zip",
-    "path": "/package/ti_recordedfuture/0.1.2",
-    "icons": [
-      {
-        "src": "/img/logo.svg",
-        "path": "/package/ti_recordedfuture/0.1.2/img/logo.svg",
-        "title": "Recorded Future",
-        "size": "216x216",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "ti_recordedfuture",
-        "title": "Recorded Future",
-        "description": "Collect threat intelligence from Recorded Future."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/ti_recordedfuture/ti_recordedfuture-0.1.2.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ti_recordedfuture.threat",
-        "title": "Recorded Future"
-      }
-    ]
-  },
-  {
     "name": "redis",
     "title": "Redis",
     "version": "1.2.0",
@@ -6076,65 +5573,85 @@
     ]
   },
   {
-    "name": "stan",
-    "title": "STAN",
-    "version": "1.2.0",
+    "name": "santa",
+    "title": "Google Santa Logs",
+    "version": "2.0.1",
     "release": "ga",
-    "description": "Collect logs and metrics from STAN servers with Elastic Agent.",
+    "description": "Collect and parse logs from Google Santa instances with Elastic Agent.",
     "type": "integration",
-    "download": "/epr/stan/stan-1.2.0.zip",
-    "path": "/package/stan/1.2.0",
+    "download": "/epr/santa/santa-2.0.1.zip",
+    "path": "/package/santa/2.0.1",
     "icons": [
       {
-        "src": "/img/stan.svg",
-        "path": "/package/stan/1.2.0/img/stan.svg",
-        "title": "STAN Logo",
-        "size": "32x32",
+        "src": "/img/icon.svg",
+        "path": "/package/santa/2.0.1/img/icon.svg",
+        "title": "Google Santa",
         "type": "image/svg+xml"
       }
     ],
     "policy_templates": [
       {
-        "name": "stan",
-        "title": "STAN Logs and Metrics",
-        "description": "Collect logs and metrics from STAN instances"
+        "name": "santa",
+        "title": "Google Santa logs",
+        "description": "Collect logs from Google Santa instances"
       }
     ],
     "conditions": {
       "kibana": {
-        "version": "^7.14.0 || ^8.0.0"
+        "version": "^7.17.0 || ^8.0.0"
       }
     },
     "owner": {
-      "github": "elastic/integrations"
+      "github": "elastic/security-external-integrations"
     },
     "categories": [
-      "message_queue",
-      "kubernetes"
+      "security",
+      "os_system"
     ],
-    "signature_path": "/epr/stan/stan-1.2.0.zip.sig",
+    "signature_path": "/epr/santa/santa-2.0.1.zip.sig",
     "data_streams": [
       {
-        "type": "metrics",
-        "dataset": "stan.channels",
-        "title": "Stan channels metrics"
-      },
-      {
         "type": "logs",
-        "dataset": "stan.log",
-        "title": "STAN logs"
-      },
-      {
-        "type": "metrics",
-        "dataset": "stan.stats",
-        "title": "Stan stats metrics"
-      },
-      {
-        "type": "metrics",
-        "dataset": "stan.subscriptions",
-        "title": "Stan subscriptions metrics"
+        "dataset": "santa.log",
+        "title": "Google Santa log logs"
       }
     ]
+  },
+  {
+    "name": "security_detection_engine",
+    "title": "Prebuilt Security Detection Rules",
+    "version": "1.0.2",
+    "release": "ga",
+    "description": "Prebuilt detection rules for Elastic Security",
+    "type": "integration",
+    "download": "/epr/security_detection_engine/security_detection_engine-1.0.2.zip",
+    "path": "/package/security_detection_engine/1.0.2",
+    "icons": [
+      {
+        "src": "/img/security-logo-color-64px.svg",
+        "path": "/package/security_detection_engine/1.0.2/img/security-logo-color-64px.svg",
+        "size": "16x16",
+        "type": "image/svg+xml"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      },
+      "elastic": {
+        "subscription": "basic",
+        "capabilities": [
+          "security"
+        ]
+      }
+    },
+    "owner": {
+      "github": "elastic/protections"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/security_detection_engine/security_detection_engine-1.0.2.zip.sig"
   },
   {
     "name": "snyk",
@@ -6237,6 +5754,67 @@
     ]
   },
   {
+    "name": "stan",
+    "title": "STAN",
+    "version": "1.2.0",
+    "release": "ga",
+    "description": "Collect logs and metrics from STAN servers with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/stan/stan-1.2.0.zip",
+    "path": "/package/stan/1.2.0",
+    "icons": [
+      {
+        "src": "/img/stan.svg",
+        "path": "/package/stan/1.2.0/img/stan.svg",
+        "title": "STAN Logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "stan",
+        "title": "STAN Logs and Metrics",
+        "description": "Collect logs and metrics from STAN instances"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "message_queue",
+      "kubernetes"
+    ],
+    "signature_path": "/epr/stan/stan-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "stan.channels",
+        "title": "Stan channels metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "stan.log",
+        "title": "STAN logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "stan.stats",
+        "title": "Stan stats metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "stan.subscriptions",
+        "title": "Stan subscriptions metrics"
+      }
+    ]
+  },
+  {
     "name": "suricata",
     "title": "Suricata Events",
     "version": "1.6.1",
@@ -6324,6 +5902,77 @@
         "type": "logs",
         "dataset": "symantec_endpoint.log",
         "title": "Symantec Endpoint Protection (SEP) Logs"
+      }
+    ]
+  },
+  {
+    "name": "synthetics",
+    "title": "Elastic Synthetics",
+    "version": "0.8.1",
+    "release": "beta",
+    "description": "Monitor the availability of your services with Elastic Synthetics.",
+    "type": "integration",
+    "download": "/epr/synthetics/synthetics-0.8.1.zip",
+    "path": "/package/synthetics/0.8.1",
+    "icons": [
+      {
+        "src": "/img/uptime-logo-color-64px.svg",
+        "path": "/package/synthetics/0.8.1/img/uptime-logo-color-64px.svg",
+        "size": "16x16",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "synthetics",
+        "title": "Elastic Synthetics",
+        "description": "Perform synthetic health checks on network endpoints."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/uptime"
+    },
+    "categories": [
+      "elastic_stack",
+      "monitoring",
+      "web"
+    ],
+    "signature_path": "/epr/synthetics/synthetics-0.8.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "synthetics",
+        "dataset": "browser",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "browser.network",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "browser.screenshot",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "http",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "icmp",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "tcp",
+        "title": "synthetic monitor check"
       }
     ]
   },
@@ -6454,6 +6103,49 @@
     ]
   },
   {
+    "name": "tcp",
+    "title": "Custom TCP Logs",
+    "version": "1.0.0",
+    "release": "ga",
+    "description": "Collect raw TCP data from listening TCP port with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/tcp/tcp-1.0.0.zip",
+    "path": "/package/tcp/1.0.0",
+    "icons": [
+      {
+        "src": "/img/icon.svg",
+        "path": "/package/tcp/1.0.0/img/icon.svg",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "tcp",
+        "title": "Custom TCP Logs",
+        "description": "Collect raw TCP data from listening TCP port with Elastic Agent."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "signature_path": "/epr/tcp/tcp-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "tcp.generic",
+        "title": "Custom TCP Logs"
+      }
+    ]
+  },
+  {
     "name": "tenable_sc",
     "title": "Tenable.sc",
     "version": "1.0.0",
@@ -6509,6 +6201,292 @@
     ]
   },
   {
+    "name": "ti_abusech",
+    "title": "AbuseCH",
+    "version": "1.2.3",
+    "release": "ga",
+    "description": "Collect threat intelligence from AbuseCH API with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/ti_abusech/ti_abusech-1.2.3.zip",
+    "path": "/package/ti_abusech/1.2.3",
+    "icons": [
+      {
+        "src": "/img/abusech2.svg",
+        "path": "/package/ti_abusech/1.2.3/img/abusech2.svg",
+        "title": "AbuseCH",
+        "size": "512x512",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "ti_abusech",
+        "title": "AbuseCH API",
+        "description": "Collect threat intelligence from the AbuseCH API"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/ti_abusech/ti_abusech-1.2.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_abusech.malware",
+        "title": "AbuseCH Malware logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "ti_abusech.malwarebazaar",
+        "title": "AbuseCH MalwareBazaar logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "ti_abusech.url",
+        "title": "AbuseCH URL logs"
+      }
+    ]
+  },
+  {
+    "name": "ti_anomali",
+    "title": "Anomali",
+    "version": "1.2.3",
+    "release": "ga",
+    "description": "Collect threat intelligence from Anomali APIs with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/ti_anomali/ti_anomali-1.2.3.zip",
+    "path": "/package/ti_anomali/1.2.3",
+    "icons": [
+      {
+        "src": "/img/anomali.svg",
+        "path": "/package/ti_anomali/1.2.3/img/anomali.svg",
+        "title": "Anomali",
+        "size": "216x216",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "ti_anomali",
+        "title": "Anomali",
+        "description": "Collect threat intelligence from the Anomali Limo API and Anomali Threatstream."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/ti_anomali/ti_anomali-1.2.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_anomali.limo",
+        "title": "Anomali Limo"
+      },
+      {
+        "type": "logs",
+        "dataset": "ti_anomali.threatstream",
+        "title": "Anomali Threatstream"
+      }
+    ]
+  },
+  {
+    "name": "ti_cybersixgill",
+    "title": "Cybersixgill",
+    "version": "1.3.2",
+    "release": "ga",
+    "description": "This Elastic integration collects threat intelligence from Cybersixgill",
+    "type": "integration",
+    "download": "/epr/ti_cybersixgill/ti_cybersixgill-1.3.2.zip",
+    "path": "/package/ti_cybersixgill/1.3.2",
+    "icons": [
+      {
+        "src": "/img/cybersixgill.svg",
+        "path": "/package/ti_cybersixgill/1.3.2/img/cybersixgill.svg",
+        "title": "Cybersixgill",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "cybersixgill",
+        "title": "Cybersixgill Threat Intel",
+        "description": "Collect Threat Intel from Cybersixgill"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security",
+      "productivity"
+    ],
+    "signature_path": "/epr/ti_cybersixgill/ti_cybersixgill-1.3.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_cybersixgill.threat",
+        "title": "Cybersixgill Darkfeed Logs"
+      }
+    ]
+  },
+  {
+    "name": "ti_misp",
+    "title": "MISP",
+    "version": "1.2.2",
+    "release": "ga",
+    "description": "This Elastic integration collects events from MISP",
+    "type": "integration",
+    "download": "/epr/ti_misp/ti_misp-1.2.2.zip",
+    "path": "/package/ti_misp/1.2.2",
+    "icons": [
+      {
+        "src": "/img/misp.svg",
+        "path": "/package/ti_misp/1.2.2/img/misp.svg",
+        "title": "MISP",
+        "size": "216x216",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "ti_misp",
+        "title": "MISP",
+        "description": "Collect threat intelligence from the MISP API."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/ti_misp/ti_misp-1.2.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_misp.threat",
+        "title": "MISP"
+      }
+    ]
+  },
+  {
+    "name": "ti_otx",
+    "title": "AlienVault OTX",
+    "version": "1.2.2",
+    "release": "ga",
+    "description": "Collect threat intelligence from AlienVault OTX with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/ti_otx/ti_otx-1.2.2.zip",
+    "path": "/package/ti_otx/1.2.2",
+    "icons": [
+      {
+        "src": "/img/otx.svg",
+        "path": "/package/ti_otx/1.2.2/img/otx.svg",
+        "title": "Alienvault OTX",
+        "size": "216x216",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "ti_otx",
+        "title": "Alienvault OTX",
+        "description": "Collect threat intelligence from the Alienvault OTX"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/ti_otx/ti_otx-1.2.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_otx.threat",
+        "title": "Alienvault OTX logs"
+      }
+    ]
+  },
+  {
+    "name": "ti_recordedfuture",
+    "title": "Recorded Future",
+    "version": "0.1.2",
+    "release": "beta",
+    "description": "Collect threat intelligence from Recorded Future with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/ti_recordedfuture/ti_recordedfuture-0.1.2.zip",
+    "path": "/package/ti_recordedfuture/0.1.2",
+    "icons": [
+      {
+        "src": "/img/logo.svg",
+        "path": "/package/ti_recordedfuture/0.1.2/img/logo.svg",
+        "title": "Recorded Future",
+        "size": "216x216",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "ti_recordedfuture",
+        "title": "Recorded Future",
+        "description": "Collect threat intelligence from Recorded Future."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/ti_recordedfuture/ti_recordedfuture-0.1.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_recordedfuture.threat",
+        "title": "Recorded Future"
+      }
+    ]
+  },
+  {
     "name": "ti_threatq",
     "title": "ThreatQuotient",
     "version": "1.2.2",
@@ -6550,6 +6528,52 @@
         "type": "logs",
         "dataset": "ti_threatq.threat",
         "title": "ThreatQ"
+      }
+    ]
+  },
+  {
+    "name": "tomcat",
+    "title": "Apache Tomcat",
+    "version": "1.3.1",
+    "release": "ga",
+    "description": "Collect and parse logs from Apache Tomcat servers with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/tomcat/tomcat-1.3.1.zip",
+    "path": "/package/tomcat/1.3.1",
+    "icons": [
+      {
+        "src": "/img/logo.svg",
+        "path": "/package/tomcat/1.3.1/img/logo.svg",
+        "title": "Apache Tomcat logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "log",
+        "title": "Apache Tomcat",
+        "description": "Collect Apache Tomcat logs from syslog or a file."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.1 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "web",
+      "security"
+    ],
+    "signature_path": "/epr/tomcat/tomcat-1.3.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "tomcat.log",
+        "title": "Apache Tomcat logs"
       }
     ]
   },
@@ -6605,112 +6629,45 @@
     ]
   },
   {
-    "name": "carbon_black_cloud",
-    "title": "VMware Carbon Black Cloud",
-    "version": "1.0.2",
+    "name": "udp",
+    "title": "Custom UDP Logs",
+    "version": "1.0.1",
     "release": "ga",
-    "description": "Collect logs from VMWare Carbon Black Cloud with Elastic Agent.",
+    "description": "Collect raw UDP data from listening UDP port with Elastic Agent.",
     "type": "integration",
-    "download": "/epr/carbon_black_cloud/carbon_black_cloud-1.0.2.zip",
-    "path": "/package/carbon_black_cloud/1.0.2",
+    "download": "/epr/udp/udp-1.0.1.zip",
+    "path": "/package/udp/1.0.1",
     "icons": [
       {
-        "src": "/img/carbon_black_cloud-logo.svg",
-        "path": "/package/carbon_black_cloud/1.0.2/img/carbon_black_cloud-logo.svg",
-        "title": "Carbon Black Cloud logo",
-        "size": "32x32",
+        "src": "/img/icon.svg",
+        "path": "/package/udp/1.0.1/img/icon.svg",
         "type": "image/svg+xml"
       }
     ],
     "policy_templates": [
       {
-        "name": "carbon_black_cloud",
-        "title": "Carbon Black Cloud",
-        "description": "Collect Logs from Carbon Black Cloud"
+        "name": "udp",
+        "title": "Custom UDP Logs",
+        "description": "Collect raw UDP data from listening UDP port with Elastic Agent."
       }
     ],
     "conditions": {
       "kibana": {
-        "version": "^7.17.0 || ^8.0.0"
+        "version": "^7.16.0 || ^8.0.0"
       }
     },
     "owner": {
       "github": "elastic/security-external-integrations"
     },
     "categories": [
-      "security"
+      "custom"
     ],
-    "signature_path": "/epr/carbon_black_cloud/carbon_black_cloud-1.0.2.zip.sig",
+    "signature_path": "/epr/udp/udp-1.0.1.zip.sig",
     "data_streams": [
       {
         "type": "logs",
-        "dataset": "carbon_black_cloud.alert",
-        "title": "Alert"
-      },
-      {
-        "type": "logs",
-        "dataset": "carbon_black_cloud.asset_vulnerability_summary",
-        "title": "Asset Vulnerability Summary"
-      },
-      {
-        "type": "logs",
-        "dataset": "carbon_black_cloud.audit",
-        "title": "Audit"
-      },
-      {
-        "type": "logs",
-        "dataset": "carbon_black_cloud.endpoint_event",
-        "title": "Endpoint Event"
-      },
-      {
-        "type": "logs",
-        "dataset": "carbon_black_cloud.watchlist_hit",
-        "title": "Watchlist Hit"
-      }
-    ]
-  },
-  {
-    "name": "carbonblack_edr",
-    "title": "VMware Carbon Black EDR",
-    "version": "1.2.0",
-    "release": "ga",
-    "description": "Collect logs from VMware Carbon Black EDR with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/carbonblack_edr/carbonblack_edr-1.2.0.zip",
-    "path": "/package/carbonblack_edr/1.2.0",
-    "icons": [
-      {
-        "src": "/img/carbon-black-logo.svg",
-        "path": "/package/carbonblack_edr/1.2.0/img/carbon-black-logo.svg",
-        "title": "VMWare Carbon Black",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "log",
-        "title": "Carbon Black EDR logs",
-        "description": "Collect logs from Carbon Black EDR"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/carbonblack_edr/carbonblack_edr-1.2.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "carbonblack_edr.log",
-        "title": "Carbon Black EDR logs"
+        "dataset": "udp.generic",
+        "title": "Custom UDP Logs"
       }
     ]
   },
@@ -6843,6 +6800,49 @@
         "type": "logs",
         "dataset": "windows.sysmon_operational",
         "title": "Windows Sysmon/Operational events"
+      }
+    ]
+  },
+  {
+    "name": "winlog",
+    "title": "Custom Windows Event Logs",
+    "version": "1.4.0",
+    "release": "ga",
+    "description": "Collect and parse logs from any Windows event log channel with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/winlog/winlog-1.4.0.zip",
+    "path": "/package/winlog/1.4.0",
+    "icons": [
+      {
+        "src": "/img/logo_windows.svg",
+        "path": "/package/winlog/1.4.0/img/logo_windows.svg",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "winlogs",
+        "title": "Custom Windows event logs",
+        "description": "Collect your custom Windows event logs."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "signature_path": "/epr/winlog/winlog-1.4.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "winlog.winlog",
+        "title": "Custom Windows Event Log Dataset"
       }
     ]
   },

--- a/testdata/generated/storage-indexer/search-package-experimental.json
+++ b/testdata/generated/storage-indexer/search-package-experimental.json
@@ -54,6 +54,538 @@
     ]
   },
   {
+    "name": "activemq",
+    "title": "ActiveMQ",
+    "version": "0.3.0",
+    "release": "beta",
+    "description": "Collect logs and metrics from ActiveMQ instances with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/activemq/activemq-0.3.0.zip",
+    "path": "/package/activemq/0.3.0",
+    "icons": [
+      {
+        "src": "/img/activemq.svg",
+        "path": "/package/activemq/0.3.0/img/activemq.svg",
+        "title": "activemq",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "activemq",
+        "title": "ActiveMQ logs and metrics",
+        "description": "Collect logs and metrics from ActiveMQ instances"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "web"
+    ],
+    "signature_path": "/epr/activemq/activemq-0.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "activemq.audit",
+        "title": "ActiveMQ audit logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "activemq.broker",
+        "title": "ActiveMQ broker metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "activemq.log",
+        "title": "ActiveMQ log logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "activemq.queue",
+        "title": "ActiveMQ queue metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "activemq.topic",
+        "title": "ActiveMQ topic metrics"
+      }
+    ]
+  },
+  {
+    "name": "akamai",
+    "title": "Akamai",
+    "version": "2.28.0",
+    "release": "ga",
+    "description": "Collect logs from Akamai with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/akamai/akamai-2.28.0.zip",
+    "path": "/package/akamai/2.28.0",
+    "icons": [
+      {
+        "src": "/img/akamai_logo.svg",
+        "path": "/package/akamai/2.28.0/img/akamai_logo.svg",
+        "title": "Akamai",
+        "size": "409×167",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "akamai",
+        "title": "Akamai logs",
+        "description": "Collect SIEM logs from Akamai"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.13.0 || ^9.0.0"
+      }
+    },
+    "owner": {
+      "type": "community",
+      "github": "elastic/security-service-integrations"
+    },
+    "categories": [
+      "security",
+      "cdn_security"
+    ],
+    "signature_path": "/epr/akamai/akamai-2.28.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "akamai.siem",
+        "title": "Akamai SIEM Logs"
+      }
+    ]
+  },
+  {
+    "name": "apache",
+    "title": "Apache HTTP Server",
+    "version": "1.3.5",
+    "release": "ga",
+    "description": "Collect logs and metrics from Apache servers with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/apache/apache-1.3.5.zip",
+    "path": "/package/apache/1.3.5",
+    "icons": [
+      {
+        "src": "/img/logo_apache.svg",
+        "path": "/package/apache/1.3.5/img/logo_apache.svg",
+        "title": "Apache Logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "apache",
+        "title": "Apache logs and metrics",
+        "description": "Collect logs and metrics from Apache instances"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "web"
+    ],
+    "signature_path": "/epr/apache/apache-1.3.5.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "apache.access",
+        "title": "Apache access logs",
+        "deprecated": {
+          "since": "1.3.5",
+          "description": "This data stream is deprecated"
+        }
+      },
+      {
+        "type": "logs",
+        "dataset": "apache.error",
+        "title": "Apache error logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apache.status",
+        "title": "Apache status metrics"
+      }
+    ],
+    "deprecated": {
+      "since": "1.3.0",
+      "description": "This package is deprecated"
+    }
+  },
+  {
+    "name": "apm",
+    "title": "Elastic APM",
+    "version": "8.2.0",
+    "release": "ga",
+    "description": "Ingest APM data",
+    "type": "integration",
+    "download": "/epr/apm/apm-8.2.0.zip",
+    "path": "/package/apm/8.2.0",
+    "icons": [
+      {
+        "src": "/img/logo_apm.svg",
+        "path": "/package/apm/8.2.0/img/logo_apm.svg",
+        "title": "APM Logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "apmserver",
+        "title": "Elastic APM Integration",
+        "description": "Elastic APM Integration"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.2.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/apm-server"
+    },
+    "categories": [
+      "elastic_stack",
+      "monitoring"
+    ],
+    "signature_path": "/epr/apm/apm-8.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "apm.app",
+        "title": "APM application logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.app",
+        "title": "APM application metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "apm.error",
+        "title": "APM errors"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.internal",
+        "title": "APM internal metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.profiling",
+        "title": "APM profiles"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm.rum",
+        "title": "APM RUM traces"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm.sampled",
+        "title": "APM tail-sampled traces"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm",
+        "title": "APM traces"
+      }
+    ]
+  },
+  {
+    "name": "atlassian_bitbucket",
+    "title": "Atlassian Bitbucket",
+    "version": "1.2.1",
+    "release": "ga",
+    "description": "Collect logs from Atlassian Bitbucket with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.2.1.zip",
+    "path": "/package/atlassian_bitbucket/1.2.1",
+    "icons": [
+      {
+        "src": "/img/bitbucket-logo.svg",
+        "path": "/package/atlassian_bitbucket/1.2.1/img/bitbucket-logo.svg",
+        "title": "Bitbucket Logo",
+        "size": "625x564",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "audit",
+        "title": "Audit Logs",
+        "description": "Collect audit logs from Atlassian Bitbucket with Elastic Agent."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security",
+      "web"
+    ],
+    "signature_path": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_bitbucket.audit",
+        "title": "Bitbucket Audit Logs"
+      }
+    ]
+  },
+  {
+    "name": "atlassian_confluence",
+    "title": "Atlassian Confluence",
+    "version": "1.3.0",
+    "release": "ga",
+    "description": "Collect logs from Atlassian Confluence with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/atlassian_confluence/atlassian_confluence-1.3.0.zip",
+    "path": "/package/atlassian_confluence/1.3.0",
+    "icons": [
+      {
+        "src": "/img/confluence-logo.svg",
+        "path": "/package/atlassian_confluence/1.3.0/img/confluence-logo.svg",
+        "title": "Confluence Logo",
+        "size": "400x400",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "audit",
+        "title": "Audit Logs",
+        "description": "Collect audit logs from Atlassian Confluence with Elastic Agent."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security",
+      "web"
+    ],
+    "signature_path": "/epr/atlassian_confluence/atlassian_confluence-1.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_confluence.audit",
+        "title": "Confluence Audit Logs"
+      }
+    ]
+  },
+  {
+    "name": "atlassian_jira",
+    "title": "Atlassian Jira",
+    "version": "1.3.0",
+    "release": "ga",
+    "description": "Collect logs from Atlassian Jira with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/atlassian_jira/atlassian_jira-1.3.0.zip",
+    "path": "/package/atlassian_jira/1.3.0",
+    "icons": [
+      {
+        "src": "/img/jira-software-logo.svg",
+        "path": "/package/atlassian_jira/1.3.0/img/jira-software-logo.svg",
+        "title": "Jira Software Logo",
+        "size": "590x625",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "audit",
+        "title": "Audit Logs",
+        "description": "Collect audit logs from Atlassian Jira with Elastic Agent."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security",
+      "web"
+    ],
+    "signature_path": "/epr/atlassian_jira/atlassian_jira-1.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_jira.audit",
+        "title": "Jira Audit Logs"
+      }
+    ]
+  },
+  {
+    "name": "auditd",
+    "title": "Auditd Logs",
+    "version": "3.1.0",
+    "release": "ga",
+    "description": "Collect logs from Linux audit daemon with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/auditd/auditd-3.1.0.zip",
+    "path": "/package/auditd/3.1.0",
+    "icons": [
+      {
+        "src": "/img/linux.svg",
+        "path": "/package/auditd/3.1.0/img/linux.svg",
+        "title": "linux",
+        "size": "299x354",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "auditd",
+        "title": "Auditd logs",
+        "description": "Collect logs from Auditd instances"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "os_system"
+    ],
+    "signature_path": "/epr/auditd/auditd-3.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "auditd.log",
+        "title": "Auditd logs"
+      }
+    ]
+  },
+  {
+    "name": "auditd_manager",
+    "title": "Auditd Manager",
+    "version": "1.0.0",
+    "release": "ga",
+    "description": "The Auditd Manager Integration receives audit events from the Linux Audit Framework that is a part of the Linux kernel.",
+    "type": "integration",
+    "download": "/epr/auditd_manager/auditd_manager-1.0.0.zip",
+    "path": "/package/auditd_manager/1.0.0",
+    "icons": [
+      {
+        "src": "/img/linux.svg",
+        "path": "/package/auditd_manager/1.0.0/img/linux.svg",
+        "title": "linux",
+        "size": "299x354",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "auditd",
+        "title": "Auditd",
+        "description": "Collect auditd events"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.2.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "os_system",
+      "security"
+    ],
+    "signature_path": "/epr/auditd_manager/auditd_manager-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "auditd_manager.auditd",
+        "title": "Auditd Manager"
+      }
+    ]
+  },
+  {
+    "name": "auth0",
+    "title": "Auth0 Log Streams Integration",
+    "version": "1.0.0",
+    "release": "ga",
+    "description": "Collect logs from Auth0 with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/auth0/auth0-1.0.0.zip",
+    "path": "/package/auth0/1.0.0",
+    "icons": [
+      {
+        "src": "/img/auth0-logo.svg",
+        "path": "/package/auth0/1.0.0/img/auth0-logo.svg",
+        "title": "Auth0 logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "auth0_events",
+        "title": "Auth0 log stream events via Webhooks",
+        "description": "Collect Auth0 log streams events via Webhooks."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "cloud",
+      "network",
+      "security"
+    ],
+    "signature_path": "/epr/auth0/auth0-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "auth0.logs",
+        "title": "Auth0 logs via Webhooks"
+      }
+    ]
+  },
+  {
     "name": "aws",
     "title": "AWS",
     "version": "1.16.4",
@@ -649,6 +1181,51 @@
     ]
   },
   {
+    "name": "aws_logs",
+    "title": "Custom AWS Logs",
+    "version": "0.2.1",
+    "release": "beta",
+    "description": "Collect raw logs from AWS S3 or CloudWatch with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/aws_logs/aws_logs-0.2.1.zip",
+    "path": "/package/aws_logs/0.2.1",
+    "icons": [
+      {
+        "src": "/img/icon.svg",
+        "path": "/package/aws_logs/0.2.1/img/icon.svg",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "aws_logs",
+        "title": "Custom AWS Logs",
+        "description": "Collect raw logs from AWS S3 or CloudWatch with Elastic Agent."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/obs-cloud-monitoring"
+    },
+    "categories": [
+      "custom",
+      "cloud",
+      "aws"
+    ],
+    "signature_path": "/epr/aws_logs/aws_logs-0.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "aws_logs.generic",
+        "title": "Custom logs from AWS"
+      }
+    ]
+  },
+  {
     "name": "awsfargate",
     "title": "AWS Fargate",
     "version": "0.1.1",
@@ -692,835 +1269,6 @@
         "type": "metrics",
         "dataset": "awsfargate.task_stats",
         "title": "AWS Fargate task_stats metrics"
-      }
-    ]
-  },
-  {
-    "name": "ti_abusech",
-    "title": "AbuseCH",
-    "version": "1.2.3",
-    "release": "ga",
-    "description": "Collect threat intelligence from AbuseCH API with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/ti_abusech/ti_abusech-1.2.3.zip",
-    "path": "/package/ti_abusech/1.2.3",
-    "icons": [
-      {
-        "src": "/img/abusech2.svg",
-        "path": "/package/ti_abusech/1.2.3/img/abusech2.svg",
-        "title": "AbuseCH",
-        "size": "512x512",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "ti_abusech",
-        "title": "AbuseCH API",
-        "description": "Collect threat intelligence from the AbuseCH API"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/ti_abusech/ti_abusech-1.2.3.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ti_abusech.malware",
-        "title": "AbuseCH Malware logs"
-      },
-      {
-        "type": "logs",
-        "dataset": "ti_abusech.malwarebazaar",
-        "title": "AbuseCH MalwareBazaar logs"
-      },
-      {
-        "type": "logs",
-        "dataset": "ti_abusech.url",
-        "title": "AbuseCH URL logs"
-      }
-    ]
-  },
-  {
-    "name": "activemq",
-    "title": "ActiveMQ",
-    "version": "0.3.0",
-    "release": "beta",
-    "description": "Collect logs and metrics from ActiveMQ instances with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/activemq/activemq-0.3.0.zip",
-    "path": "/package/activemq/0.3.0",
-    "icons": [
-      {
-        "src": "/img/activemq.svg",
-        "path": "/package/activemq/0.3.0/img/activemq.svg",
-        "title": "activemq",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "activemq",
-        "title": "ActiveMQ logs and metrics",
-        "description": "Collect logs and metrics from ActiveMQ instances"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "web"
-    ],
-    "signature_path": "/epr/activemq/activemq-0.3.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "activemq.audit",
-        "title": "ActiveMQ audit logs"
-      },
-      {
-        "type": "metrics",
-        "dataset": "activemq.broker",
-        "title": "ActiveMQ broker metrics"
-      },
-      {
-        "type": "logs",
-        "dataset": "activemq.log",
-        "title": "ActiveMQ log logs"
-      },
-      {
-        "type": "metrics",
-        "dataset": "activemq.queue",
-        "title": "ActiveMQ queue metrics"
-      },
-      {
-        "type": "metrics",
-        "dataset": "activemq.topic",
-        "title": "ActiveMQ topic metrics"
-      }
-    ]
-  },
-  {
-    "name": "akamai",
-    "title": "Akamai",
-    "version": "2.28.0",
-    "release": "ga",
-    "description": "Collect logs from Akamai with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/akamai/akamai-2.28.0.zip",
-    "path": "/package/akamai/2.28.0",
-    "icons": [
-      {
-        "src": "/img/akamai_logo.svg",
-        "path": "/package/akamai/2.28.0/img/akamai_logo.svg",
-        "title": "Akamai",
-        "size": "409×167",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "akamai",
-        "title": "Akamai logs",
-        "description": "Collect SIEM logs from Akamai"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.13.0 || ^9.0.0"
-      }
-    },
-    "owner": {
-      "type": "community",
-      "github": "elastic/security-service-integrations"
-    },
-    "categories": [
-      "security",
-      "cdn_security"
-    ],
-    "signature_path": "/epr/akamai/akamai-2.28.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "akamai.siem",
-        "title": "Akamai SIEM Logs"
-      }
-    ]
-  },
-  {
-    "name": "ti_otx",
-    "title": "AlienVault OTX",
-    "version": "1.2.2",
-    "release": "ga",
-    "description": "Collect threat intelligence from AlienVault OTX with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/ti_otx/ti_otx-1.2.2.zip",
-    "path": "/package/ti_otx/1.2.2",
-    "icons": [
-      {
-        "src": "/img/otx.svg",
-        "path": "/package/ti_otx/1.2.2/img/otx.svg",
-        "title": "Alienvault OTX",
-        "size": "216x216",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "ti_otx",
-        "title": "Alienvault OTX",
-        "description": "Collect threat intelligence from the Alienvault OTX"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/ti_otx/ti_otx-1.2.2.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ti_otx.threat",
-        "title": "Alienvault OTX logs"
-      }
-    ]
-  },
-  {
-    "name": "ti_anomali",
-    "title": "Anomali",
-    "version": "1.2.3",
-    "release": "ga",
-    "description": "Collect threat intelligence from Anomali APIs with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/ti_anomali/ti_anomali-1.2.3.zip",
-    "path": "/package/ti_anomali/1.2.3",
-    "icons": [
-      {
-        "src": "/img/anomali.svg",
-        "path": "/package/ti_anomali/1.2.3/img/anomali.svg",
-        "title": "Anomali",
-        "size": "216x216",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "ti_anomali",
-        "title": "Anomali",
-        "description": "Collect threat intelligence from the Anomali Limo API and Anomali Threatstream."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/ti_anomali/ti_anomali-1.2.3.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ti_anomali.limo",
-        "title": "Anomali Limo"
-      },
-      {
-        "type": "logs",
-        "dataset": "ti_anomali.threatstream",
-        "title": "Anomali Threatstream"
-      }
-    ]
-  },
-  {
-    "name": "apache",
-    "title": "Apache HTTP Server",
-    "version": "1.3.5",
-    "release": "ga",
-    "description": "Collect logs and metrics from Apache servers with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/apache/apache-1.3.5.zip",
-    "path": "/package/apache/1.3.5",
-    "icons": [
-      {
-        "src": "/img/logo_apache.svg",
-        "path": "/package/apache/1.3.5/img/logo_apache.svg",
-        "title": "Apache Logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "apache",
-        "title": "Apache logs and metrics",
-        "description": "Collect logs and metrics from Apache instances"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "web"
-    ],
-    "signature_path": "/epr/apache/apache-1.3.5.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "apache.access",
-        "title": "Apache access logs",
-        "deprecated": {
-          "since": "1.3.5",
-          "description": "This data stream is deprecated"
-        }
-      },
-      {
-        "type": "logs",
-        "dataset": "apache.error",
-        "title": "Apache error logs"
-      },
-      {
-        "type": "metrics",
-        "dataset": "apache.status",
-        "title": "Apache status metrics"
-      }
-    ],
-    "deprecated": {
-      "since": "1.3.0",
-      "description": "This package is deprecated"
-    }
-  },
-  {
-    "name": "tomcat",
-    "title": "Apache Tomcat",
-    "version": "1.3.1",
-    "release": "ga",
-    "description": "Collect and parse logs from Apache Tomcat servers with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/tomcat/tomcat-1.3.1.zip",
-    "path": "/package/tomcat/1.3.1",
-    "icons": [
-      {
-        "src": "/img/logo.svg",
-        "path": "/package/tomcat/1.3.1/img/logo.svg",
-        "title": "Apache Tomcat logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "log",
-        "title": "Apache Tomcat",
-        "description": "Collect Apache Tomcat logs from syslog or a file."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.1 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "web",
-      "security"
-    ],
-    "signature_path": "/epr/tomcat/tomcat-1.3.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "tomcat.log",
-        "title": "Apache Tomcat logs"
-      }
-    ]
-  },
-  {
-    "name": "netscout",
-    "title": "Arbor Peakflow SP Logs",
-    "version": "0.7.0",
-    "release": "experimental",
-    "description": "Collect and parse logs from Netscout Arbor Peakflow SP with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/netscout/netscout-0.7.0.zip",
-    "path": "/package/netscout/0.7.0",
-    "icons": [
-      {
-        "src": "/img/logo.svg",
-        "path": "/package/netscout/0.7.0/img/logo.svg",
-        "title": "Arbor Peakflow SP logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "sightline",
-        "title": "Arbor Peakflow SP",
-        "description": "Collect Arbor Peakflow SP logs from syslog or a file."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.1 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/netscout/netscout-0.7.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "netscout.sightline",
-        "title": "Arbor Peakflow SP logs"
-      }
-    ]
-  },
-  {
-    "name": "atlassian_bitbucket",
-    "title": "Atlassian Bitbucket",
-    "version": "1.2.1",
-    "release": "ga",
-    "description": "Collect logs from Atlassian Bitbucket with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.2.1.zip",
-    "path": "/package/atlassian_bitbucket/1.2.1",
-    "icons": [
-      {
-        "src": "/img/bitbucket-logo.svg",
-        "path": "/package/atlassian_bitbucket/1.2.1/img/bitbucket-logo.svg",
-        "title": "Bitbucket Logo",
-        "size": "625x564",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "audit",
-        "title": "Audit Logs",
-        "description": "Collect audit logs from Atlassian Bitbucket with Elastic Agent."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security",
-      "web"
-    ],
-    "signature_path": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.2.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "atlassian_bitbucket.audit",
-        "title": "Bitbucket Audit Logs"
-      }
-    ]
-  },
-  {
-    "name": "atlassian_confluence",
-    "title": "Atlassian Confluence",
-    "version": "1.3.0",
-    "release": "ga",
-    "description": "Collect logs from Atlassian Confluence with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/atlassian_confluence/atlassian_confluence-1.3.0.zip",
-    "path": "/package/atlassian_confluence/1.3.0",
-    "icons": [
-      {
-        "src": "/img/confluence-logo.svg",
-        "path": "/package/atlassian_confluence/1.3.0/img/confluence-logo.svg",
-        "title": "Confluence Logo",
-        "size": "400x400",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "audit",
-        "title": "Audit Logs",
-        "description": "Collect audit logs from Atlassian Confluence with Elastic Agent."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security",
-      "web"
-    ],
-    "signature_path": "/epr/atlassian_confluence/atlassian_confluence-1.3.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "atlassian_confluence.audit",
-        "title": "Confluence Audit Logs"
-      }
-    ]
-  },
-  {
-    "name": "atlassian_jira",
-    "title": "Atlassian Jira",
-    "version": "1.3.0",
-    "release": "ga",
-    "description": "Collect logs from Atlassian Jira with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/atlassian_jira/atlassian_jira-1.3.0.zip",
-    "path": "/package/atlassian_jira/1.3.0",
-    "icons": [
-      {
-        "src": "/img/jira-software-logo.svg",
-        "path": "/package/atlassian_jira/1.3.0/img/jira-software-logo.svg",
-        "title": "Jira Software Logo",
-        "size": "590x625",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "audit",
-        "title": "Audit Logs",
-        "description": "Collect audit logs from Atlassian Jira with Elastic Agent."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security",
-      "web"
-    ],
-    "signature_path": "/epr/atlassian_jira/atlassian_jira-1.3.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "atlassian_jira.audit",
-        "title": "Jira Audit Logs"
-      }
-    ]
-  },
-  {
-    "name": "auditd",
-    "title": "Auditd Logs",
-    "version": "3.1.0",
-    "release": "ga",
-    "description": "Collect logs from Linux audit daemon with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/auditd/auditd-3.1.0.zip",
-    "path": "/package/auditd/3.1.0",
-    "icons": [
-      {
-        "src": "/img/linux.svg",
-        "path": "/package/auditd/3.1.0/img/linux.svg",
-        "title": "linux",
-        "size": "299x354",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "auditd",
-        "title": "Auditd logs",
-        "description": "Collect logs from Auditd instances"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "os_system"
-    ],
-    "signature_path": "/epr/auditd/auditd-3.1.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "auditd.log",
-        "title": "Auditd logs"
-      }
-    ]
-  },
-  {
-    "name": "auditd_manager",
-    "title": "Auditd Manager",
-    "version": "1.0.0",
-    "release": "ga",
-    "description": "The Auditd Manager Integration receives audit events from the Linux Audit Framework that is a part of the Linux kernel.",
-    "type": "integration",
-    "download": "/epr/auditd_manager/auditd_manager-1.0.0.zip",
-    "path": "/package/auditd_manager/1.0.0",
-    "icons": [
-      {
-        "src": "/img/linux.svg",
-        "path": "/package/auditd_manager/1.0.0/img/linux.svg",
-        "title": "linux",
-        "size": "299x354",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "auditd",
-        "title": "Auditd",
-        "description": "Collect auditd events"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.2.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "os_system",
-      "security"
-    ],
-    "signature_path": "/epr/auditd_manager/auditd_manager-1.0.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "auditd_manager.auditd",
-        "title": "Auditd Manager"
-      }
-    ]
-  },
-  {
-    "name": "auth0",
-    "title": "Auth0 Log Streams Integration",
-    "version": "1.0.0",
-    "release": "ga",
-    "description": "Collect logs from Auth0 with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/auth0/auth0-1.0.0.zip",
-    "path": "/package/auth0/1.0.0",
-    "icons": [
-      {
-        "src": "/img/auth0-logo.svg",
-        "path": "/package/auth0/1.0.0/img/auth0-logo.svg",
-        "title": "Auth0 logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "auth0_events",
-        "title": "Auth0 log stream events via Webhooks",
-        "description": "Collect Auth0 log streams events via Webhooks."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "cloud",
-      "network",
-      "security"
-    ],
-    "signature_path": "/epr/auth0/auth0-1.0.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "auth0.logs",
-        "title": "Auth0 logs via Webhooks"
-      }
-    ]
-  },
-  {
-    "name": "azure_application_insights",
-    "title": "Azure Application Insights Metrics Overview",
-    "version": "1.0.1",
-    "release": "ga",
-    "description": "Collect application insights metrics from Azure Monitor with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/azure_application_insights/azure_application_insights-1.0.1.zip",
-    "path": "/package/azure_application_insights/1.0.1",
-    "icons": [
-      {
-        "src": "/img/app_insights.png",
-        "path": "/package/azure_application_insights/1.0.1/img/app_insights.png",
-        "title": "logo docker",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "app_insights",
-        "title": "Azure Application Insights Metrics",
-        "description": "Collect application insights metrics from Azure Monitor with Elastic Agent.",
-        "icons": [
-          {
-            "src": "/img//app_insights.png",
-            "path": "/package/azure_application_insights/1.0.1/img/app_insights.png",
-            "title": "logo azure",
-            "size": "32x32",
-            "type": "image/svg+xml"
-          }
-        ],
-        "data_streams": [
-          "app_insights"
-        ]
-      },
-      {
-        "name": "app_state",
-        "title": "Azure Application State Insights Metrics",
-        "description": "Collect application state related metrics from Azure Monitor with Elastic Agent.",
-        "icons": [
-          {
-            "src": "/img/application_insights_blue.png",
-            "path": "/package/azure_application_insights/1.0.1/img/application_insights_blue.png",
-            "title": "logo azure",
-            "size": "32x32",
-            "type": "image/svg+xml"
-          }
-        ],
-        "data_streams": [
-          "app_state"
-        ]
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "azure",
-      "web"
-    ],
-    "signature_path": "/epr/azure_application_insights/azure_application_insights-1.0.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "metrics",
-        "dataset": "azure.app_insights",
-        "title": "Azure Application Insights"
-      },
-      {
-        "type": "metrics",
-        "dataset": "azure.app_state",
-        "title": "Azure Application State"
-      }
-    ]
-  },
-  {
-    "name": "azure_billing",
-    "title": "Azure Billing Metrics",
-    "version": "1.0.1",
-    "release": "ga",
-    "description": "Collect billing metrics with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/azure_billing/azure_billing-1.0.1.zip",
-    "path": "/package/azure_billing/1.0.1",
-    "icons": [
-      {
-        "src": "/img/billing.png",
-        "path": "/package/azure_billing/1.0.1/img/billing.png",
-        "title": "logo docker",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "billing",
-        "title": "Azure Billing Metrics",
-        "description": "Collect billing information with Elastic Agent.",
-        "icons": [
-          {
-            "src": "/img//billing.png",
-            "path": "/package/azure_billing/1.0.1/img/billing.png",
-            "title": "logo azure",
-            "size": "32x32",
-            "type": "image/svg+xml"
-          }
-        ],
-        "data_streams": [
-          "billing"
-        ]
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.15.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "azure"
-    ],
-    "signature_path": "/epr/azure_billing/azure_billing-1.0.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "metrics",
-        "dataset": "azure.billing",
-        "title": "Azure Billing Metrics"
       }
     ]
   },
@@ -1675,6 +1423,143 @@
         "type": "logs",
         "dataset": "azure.springcloudlogs",
         "title": "Azure Spring Cloud Logs"
+      }
+    ]
+  },
+  {
+    "name": "azure_application_insights",
+    "title": "Azure Application Insights Metrics Overview",
+    "version": "1.0.1",
+    "release": "ga",
+    "description": "Collect application insights metrics from Azure Monitor with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/azure_application_insights/azure_application_insights-1.0.1.zip",
+    "path": "/package/azure_application_insights/1.0.1",
+    "icons": [
+      {
+        "src": "/img/app_insights.png",
+        "path": "/package/azure_application_insights/1.0.1/img/app_insights.png",
+        "title": "logo docker",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "app_insights",
+        "title": "Azure Application Insights Metrics",
+        "description": "Collect application insights metrics from Azure Monitor with Elastic Agent.",
+        "icons": [
+          {
+            "src": "/img//app_insights.png",
+            "path": "/package/azure_application_insights/1.0.1/img/app_insights.png",
+            "title": "logo azure",
+            "size": "32x32",
+            "type": "image/svg+xml"
+          }
+        ],
+        "data_streams": [
+          "app_insights"
+        ]
+      },
+      {
+        "name": "app_state",
+        "title": "Azure Application State Insights Metrics",
+        "description": "Collect application state related metrics from Azure Monitor with Elastic Agent.",
+        "icons": [
+          {
+            "src": "/img/application_insights_blue.png",
+            "path": "/package/azure_application_insights/1.0.1/img/application_insights_blue.png",
+            "title": "logo azure",
+            "size": "32x32",
+            "type": "image/svg+xml"
+          }
+        ],
+        "data_streams": [
+          "app_state"
+        ]
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "azure",
+      "web"
+    ],
+    "signature_path": "/epr/azure_application_insights/azure_application_insights-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "azure.app_insights",
+        "title": "Azure Application Insights"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.app_state",
+        "title": "Azure Application State"
+      }
+    ]
+  },
+  {
+    "name": "azure_billing",
+    "title": "Azure Billing Metrics",
+    "version": "1.0.1",
+    "release": "ga",
+    "description": "Collect billing metrics with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/azure_billing/azure_billing-1.0.1.zip",
+    "path": "/package/azure_billing/1.0.1",
+    "icons": [
+      {
+        "src": "/img/billing.png",
+        "path": "/package/azure_billing/1.0.1/img/billing.png",
+        "title": "logo docker",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "billing",
+        "title": "Azure Billing Metrics",
+        "description": "Collect billing information with Elastic Agent.",
+        "icons": [
+          {
+            "src": "/img//billing.png",
+            "path": "/package/azure_billing/1.0.1/img/billing.png",
+            "title": "logo azure",
+            "size": "32x32",
+            "type": "image/svg+xml"
+          }
+        ],
+        "data_streams": [
+          "billing"
+        ]
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.15.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "azure"
+    ],
+    "signature_path": "/epr/azure_billing/azure_billing-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "azure.billing",
+        "title": "Azure Billing Metrics"
       }
     ]
   },
@@ -1979,85 +1864,112 @@
     ]
   },
   {
-    "name": "cef",
-    "title": "CEF Logs",
-    "version": "2.0.0",
+    "name": "carbon_black_cloud",
+    "title": "VMware Carbon Black Cloud",
+    "version": "1.0.2",
     "release": "ga",
-    "description": "Collect logs from CEF Logs with Elastic Agent.",
+    "description": "Collect logs from VMWare Carbon Black Cloud with Elastic Agent.",
     "type": "integration",
-    "download": "/epr/cef/cef-2.0.0.zip",
-    "path": "/package/cef/2.0.0",
-    "policy_templates": [
-      {
-        "name": "cef",
-        "title": "CEF logs",
-        "description": "Collect logs from CEF instances"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "network",
-      "security"
-    ],
-    "signature_path": "/epr/cef/cef-2.0.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "cef.log",
-        "title": "CEF log logs"
-      }
-    ]
-  },
-  {
-    "name": "cloud_security_posture",
-    "title": "CIS Kubernetes Benchmark",
-    "version": "0.0.14",
-    "release": "experimental",
-    "description": "Check Kubernetes cluster compliance with the Kubernetes CIS benchmark.",
-    "type": "integration",
-    "download": "/epr/cloud_security_posture/cloud_security_posture-0.0.14.zip",
-    "path": "/package/cloud_security_posture/0.0.14",
+    "download": "/epr/carbon_black_cloud/carbon_black_cloud-1.0.2.zip",
+    "path": "/package/carbon_black_cloud/1.0.2",
     "icons": [
       {
-        "src": "/img/cis-kubernetes-benchmark-logo.svg",
-        "path": "/package/cloud_security_posture/0.0.14/img/cis-kubernetes-benchmark-logo.svg",
-        "title": "CIS Kubernetes Benchmark logo",
+        "src": "/img/carbon_black_cloud-logo.svg",
+        "path": "/package/carbon_black_cloud/1.0.2/img/carbon_black_cloud-logo.svg",
+        "title": "Carbon Black Cloud logo",
         "size": "32x32",
         "type": "image/svg+xml"
       }
     ],
     "policy_templates": [
       {
-        "name": "kspm",
-        "title": "CIS Kubernetes Benchmark",
-        "description": "Check Kubernetes cluster compliance with the Kubernetes CIS benchmark."
+        "name": "carbon_black_cloud",
+        "title": "Carbon Black Cloud",
+        "description": "Collect Logs from Carbon Black Cloud"
       }
     ],
     "conditions": {
       "kibana": {
-        "version": "^8.3.0"
+        "version": "^7.17.0 || ^8.0.0"
       }
     },
     "owner": {
-      "github": "elastic/cloud-security-posture"
+      "github": "elastic/security-external-integrations"
     },
     "categories": [
-      "containers",
-      "kubernetes"
+      "security"
     ],
-    "signature_path": "/epr/cloud_security_posture/cloud_security_posture-0.0.14.zip.sig",
+    "signature_path": "/epr/carbon_black_cloud/carbon_black_cloud-1.0.2.zip.sig",
     "data_streams": [
       {
         "type": "logs",
-        "dataset": "cloud_security_posture.findings",
-        "title": "Findings"
+        "dataset": "carbon_black_cloud.alert",
+        "title": "Alert"
+      },
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.asset_vulnerability_summary",
+        "title": "Asset Vulnerability Summary"
+      },
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.audit",
+        "title": "Audit"
+      },
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.endpoint_event",
+        "title": "Endpoint Event"
+      },
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.watchlist_hit",
+        "title": "Watchlist Hit"
+      }
+    ]
+  },
+  {
+    "name": "carbonblack_edr",
+    "title": "VMware Carbon Black EDR",
+    "version": "1.2.0",
+    "release": "ga",
+    "description": "Collect logs from VMware Carbon Black EDR with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/carbonblack_edr/carbonblack_edr-1.2.0.zip",
+    "path": "/package/carbonblack_edr/1.2.0",
+    "icons": [
+      {
+        "src": "/img/carbon-black-logo.svg",
+        "path": "/package/carbonblack_edr/1.2.0/img/carbon-black-logo.svg",
+        "title": "VMWare Carbon Black",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "log",
+        "title": "Carbon Black EDR logs",
+        "description": "Collect logs from Carbon Black EDR"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/carbonblack_edr/carbonblack_edr-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "carbonblack_edr.log",
+        "title": "Carbon Black EDR logs"
       }
     ]
   },
@@ -2109,6 +2021,43 @@
         "type": "metrics",
         "dataset": "cassandra.metrics",
         "title": "metrics"
+      }
+    ]
+  },
+  {
+    "name": "cef",
+    "title": "CEF Logs",
+    "version": "2.0.0",
+    "release": "ga",
+    "description": "Collect logs from CEF Logs with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/cef/cef-2.0.0.zip",
+    "path": "/package/cef/2.0.0",
+    "policy_templates": [
+      {
+        "name": "cef",
+        "title": "CEF logs",
+        "description": "Collect logs from CEF instances"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "network",
+      "security"
+    ],
+    "signature_path": "/epr/cef/cef-2.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cef.log",
+        "title": "CEF log logs"
       }
     ]
   },
@@ -2706,6 +2655,52 @@
     ]
   },
   {
+    "name": "cloud_security_posture",
+    "title": "CIS Kubernetes Benchmark",
+    "version": "0.0.14",
+    "release": "experimental",
+    "description": "Check Kubernetes cluster compliance with the Kubernetes CIS benchmark.",
+    "type": "integration",
+    "download": "/epr/cloud_security_posture/cloud_security_posture-0.0.14.zip",
+    "path": "/package/cloud_security_posture/0.0.14",
+    "icons": [
+      {
+        "src": "/img/cis-kubernetes-benchmark-logo.svg",
+        "path": "/package/cloud_security_posture/0.0.14/img/cis-kubernetes-benchmark-logo.svg",
+        "title": "CIS Kubernetes Benchmark logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "kspm",
+        "title": "CIS Kubernetes Benchmark",
+        "description": "Check Kubernetes cluster compliance with the Kubernetes CIS benchmark."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.3.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/cloud-security-posture"
+    },
+    "categories": [
+      "containers",
+      "kubernetes"
+    ],
+    "signature_path": "/epr/cloud_security_posture/cloud_security_posture-0.0.14.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cloud_security_posture.findings",
+        "title": "Findings"
+      }
+    ]
+  },
+  {
     "name": "cloudflare",
     "title": "Cloudflare",
     "version": "2.0.0",
@@ -2866,389 +2861,6 @@
     ]
   },
   {
-    "name": "aws_logs",
-    "title": "Custom AWS Logs",
-    "version": "0.2.1",
-    "release": "beta",
-    "description": "Collect raw logs from AWS S3 or CloudWatch with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/aws_logs/aws_logs-0.2.1.zip",
-    "path": "/package/aws_logs/0.2.1",
-    "icons": [
-      {
-        "src": "/img/icon.svg",
-        "path": "/package/aws_logs/0.2.1/img/icon.svg",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "aws_logs",
-        "title": "Custom AWS Logs",
-        "description": "Collect raw logs from AWS S3 or CloudWatch with Elastic Agent."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/obs-cloud-monitoring"
-    },
-    "categories": [
-      "custom",
-      "cloud",
-      "aws"
-    ],
-    "signature_path": "/epr/aws_logs/aws_logs-0.2.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "aws_logs.generic",
-        "title": "Custom logs from AWS"
-      }
-    ]
-  },
-  {
-    "name": "gcp_pubsub",
-    "title": "Custom Google Pub/Sub Logs",
-    "version": "1.0.0",
-    "release": "ga",
-    "description": "Collect Logs from Google Pub/Sub topics",
-    "type": "integration",
-    "download": "/epr/gcp_pubsub/gcp_pubsub-1.0.0.zip",
-    "path": "/package/gcp_pubsub/1.0.0",
-    "icons": [
-      {
-        "src": "/img/logo_gcp.svg",
-        "path": "/package/gcp_pubsub/1.0.0/img/logo_gcp.svg",
-        "title": "logo gcp",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "gcp",
-        "title": "Custom Google Pub/Sub Logs",
-        "description": "Collect Logs from Google Pub/Sub topics"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "google_cloud",
-      "cloud",
-      "custom"
-    ],
-    "signature_path": "/epr/gcp_pubsub/gcp_pubsub-1.0.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "gcp_pubsub.generic",
-        "title": "Custom Google Pub/Sub Logs"
-      }
-    ]
-  },
-  {
-    "name": "http_endpoint",
-    "title": "Custom HTTP Endpoint Logs",
-    "version": "1.0.1",
-    "release": "ga",
-    "description": "Collect JSON data from listening HTTP port with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/http_endpoint/http_endpoint-1.0.1.zip",
-    "path": "/package/http_endpoint/1.0.1",
-    "icons": [
-      {
-        "src": "/img/icon.svg",
-        "path": "/package/http_endpoint/1.0.1/img/icon.svg",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "http_endpoint",
-        "title": "Custom HTTP Endpoint Logs",
-        "description": "Collect JSON data from listening HTTP port with Elastic Agent."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "signature_path": "/epr/http_endpoint/http_endpoint-1.0.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "http_endpoint.generic",
-        "title": "Custom HTTP Endpoint Logs"
-      }
-    ]
-  },
-  {
-    "name": "httpjson",
-    "title": "Custom HTTPJSON Input",
-    "version": "1.1.1",
-    "release": "ga",
-    "description": "Collect custom data from REST API's with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/httpjson/httpjson-1.1.1.zip",
-    "path": "/package/httpjson/1.1.1",
-    "policy_templates": [
-      {
-        "name": "generic",
-        "title": "Custom HTTPJSON Input",
-        "description": "Collect custom data from REST API's"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "signature_path": "/epr/httpjson/httpjson-1.1.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "httpjson.generic",
-        "title": "Custom HTTPJSON Input"
-      }
-    ]
-  },
-  {
-    "name": "journald",
-    "title": "Custom Journald logs",
-    "version": "0.0.2",
-    "release": "experimental",
-    "description": "Collect logs from journald with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/journald/journald-0.0.2.zip",
-    "path": "/package/journald/0.0.2",
-    "icons": [
-      {
-        "src": "/img/systemd-logo.svg",
-        "path": "/package/journald/0.0.2/img/systemd-logo.svg",
-        "title": "systemd logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "logs",
-        "title": "Journald",
-        "description": "Collect sample logs"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "signature_path": "/epr/journald/journald-0.0.2.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "journald.log",
-        "title": "Journald Log"
-      }
-    ]
-  },
-  {
-    "name": "log",
-    "title": "Custom Logs",
-    "version": "1.0.0",
-    "release": "ga",
-    "description": "Collect custom logs with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/log/log-1.0.0.zip",
-    "path": "/package/log/1.0.0",
-    "icons": [
-      {
-        "src": "/img/icon.svg",
-        "path": "/package/log/1.0.0/img/icon.svg",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "logs",
-        "title": "Custom logs",
-        "description": "Collect your custom log files."
-      }
-    ],
-    "owner": {
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "signature_path": "/epr/log/log-1.0.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "log.log",
-        "title": "Log Dataset"
-      }
-    ]
-  },
-  {
-    "name": "tcp",
-    "title": "Custom TCP Logs",
-    "version": "1.0.0",
-    "release": "ga",
-    "description": "Collect raw TCP data from listening TCP port with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/tcp/tcp-1.0.0.zip",
-    "path": "/package/tcp/1.0.0",
-    "icons": [
-      {
-        "src": "/img/icon.svg",
-        "path": "/package/tcp/1.0.0/img/icon.svg",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "tcp",
-        "title": "Custom TCP Logs",
-        "description": "Collect raw TCP data from listening TCP port with Elastic Agent."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "signature_path": "/epr/tcp/tcp-1.0.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "tcp.generic",
-        "title": "Custom TCP Logs"
-      }
-    ]
-  },
-  {
-    "name": "udp",
-    "title": "Custom UDP Logs",
-    "version": "1.0.1",
-    "release": "ga",
-    "description": "Collect raw UDP data from listening UDP port with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/udp/udp-1.0.1.zip",
-    "path": "/package/udp/1.0.1",
-    "icons": [
-      {
-        "src": "/img/icon.svg",
-        "path": "/package/udp/1.0.1/img/icon.svg",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "udp",
-        "title": "Custom UDP Logs",
-        "description": "Collect raw UDP data from listening UDP port with Elastic Agent."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "signature_path": "/epr/udp/udp-1.0.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "udp.generic",
-        "title": "Custom UDP Logs"
-      }
-    ]
-  },
-  {
-    "name": "winlog",
-    "title": "Custom Windows Event Logs",
-    "version": "1.4.0",
-    "release": "ga",
-    "description": "Collect and parse logs from any Windows event log channel with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/winlog/winlog-1.4.0.zip",
-    "path": "/package/winlog/1.4.0",
-    "icons": [
-      {
-        "src": "/img/logo_windows.svg",
-        "path": "/package/winlog/1.4.0/img/logo_windows.svg",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "winlogs",
-        "title": "Custom Windows event logs",
-        "description": "Collect your custom Windows event logs."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "signature_path": "/epr/winlog/winlog-1.4.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "winlog.winlog",
-        "title": "Custom Windows Event Log Dataset"
-      }
-    ]
-  },
-  {
     "name": "cyberark",
     "title": "CyberArk",
     "version": "0.4.4",
@@ -3335,52 +2947,6 @@
         "type": "logs",
         "dataset": "cyberarkpas.audit",
         "title": "CyberArk PAS audit logs"
-      }
-    ]
-  },
-  {
-    "name": "ti_cybersixgill",
-    "title": "Cybersixgill",
-    "version": "1.3.2",
-    "release": "ga",
-    "description": "This Elastic integration collects threat intelligence from Cybersixgill",
-    "type": "integration",
-    "download": "/epr/ti_cybersixgill/ti_cybersixgill-1.3.2.zip",
-    "path": "/package/ti_cybersixgill/1.3.2",
-    "icons": [
-      {
-        "src": "/img/cybersixgill.svg",
-        "path": "/package/ti_cybersixgill/1.3.2/img/cybersixgill.svg",
-        "title": "Cybersixgill",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "cybersixgill",
-        "title": "Cybersixgill Threat Intel",
-        "description": "Collect Threat Intel from Cybersixgill"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security",
-      "productivity"
-    ],
-    "signature_path": "/epr/ti_cybersixgill/ti_cybersixgill-1.3.2.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ti_cybersixgill.threat",
-        "title": "Cybersixgill Darkfeed Logs"
       }
     ]
   },
@@ -3636,87 +3202,6 @@
     ]
   },
   {
-    "name": "apm",
-    "title": "Elastic APM",
-    "version": "8.2.0",
-    "release": "ga",
-    "description": "Ingest APM data",
-    "type": "integration",
-    "download": "/epr/apm/apm-8.2.0.zip",
-    "path": "/package/apm/8.2.0",
-    "icons": [
-      {
-        "src": "/img/logo_apm.svg",
-        "path": "/package/apm/8.2.0/img/logo_apm.svg",
-        "title": "APM Logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "apmserver",
-        "title": "Elastic APM Integration",
-        "description": "Elastic APM Integration"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.2.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/apm-server"
-    },
-    "categories": [
-      "elastic_stack",
-      "monitoring"
-    ],
-    "signature_path": "/epr/apm/apm-8.2.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "apm.app",
-        "title": "APM application logs"
-      },
-      {
-        "type": "metrics",
-        "dataset": "apm.app",
-        "title": "APM application metrics"
-      },
-      {
-        "type": "logs",
-        "dataset": "apm.error",
-        "title": "APM errors"
-      },
-      {
-        "type": "metrics",
-        "dataset": "apm.internal",
-        "title": "APM internal metrics"
-      },
-      {
-        "type": "metrics",
-        "dataset": "apm.profiling",
-        "title": "APM profiles"
-      },
-      {
-        "type": "traces",
-        "dataset": "apm.rum",
-        "title": "APM RUM traces"
-      },
-      {
-        "type": "traces",
-        "dataset": "apm.sampled",
-        "title": "APM tail-sampled traces"
-      },
-      {
-        "type": "traces",
-        "dataset": "apm",
-        "title": "APM traces"
-      }
-    ]
-  },
-  {
     "name": "elastic_agent",
     "title": "Elastic Agent",
     "version": "1.3.1",
@@ -3846,77 +3331,6 @@
         "type": "metrics",
         "dataset": "elastic_agent.packetbeat",
         "title": "Elastic Agent"
-      }
-    ]
-  },
-  {
-    "name": "synthetics",
-    "title": "Elastic Synthetics",
-    "version": "0.9.2",
-    "release": "beta",
-    "description": "Monitor the availability of your services with Elastic Synthetics.",
-    "type": "integration",
-    "download": "/epr/synthetics/synthetics-0.9.2.zip",
-    "path": "/package/synthetics/0.9.2",
-    "icons": [
-      {
-        "src": "/img/uptime-logo-color-64px.svg",
-        "path": "/package/synthetics/0.9.2/img/uptime-logo-color-64px.svg",
-        "size": "16x16",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "synthetics",
-        "title": "Elastic Synthetics",
-        "description": "Perform synthetic health checks on network endpoints."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.1.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/uptime"
-    },
-    "categories": [
-      "elastic_stack",
-      "monitoring",
-      "web"
-    ],
-    "signature_path": "/epr/synthetics/synthetics-0.9.2.zip.sig",
-    "data_streams": [
-      {
-        "type": "synthetics",
-        "dataset": "browser",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "browser.network",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "browser.screenshot",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "http",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "icmp",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "tcp",
-        "title": "synthetic monitor check"
       }
     ]
   },
@@ -4390,51 +3804,6 @@
     ]
   },
   {
-    "name": "github",
-    "title": "GitHub",
-    "version": "1.0.0",
-    "release": "ga",
-    "description": "Collect events from GitHub with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/github/github-1.0.0.zip",
-    "path": "/package/github/1.0.0",
-    "icons": [
-      {
-        "src": "/img/github.svg",
-        "path": "/package/github/1.0.0/img/github.svg",
-        "title": "GitHub",
-        "size": "1024x1024",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "github",
-        "title": "GitHub logs",
-        "description": "Collect logs from GitHub"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/github/github-1.0.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "github.audit",
-        "title": "GitHub Audit Logs"
-      }
-    ]
-  },
-  {
     "name": "gcp",
     "title": "Google Cloud Platform",
     "version": "1.9.0",
@@ -4498,47 +3867,94 @@
     ]
   },
   {
-    "name": "santa",
-    "title": "Google Santa Logs",
-    "version": "2.0.1",
+    "name": "gcp_pubsub",
+    "title": "Custom Google Pub/Sub Logs",
+    "version": "1.0.0",
     "release": "ga",
-    "description": "Collect and parse logs from Google Santa instances with Elastic Agent.",
+    "description": "Collect Logs from Google Pub/Sub topics",
     "type": "integration",
-    "download": "/epr/santa/santa-2.0.1.zip",
-    "path": "/package/santa/2.0.1",
+    "download": "/epr/gcp_pubsub/gcp_pubsub-1.0.0.zip",
+    "path": "/package/gcp_pubsub/1.0.0",
     "icons": [
       {
-        "src": "/img/icon.svg",
-        "path": "/package/santa/2.0.1/img/icon.svg",
-        "title": "Google Santa",
+        "src": "/img/logo_gcp.svg",
+        "path": "/package/gcp_pubsub/1.0.0/img/logo_gcp.svg",
+        "title": "logo gcp",
+        "size": "32x32",
         "type": "image/svg+xml"
       }
     ],
     "policy_templates": [
       {
-        "name": "santa",
-        "title": "Google Santa logs",
-        "description": "Collect logs from Google Santa instances"
+        "name": "gcp",
+        "title": "Custom Google Pub/Sub Logs",
+        "description": "Collect Logs from Google Pub/Sub topics"
       }
     ],
     "conditions": {
       "kibana": {
-        "version": "^7.17.0 || ^8.0.0"
+        "version": "^7.16.0 || ^8.0.0"
       }
     },
     "owner": {
       "github": "elastic/security-external-integrations"
     },
     "categories": [
-      "security",
-      "os_system"
+      "google_cloud",
+      "cloud",
+      "custom"
     ],
-    "signature_path": "/epr/santa/santa-2.0.1.zip.sig",
+    "signature_path": "/epr/gcp_pubsub/gcp_pubsub-1.0.0.zip.sig",
     "data_streams": [
       {
         "type": "logs",
-        "dataset": "santa.log",
-        "title": "Google Santa log logs"
+        "dataset": "gcp_pubsub.generic",
+        "title": "Custom Google Pub/Sub Logs"
+      }
+    ]
+  },
+  {
+    "name": "github",
+    "title": "GitHub",
+    "version": "1.0.0",
+    "release": "ga",
+    "description": "Collect events from GitHub with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/github/github-1.0.0.zip",
+    "path": "/package/github/1.0.0",
+    "icons": [
+      {
+        "src": "/img/github.svg",
+        "path": "/package/github/1.0.0/img/github.svg",
+        "title": "GitHub",
+        "size": "1024x1024",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "github",
+        "title": "GitHub logs",
+        "description": "Collect logs from GitHub"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/github/github-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "github.audit",
+        "title": "GitHub Audit Logs"
       }
     ]
   },
@@ -4774,6 +4190,85 @@
     ]
   },
   {
+    "name": "http_endpoint",
+    "title": "Custom HTTP Endpoint Logs",
+    "version": "1.0.1",
+    "release": "ga",
+    "description": "Collect JSON data from listening HTTP port with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/http_endpoint/http_endpoint-1.0.1.zip",
+    "path": "/package/http_endpoint/1.0.1",
+    "icons": [
+      {
+        "src": "/img/icon.svg",
+        "path": "/package/http_endpoint/1.0.1/img/icon.svg",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "http_endpoint",
+        "title": "Custom HTTP Endpoint Logs",
+        "description": "Collect JSON data from listening HTTP port with Elastic Agent."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "signature_path": "/epr/http_endpoint/http_endpoint-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "http_endpoint.generic",
+        "title": "Custom HTTP Endpoint Logs"
+      }
+    ]
+  },
+  {
+    "name": "httpjson",
+    "title": "Custom HTTPJSON Input",
+    "version": "1.1.1",
+    "release": "ga",
+    "description": "Collect custom data from REST API's with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/httpjson/httpjson-1.1.1.zip",
+    "path": "/package/httpjson/1.1.1",
+    "policy_templates": [
+      {
+        "name": "generic",
+        "title": "Custom HTTPJSON Input",
+        "description": "Collect custom data from REST API's"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "signature_path": "/epr/httpjson/httpjson-1.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "httpjson.generic",
+        "title": "Custom HTTPJSON Input"
+      }
+    ]
+  },
+  {
     "name": "iis",
     "title": "IIS",
     "version": "0.8.0",
@@ -4967,48 +4462,47 @@
     ]
   },
   {
-    "name": "juniper_junos",
-    "title": "Juniper JunOS",
-    "version": "0.1.1",
+    "name": "journald",
+    "title": "Custom Journald logs",
+    "version": "0.0.2",
     "release": "experimental",
-    "description": "Collect logs from Juniper JunOS with Elastic Agent.",
+    "description": "Collect logs from journald with Elastic Agent.",
     "type": "integration",
-    "download": "/epr/juniper_junos/juniper_junos-0.1.1.zip",
-    "path": "/package/juniper_junos/0.1.1",
+    "download": "/epr/journald/journald-0.0.2.zip",
+    "path": "/package/journald/0.0.2",
     "icons": [
       {
-        "src": "/img/logo.svg",
-        "path": "/package/juniper_junos/0.1.1/img/logo.svg",
-        "title": "Juniper logo",
+        "src": "/img/systemd-logo.svg",
+        "path": "/package/journald/0.0.2/img/systemd-logo.svg",
+        "title": "systemd logo",
         "size": "32x32",
         "type": "image/svg+xml"
       }
     ],
     "policy_templates": [
       {
-        "name": "juniper",
-        "title": "Juniper JunOS logs",
-        "description": "Collect Juniper JunOS logs from syslog or a file."
+        "name": "logs",
+        "title": "Journald",
+        "description": "Collect sample logs"
       }
     ],
     "conditions": {
       "kibana": {
-        "version": "^8.0.0"
+        "version": "^7.16.0"
       }
     },
     "owner": {
-      "github": "elastic/security-external-integrations"
+      "github": "elastic/integrations"
     },
     "categories": [
-      "network",
-      "security"
+      "custom"
     ],
-    "signature_path": "/epr/juniper_junos/juniper_junos-0.1.1.zip.sig",
+    "signature_path": "/epr/journald/journald-0.0.2.zip.sig",
     "data_streams": [
       {
         "type": "logs",
-        "dataset": "juniper_junos.log",
-        "title": "Juniper JUNOS logs"
+        "dataset": "journald.log",
+        "title": "Journald Log"
       }
     ]
   },
@@ -5065,6 +4559,52 @@
         "type": "logs",
         "dataset": "juniper.srx",
         "title": "Juniper SRX logs"
+      }
+    ]
+  },
+  {
+    "name": "juniper_junos",
+    "title": "Juniper JunOS",
+    "version": "0.1.1",
+    "release": "experimental",
+    "description": "Collect logs from Juniper JunOS with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/juniper_junos/juniper_junos-0.1.1.zip",
+    "path": "/package/juniper_junos/0.1.1",
+    "icons": [
+      {
+        "src": "/img/logo.svg",
+        "path": "/package/juniper_junos/0.1.1/img/logo.svg",
+        "title": "Juniper logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "juniper",
+        "title": "Juniper JunOS logs",
+        "description": "Collect Juniper JunOS logs from syslog or a file."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "network",
+      "security"
+    ],
+    "signature_path": "/epr/juniper_junos/juniper_junos-0.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "juniper_junos.log",
+        "title": "Juniper JUNOS logs"
       }
     ]
   },
@@ -5784,6 +5324,44 @@
     ]
   },
   {
+    "name": "log",
+    "title": "Custom Logs",
+    "version": "1.0.0",
+    "release": "ga",
+    "description": "Collect custom logs with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/log/log-1.0.0.zip",
+    "path": "/package/log/1.0.0",
+    "icons": [
+      {
+        "src": "/img/icon.svg",
+        "path": "/package/log/1.0.0/img/icon.svg",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "logs",
+        "title": "Custom logs",
+        "description": "Collect your custom log files."
+      }
+    ],
+    "owner": {
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "signature_path": "/epr/log/log-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "log.log",
+        "title": "Log Dataset"
+      }
+    ]
+  },
+  {
     "name": "logstash",
     "title": "Logstash",
     "version": "1.1.0",
@@ -5844,37 +5422,6 @@
     ]
   },
   {
-    "name": "problemchild",
-    "title": "LotL Attack Detection",
-    "version": "0.0.2",
-    "release": "experimental",
-    "description": "The ProblemChild framework is used to detect living off the land activity. Requires a Platinum subscription.",
-    "type": "integration",
-    "download": "/epr/problemchild/problemchild-0.0.2.zip",
-    "path": "/package/problemchild/0.0.2",
-    "icons": [
-      {
-        "src": "/img/icon-machine-learning.svg",
-        "path": "/package/problemchild/0.0.2/img/icon-machine-learning.svg",
-        "title": "Sample logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/ml-ui"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/problemchild/problemchild-0.0.2.zip.sig"
-  },
-  {
     "name": "m365_defender",
     "title": "M365 Defender Logs",
     "version": "1.0.3",
@@ -5918,51 +5465,6 @@
         "type": "logs",
         "dataset": "m365_defender.log",
         "title": "M365 Defender Logs"
-      }
-    ]
-  },
-  {
-    "name": "ti_misp",
-    "title": "MISP",
-    "version": "1.2.2",
-    "release": "ga",
-    "description": "This Elastic integration collects events from MISP",
-    "type": "integration",
-    "download": "/epr/ti_misp/ti_misp-1.2.2.zip",
-    "path": "/package/ti_misp/1.2.2",
-    "icons": [
-      {
-        "src": "/img/misp.svg",
-        "path": "/package/ti_misp/1.2.2/img/misp.svg",
-        "title": "MISP",
-        "size": "216x216",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "ti_misp",
-        "title": "MISP",
-        "description": "Collect threat intelligence from the MISP API."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/ti_misp/ti_misp-1.2.2.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ti_misp.threat",
-        "title": "MISP"
       }
     ]
   },
@@ -6065,51 +5567,6 @@
     ]
   },
   {
-    "name": "microsoft_dhcp",
-    "title": "Microsoft DHCP",
-    "version": "1.3.1",
-    "release": "ga",
-    "description": "Collect logs from Microsoft DHCP with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/microsoft_dhcp/microsoft_dhcp-1.3.1.zip",
-    "path": "/package/microsoft_dhcp/1.3.1",
-    "icons": [
-      {
-        "src": "/img/logo.svg",
-        "path": "/package/microsoft_dhcp/1.3.1/img/logo.svg",
-        "title": "Microsoft logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "microsoft_dhcp",
-        "title": "Microsoft DHCP",
-        "description": "Collect Microsoft DHCP logs."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "network"
-    ],
-    "signature_path": "/epr/microsoft_dhcp/microsoft_dhcp-1.3.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "microsoft_dhcp.log",
-        "title": "Microsoft DHCP Logs"
-      }
-    ]
-  },
-  {
     "name": "microsoft_defender_endpoint",
     "title": "Microsoft Defender for Endpoint",
     "version": "2.1.0",
@@ -6153,6 +5610,51 @@
         "type": "logs",
         "dataset": "microsoft_defender_endpoint.log",
         "title": "Microsoft Defender for Endpoint logs"
+      }
+    ]
+  },
+  {
+    "name": "microsoft_dhcp",
+    "title": "Microsoft DHCP",
+    "version": "1.3.1",
+    "release": "ga",
+    "description": "Collect logs from Microsoft DHCP with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/microsoft_dhcp/microsoft_dhcp-1.3.1.zip",
+    "path": "/package/microsoft_dhcp/1.3.1",
+    "icons": [
+      {
+        "src": "/img/logo.svg",
+        "path": "/package/microsoft_dhcp/1.3.1/img/logo.svg",
+        "title": "Microsoft logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "microsoft_dhcp",
+        "title": "Microsoft DHCP",
+        "description": "Collect Microsoft DHCP logs."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "network"
+    ],
+    "signature_path": "/epr/microsoft_dhcp/microsoft_dhcp-1.3.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "microsoft_dhcp.log",
+        "title": "Microsoft DHCP Logs"
       }
     ]
   },
@@ -6538,6 +6040,51 @@
         "type": "logs",
         "dataset": "netflow.log",
         "title": "NetFlow logs"
+      }
+    ]
+  },
+  {
+    "name": "netscout",
+    "title": "Arbor Peakflow SP Logs",
+    "version": "0.7.0",
+    "release": "experimental",
+    "description": "Collect and parse logs from Netscout Arbor Peakflow SP with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/netscout/netscout-0.7.0.zip",
+    "path": "/package/netscout/0.7.0",
+    "icons": [
+      {
+        "src": "/img/logo.svg",
+        "path": "/package/netscout/0.7.0/img/logo.svg",
+        "title": "Arbor Peakflow SP logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "sightline",
+        "title": "Arbor Peakflow SP",
+        "description": "Collect Arbor Peakflow SP logs from syslog or a file."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.1 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/netscout/netscout-0.7.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "netscout.sightline",
+        "title": "Arbor Peakflow SP logs"
       }
     ]
   },
@@ -7039,6 +6586,51 @@
     ]
   },
   {
+    "name": "panw",
+    "title": "Palo Alto Networks Logs",
+    "version": "1.5.3",
+    "release": "ga",
+    "description": "Collect PAN-OS firewall monitoring logs from Palo Alto Networks devices with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/panw/panw-1.5.3.zip",
+    "path": "/package/panw/1.5.3",
+    "icons": [
+      {
+        "src": "/img/logo-integrations-paloalto-networks.svg",
+        "path": "/package/panw/1.5.3/img/logo-integrations-paloalto-networks.svg",
+        "title": "Palo Alto Networks",
+        "size": "216x216",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "panw",
+        "title": "Palo Alto Networks PAN-OS firewall logs",
+        "description": "Collect logs from Palo Alto Networks PAN-OS firewall"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/panw/panw-1.5.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "panw.panos",
+        "title": "Palo Alto Networks PAN-OS firewall logs"
+      }
+    ]
+  },
+  {
     "name": "panw_cortex_xdr",
     "title": "Palo Alto Cortex XDR Logs",
     "version": "1.1.1",
@@ -7084,47 +6676,48 @@
     ]
   },
   {
-    "name": "panw",
-    "title": "Palo Alto Networks Logs",
-    "version": "1.5.3",
-    "release": "ga",
-    "description": "Collect PAN-OS firewall monitoring logs from Palo Alto Networks devices with Elastic Agent.",
+    "name": "pfsense",
+    "title": "pfSense Logs",
+    "version": "0.3.1",
+    "release": "experimental",
+    "description": "Collect and parse logs from pfSense devices with Elastic Agent.",
     "type": "integration",
-    "download": "/epr/panw/panw-1.5.3.zip",
-    "path": "/package/panw/1.5.3",
+    "download": "/epr/pfsense/pfsense-0.3.1.zip",
+    "path": "/package/pfsense/0.3.1",
     "icons": [
       {
-        "src": "/img/logo-integrations-paloalto-networks.svg",
-        "path": "/package/panw/1.5.3/img/logo-integrations-paloalto-networks.svg",
-        "title": "Palo Alto Networks",
-        "size": "216x216",
+        "src": "/img/pfsense.svg",
+        "path": "/package/pfsense/0.3.1/img/pfsense.svg",
+        "title": "pfsense",
+        "size": "512x143",
         "type": "image/svg+xml"
       }
     ],
     "policy_templates": [
       {
-        "name": "panw",
-        "title": "Palo Alto Networks PAN-OS firewall logs",
-        "description": "Collect logs from Palo Alto Networks PAN-OS firewall"
+        "name": "pfsense",
+        "title": "pfSense logs",
+        "description": "Collect logs from pfSense systems"
       }
     ],
     "conditions": {
       "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
+        "version": "^7.15.0 || ^8.0.0"
       }
     },
     "owner": {
       "github": "elastic/security-external-integrations"
     },
     "categories": [
+      "network",
       "security"
     ],
-    "signature_path": "/epr/panw/panw-1.5.3.zip.sig",
+    "signature_path": "/epr/pfsense/pfsense-0.3.1.zip.sig",
     "data_streams": [
       {
         "type": "logs",
-        "dataset": "panw.panos",
-        "title": "Palo Alto Networks PAN-OS firewall logs"
+        "dataset": "pfsense.log",
+        "title": "pfSense log logs"
       }
     ]
   },
@@ -7194,40 +6787,35 @@
     ]
   },
   {
-    "name": "security_detection_engine",
-    "title": "Prebuilt Security Detection Rules",
-    "version": "1.0.2",
-    "release": "ga",
-    "description": "Prebuilt detection rules for Elastic Security",
+    "name": "problemchild",
+    "title": "LotL Attack Detection",
+    "version": "0.0.2",
+    "release": "experimental",
+    "description": "The ProblemChild framework is used to detect living off the land activity. Requires a Platinum subscription.",
     "type": "integration",
-    "download": "/epr/security_detection_engine/security_detection_engine-1.0.2.zip",
-    "path": "/package/security_detection_engine/1.0.2",
+    "download": "/epr/problemchild/problemchild-0.0.2.zip",
+    "path": "/package/problemchild/0.0.2",
     "icons": [
       {
-        "src": "/img/security-logo-color-64px.svg",
-        "path": "/package/security_detection_engine/1.0.2/img/security-logo-color-64px.svg",
-        "size": "16x16",
+        "src": "/img/icon-machine-learning.svg",
+        "path": "/package/problemchild/0.0.2/img/icon-machine-learning.svg",
+        "title": "Sample logo",
+        "size": "32x32",
         "type": "image/svg+xml"
       }
     ],
     "conditions": {
       "kibana": {
         "version": "^8.0.0"
-      },
-      "elastic": {
-        "subscription": "basic",
-        "capabilities": [
-          "security"
-        ]
       }
     },
     "owner": {
-      "github": "elastic/protections"
+      "github": "elastic/ml-ui"
     },
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/security_detection_engine/security_detection_engine-1.0.2.zip.sig"
+    "signature_path": "/epr/problemchild/problemchild-0.0.2.zip.sig"
   },
   {
     "name": "prometheus",
@@ -7532,51 +7120,6 @@
     ]
   },
   {
-    "name": "ti_recordedfuture",
-    "title": "Recorded Future",
-    "version": "0.1.2",
-    "release": "beta",
-    "description": "Collect threat intelligence from Recorded Future with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/ti_recordedfuture/ti_recordedfuture-0.1.2.zip",
-    "path": "/package/ti_recordedfuture/0.1.2",
-    "icons": [
-      {
-        "src": "/img/logo.svg",
-        "path": "/package/ti_recordedfuture/0.1.2/img/logo.svg",
-        "title": "Recorded Future",
-        "size": "216x216",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "ti_recordedfuture",
-        "title": "Recorded Future",
-        "description": "Collect threat intelligence from Recorded Future."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/ti_recordedfuture/ti_recordedfuture-0.1.2.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ti_recordedfuture.threat",
-        "title": "Recorded Future"
-      }
-    ]
-  },
-  {
     "name": "redis",
     "title": "Redis",
     "version": "1.2.0",
@@ -7643,114 +7186,85 @@
     ]
   },
   {
-    "name": "sql",
-    "title": "SQL Input",
-    "version": "0.5.0",
-    "release": "beta",
-    "description": "Collects Metrics by Quering on SQL Databases",
-    "type": "input",
-    "download": "/epr/sql/sql-0.5.0.zip",
-    "path": "/package/sql/0.5.0",
-    "icons": [
-      {
-        "src": "/img/sql-server-icon.svg",
-        "path": "/package/sql/0.5.0/img/sql-server-icon.svg",
-        "title": "SQL logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "sql",
-        "title": "SQL Metrics",
-        "description": "Collects Metrics by Quering on SQL Databases",
-        "deprecated": {
-          "since": "0.5.0",
-          "description": "This policy is deprecated"
-        }
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.13.0"
-      },
-      "elastic": {
-        "subscription": "basic"
-      }
-    },
-    "owner": {
-      "github": "elastic/obs-infraobs-integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "signature_path": "/epr/sql/sql-0.5.0.zip.sig",
-    "deprecated": {
-      "since": "0.5.0",
-      "description": "This package is deprecated"
-    }
-  },
-  {
-    "name": "stan",
-    "title": "STAN",
-    "version": "1.2.0",
+    "name": "santa",
+    "title": "Google Santa Logs",
+    "version": "2.0.1",
     "release": "ga",
-    "description": "Collect logs and metrics from STAN servers with Elastic Agent.",
+    "description": "Collect and parse logs from Google Santa instances with Elastic Agent.",
     "type": "integration",
-    "download": "/epr/stan/stan-1.2.0.zip",
-    "path": "/package/stan/1.2.0",
+    "download": "/epr/santa/santa-2.0.1.zip",
+    "path": "/package/santa/2.0.1",
     "icons": [
       {
-        "src": "/img/stan.svg",
-        "path": "/package/stan/1.2.0/img/stan.svg",
-        "title": "STAN Logo",
-        "size": "32x32",
+        "src": "/img/icon.svg",
+        "path": "/package/santa/2.0.1/img/icon.svg",
+        "title": "Google Santa",
         "type": "image/svg+xml"
       }
     ],
     "policy_templates": [
       {
-        "name": "stan",
-        "title": "STAN Logs and Metrics",
-        "description": "Collect logs and metrics from STAN instances"
+        "name": "santa",
+        "title": "Google Santa logs",
+        "description": "Collect logs from Google Santa instances"
       }
     ],
     "conditions": {
       "kibana": {
-        "version": "^7.14.0 || ^8.0.0"
+        "version": "^7.17.0 || ^8.0.0"
       }
     },
     "owner": {
-      "github": "elastic/integrations"
+      "github": "elastic/security-external-integrations"
     },
     "categories": [
-      "message_queue",
-      "kubernetes"
+      "security",
+      "os_system"
     ],
-    "signature_path": "/epr/stan/stan-1.2.0.zip.sig",
+    "signature_path": "/epr/santa/santa-2.0.1.zip.sig",
     "data_streams": [
       {
-        "type": "metrics",
-        "dataset": "stan.channels",
-        "title": "Stan channels metrics"
-      },
-      {
         "type": "logs",
-        "dataset": "stan.log",
-        "title": "STAN logs"
-      },
-      {
-        "type": "metrics",
-        "dataset": "stan.stats",
-        "title": "Stan stats metrics"
-      },
-      {
-        "type": "metrics",
-        "dataset": "stan.subscriptions",
-        "title": "Stan subscriptions metrics"
+        "dataset": "santa.log",
+        "title": "Google Santa log logs"
       }
     ]
+  },
+  {
+    "name": "security_detection_engine",
+    "title": "Prebuilt Security Detection Rules",
+    "version": "1.0.2",
+    "release": "ga",
+    "description": "Prebuilt detection rules for Elastic Security",
+    "type": "integration",
+    "download": "/epr/security_detection_engine/security_detection_engine-1.0.2.zip",
+    "path": "/package/security_detection_engine/1.0.2",
+    "icons": [
+      {
+        "src": "/img/security-logo-color-64px.svg",
+        "path": "/package/security_detection_engine/1.0.2/img/security-logo-color-64px.svg",
+        "size": "16x16",
+        "type": "image/svg+xml"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      },
+      "elastic": {
+        "subscription": "basic",
+        "capabilities": [
+          "security"
+        ]
+      }
+    },
+    "owner": {
+      "github": "elastic/protections"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/security_detection_engine/security_detection_engine-1.0.2.zip.sig"
   },
   {
     "name": "snort",
@@ -7945,6 +7459,55 @@
     ]
   },
   {
+    "name": "sql",
+    "title": "SQL Input",
+    "version": "0.5.0",
+    "release": "beta",
+    "description": "Collects Metrics by Quering on SQL Databases",
+    "type": "input",
+    "download": "/epr/sql/sql-0.5.0.zip",
+    "path": "/package/sql/0.5.0",
+    "icons": [
+      {
+        "src": "/img/sql-server-icon.svg",
+        "path": "/package/sql/0.5.0/img/sql-server-icon.svg",
+        "title": "SQL logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "sql",
+        "title": "SQL Metrics",
+        "description": "Collects Metrics by Quering on SQL Databases",
+        "deprecated": {
+          "since": "0.5.0",
+          "description": "This policy is deprecated"
+        }
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.13.0"
+      },
+      "elastic": {
+        "subscription": "basic"
+      }
+    },
+    "owner": {
+      "github": "elastic/obs-infraobs-integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "signature_path": "/epr/sql/sql-0.5.0.zip.sig",
+    "deprecated": {
+      "since": "0.5.0",
+      "description": "This package is deprecated"
+    }
+  },
+  {
     "name": "squid",
     "title": "Squid Logs",
     "version": "0.7.0",
@@ -7977,6 +7540,67 @@
         "type": "logs",
         "dataset": "squid.log",
         "title": "Squid logs"
+      }
+    ]
+  },
+  {
+    "name": "stan",
+    "title": "STAN",
+    "version": "1.2.0",
+    "release": "ga",
+    "description": "Collect logs and metrics from STAN servers with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/stan/stan-1.2.0.zip",
+    "path": "/package/stan/1.2.0",
+    "icons": [
+      {
+        "src": "/img/stan.svg",
+        "path": "/package/stan/1.2.0/img/stan.svg",
+        "title": "STAN Logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "stan",
+        "title": "STAN Logs and Metrics",
+        "description": "Collect logs and metrics from STAN instances"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "message_queue",
+      "kubernetes"
+    ],
+    "signature_path": "/epr/stan/stan-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "stan.channels",
+        "title": "Stan channels metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "stan.log",
+        "title": "STAN logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "stan.stats",
+        "title": "Stan stats metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "stan.subscriptions",
+        "title": "Stan subscriptions metrics"
       }
     ]
   },
@@ -8114,6 +7738,77 @@
     ]
   },
   {
+    "name": "synthetics",
+    "title": "Elastic Synthetics",
+    "version": "0.9.2",
+    "release": "beta",
+    "description": "Monitor the availability of your services with Elastic Synthetics.",
+    "type": "integration",
+    "download": "/epr/synthetics/synthetics-0.9.2.zip",
+    "path": "/package/synthetics/0.9.2",
+    "icons": [
+      {
+        "src": "/img/uptime-logo-color-64px.svg",
+        "path": "/package/synthetics/0.9.2/img/uptime-logo-color-64px.svg",
+        "size": "16x16",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "synthetics",
+        "title": "Elastic Synthetics",
+        "description": "Perform synthetic health checks on network endpoints."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.1.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/uptime"
+    },
+    "categories": [
+      "elastic_stack",
+      "monitoring",
+      "web"
+    ],
+    "signature_path": "/epr/synthetics/synthetics-0.9.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "synthetics",
+        "dataset": "browser",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "browser.network",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "browser.screenshot",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "http",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "icmp",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "tcp",
+        "title": "synthetic monitor check"
+      }
+    ]
+  },
+  {
     "name": "system",
     "title": "System",
     "version": "1.6.4",
@@ -8240,6 +7935,49 @@
     ]
   },
   {
+    "name": "tcp",
+    "title": "Custom TCP Logs",
+    "version": "1.0.0",
+    "release": "ga",
+    "description": "Collect raw TCP data from listening TCP port with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/tcp/tcp-1.0.0.zip",
+    "path": "/package/tcp/1.0.0",
+    "icons": [
+      {
+        "src": "/img/icon.svg",
+        "path": "/package/tcp/1.0.0/img/icon.svg",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "tcp",
+        "title": "Custom TCP Logs",
+        "description": "Collect raw TCP data from listening TCP port with Elastic Agent."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "signature_path": "/epr/tcp/tcp-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "tcp.generic",
+        "title": "Custom TCP Logs"
+      }
+    ]
+  },
+  {
     "name": "tenable_sc",
     "title": "Tenable.sc",
     "version": "1.1.1",
@@ -8295,6 +8033,292 @@
     ]
   },
   {
+    "name": "ti_abusech",
+    "title": "AbuseCH",
+    "version": "1.2.3",
+    "release": "ga",
+    "description": "Collect threat intelligence from AbuseCH API with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/ti_abusech/ti_abusech-1.2.3.zip",
+    "path": "/package/ti_abusech/1.2.3",
+    "icons": [
+      {
+        "src": "/img/abusech2.svg",
+        "path": "/package/ti_abusech/1.2.3/img/abusech2.svg",
+        "title": "AbuseCH",
+        "size": "512x512",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "ti_abusech",
+        "title": "AbuseCH API",
+        "description": "Collect threat intelligence from the AbuseCH API"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/ti_abusech/ti_abusech-1.2.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_abusech.malware",
+        "title": "AbuseCH Malware logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "ti_abusech.malwarebazaar",
+        "title": "AbuseCH MalwareBazaar logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "ti_abusech.url",
+        "title": "AbuseCH URL logs"
+      }
+    ]
+  },
+  {
+    "name": "ti_anomali",
+    "title": "Anomali",
+    "version": "1.2.3",
+    "release": "ga",
+    "description": "Collect threat intelligence from Anomali APIs with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/ti_anomali/ti_anomali-1.2.3.zip",
+    "path": "/package/ti_anomali/1.2.3",
+    "icons": [
+      {
+        "src": "/img/anomali.svg",
+        "path": "/package/ti_anomali/1.2.3/img/anomali.svg",
+        "title": "Anomali",
+        "size": "216x216",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "ti_anomali",
+        "title": "Anomali",
+        "description": "Collect threat intelligence from the Anomali Limo API and Anomali Threatstream."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/ti_anomali/ti_anomali-1.2.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_anomali.limo",
+        "title": "Anomali Limo"
+      },
+      {
+        "type": "logs",
+        "dataset": "ti_anomali.threatstream",
+        "title": "Anomali Threatstream"
+      }
+    ]
+  },
+  {
+    "name": "ti_cybersixgill",
+    "title": "Cybersixgill",
+    "version": "1.3.2",
+    "release": "ga",
+    "description": "This Elastic integration collects threat intelligence from Cybersixgill",
+    "type": "integration",
+    "download": "/epr/ti_cybersixgill/ti_cybersixgill-1.3.2.zip",
+    "path": "/package/ti_cybersixgill/1.3.2",
+    "icons": [
+      {
+        "src": "/img/cybersixgill.svg",
+        "path": "/package/ti_cybersixgill/1.3.2/img/cybersixgill.svg",
+        "title": "Cybersixgill",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "cybersixgill",
+        "title": "Cybersixgill Threat Intel",
+        "description": "Collect Threat Intel from Cybersixgill"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security",
+      "productivity"
+    ],
+    "signature_path": "/epr/ti_cybersixgill/ti_cybersixgill-1.3.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_cybersixgill.threat",
+        "title": "Cybersixgill Darkfeed Logs"
+      }
+    ]
+  },
+  {
+    "name": "ti_misp",
+    "title": "MISP",
+    "version": "1.2.2",
+    "release": "ga",
+    "description": "This Elastic integration collects events from MISP",
+    "type": "integration",
+    "download": "/epr/ti_misp/ti_misp-1.2.2.zip",
+    "path": "/package/ti_misp/1.2.2",
+    "icons": [
+      {
+        "src": "/img/misp.svg",
+        "path": "/package/ti_misp/1.2.2/img/misp.svg",
+        "title": "MISP",
+        "size": "216x216",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "ti_misp",
+        "title": "MISP",
+        "description": "Collect threat intelligence from the MISP API."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/ti_misp/ti_misp-1.2.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_misp.threat",
+        "title": "MISP"
+      }
+    ]
+  },
+  {
+    "name": "ti_otx",
+    "title": "AlienVault OTX",
+    "version": "1.2.2",
+    "release": "ga",
+    "description": "Collect threat intelligence from AlienVault OTX with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/ti_otx/ti_otx-1.2.2.zip",
+    "path": "/package/ti_otx/1.2.2",
+    "icons": [
+      {
+        "src": "/img/otx.svg",
+        "path": "/package/ti_otx/1.2.2/img/otx.svg",
+        "title": "Alienvault OTX",
+        "size": "216x216",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "ti_otx",
+        "title": "Alienvault OTX",
+        "description": "Collect threat intelligence from the Alienvault OTX"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/ti_otx/ti_otx-1.2.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_otx.threat",
+        "title": "Alienvault OTX logs"
+      }
+    ]
+  },
+  {
+    "name": "ti_recordedfuture",
+    "title": "Recorded Future",
+    "version": "0.1.2",
+    "release": "beta",
+    "description": "Collect threat intelligence from Recorded Future with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/ti_recordedfuture/ti_recordedfuture-0.1.2.zip",
+    "path": "/package/ti_recordedfuture/0.1.2",
+    "icons": [
+      {
+        "src": "/img/logo.svg",
+        "path": "/package/ti_recordedfuture/0.1.2/img/logo.svg",
+        "title": "Recorded Future",
+        "size": "216x216",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "ti_recordedfuture",
+        "title": "Recorded Future",
+        "description": "Collect threat intelligence from Recorded Future."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/ti_recordedfuture/ti_recordedfuture-0.1.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_recordedfuture.threat",
+        "title": "Recorded Future"
+      }
+    ]
+  },
+  {
     "name": "ti_threatq",
     "title": "ThreatQuotient",
     "version": "1.2.2",
@@ -8336,6 +8360,52 @@
         "type": "logs",
         "dataset": "ti_threatq.threat",
         "title": "ThreatQ"
+      }
+    ]
+  },
+  {
+    "name": "tomcat",
+    "title": "Apache Tomcat",
+    "version": "1.3.1",
+    "release": "ga",
+    "description": "Collect and parse logs from Apache Tomcat servers with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/tomcat/tomcat-1.3.1.zip",
+    "path": "/package/tomcat/1.3.1",
+    "icons": [
+      {
+        "src": "/img/logo.svg",
+        "path": "/package/tomcat/1.3.1/img/logo.svg",
+        "title": "Apache Tomcat logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "log",
+        "title": "Apache Tomcat",
+        "description": "Collect Apache Tomcat logs from syslog or a file."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.1 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "web",
+      "security"
+    ],
+    "signature_path": "/epr/tomcat/tomcat-1.3.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "tomcat.log",
+        "title": "Apache Tomcat logs"
       }
     ]
   },
@@ -8391,112 +8461,45 @@
     ]
   },
   {
-    "name": "carbon_black_cloud",
-    "title": "VMware Carbon Black Cloud",
-    "version": "1.0.2",
+    "name": "udp",
+    "title": "Custom UDP Logs",
+    "version": "1.0.1",
     "release": "ga",
-    "description": "Collect logs from VMWare Carbon Black Cloud with Elastic Agent.",
+    "description": "Collect raw UDP data from listening UDP port with Elastic Agent.",
     "type": "integration",
-    "download": "/epr/carbon_black_cloud/carbon_black_cloud-1.0.2.zip",
-    "path": "/package/carbon_black_cloud/1.0.2",
+    "download": "/epr/udp/udp-1.0.1.zip",
+    "path": "/package/udp/1.0.1",
     "icons": [
       {
-        "src": "/img/carbon_black_cloud-logo.svg",
-        "path": "/package/carbon_black_cloud/1.0.2/img/carbon_black_cloud-logo.svg",
-        "title": "Carbon Black Cloud logo",
-        "size": "32x32",
+        "src": "/img/icon.svg",
+        "path": "/package/udp/1.0.1/img/icon.svg",
         "type": "image/svg+xml"
       }
     ],
     "policy_templates": [
       {
-        "name": "carbon_black_cloud",
-        "title": "Carbon Black Cloud",
-        "description": "Collect Logs from Carbon Black Cloud"
+        "name": "udp",
+        "title": "Custom UDP Logs",
+        "description": "Collect raw UDP data from listening UDP port with Elastic Agent."
       }
     ],
     "conditions": {
       "kibana": {
-        "version": "^7.17.0 || ^8.0.0"
+        "version": "^7.16.0 || ^8.0.0"
       }
     },
     "owner": {
       "github": "elastic/security-external-integrations"
     },
     "categories": [
-      "security"
+      "custom"
     ],
-    "signature_path": "/epr/carbon_black_cloud/carbon_black_cloud-1.0.2.zip.sig",
+    "signature_path": "/epr/udp/udp-1.0.1.zip.sig",
     "data_streams": [
       {
         "type": "logs",
-        "dataset": "carbon_black_cloud.alert",
-        "title": "Alert"
-      },
-      {
-        "type": "logs",
-        "dataset": "carbon_black_cloud.asset_vulnerability_summary",
-        "title": "Asset Vulnerability Summary"
-      },
-      {
-        "type": "logs",
-        "dataset": "carbon_black_cloud.audit",
-        "title": "Audit"
-      },
-      {
-        "type": "logs",
-        "dataset": "carbon_black_cloud.endpoint_event",
-        "title": "Endpoint Event"
-      },
-      {
-        "type": "logs",
-        "dataset": "carbon_black_cloud.watchlist_hit",
-        "title": "Watchlist Hit"
-      }
-    ]
-  },
-  {
-    "name": "carbonblack_edr",
-    "title": "VMware Carbon Black EDR",
-    "version": "1.2.0",
-    "release": "ga",
-    "description": "Collect logs from VMware Carbon Black EDR with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/carbonblack_edr/carbonblack_edr-1.2.0.zip",
-    "path": "/package/carbonblack_edr/1.2.0",
-    "icons": [
-      {
-        "src": "/img/carbon-black-logo.svg",
-        "path": "/package/carbonblack_edr/1.2.0/img/carbon-black-logo.svg",
-        "title": "VMWare Carbon Black",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "log",
-        "title": "Carbon Black EDR logs",
-        "description": "Collect logs from Carbon Black EDR"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/carbonblack_edr/carbonblack_edr-1.2.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "carbonblack_edr.log",
-        "title": "Carbon Black EDR logs"
+        "dataset": "udp.generic",
+        "title": "Custom UDP Logs"
       }
     ]
   },
@@ -8629,6 +8632,49 @@
         "type": "logs",
         "dataset": "windows.sysmon_operational",
         "title": "Windows Sysmon/Operational events"
+      }
+    ]
+  },
+  {
+    "name": "winlog",
+    "title": "Custom Windows Event Logs",
+    "version": "1.4.0",
+    "release": "ga",
+    "description": "Collect and parse logs from any Windows event log channel with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/winlog/winlog-1.4.0.zip",
+    "path": "/package/winlog/1.4.0",
+    "icons": [
+      {
+        "src": "/img/logo_windows.svg",
+        "path": "/package/winlog/1.4.0/img/logo_windows.svg",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "winlogs",
+        "title": "Custom Windows event logs",
+        "description": "Collect your custom Windows event logs."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "signature_path": "/epr/winlog/winlog-1.4.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "winlog.winlog",
+        "title": "Custom Windows Event Log Dataset"
       }
     ]
   },
@@ -9018,6 +9064,52 @@
     ]
   },
   {
+    "name": "zscaler",
+    "title": "Zscaler NSS Logs",
+    "version": "0.5.1",
+    "release": "experimental",
+    "description": "Deprecated. Use the Zscaler ZIA integration instead.",
+    "type": "integration",
+    "download": "/epr/zscaler/zscaler-0.5.1.zip",
+    "path": "/package/zscaler/0.5.1",
+    "icons": [
+      {
+        "src": "/img/logo.svg",
+        "path": "/package/zscaler/0.5.1/img/logo.svg",
+        "title": "Zscaler NSS logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "zia",
+        "title": "Zscaler NSS",
+        "description": "Collect Zscaler NSS logs from syslog or a file."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.1"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "network",
+      "security"
+    ],
+    "signature_path": "/epr/zscaler/zscaler-0.5.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "zscaler.zia",
+        "title": "Zscaler NSS logs"
+      }
+    ]
+  },
+  {
     "name": "zscaler_zia",
     "title": "Zscaler Internet Access",
     "version": "0.1.3",
@@ -9083,52 +9175,6 @@
     ]
   },
   {
-    "name": "zscaler",
-    "title": "Zscaler NSS Logs",
-    "version": "0.5.1",
-    "release": "experimental",
-    "description": "Deprecated. Use the Zscaler ZIA integration instead.",
-    "type": "integration",
-    "download": "/epr/zscaler/zscaler-0.5.1.zip",
-    "path": "/package/zscaler/0.5.1",
-    "icons": [
-      {
-        "src": "/img/logo.svg",
-        "path": "/package/zscaler/0.5.1/img/logo.svg",
-        "title": "Zscaler NSS logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "zia",
-        "title": "Zscaler NSS",
-        "description": "Collect Zscaler NSS logs from syslog or a file."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.1"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "network",
-      "security"
-    ],
-    "signature_path": "/epr/zscaler/zscaler-0.5.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "zscaler.zia",
-        "title": "Zscaler NSS logs"
-      }
-    ]
-  },
-  {
     "name": "zscaler_zpa",
     "title": "Zscaler Private Access",
     "version": "0.1.2",
@@ -9190,52 +9236,6 @@
         "type": "logs",
         "dataset": "zscaler_zpa.user_status",
         "title": "User Status Logs"
-      }
-    ]
-  },
-  {
-    "name": "pfsense",
-    "title": "pfSense Logs",
-    "version": "0.3.1",
-    "release": "experimental",
-    "description": "Collect and parse logs from pfSense devices with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/pfsense/pfsense-0.3.1.zip",
-    "path": "/package/pfsense/0.3.1",
-    "icons": [
-      {
-        "src": "/img/pfsense.svg",
-        "path": "/package/pfsense/0.3.1/img/pfsense.svg",
-        "title": "pfsense",
-        "size": "512x143",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "pfsense",
-        "title": "pfSense logs",
-        "description": "Collect logs from pfSense systems"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.15.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "network",
-      "security"
-    ],
-    "signature_path": "/epr/pfsense/pfsense-0.3.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "pfsense.log",
-        "title": "pfSense log logs"
       }
     ]
   }

--- a/testdata/generated/storage-indexer/search-package-internal.json
+++ b/testdata/generated/storage-indexer/search-package-internal.json
@@ -54,6 +54,538 @@
     ]
   },
   {
+    "name": "activemq",
+    "title": "ActiveMQ",
+    "version": "0.3.0",
+    "release": "beta",
+    "description": "Collect logs and metrics from ActiveMQ instances with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/activemq/activemq-0.3.0.zip",
+    "path": "/package/activemq/0.3.0",
+    "icons": [
+      {
+        "src": "/img/activemq.svg",
+        "path": "/package/activemq/0.3.0/img/activemq.svg",
+        "title": "activemq",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "activemq",
+        "title": "ActiveMQ logs and metrics",
+        "description": "Collect logs and metrics from ActiveMQ instances"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "web"
+    ],
+    "signature_path": "/epr/activemq/activemq-0.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "activemq.audit",
+        "title": "ActiveMQ audit logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "activemq.broker",
+        "title": "ActiveMQ broker metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "activemq.log",
+        "title": "ActiveMQ log logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "activemq.queue",
+        "title": "ActiveMQ queue metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "activemq.topic",
+        "title": "ActiveMQ topic metrics"
+      }
+    ]
+  },
+  {
+    "name": "akamai",
+    "title": "Akamai",
+    "version": "2.28.0",
+    "release": "ga",
+    "description": "Collect logs from Akamai with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/akamai/akamai-2.28.0.zip",
+    "path": "/package/akamai/2.28.0",
+    "icons": [
+      {
+        "src": "/img/akamai_logo.svg",
+        "path": "/package/akamai/2.28.0/img/akamai_logo.svg",
+        "title": "Akamai",
+        "size": "409×167",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "akamai",
+        "title": "Akamai logs",
+        "description": "Collect SIEM logs from Akamai"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.13.0 || ^9.0.0"
+      }
+    },
+    "owner": {
+      "type": "community",
+      "github": "elastic/security-service-integrations"
+    },
+    "categories": [
+      "security",
+      "cdn_security"
+    ],
+    "signature_path": "/epr/akamai/akamai-2.28.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "akamai.siem",
+        "title": "Akamai SIEM Logs"
+      }
+    ]
+  },
+  {
+    "name": "apache",
+    "title": "Apache HTTP Server",
+    "version": "1.3.5",
+    "release": "ga",
+    "description": "Collect logs and metrics from Apache servers with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/apache/apache-1.3.5.zip",
+    "path": "/package/apache/1.3.5",
+    "icons": [
+      {
+        "src": "/img/logo_apache.svg",
+        "path": "/package/apache/1.3.5/img/logo_apache.svg",
+        "title": "Apache Logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "apache",
+        "title": "Apache logs and metrics",
+        "description": "Collect logs and metrics from Apache instances"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "web"
+    ],
+    "signature_path": "/epr/apache/apache-1.3.5.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "apache.access",
+        "title": "Apache access logs",
+        "deprecated": {
+          "since": "1.3.5",
+          "description": "This data stream is deprecated"
+        }
+      },
+      {
+        "type": "logs",
+        "dataset": "apache.error",
+        "title": "Apache error logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apache.status",
+        "title": "Apache status metrics"
+      }
+    ],
+    "deprecated": {
+      "since": "1.3.0",
+      "description": "This package is deprecated"
+    }
+  },
+  {
+    "name": "apm",
+    "title": "Elastic APM",
+    "version": "8.2.0",
+    "release": "ga",
+    "description": "Ingest APM data",
+    "type": "integration",
+    "download": "/epr/apm/apm-8.2.0.zip",
+    "path": "/package/apm/8.2.0",
+    "icons": [
+      {
+        "src": "/img/logo_apm.svg",
+        "path": "/package/apm/8.2.0/img/logo_apm.svg",
+        "title": "APM Logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "apmserver",
+        "title": "Elastic APM Integration",
+        "description": "Elastic APM Integration"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.2.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/apm-server"
+    },
+    "categories": [
+      "elastic_stack",
+      "monitoring"
+    ],
+    "signature_path": "/epr/apm/apm-8.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "apm.app",
+        "title": "APM application logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.app",
+        "title": "APM application metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "apm.error",
+        "title": "APM errors"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.internal",
+        "title": "APM internal metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.profiling",
+        "title": "APM profiles"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm.rum",
+        "title": "APM RUM traces"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm.sampled",
+        "title": "APM tail-sampled traces"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm",
+        "title": "APM traces"
+      }
+    ]
+  },
+  {
+    "name": "atlassian_bitbucket",
+    "title": "Atlassian Bitbucket",
+    "version": "1.2.1",
+    "release": "ga",
+    "description": "Collect logs from Atlassian Bitbucket with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.2.1.zip",
+    "path": "/package/atlassian_bitbucket/1.2.1",
+    "icons": [
+      {
+        "src": "/img/bitbucket-logo.svg",
+        "path": "/package/atlassian_bitbucket/1.2.1/img/bitbucket-logo.svg",
+        "title": "Bitbucket Logo",
+        "size": "625x564",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "audit",
+        "title": "Audit Logs",
+        "description": "Collect audit logs from Atlassian Bitbucket with Elastic Agent."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security",
+      "web"
+    ],
+    "signature_path": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_bitbucket.audit",
+        "title": "Bitbucket Audit Logs"
+      }
+    ]
+  },
+  {
+    "name": "atlassian_confluence",
+    "title": "Atlassian Confluence",
+    "version": "1.3.0",
+    "release": "ga",
+    "description": "Collect logs from Atlassian Confluence with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/atlassian_confluence/atlassian_confluence-1.3.0.zip",
+    "path": "/package/atlassian_confluence/1.3.0",
+    "icons": [
+      {
+        "src": "/img/confluence-logo.svg",
+        "path": "/package/atlassian_confluence/1.3.0/img/confluence-logo.svg",
+        "title": "Confluence Logo",
+        "size": "400x400",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "audit",
+        "title": "Audit Logs",
+        "description": "Collect audit logs from Atlassian Confluence with Elastic Agent."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security",
+      "web"
+    ],
+    "signature_path": "/epr/atlassian_confluence/atlassian_confluence-1.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_confluence.audit",
+        "title": "Confluence Audit Logs"
+      }
+    ]
+  },
+  {
+    "name": "atlassian_jira",
+    "title": "Atlassian Jira",
+    "version": "1.3.0",
+    "release": "ga",
+    "description": "Collect logs from Atlassian Jira with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/atlassian_jira/atlassian_jira-1.3.0.zip",
+    "path": "/package/atlassian_jira/1.3.0",
+    "icons": [
+      {
+        "src": "/img/jira-software-logo.svg",
+        "path": "/package/atlassian_jira/1.3.0/img/jira-software-logo.svg",
+        "title": "Jira Software Logo",
+        "size": "590x625",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "audit",
+        "title": "Audit Logs",
+        "description": "Collect audit logs from Atlassian Jira with Elastic Agent."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security",
+      "web"
+    ],
+    "signature_path": "/epr/atlassian_jira/atlassian_jira-1.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_jira.audit",
+        "title": "Jira Audit Logs"
+      }
+    ]
+  },
+  {
+    "name": "auditd",
+    "title": "Auditd Logs",
+    "version": "3.1.0",
+    "release": "ga",
+    "description": "Collect logs from Linux audit daemon with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/auditd/auditd-3.1.0.zip",
+    "path": "/package/auditd/3.1.0",
+    "icons": [
+      {
+        "src": "/img/linux.svg",
+        "path": "/package/auditd/3.1.0/img/linux.svg",
+        "title": "linux",
+        "size": "299x354",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "auditd",
+        "title": "Auditd logs",
+        "description": "Collect logs from Auditd instances"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "os_system"
+    ],
+    "signature_path": "/epr/auditd/auditd-3.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "auditd.log",
+        "title": "Auditd logs"
+      }
+    ]
+  },
+  {
+    "name": "auditd_manager",
+    "title": "Auditd Manager",
+    "version": "1.0.0",
+    "release": "ga",
+    "description": "The Auditd Manager Integration receives audit events from the Linux Audit Framework that is a part of the Linux kernel.",
+    "type": "integration",
+    "download": "/epr/auditd_manager/auditd_manager-1.0.0.zip",
+    "path": "/package/auditd_manager/1.0.0",
+    "icons": [
+      {
+        "src": "/img/linux.svg",
+        "path": "/package/auditd_manager/1.0.0/img/linux.svg",
+        "title": "linux",
+        "size": "299x354",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "auditd",
+        "title": "Auditd",
+        "description": "Collect auditd events"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.2.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "os_system",
+      "security"
+    ],
+    "signature_path": "/epr/auditd_manager/auditd_manager-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "auditd_manager.auditd",
+        "title": "Auditd Manager"
+      }
+    ]
+  },
+  {
+    "name": "auth0",
+    "title": "Auth0 Log Streams Integration",
+    "version": "1.0.0",
+    "release": "ga",
+    "description": "Collect logs from Auth0 with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/auth0/auth0-1.0.0.zip",
+    "path": "/package/auth0/1.0.0",
+    "icons": [
+      {
+        "src": "/img/auth0-logo.svg",
+        "path": "/package/auth0/1.0.0/img/auth0-logo.svg",
+        "title": "Auth0 logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "auth0_events",
+        "title": "Auth0 log stream events via Webhooks",
+        "description": "Collect Auth0 log streams events via Webhooks."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "cloud",
+      "network",
+      "security"
+    ],
+    "signature_path": "/epr/auth0/auth0-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "auth0.logs",
+        "title": "Auth0 logs via Webhooks"
+      }
+    ]
+  },
+  {
     "name": "aws",
     "title": "AWS",
     "version": "1.16.4",
@@ -649,6 +1181,51 @@
     ]
   },
   {
+    "name": "aws_logs",
+    "title": "Custom AWS Logs",
+    "version": "0.2.1",
+    "release": "beta",
+    "description": "Collect raw logs from AWS S3 or CloudWatch with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/aws_logs/aws_logs-0.2.1.zip",
+    "path": "/package/aws_logs/0.2.1",
+    "icons": [
+      {
+        "src": "/img/icon.svg",
+        "path": "/package/aws_logs/0.2.1/img/icon.svg",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "aws_logs",
+        "title": "Custom AWS Logs",
+        "description": "Collect raw logs from AWS S3 or CloudWatch with Elastic Agent."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/obs-cloud-monitoring"
+    },
+    "categories": [
+      "custom",
+      "cloud",
+      "aws"
+    ],
+    "signature_path": "/epr/aws_logs/aws_logs-0.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "aws_logs.generic",
+        "title": "Custom logs from AWS"
+      }
+    ]
+  },
+  {
     "name": "awsfargate",
     "title": "AWS Fargate",
     "version": "0.1.1",
@@ -692,790 +1269,6 @@
         "type": "metrics",
         "dataset": "awsfargate.task_stats",
         "title": "AWS Fargate task_stats metrics"
-      }
-    ]
-  },
-  {
-    "name": "ti_abusech",
-    "title": "AbuseCH",
-    "version": "1.2.3",
-    "release": "ga",
-    "description": "Collect threat intelligence from AbuseCH API with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/ti_abusech/ti_abusech-1.2.3.zip",
-    "path": "/package/ti_abusech/1.2.3",
-    "icons": [
-      {
-        "src": "/img/abusech2.svg",
-        "path": "/package/ti_abusech/1.2.3/img/abusech2.svg",
-        "title": "AbuseCH",
-        "size": "512x512",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "ti_abusech",
-        "title": "AbuseCH API",
-        "description": "Collect threat intelligence from the AbuseCH API"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/ti_abusech/ti_abusech-1.2.3.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ti_abusech.malware",
-        "title": "AbuseCH Malware logs"
-      },
-      {
-        "type": "logs",
-        "dataset": "ti_abusech.malwarebazaar",
-        "title": "AbuseCH MalwareBazaar logs"
-      },
-      {
-        "type": "logs",
-        "dataset": "ti_abusech.url",
-        "title": "AbuseCH URL logs"
-      }
-    ]
-  },
-  {
-    "name": "activemq",
-    "title": "ActiveMQ",
-    "version": "0.3.0",
-    "release": "beta",
-    "description": "Collect logs and metrics from ActiveMQ instances with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/activemq/activemq-0.3.0.zip",
-    "path": "/package/activemq/0.3.0",
-    "icons": [
-      {
-        "src": "/img/activemq.svg",
-        "path": "/package/activemq/0.3.0/img/activemq.svg",
-        "title": "activemq",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "activemq",
-        "title": "ActiveMQ logs and metrics",
-        "description": "Collect logs and metrics from ActiveMQ instances"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "web"
-    ],
-    "signature_path": "/epr/activemq/activemq-0.3.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "activemq.audit",
-        "title": "ActiveMQ audit logs"
-      },
-      {
-        "type": "metrics",
-        "dataset": "activemq.broker",
-        "title": "ActiveMQ broker metrics"
-      },
-      {
-        "type": "logs",
-        "dataset": "activemq.log",
-        "title": "ActiveMQ log logs"
-      },
-      {
-        "type": "metrics",
-        "dataset": "activemq.queue",
-        "title": "ActiveMQ queue metrics"
-      },
-      {
-        "type": "metrics",
-        "dataset": "activemq.topic",
-        "title": "ActiveMQ topic metrics"
-      }
-    ]
-  },
-  {
-    "name": "akamai",
-    "title": "Akamai",
-    "version": "2.28.0",
-    "release": "ga",
-    "description": "Collect logs from Akamai with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/akamai/akamai-2.28.0.zip",
-    "path": "/package/akamai/2.28.0",
-    "icons": [
-      {
-        "src": "/img/akamai_logo.svg",
-        "path": "/package/akamai/2.28.0/img/akamai_logo.svg",
-        "title": "Akamai",
-        "size": "409×167",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "akamai",
-        "title": "Akamai logs",
-        "description": "Collect SIEM logs from Akamai"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.13.0 || ^9.0.0"
-      }
-    },
-    "owner": {
-      "type": "community",
-      "github": "elastic/security-service-integrations"
-    },
-    "categories": [
-      "security",
-      "cdn_security"
-    ],
-    "signature_path": "/epr/akamai/akamai-2.28.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "akamai.siem",
-        "title": "Akamai SIEM Logs"
-      }
-    ]
-  },
-  {
-    "name": "ti_otx",
-    "title": "AlienVault OTX",
-    "version": "1.2.2",
-    "release": "ga",
-    "description": "Collect threat intelligence from AlienVault OTX with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/ti_otx/ti_otx-1.2.2.zip",
-    "path": "/package/ti_otx/1.2.2",
-    "icons": [
-      {
-        "src": "/img/otx.svg",
-        "path": "/package/ti_otx/1.2.2/img/otx.svg",
-        "title": "Alienvault OTX",
-        "size": "216x216",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "ti_otx",
-        "title": "Alienvault OTX",
-        "description": "Collect threat intelligence from the Alienvault OTX"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/ti_otx/ti_otx-1.2.2.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ti_otx.threat",
-        "title": "Alienvault OTX logs"
-      }
-    ]
-  },
-  {
-    "name": "ti_anomali",
-    "title": "Anomali",
-    "version": "1.2.3",
-    "release": "ga",
-    "description": "Collect threat intelligence from Anomali APIs with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/ti_anomali/ti_anomali-1.2.3.zip",
-    "path": "/package/ti_anomali/1.2.3",
-    "icons": [
-      {
-        "src": "/img/anomali.svg",
-        "path": "/package/ti_anomali/1.2.3/img/anomali.svg",
-        "title": "Anomali",
-        "size": "216x216",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "ti_anomali",
-        "title": "Anomali",
-        "description": "Collect threat intelligence from the Anomali Limo API and Anomali Threatstream."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/ti_anomali/ti_anomali-1.2.3.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ti_anomali.limo",
-        "title": "Anomali Limo"
-      },
-      {
-        "type": "logs",
-        "dataset": "ti_anomali.threatstream",
-        "title": "Anomali Threatstream"
-      }
-    ]
-  },
-  {
-    "name": "apache",
-    "title": "Apache HTTP Server",
-    "version": "1.3.5",
-    "release": "ga",
-    "description": "Collect logs and metrics from Apache servers with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/apache/apache-1.3.5.zip",
-    "path": "/package/apache/1.3.5",
-    "icons": [
-      {
-        "src": "/img/logo_apache.svg",
-        "path": "/package/apache/1.3.5/img/logo_apache.svg",
-        "title": "Apache Logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "apache",
-        "title": "Apache logs and metrics",
-        "description": "Collect logs and metrics from Apache instances"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "web"
-    ],
-    "signature_path": "/epr/apache/apache-1.3.5.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "apache.access",
-        "title": "Apache access logs",
-        "deprecated": {
-          "since": "1.3.5",
-          "description": "This data stream is deprecated"
-        }
-      },
-      {
-        "type": "logs",
-        "dataset": "apache.error",
-        "title": "Apache error logs"
-      },
-      {
-        "type": "metrics",
-        "dataset": "apache.status",
-        "title": "Apache status metrics"
-      }
-    ],
-    "deprecated": {
-      "since": "1.3.0",
-      "description": "This package is deprecated"
-    }
-  },
-  {
-    "name": "tomcat",
-    "title": "Apache Tomcat",
-    "version": "1.3.1",
-    "release": "ga",
-    "description": "Collect and parse logs from Apache Tomcat servers with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/tomcat/tomcat-1.3.1.zip",
-    "path": "/package/tomcat/1.3.1",
-    "icons": [
-      {
-        "src": "/img/logo.svg",
-        "path": "/package/tomcat/1.3.1/img/logo.svg",
-        "title": "Apache Tomcat logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "log",
-        "title": "Apache Tomcat",
-        "description": "Collect Apache Tomcat logs from syslog or a file."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.1 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "web",
-      "security"
-    ],
-    "signature_path": "/epr/tomcat/tomcat-1.3.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "tomcat.log",
-        "title": "Apache Tomcat logs"
-      }
-    ]
-  },
-  {
-    "name": "atlassian_bitbucket",
-    "title": "Atlassian Bitbucket",
-    "version": "1.2.1",
-    "release": "ga",
-    "description": "Collect logs from Atlassian Bitbucket with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.2.1.zip",
-    "path": "/package/atlassian_bitbucket/1.2.1",
-    "icons": [
-      {
-        "src": "/img/bitbucket-logo.svg",
-        "path": "/package/atlassian_bitbucket/1.2.1/img/bitbucket-logo.svg",
-        "title": "Bitbucket Logo",
-        "size": "625x564",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "audit",
-        "title": "Audit Logs",
-        "description": "Collect audit logs from Atlassian Bitbucket with Elastic Agent."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security",
-      "web"
-    ],
-    "signature_path": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.2.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "atlassian_bitbucket.audit",
-        "title": "Bitbucket Audit Logs"
-      }
-    ]
-  },
-  {
-    "name": "atlassian_confluence",
-    "title": "Atlassian Confluence",
-    "version": "1.3.0",
-    "release": "ga",
-    "description": "Collect logs from Atlassian Confluence with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/atlassian_confluence/atlassian_confluence-1.3.0.zip",
-    "path": "/package/atlassian_confluence/1.3.0",
-    "icons": [
-      {
-        "src": "/img/confluence-logo.svg",
-        "path": "/package/atlassian_confluence/1.3.0/img/confluence-logo.svg",
-        "title": "Confluence Logo",
-        "size": "400x400",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "audit",
-        "title": "Audit Logs",
-        "description": "Collect audit logs from Atlassian Confluence with Elastic Agent."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security",
-      "web"
-    ],
-    "signature_path": "/epr/atlassian_confluence/atlassian_confluence-1.3.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "atlassian_confluence.audit",
-        "title": "Confluence Audit Logs"
-      }
-    ]
-  },
-  {
-    "name": "atlassian_jira",
-    "title": "Atlassian Jira",
-    "version": "1.3.0",
-    "release": "ga",
-    "description": "Collect logs from Atlassian Jira with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/atlassian_jira/atlassian_jira-1.3.0.zip",
-    "path": "/package/atlassian_jira/1.3.0",
-    "icons": [
-      {
-        "src": "/img/jira-software-logo.svg",
-        "path": "/package/atlassian_jira/1.3.0/img/jira-software-logo.svg",
-        "title": "Jira Software Logo",
-        "size": "590x625",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "audit",
-        "title": "Audit Logs",
-        "description": "Collect audit logs from Atlassian Jira with Elastic Agent."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security",
-      "web"
-    ],
-    "signature_path": "/epr/atlassian_jira/atlassian_jira-1.3.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "atlassian_jira.audit",
-        "title": "Jira Audit Logs"
-      }
-    ]
-  },
-  {
-    "name": "auditd",
-    "title": "Auditd Logs",
-    "version": "3.1.0",
-    "release": "ga",
-    "description": "Collect logs from Linux audit daemon with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/auditd/auditd-3.1.0.zip",
-    "path": "/package/auditd/3.1.0",
-    "icons": [
-      {
-        "src": "/img/linux.svg",
-        "path": "/package/auditd/3.1.0/img/linux.svg",
-        "title": "linux",
-        "size": "299x354",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "auditd",
-        "title": "Auditd logs",
-        "description": "Collect logs from Auditd instances"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "os_system"
-    ],
-    "signature_path": "/epr/auditd/auditd-3.1.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "auditd.log",
-        "title": "Auditd logs"
-      }
-    ]
-  },
-  {
-    "name": "auditd_manager",
-    "title": "Auditd Manager",
-    "version": "1.0.0",
-    "release": "ga",
-    "description": "The Auditd Manager Integration receives audit events from the Linux Audit Framework that is a part of the Linux kernel.",
-    "type": "integration",
-    "download": "/epr/auditd_manager/auditd_manager-1.0.0.zip",
-    "path": "/package/auditd_manager/1.0.0",
-    "icons": [
-      {
-        "src": "/img/linux.svg",
-        "path": "/package/auditd_manager/1.0.0/img/linux.svg",
-        "title": "linux",
-        "size": "299x354",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "auditd",
-        "title": "Auditd",
-        "description": "Collect auditd events"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.2.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "os_system",
-      "security"
-    ],
-    "signature_path": "/epr/auditd_manager/auditd_manager-1.0.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "auditd_manager.auditd",
-        "title": "Auditd Manager"
-      }
-    ]
-  },
-  {
-    "name": "auth0",
-    "title": "Auth0 Log Streams Integration",
-    "version": "1.0.0",
-    "release": "ga",
-    "description": "Collect logs from Auth0 with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/auth0/auth0-1.0.0.zip",
-    "path": "/package/auth0/1.0.0",
-    "icons": [
-      {
-        "src": "/img/auth0-logo.svg",
-        "path": "/package/auth0/1.0.0/img/auth0-logo.svg",
-        "title": "Auth0 logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "auth0_events",
-        "title": "Auth0 log stream events via Webhooks",
-        "description": "Collect Auth0 log streams events via Webhooks."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "cloud",
-      "network",
-      "security"
-    ],
-    "signature_path": "/epr/auth0/auth0-1.0.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "auth0.logs",
-        "title": "Auth0 logs via Webhooks"
-      }
-    ]
-  },
-  {
-    "name": "azure_application_insights",
-    "title": "Azure Application Insights Metrics Overview",
-    "version": "1.0.1",
-    "release": "ga",
-    "description": "Collect application insights metrics from Azure Monitor with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/azure_application_insights/azure_application_insights-1.0.1.zip",
-    "path": "/package/azure_application_insights/1.0.1",
-    "icons": [
-      {
-        "src": "/img/app_insights.png",
-        "path": "/package/azure_application_insights/1.0.1/img/app_insights.png",
-        "title": "logo docker",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "app_insights",
-        "title": "Azure Application Insights Metrics",
-        "description": "Collect application insights metrics from Azure Monitor with Elastic Agent.",
-        "icons": [
-          {
-            "src": "/img//app_insights.png",
-            "path": "/package/azure_application_insights/1.0.1/img/app_insights.png",
-            "title": "logo azure",
-            "size": "32x32",
-            "type": "image/svg+xml"
-          }
-        ],
-        "data_streams": [
-          "app_insights"
-        ]
-      },
-      {
-        "name": "app_state",
-        "title": "Azure Application State Insights Metrics",
-        "description": "Collect application state related metrics from Azure Monitor with Elastic Agent.",
-        "icons": [
-          {
-            "src": "/img/application_insights_blue.png",
-            "path": "/package/azure_application_insights/1.0.1/img/application_insights_blue.png",
-            "title": "logo azure",
-            "size": "32x32",
-            "type": "image/svg+xml"
-          }
-        ],
-        "data_streams": [
-          "app_state"
-        ]
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "azure",
-      "web"
-    ],
-    "signature_path": "/epr/azure_application_insights/azure_application_insights-1.0.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "metrics",
-        "dataset": "azure.app_insights",
-        "title": "Azure Application Insights"
-      },
-      {
-        "type": "metrics",
-        "dataset": "azure.app_state",
-        "title": "Azure Application State"
-      }
-    ]
-  },
-  {
-    "name": "azure_billing",
-    "title": "Azure Billing Metrics",
-    "version": "1.0.1",
-    "release": "ga",
-    "description": "Collect billing metrics with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/azure_billing/azure_billing-1.0.1.zip",
-    "path": "/package/azure_billing/1.0.1",
-    "icons": [
-      {
-        "src": "/img/billing.png",
-        "path": "/package/azure_billing/1.0.1/img/billing.png",
-        "title": "logo docker",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "billing",
-        "title": "Azure Billing Metrics",
-        "description": "Collect billing information with Elastic Agent.",
-        "icons": [
-          {
-            "src": "/img//billing.png",
-            "path": "/package/azure_billing/1.0.1/img/billing.png",
-            "title": "logo azure",
-            "size": "32x32",
-            "type": "image/svg+xml"
-          }
-        ],
-        "data_streams": [
-          "billing"
-        ]
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.15.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "azure"
-    ],
-    "signature_path": "/epr/azure_billing/azure_billing-1.0.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "metrics",
-        "dataset": "azure.billing",
-        "title": "Azure Billing Metrics"
       }
     ]
   },
@@ -1630,6 +1423,143 @@
         "type": "logs",
         "dataset": "azure.springcloudlogs",
         "title": "Azure Spring Cloud Logs"
+      }
+    ]
+  },
+  {
+    "name": "azure_application_insights",
+    "title": "Azure Application Insights Metrics Overview",
+    "version": "1.0.1",
+    "release": "ga",
+    "description": "Collect application insights metrics from Azure Monitor with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/azure_application_insights/azure_application_insights-1.0.1.zip",
+    "path": "/package/azure_application_insights/1.0.1",
+    "icons": [
+      {
+        "src": "/img/app_insights.png",
+        "path": "/package/azure_application_insights/1.0.1/img/app_insights.png",
+        "title": "logo docker",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "app_insights",
+        "title": "Azure Application Insights Metrics",
+        "description": "Collect application insights metrics from Azure Monitor with Elastic Agent.",
+        "icons": [
+          {
+            "src": "/img//app_insights.png",
+            "path": "/package/azure_application_insights/1.0.1/img/app_insights.png",
+            "title": "logo azure",
+            "size": "32x32",
+            "type": "image/svg+xml"
+          }
+        ],
+        "data_streams": [
+          "app_insights"
+        ]
+      },
+      {
+        "name": "app_state",
+        "title": "Azure Application State Insights Metrics",
+        "description": "Collect application state related metrics from Azure Monitor with Elastic Agent.",
+        "icons": [
+          {
+            "src": "/img/application_insights_blue.png",
+            "path": "/package/azure_application_insights/1.0.1/img/application_insights_blue.png",
+            "title": "logo azure",
+            "size": "32x32",
+            "type": "image/svg+xml"
+          }
+        ],
+        "data_streams": [
+          "app_state"
+        ]
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "azure",
+      "web"
+    ],
+    "signature_path": "/epr/azure_application_insights/azure_application_insights-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "azure.app_insights",
+        "title": "Azure Application Insights"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.app_state",
+        "title": "Azure Application State"
+      }
+    ]
+  },
+  {
+    "name": "azure_billing",
+    "title": "Azure Billing Metrics",
+    "version": "1.0.1",
+    "release": "ga",
+    "description": "Collect billing metrics with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/azure_billing/azure_billing-1.0.1.zip",
+    "path": "/package/azure_billing/1.0.1",
+    "icons": [
+      {
+        "src": "/img/billing.png",
+        "path": "/package/azure_billing/1.0.1/img/billing.png",
+        "title": "logo docker",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "billing",
+        "title": "Azure Billing Metrics",
+        "description": "Collect billing information with Elastic Agent.",
+        "icons": [
+          {
+            "src": "/img//billing.png",
+            "path": "/package/azure_billing/1.0.1/img/billing.png",
+            "title": "logo azure",
+            "size": "32x32",
+            "type": "image/svg+xml"
+          }
+        ],
+        "data_streams": [
+          "billing"
+        ]
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.15.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "azure"
+    ],
+    "signature_path": "/epr/azure_billing/azure_billing-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "azure.billing",
+        "title": "Azure Billing Metrics"
       }
     ]
   },
@@ -1846,39 +1776,112 @@
     ]
   },
   {
-    "name": "cef",
-    "title": "CEF Logs",
-    "version": "2.0.0",
+    "name": "carbon_black_cloud",
+    "title": "VMware Carbon Black Cloud",
+    "version": "1.0.2",
     "release": "ga",
-    "description": "Collect logs from CEF Logs with Elastic Agent.",
+    "description": "Collect logs from VMWare Carbon Black Cloud with Elastic Agent.",
     "type": "integration",
-    "download": "/epr/cef/cef-2.0.0.zip",
-    "path": "/package/cef/2.0.0",
+    "download": "/epr/carbon_black_cloud/carbon_black_cloud-1.0.2.zip",
+    "path": "/package/carbon_black_cloud/1.0.2",
+    "icons": [
+      {
+        "src": "/img/carbon_black_cloud-logo.svg",
+        "path": "/package/carbon_black_cloud/1.0.2/img/carbon_black_cloud-logo.svg",
+        "title": "Carbon Black Cloud logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
     "policy_templates": [
       {
-        "name": "cef",
-        "title": "CEF logs",
-        "description": "Collect logs from CEF instances"
+        "name": "carbon_black_cloud",
+        "title": "Carbon Black Cloud",
+        "description": "Collect Logs from Carbon Black Cloud"
       }
     ],
     "conditions": {
       "kibana": {
-        "version": "^8.0.0"
+        "version": "^7.17.0 || ^8.0.0"
       }
     },
     "owner": {
       "github": "elastic/security-external-integrations"
     },
     "categories": [
-      "network",
       "security"
     ],
-    "signature_path": "/epr/cef/cef-2.0.0.zip.sig",
+    "signature_path": "/epr/carbon_black_cloud/carbon_black_cloud-1.0.2.zip.sig",
     "data_streams": [
       {
         "type": "logs",
-        "dataset": "cef.log",
-        "title": "CEF log logs"
+        "dataset": "carbon_black_cloud.alert",
+        "title": "Alert"
+      },
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.asset_vulnerability_summary",
+        "title": "Asset Vulnerability Summary"
+      },
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.audit",
+        "title": "Audit"
+      },
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.endpoint_event",
+        "title": "Endpoint Event"
+      },
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.watchlist_hit",
+        "title": "Watchlist Hit"
+      }
+    ]
+  },
+  {
+    "name": "carbonblack_edr",
+    "title": "VMware Carbon Black EDR",
+    "version": "1.2.0",
+    "release": "ga",
+    "description": "Collect logs from VMware Carbon Black EDR with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/carbonblack_edr/carbonblack_edr-1.2.0.zip",
+    "path": "/package/carbonblack_edr/1.2.0",
+    "icons": [
+      {
+        "src": "/img/carbon-black-logo.svg",
+        "path": "/package/carbonblack_edr/1.2.0/img/carbon-black-logo.svg",
+        "title": "VMWare Carbon Black",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "log",
+        "title": "Carbon Black EDR logs",
+        "description": "Collect logs from Carbon Black EDR"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/carbonblack_edr/carbonblack_edr-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "carbonblack_edr.log",
+        "title": "Carbon Black EDR logs"
       }
     ]
   },
@@ -1930,6 +1933,43 @@
         "type": "metrics",
         "dataset": "cassandra.metrics",
         "title": "metrics"
+      }
+    ]
+  },
+  {
+    "name": "cef",
+    "title": "CEF Logs",
+    "version": "2.0.0",
+    "release": "ga",
+    "description": "Collect logs from CEF Logs with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/cef/cef-2.0.0.zip",
+    "path": "/package/cef/2.0.0",
+    "policy_templates": [
+      {
+        "name": "cef",
+        "title": "CEF logs",
+        "description": "Collect logs from CEF instances"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "network",
+      "security"
+    ],
+    "signature_path": "/epr/cef/cef-2.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cef.log",
+        "title": "CEF log logs"
       }
     ]
   },
@@ -2524,344 +2564,6 @@
     ]
   },
   {
-    "name": "aws_logs",
-    "title": "Custom AWS Logs",
-    "version": "0.2.1",
-    "release": "beta",
-    "description": "Collect raw logs from AWS S3 or CloudWatch with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/aws_logs/aws_logs-0.2.1.zip",
-    "path": "/package/aws_logs/0.2.1",
-    "icons": [
-      {
-        "src": "/img/icon.svg",
-        "path": "/package/aws_logs/0.2.1/img/icon.svg",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "aws_logs",
-        "title": "Custom AWS Logs",
-        "description": "Collect raw logs from AWS S3 or CloudWatch with Elastic Agent."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/obs-cloud-monitoring"
-    },
-    "categories": [
-      "custom",
-      "cloud",
-      "aws"
-    ],
-    "signature_path": "/epr/aws_logs/aws_logs-0.2.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "aws_logs.generic",
-        "title": "Custom logs from AWS"
-      }
-    ]
-  },
-  {
-    "name": "gcp_pubsub",
-    "title": "Custom Google Pub/Sub Logs",
-    "version": "1.0.0",
-    "release": "ga",
-    "description": "Collect Logs from Google Pub/Sub topics",
-    "type": "integration",
-    "download": "/epr/gcp_pubsub/gcp_pubsub-1.0.0.zip",
-    "path": "/package/gcp_pubsub/1.0.0",
-    "icons": [
-      {
-        "src": "/img/logo_gcp.svg",
-        "path": "/package/gcp_pubsub/1.0.0/img/logo_gcp.svg",
-        "title": "logo gcp",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "gcp",
-        "title": "Custom Google Pub/Sub Logs",
-        "description": "Collect Logs from Google Pub/Sub topics"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "google_cloud",
-      "cloud",
-      "custom"
-    ],
-    "signature_path": "/epr/gcp_pubsub/gcp_pubsub-1.0.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "gcp_pubsub.generic",
-        "title": "Custom Google Pub/Sub Logs"
-      }
-    ]
-  },
-  {
-    "name": "http_endpoint",
-    "title": "Custom HTTP Endpoint Logs",
-    "version": "1.0.1",
-    "release": "ga",
-    "description": "Collect JSON data from listening HTTP port with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/http_endpoint/http_endpoint-1.0.1.zip",
-    "path": "/package/http_endpoint/1.0.1",
-    "icons": [
-      {
-        "src": "/img/icon.svg",
-        "path": "/package/http_endpoint/1.0.1/img/icon.svg",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "http_endpoint",
-        "title": "Custom HTTP Endpoint Logs",
-        "description": "Collect JSON data from listening HTTP port with Elastic Agent."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "signature_path": "/epr/http_endpoint/http_endpoint-1.0.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "http_endpoint.generic",
-        "title": "Custom HTTP Endpoint Logs"
-      }
-    ]
-  },
-  {
-    "name": "httpjson",
-    "title": "Custom HTTPJSON Input",
-    "version": "1.1.1",
-    "release": "ga",
-    "description": "Collect custom data from REST API's with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/httpjson/httpjson-1.1.1.zip",
-    "path": "/package/httpjson/1.1.1",
-    "policy_templates": [
-      {
-        "name": "generic",
-        "title": "Custom HTTPJSON Input",
-        "description": "Collect custom data from REST API's"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "signature_path": "/epr/httpjson/httpjson-1.1.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "httpjson.generic",
-        "title": "Custom HTTPJSON Input"
-      }
-    ]
-  },
-  {
-    "name": "log",
-    "title": "Custom Logs",
-    "version": "1.0.0",
-    "release": "ga",
-    "description": "Collect custom logs with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/log/log-1.0.0.zip",
-    "path": "/package/log/1.0.0",
-    "icons": [
-      {
-        "src": "/img/icon.svg",
-        "path": "/package/log/1.0.0/img/icon.svg",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "logs",
-        "title": "Custom logs",
-        "description": "Collect your custom log files."
-      }
-    ],
-    "owner": {
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "signature_path": "/epr/log/log-1.0.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "log.log",
-        "title": "Log Dataset"
-      }
-    ]
-  },
-  {
-    "name": "tcp",
-    "title": "Custom TCP Logs",
-    "version": "1.0.0",
-    "release": "ga",
-    "description": "Collect raw TCP data from listening TCP port with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/tcp/tcp-1.0.0.zip",
-    "path": "/package/tcp/1.0.0",
-    "icons": [
-      {
-        "src": "/img/icon.svg",
-        "path": "/package/tcp/1.0.0/img/icon.svg",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "tcp",
-        "title": "Custom TCP Logs",
-        "description": "Collect raw TCP data from listening TCP port with Elastic Agent."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "signature_path": "/epr/tcp/tcp-1.0.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "tcp.generic",
-        "title": "Custom TCP Logs"
-      }
-    ]
-  },
-  {
-    "name": "udp",
-    "title": "Custom UDP Logs",
-    "version": "1.0.1",
-    "release": "ga",
-    "description": "Collect raw UDP data from listening UDP port with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/udp/udp-1.0.1.zip",
-    "path": "/package/udp/1.0.1",
-    "icons": [
-      {
-        "src": "/img/icon.svg",
-        "path": "/package/udp/1.0.1/img/icon.svg",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "udp",
-        "title": "Custom UDP Logs",
-        "description": "Collect raw UDP data from listening UDP port with Elastic Agent."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "signature_path": "/epr/udp/udp-1.0.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "udp.generic",
-        "title": "Custom UDP Logs"
-      }
-    ]
-  },
-  {
-    "name": "winlog",
-    "title": "Custom Windows Event Logs",
-    "version": "1.4.0",
-    "release": "ga",
-    "description": "Collect and parse logs from any Windows event log channel with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/winlog/winlog-1.4.0.zip",
-    "path": "/package/winlog/1.4.0",
-    "icons": [
-      {
-        "src": "/img/logo_windows.svg",
-        "path": "/package/winlog/1.4.0/img/logo_windows.svg",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "winlogs",
-        "title": "Custom Windows event logs",
-        "description": "Collect your custom Windows event logs."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "signature_path": "/epr/winlog/winlog-1.4.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "winlog.winlog",
-        "title": "Custom Windows Event Log Dataset"
-      }
-    ]
-  },
-  {
     "name": "cyberarkpas",
     "title": "CyberArk Privileged Access Security Logs",
     "version": "2.4.2",
@@ -2907,49 +2609,40 @@
     ]
   },
   {
-    "name": "ti_cybersixgill",
-    "title": "Cybersixgill",
-    "version": "1.3.2",
-    "release": "ga",
-    "description": "This Elastic integration collects threat intelligence from Cybersixgill",
-    "type": "integration",
-    "download": "/epr/ti_cybersixgill/ti_cybersixgill-1.3.2.zip",
-    "path": "/package/ti_cybersixgill/1.3.2",
+    "name": "discovery_empty",
+    "title": "Discovery Empty",
+    "version": "0.1.0",
+    "release": "beta",
+    "source": {
+      "license": "Apache-2.0"
+    },
+    "description": "This package is a dummy example for packages with the content type and discovery field empty. These packages contain resources that are useful with data ingested by other integrations. They are not used to configure data sources.\n",
+    "type": "content",
+    "download": "/epr/discovery_empty/discovery_empty-0.1.0.zip",
+    "path": "/package/discovery_empty/0.1.0",
     "icons": [
       {
-        "src": "/img/cybersixgill.svg",
-        "path": "/package/ti_cybersixgill/1.3.2/img/cybersixgill.svg",
-        "title": "Cybersixgill",
-        "size": "32x32",
+        "src": "/img/system.svg",
+        "path": "/package/discovery_empty/0.1.0/img/system.svg",
+        "title": "system",
+        "size": "1000x1000",
         "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "cybersixgill",
-        "title": "Cybersixgill Threat Intel",
-        "description": "Collect Threat Intel from Cybersixgill"
       }
     ],
     "conditions": {
       "kibana": {
-        "version": "^8.0.0"
+        "version": "^8.16.0"
+      },
+      "elastic": {
+        "subscription": "basic"
       }
     },
     "owner": {
-      "github": "elastic/security-external-integrations"
+      "type": "elastic",
+      "github": "elastic/ecosystem"
     },
     "categories": [
-      "security",
-      "productivity"
-    ],
-    "signature_path": "/epr/ti_cybersixgill/ti_cybersixgill-1.3.2.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ti_cybersixgill.threat",
-        "title": "Cybersixgill Darkfeed Logs"
-      }
+      "support"
     ]
   },
   {
@@ -3003,43 +2696,6 @@
         }
       ]
     }
-  },
-  {
-    "name": "discovery_empty",
-    "title": "Discovery Empty",
-    "version": "0.1.0",
-    "release": "beta",
-    "source": {
-      "license": "Apache-2.0"
-    },
-    "description": "This package is a dummy example for packages with the content type and discovery field empty. These packages contain resources that are useful with data ingested by other integrations. They are not used to configure data sources.\n",
-    "type": "content",
-    "download": "/epr/discovery_empty/discovery_empty-0.1.0.zip",
-    "path": "/package/discovery_empty/0.1.0",
-    "icons": [
-      {
-        "src": "/img/system.svg",
-        "path": "/package/discovery_empty/0.1.0/img/system.svg",
-        "title": "system",
-        "size": "1000x1000",
-        "type": "image/svg+xml"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.16.0"
-      },
-      "elastic": {
-        "subscription": "basic"
-      }
-    },
-    "owner": {
-      "type": "elastic",
-      "github": "elastic/ecosystem"
-    },
-    "categories": [
-      "support"
-    ]
   },
   {
     "name": "docker",
@@ -3124,87 +2780,6 @@
         "type": "metrics",
         "dataset": "docker.network",
         "title": "Docker network metrics"
-      }
-    ]
-  },
-  {
-    "name": "apm",
-    "title": "Elastic APM",
-    "version": "8.2.0",
-    "release": "ga",
-    "description": "Ingest APM data",
-    "type": "integration",
-    "download": "/epr/apm/apm-8.2.0.zip",
-    "path": "/package/apm/8.2.0",
-    "icons": [
-      {
-        "src": "/img/logo_apm.svg",
-        "path": "/package/apm/8.2.0/img/logo_apm.svg",
-        "title": "APM Logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "apmserver",
-        "title": "Elastic APM Integration",
-        "description": "Elastic APM Integration"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.2.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/apm-server"
-    },
-    "categories": [
-      "elastic_stack",
-      "monitoring"
-    ],
-    "signature_path": "/epr/apm/apm-8.2.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "apm.app",
-        "title": "APM application logs"
-      },
-      {
-        "type": "metrics",
-        "dataset": "apm.app",
-        "title": "APM application metrics"
-      },
-      {
-        "type": "logs",
-        "dataset": "apm.error",
-        "title": "APM errors"
-      },
-      {
-        "type": "metrics",
-        "dataset": "apm.internal",
-        "title": "APM internal metrics"
-      },
-      {
-        "type": "metrics",
-        "dataset": "apm.profiling",
-        "title": "APM profiles"
-      },
-      {
-        "type": "traces",
-        "dataset": "apm.rum",
-        "title": "APM RUM traces"
-      },
-      {
-        "type": "traces",
-        "dataset": "apm.sampled",
-        "title": "APM tail-sampled traces"
-      },
-      {
-        "type": "traces",
-        "dataset": "apm",
-        "title": "APM traces"
       }
     ]
   },
@@ -3338,77 +2913,6 @@
         "type": "metrics",
         "dataset": "elastic_agent.packetbeat",
         "title": "Elastic Agent"
-      }
-    ]
-  },
-  {
-    "name": "synthetics",
-    "title": "Elastic Synthetics",
-    "version": "0.9.2",
-    "release": "beta",
-    "description": "Monitor the availability of your services with Elastic Synthetics.",
-    "type": "integration",
-    "download": "/epr/synthetics/synthetics-0.9.2.zip",
-    "path": "/package/synthetics/0.9.2",
-    "icons": [
-      {
-        "src": "/img/uptime-logo-color-64px.svg",
-        "path": "/package/synthetics/0.9.2/img/uptime-logo-color-64px.svg",
-        "size": "16x16",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "synthetics",
-        "title": "Elastic Synthetics",
-        "description": "Perform synthetic health checks on network endpoints."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.1.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/uptime"
-    },
-    "categories": [
-      "elastic_stack",
-      "monitoring",
-      "web"
-    ],
-    "signature_path": "/epr/synthetics/synthetics-0.9.2.zip.sig",
-    "data_streams": [
-      {
-        "type": "synthetics",
-        "dataset": "browser",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "browser.network",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "browser.screenshot",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "http",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "icmp",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "tcp",
-        "title": "synthetic monitor check"
       }
     ]
   },
@@ -3710,51 +3214,6 @@
     ]
   },
   {
-    "name": "github",
-    "title": "GitHub",
-    "version": "1.0.0",
-    "release": "ga",
-    "description": "Collect events from GitHub with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/github/github-1.0.0.zip",
-    "path": "/package/github/1.0.0",
-    "icons": [
-      {
-        "src": "/img/github.svg",
-        "path": "/package/github/1.0.0/img/github.svg",
-        "title": "GitHub",
-        "size": "1024x1024",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "github",
-        "title": "GitHub logs",
-        "description": "Collect logs from GitHub"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/github/github-1.0.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "github.audit",
-        "title": "GitHub Audit Logs"
-      }
-    ]
-  },
-  {
     "name": "gcp",
     "title": "Google Cloud Platform",
     "version": "1.9.0",
@@ -3818,47 +3277,94 @@
     ]
   },
   {
-    "name": "santa",
-    "title": "Google Santa Logs",
-    "version": "2.0.1",
+    "name": "gcp_pubsub",
+    "title": "Custom Google Pub/Sub Logs",
+    "version": "1.0.0",
     "release": "ga",
-    "description": "Collect and parse logs from Google Santa instances with Elastic Agent.",
+    "description": "Collect Logs from Google Pub/Sub topics",
     "type": "integration",
-    "download": "/epr/santa/santa-2.0.1.zip",
-    "path": "/package/santa/2.0.1",
+    "download": "/epr/gcp_pubsub/gcp_pubsub-1.0.0.zip",
+    "path": "/package/gcp_pubsub/1.0.0",
     "icons": [
       {
-        "src": "/img/icon.svg",
-        "path": "/package/santa/2.0.1/img/icon.svg",
-        "title": "Google Santa",
+        "src": "/img/logo_gcp.svg",
+        "path": "/package/gcp_pubsub/1.0.0/img/logo_gcp.svg",
+        "title": "logo gcp",
+        "size": "32x32",
         "type": "image/svg+xml"
       }
     ],
     "policy_templates": [
       {
-        "name": "santa",
-        "title": "Google Santa logs",
-        "description": "Collect logs from Google Santa instances"
+        "name": "gcp",
+        "title": "Custom Google Pub/Sub Logs",
+        "description": "Collect Logs from Google Pub/Sub topics"
       }
     ],
     "conditions": {
       "kibana": {
-        "version": "^7.17.0 || ^8.0.0"
+        "version": "^7.16.0 || ^8.0.0"
       }
     },
     "owner": {
       "github": "elastic/security-external-integrations"
     },
     "categories": [
-      "security",
-      "os_system"
+      "google_cloud",
+      "cloud",
+      "custom"
     ],
-    "signature_path": "/epr/santa/santa-2.0.1.zip.sig",
+    "signature_path": "/epr/gcp_pubsub/gcp_pubsub-1.0.0.zip.sig",
     "data_streams": [
       {
         "type": "logs",
-        "dataset": "santa.log",
-        "title": "Google Santa log logs"
+        "dataset": "gcp_pubsub.generic",
+        "title": "Custom Google Pub/Sub Logs"
+      }
+    ]
+  },
+  {
+    "name": "github",
+    "title": "GitHub",
+    "version": "1.0.0",
+    "release": "ga",
+    "description": "Collect events from GitHub with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/github/github-1.0.0.zip",
+    "path": "/package/github/1.0.0",
+    "icons": [
+      {
+        "src": "/img/github.svg",
+        "path": "/package/github/1.0.0/img/github.svg",
+        "title": "GitHub",
+        "size": "1024x1024",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "github",
+        "title": "GitHub logs",
+        "description": "Collect logs from GitHub"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/github/github-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "github.audit",
+        "title": "GitHub Audit Logs"
       }
     ]
   },
@@ -4034,6 +3540,85 @@
         "type": "logs",
         "dataset": "hid_bravura_monitor.winlog",
         "title": "Hitachi ID Security Fabric logs"
+      }
+    ]
+  },
+  {
+    "name": "http_endpoint",
+    "title": "Custom HTTP Endpoint Logs",
+    "version": "1.0.1",
+    "release": "ga",
+    "description": "Collect JSON data from listening HTTP port with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/http_endpoint/http_endpoint-1.0.1.zip",
+    "path": "/package/http_endpoint/1.0.1",
+    "icons": [
+      {
+        "src": "/img/icon.svg",
+        "path": "/package/http_endpoint/1.0.1/img/icon.svg",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "http_endpoint",
+        "title": "Custom HTTP Endpoint Logs",
+        "description": "Collect JSON data from listening HTTP port with Elastic Agent."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "signature_path": "/epr/http_endpoint/http_endpoint-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "http_endpoint.generic",
+        "title": "Custom HTTP Endpoint Logs"
+      }
+    ]
+  },
+  {
+    "name": "httpjson",
+    "title": "Custom HTTPJSON Input",
+    "version": "1.1.1",
+    "release": "ga",
+    "description": "Collect custom data from REST API's with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/httpjson/httpjson-1.1.1.zip",
+    "path": "/package/httpjson/1.1.1",
+    "policy_templates": [
+      {
+        "name": "generic",
+        "title": "Custom HTTPJSON Input",
+        "description": "Collect custom data from REST API's"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "signature_path": "/epr/httpjson/httpjson-1.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "httpjson.generic",
+        "title": "Custom HTTPJSON Input"
       }
     ]
   },
@@ -4874,6 +4459,44 @@
     ]
   },
   {
+    "name": "log",
+    "title": "Custom Logs",
+    "version": "1.0.0",
+    "release": "ga",
+    "description": "Collect custom logs with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/log/log-1.0.0.zip",
+    "path": "/package/log/1.0.0",
+    "icons": [
+      {
+        "src": "/img/icon.svg",
+        "path": "/package/log/1.0.0/img/icon.svg",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "logs",
+        "title": "Custom logs",
+        "description": "Collect your custom log files."
+      }
+    ],
+    "owner": {
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "signature_path": "/epr/log/log-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "log.log",
+        "title": "Log Dataset"
+      }
+    ]
+  },
+  {
     "name": "logstash",
     "title": "Logstash",
     "version": "1.0.0",
@@ -4981,51 +4604,6 @@
     ]
   },
   {
-    "name": "ti_misp",
-    "title": "MISP",
-    "version": "1.2.2",
-    "release": "ga",
-    "description": "This Elastic integration collects events from MISP",
-    "type": "integration",
-    "download": "/epr/ti_misp/ti_misp-1.2.2.zip",
-    "path": "/package/ti_misp/1.2.2",
-    "icons": [
-      {
-        "src": "/img/misp.svg",
-        "path": "/package/ti_misp/1.2.2/img/misp.svg",
-        "title": "MISP",
-        "size": "216x216",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "ti_misp",
-        "title": "MISP",
-        "description": "Collect threat intelligence from the MISP API."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/ti_misp/ti_misp-1.2.2.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ti_misp.threat",
-        "title": "MISP"
-      }
-    ]
-  },
-  {
     "name": "mattermost",
     "title": "Mattermost",
     "version": "1.1.1",
@@ -5124,51 +4702,6 @@
     ]
   },
   {
-    "name": "microsoft_dhcp",
-    "title": "Microsoft DHCP",
-    "version": "1.3.1",
-    "release": "ga",
-    "description": "Collect logs from Microsoft DHCP with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/microsoft_dhcp/microsoft_dhcp-1.3.1.zip",
-    "path": "/package/microsoft_dhcp/1.3.1",
-    "icons": [
-      {
-        "src": "/img/logo.svg",
-        "path": "/package/microsoft_dhcp/1.3.1/img/logo.svg",
-        "title": "Microsoft logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "microsoft_dhcp",
-        "title": "Microsoft DHCP",
-        "description": "Collect Microsoft DHCP logs."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "network"
-    ],
-    "signature_path": "/epr/microsoft_dhcp/microsoft_dhcp-1.3.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "microsoft_dhcp.log",
-        "title": "Microsoft DHCP Logs"
-      }
-    ]
-  },
-  {
     "name": "microsoft_defender_endpoint",
     "title": "Microsoft Defender for Endpoint",
     "version": "2.1.0",
@@ -5212,6 +4745,51 @@
         "type": "logs",
         "dataset": "microsoft_defender_endpoint.log",
         "title": "Microsoft Defender for Endpoint logs"
+      }
+    ]
+  },
+  {
+    "name": "microsoft_dhcp",
+    "title": "Microsoft DHCP",
+    "version": "1.3.1",
+    "release": "ga",
+    "description": "Collect logs from Microsoft DHCP with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/microsoft_dhcp/microsoft_dhcp-1.3.1.zip",
+    "path": "/package/microsoft_dhcp/1.3.1",
+    "icons": [
+      {
+        "src": "/img/logo.svg",
+        "path": "/package/microsoft_dhcp/1.3.1/img/logo.svg",
+        "title": "Microsoft logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "microsoft_dhcp",
+        "title": "Microsoft DHCP",
+        "description": "Collect Microsoft DHCP logs."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "network"
+    ],
+    "signature_path": "/epr/microsoft_dhcp/microsoft_dhcp-1.3.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "microsoft_dhcp.log",
+        "title": "Microsoft DHCP Logs"
       }
     ]
   },
@@ -6052,51 +5630,6 @@
     ]
   },
   {
-    "name": "panw_cortex_xdr",
-    "title": "Palo Alto Cortex XDR Logs",
-    "version": "1.1.1",
-    "release": "ga",
-    "description": "Collect and parse logs from Palo Alto Cortex XDR API with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/panw_cortex_xdr/panw_cortex_xdr-1.1.1.zip",
-    "path": "/package/panw_cortex_xdr/1.1.1",
-    "icons": [
-      {
-        "src": "/img/icon-cortex.svg",
-        "path": "/package/panw_cortex_xdr/1.1.1/img/icon-cortex.svg",
-        "title": "Palo Alto",
-        "size": "216x216",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "alerts",
-        "title": "Palo Alto Cortex XDR API",
-        "description": "Collect logs from Palo Alto Cortex XDR API"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.15.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/panw_cortex_xdr/panw_cortex_xdr-1.1.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "panw_cortex_xdr.alerts",
-        "title": "Palo Alto Cortex XDR API"
-      }
-    ]
-  },
-  {
     "name": "panw",
     "title": "Palo Alto Networks Logs",
     "version": "1.5.3",
@@ -6138,6 +5671,51 @@
         "type": "logs",
         "dataset": "panw.panos",
         "title": "Palo Alto Networks PAN-OS firewall logs"
+      }
+    ]
+  },
+  {
+    "name": "panw_cortex_xdr",
+    "title": "Palo Alto Cortex XDR Logs",
+    "version": "1.1.1",
+    "release": "ga",
+    "description": "Collect and parse logs from Palo Alto Cortex XDR API with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/panw_cortex_xdr/panw_cortex_xdr-1.1.1.zip",
+    "path": "/package/panw_cortex_xdr/1.1.1",
+    "icons": [
+      {
+        "src": "/img/icon-cortex.svg",
+        "path": "/package/panw_cortex_xdr/1.1.1/img/icon-cortex.svg",
+        "title": "Palo Alto",
+        "size": "216x216",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "alerts",
+        "title": "Palo Alto Cortex XDR API",
+        "description": "Collect logs from Palo Alto Cortex XDR API"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.15.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/panw_cortex_xdr/panw_cortex_xdr-1.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "panw_cortex_xdr.alerts",
+        "title": "Palo Alto Cortex XDR API"
       }
     ]
   },
@@ -6205,42 +5783,6 @@
         "title": "PostgreSQL statement metrics"
       }
     ]
-  },
-  {
-    "name": "security_detection_engine",
-    "title": "Prebuilt Security Detection Rules",
-    "version": "1.0.2",
-    "release": "ga",
-    "description": "Prebuilt detection rules for Elastic Security",
-    "type": "integration",
-    "download": "/epr/security_detection_engine/security_detection_engine-1.0.2.zip",
-    "path": "/package/security_detection_engine/1.0.2",
-    "icons": [
-      {
-        "src": "/img/security-logo-color-64px.svg",
-        "path": "/package/security_detection_engine/1.0.2/img/security-logo-color-64px.svg",
-        "size": "16x16",
-        "type": "image/svg+xml"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      },
-      "elastic": {
-        "subscription": "basic",
-        "capabilities": [
-          "security"
-        ]
-      }
-    },
-    "owner": {
-      "github": "elastic/protections"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/security_detection_engine/security_detection_engine-1.0.2.zip.sig"
   },
   {
     "name": "qnap_nas",
@@ -6353,51 +5895,6 @@
     ]
   },
   {
-    "name": "ti_recordedfuture",
-    "title": "Recorded Future",
-    "version": "0.1.2",
-    "release": "beta",
-    "description": "Collect threat intelligence from Recorded Future with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/ti_recordedfuture/ti_recordedfuture-0.1.2.zip",
-    "path": "/package/ti_recordedfuture/0.1.2",
-    "icons": [
-      {
-        "src": "/img/logo.svg",
-        "path": "/package/ti_recordedfuture/0.1.2/img/logo.svg",
-        "title": "Recorded Future",
-        "size": "216x216",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "ti_recordedfuture",
-        "title": "Recorded Future",
-        "description": "Collect threat intelligence from Recorded Future."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/ti_recordedfuture/ti_recordedfuture-0.1.2.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ti_recordedfuture.threat",
-        "title": "Recorded Future"
-      }
-    ]
-  },
-  {
     "name": "redis",
     "title": "Redis",
     "version": "1.2.0",
@@ -6460,6 +5957,187 @@
         "type": "logs",
         "dataset": "redis.slowlog",
         "title": "Redis slow logs"
+      }
+    ]
+  },
+  {
+    "name": "santa",
+    "title": "Google Santa Logs",
+    "version": "2.0.1",
+    "release": "ga",
+    "description": "Collect and parse logs from Google Santa instances with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/santa/santa-2.0.1.zip",
+    "path": "/package/santa/2.0.1",
+    "icons": [
+      {
+        "src": "/img/icon.svg",
+        "path": "/package/santa/2.0.1/img/icon.svg",
+        "title": "Google Santa",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "santa",
+        "title": "Google Santa logs",
+        "description": "Collect logs from Google Santa instances"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.17.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security",
+      "os_system"
+    ],
+    "signature_path": "/epr/santa/santa-2.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "santa.log",
+        "title": "Google Santa log logs"
+      }
+    ]
+  },
+  {
+    "name": "security_detection_engine",
+    "title": "Prebuilt Security Detection Rules",
+    "version": "1.0.2",
+    "release": "ga",
+    "description": "Prebuilt detection rules for Elastic Security",
+    "type": "integration",
+    "download": "/epr/security_detection_engine/security_detection_engine-1.0.2.zip",
+    "path": "/package/security_detection_engine/1.0.2",
+    "icons": [
+      {
+        "src": "/img/security-logo-color-64px.svg",
+        "path": "/package/security_detection_engine/1.0.2/img/security-logo-color-64px.svg",
+        "size": "16x16",
+        "type": "image/svg+xml"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      },
+      "elastic": {
+        "subscription": "basic",
+        "capabilities": [
+          "security"
+        ]
+      }
+    },
+    "owner": {
+      "github": "elastic/protections"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/security_detection_engine/security_detection_engine-1.0.2.zip.sig"
+  },
+  {
+    "name": "snyk",
+    "title": "Snyk",
+    "version": "1.1.2",
+    "release": "ga",
+    "description": "Collect logs from Snyk API with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/snyk/snyk-1.1.2.zip",
+    "path": "/package/snyk/1.1.2",
+    "icons": [
+      {
+        "src": "/img/snyk-logo.svg",
+        "path": "/package/snyk/1.1.2/img/snyk-logo.svg",
+        "title": "Snyk logo",
+        "size": "382x625",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "snyk",
+        "title": "Snyk Events",
+        "description": "Collect data from Snyk API"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/snyk/snyk-1.1.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "snyk.audit",
+        "title": "Collect Snyk Audit Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "snyk.vulnerabilities",
+        "title": "Collect Snyk Vulnerability Data"
+      }
+    ]
+  },
+  {
+    "name": "sophos",
+    "title": "Sophos Logs",
+    "version": "1.2.2",
+    "release": "ga",
+    "description": "Collect and parse logs from Sophos Products with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/sophos/sophos-1.2.2.zip",
+    "path": "/package/sophos/1.2.2",
+    "icons": [
+      {
+        "src": "/img/logo.svg",
+        "path": "/package/sophos/1.2.2/img/logo.svg",
+        "title": "Sophos logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "sophos",
+        "title": "Sophos logs",
+        "description": "Collect Sophos logs from syslog or a file."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.1 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/sophos/sophos-1.2.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "sophos.utm",
+        "title": "Sophos UTM logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "sophos.xg",
+        "title": "Sophos XG logs"
       }
     ]
   },
@@ -6574,106 +6252,6 @@
     ]
   },
   {
-    "name": "snyk",
-    "title": "Snyk",
-    "version": "1.1.2",
-    "release": "ga",
-    "description": "Collect logs from Snyk API with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/snyk/snyk-1.1.2.zip",
-    "path": "/package/snyk/1.1.2",
-    "icons": [
-      {
-        "src": "/img/snyk-logo.svg",
-        "path": "/package/snyk/1.1.2/img/snyk-logo.svg",
-        "title": "Snyk logo",
-        "size": "382x625",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "snyk",
-        "title": "Snyk Events",
-        "description": "Collect data from Snyk API"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/snyk/snyk-1.1.2.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "snyk.audit",
-        "title": "Collect Snyk Audit Logs"
-      },
-      {
-        "type": "logs",
-        "dataset": "snyk.vulnerabilities",
-        "title": "Collect Snyk Vulnerability Data"
-      }
-    ]
-  },
-  {
-    "name": "sophos",
-    "title": "Sophos Logs",
-    "version": "1.2.2",
-    "release": "ga",
-    "description": "Collect and parse logs from Sophos Products with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/sophos/sophos-1.2.2.zip",
-    "path": "/package/sophos/1.2.2",
-    "icons": [
-      {
-        "src": "/img/logo.svg",
-        "path": "/package/sophos/1.2.2/img/logo.svg",
-        "title": "Sophos logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "sophos",
-        "title": "Sophos logs",
-        "description": "Collect Sophos logs from syslog or a file."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.1 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/sophos/sophos-1.2.2.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "sophos.utm",
-        "title": "Sophos UTM logs"
-      },
-      {
-        "type": "logs",
-        "dataset": "sophos.xg",
-        "title": "Sophos XG logs"
-      }
-    ]
-  },
-  {
     "name": "suricata",
     "title": "Suricata Events",
     "version": "1.6.1",
@@ -6761,6 +6339,77 @@
         "type": "logs",
         "dataset": "symantec_endpoint.log",
         "title": "Symantec Endpoint Protection (SEP) Logs"
+      }
+    ]
+  },
+  {
+    "name": "synthetics",
+    "title": "Elastic Synthetics",
+    "version": "0.9.2",
+    "release": "beta",
+    "description": "Monitor the availability of your services with Elastic Synthetics.",
+    "type": "integration",
+    "download": "/epr/synthetics/synthetics-0.9.2.zip",
+    "path": "/package/synthetics/0.9.2",
+    "icons": [
+      {
+        "src": "/img/uptime-logo-color-64px.svg",
+        "path": "/package/synthetics/0.9.2/img/uptime-logo-color-64px.svg",
+        "size": "16x16",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "synthetics",
+        "title": "Elastic Synthetics",
+        "description": "Perform synthetic health checks on network endpoints."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.1.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/uptime"
+    },
+    "categories": [
+      "elastic_stack",
+      "monitoring",
+      "web"
+    ],
+    "signature_path": "/epr/synthetics/synthetics-0.9.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "synthetics",
+        "dataset": "browser",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "browser.network",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "browser.screenshot",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "http",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "icmp",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "tcp",
+        "title": "synthetic monitor check"
       }
     ]
   },
@@ -6891,6 +6540,49 @@
     ]
   },
   {
+    "name": "tcp",
+    "title": "Custom TCP Logs",
+    "version": "1.0.0",
+    "release": "ga",
+    "description": "Collect raw TCP data from listening TCP port with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/tcp/tcp-1.0.0.zip",
+    "path": "/package/tcp/1.0.0",
+    "icons": [
+      {
+        "src": "/img/icon.svg",
+        "path": "/package/tcp/1.0.0/img/icon.svg",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "tcp",
+        "title": "Custom TCP Logs",
+        "description": "Collect raw TCP data from listening TCP port with Elastic Agent."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "signature_path": "/epr/tcp/tcp-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "tcp.generic",
+        "title": "Custom TCP Logs"
+      }
+    ]
+  },
+  {
     "name": "tenable_sc",
     "title": "Tenable.sc",
     "version": "1.1.1",
@@ -6946,6 +6638,292 @@
     ]
   },
   {
+    "name": "ti_abusech",
+    "title": "AbuseCH",
+    "version": "1.2.3",
+    "release": "ga",
+    "description": "Collect threat intelligence from AbuseCH API with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/ti_abusech/ti_abusech-1.2.3.zip",
+    "path": "/package/ti_abusech/1.2.3",
+    "icons": [
+      {
+        "src": "/img/abusech2.svg",
+        "path": "/package/ti_abusech/1.2.3/img/abusech2.svg",
+        "title": "AbuseCH",
+        "size": "512x512",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "ti_abusech",
+        "title": "AbuseCH API",
+        "description": "Collect threat intelligence from the AbuseCH API"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/ti_abusech/ti_abusech-1.2.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_abusech.malware",
+        "title": "AbuseCH Malware logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "ti_abusech.malwarebazaar",
+        "title": "AbuseCH MalwareBazaar logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "ti_abusech.url",
+        "title": "AbuseCH URL logs"
+      }
+    ]
+  },
+  {
+    "name": "ti_anomali",
+    "title": "Anomali",
+    "version": "1.2.3",
+    "release": "ga",
+    "description": "Collect threat intelligence from Anomali APIs with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/ti_anomali/ti_anomali-1.2.3.zip",
+    "path": "/package/ti_anomali/1.2.3",
+    "icons": [
+      {
+        "src": "/img/anomali.svg",
+        "path": "/package/ti_anomali/1.2.3/img/anomali.svg",
+        "title": "Anomali",
+        "size": "216x216",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "ti_anomali",
+        "title": "Anomali",
+        "description": "Collect threat intelligence from the Anomali Limo API and Anomali Threatstream."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/ti_anomali/ti_anomali-1.2.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_anomali.limo",
+        "title": "Anomali Limo"
+      },
+      {
+        "type": "logs",
+        "dataset": "ti_anomali.threatstream",
+        "title": "Anomali Threatstream"
+      }
+    ]
+  },
+  {
+    "name": "ti_cybersixgill",
+    "title": "Cybersixgill",
+    "version": "1.3.2",
+    "release": "ga",
+    "description": "This Elastic integration collects threat intelligence from Cybersixgill",
+    "type": "integration",
+    "download": "/epr/ti_cybersixgill/ti_cybersixgill-1.3.2.zip",
+    "path": "/package/ti_cybersixgill/1.3.2",
+    "icons": [
+      {
+        "src": "/img/cybersixgill.svg",
+        "path": "/package/ti_cybersixgill/1.3.2/img/cybersixgill.svg",
+        "title": "Cybersixgill",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "cybersixgill",
+        "title": "Cybersixgill Threat Intel",
+        "description": "Collect Threat Intel from Cybersixgill"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security",
+      "productivity"
+    ],
+    "signature_path": "/epr/ti_cybersixgill/ti_cybersixgill-1.3.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_cybersixgill.threat",
+        "title": "Cybersixgill Darkfeed Logs"
+      }
+    ]
+  },
+  {
+    "name": "ti_misp",
+    "title": "MISP",
+    "version": "1.2.2",
+    "release": "ga",
+    "description": "This Elastic integration collects events from MISP",
+    "type": "integration",
+    "download": "/epr/ti_misp/ti_misp-1.2.2.zip",
+    "path": "/package/ti_misp/1.2.2",
+    "icons": [
+      {
+        "src": "/img/misp.svg",
+        "path": "/package/ti_misp/1.2.2/img/misp.svg",
+        "title": "MISP",
+        "size": "216x216",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "ti_misp",
+        "title": "MISP",
+        "description": "Collect threat intelligence from the MISP API."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/ti_misp/ti_misp-1.2.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_misp.threat",
+        "title": "MISP"
+      }
+    ]
+  },
+  {
+    "name": "ti_otx",
+    "title": "AlienVault OTX",
+    "version": "1.2.2",
+    "release": "ga",
+    "description": "Collect threat intelligence from AlienVault OTX with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/ti_otx/ti_otx-1.2.2.zip",
+    "path": "/package/ti_otx/1.2.2",
+    "icons": [
+      {
+        "src": "/img/otx.svg",
+        "path": "/package/ti_otx/1.2.2/img/otx.svg",
+        "title": "Alienvault OTX",
+        "size": "216x216",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "ti_otx",
+        "title": "Alienvault OTX",
+        "description": "Collect threat intelligence from the Alienvault OTX"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/ti_otx/ti_otx-1.2.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_otx.threat",
+        "title": "Alienvault OTX logs"
+      }
+    ]
+  },
+  {
+    "name": "ti_recordedfuture",
+    "title": "Recorded Future",
+    "version": "0.1.2",
+    "release": "beta",
+    "description": "Collect threat intelligence from Recorded Future with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/ti_recordedfuture/ti_recordedfuture-0.1.2.zip",
+    "path": "/package/ti_recordedfuture/0.1.2",
+    "icons": [
+      {
+        "src": "/img/logo.svg",
+        "path": "/package/ti_recordedfuture/0.1.2/img/logo.svg",
+        "title": "Recorded Future",
+        "size": "216x216",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "ti_recordedfuture",
+        "title": "Recorded Future",
+        "description": "Collect threat intelligence from Recorded Future."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/ti_recordedfuture/ti_recordedfuture-0.1.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_recordedfuture.threat",
+        "title": "Recorded Future"
+      }
+    ]
+  },
+  {
     "name": "ti_threatq",
     "title": "ThreatQuotient",
     "version": "1.2.2",
@@ -6987,6 +6965,52 @@
         "type": "logs",
         "dataset": "ti_threatq.threat",
         "title": "ThreatQ"
+      }
+    ]
+  },
+  {
+    "name": "tomcat",
+    "title": "Apache Tomcat",
+    "version": "1.3.1",
+    "release": "ga",
+    "description": "Collect and parse logs from Apache Tomcat servers with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/tomcat/tomcat-1.3.1.zip",
+    "path": "/package/tomcat/1.3.1",
+    "icons": [
+      {
+        "src": "/img/logo.svg",
+        "path": "/package/tomcat/1.3.1/img/logo.svg",
+        "title": "Apache Tomcat logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "log",
+        "title": "Apache Tomcat",
+        "description": "Collect Apache Tomcat logs from syslog or a file."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.1 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "web",
+      "security"
+    ],
+    "signature_path": "/epr/tomcat/tomcat-1.3.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "tomcat.log",
+        "title": "Apache Tomcat logs"
       }
     ]
   },
@@ -7042,112 +7066,45 @@
     ]
   },
   {
-    "name": "carbon_black_cloud",
-    "title": "VMware Carbon Black Cloud",
-    "version": "1.0.2",
+    "name": "udp",
+    "title": "Custom UDP Logs",
+    "version": "1.0.1",
     "release": "ga",
-    "description": "Collect logs from VMWare Carbon Black Cloud with Elastic Agent.",
+    "description": "Collect raw UDP data from listening UDP port with Elastic Agent.",
     "type": "integration",
-    "download": "/epr/carbon_black_cloud/carbon_black_cloud-1.0.2.zip",
-    "path": "/package/carbon_black_cloud/1.0.2",
+    "download": "/epr/udp/udp-1.0.1.zip",
+    "path": "/package/udp/1.0.1",
     "icons": [
       {
-        "src": "/img/carbon_black_cloud-logo.svg",
-        "path": "/package/carbon_black_cloud/1.0.2/img/carbon_black_cloud-logo.svg",
-        "title": "Carbon Black Cloud logo",
-        "size": "32x32",
+        "src": "/img/icon.svg",
+        "path": "/package/udp/1.0.1/img/icon.svg",
         "type": "image/svg+xml"
       }
     ],
     "policy_templates": [
       {
-        "name": "carbon_black_cloud",
-        "title": "Carbon Black Cloud",
-        "description": "Collect Logs from Carbon Black Cloud"
+        "name": "udp",
+        "title": "Custom UDP Logs",
+        "description": "Collect raw UDP data from listening UDP port with Elastic Agent."
       }
     ],
     "conditions": {
       "kibana": {
-        "version": "^7.17.0 || ^8.0.0"
+        "version": "^7.16.0 || ^8.0.0"
       }
     },
     "owner": {
       "github": "elastic/security-external-integrations"
     },
     "categories": [
-      "security"
+      "custom"
     ],
-    "signature_path": "/epr/carbon_black_cloud/carbon_black_cloud-1.0.2.zip.sig",
+    "signature_path": "/epr/udp/udp-1.0.1.zip.sig",
     "data_streams": [
       {
         "type": "logs",
-        "dataset": "carbon_black_cloud.alert",
-        "title": "Alert"
-      },
-      {
-        "type": "logs",
-        "dataset": "carbon_black_cloud.asset_vulnerability_summary",
-        "title": "Asset Vulnerability Summary"
-      },
-      {
-        "type": "logs",
-        "dataset": "carbon_black_cloud.audit",
-        "title": "Audit"
-      },
-      {
-        "type": "logs",
-        "dataset": "carbon_black_cloud.endpoint_event",
-        "title": "Endpoint Event"
-      },
-      {
-        "type": "logs",
-        "dataset": "carbon_black_cloud.watchlist_hit",
-        "title": "Watchlist Hit"
-      }
-    ]
-  },
-  {
-    "name": "carbonblack_edr",
-    "title": "VMware Carbon Black EDR",
-    "version": "1.2.0",
-    "release": "ga",
-    "description": "Collect logs from VMware Carbon Black EDR with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/carbonblack_edr/carbonblack_edr-1.2.0.zip",
-    "path": "/package/carbonblack_edr/1.2.0",
-    "icons": [
-      {
-        "src": "/img/carbon-black-logo.svg",
-        "path": "/package/carbonblack_edr/1.2.0/img/carbon-black-logo.svg",
-        "title": "VMWare Carbon Black",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "log",
-        "title": "Carbon Black EDR logs",
-        "description": "Collect logs from Carbon Black EDR"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/carbonblack_edr/carbonblack_edr-1.2.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "carbonblack_edr.log",
-        "title": "Carbon Black EDR logs"
+        "dataset": "udp.generic",
+        "title": "Custom UDP Logs"
       }
     ]
   },
@@ -7280,6 +7237,49 @@
         "type": "logs",
         "dataset": "windows.sysmon_operational",
         "title": "Windows Sysmon/Operational events"
+      }
+    ]
+  },
+  {
+    "name": "winlog",
+    "title": "Custom Windows Event Logs",
+    "version": "1.4.0",
+    "release": "ga",
+    "description": "Collect and parse logs from any Windows event log channel with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/winlog/winlog-1.4.0.zip",
+    "path": "/package/winlog/1.4.0",
+    "icons": [
+      {
+        "src": "/img/logo_windows.svg",
+        "path": "/package/winlog/1.4.0/img/logo_windows.svg",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "winlogs",
+        "title": "Custom Windows event logs",
+        "description": "Collect your custom Windows event logs."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "signature_path": "/epr/winlog/winlog-1.4.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "winlog.winlog",
+        "title": "Custom Windows Event Log Dataset"
       }
     ]
   },

--- a/testdata/generated/storage-indexer/search-package-prerelease.json
+++ b/testdata/generated/storage-indexer/search-package-prerelease.json
@@ -54,6 +54,538 @@
     ]
   },
   {
+    "name": "activemq",
+    "title": "ActiveMQ",
+    "version": "0.3.0",
+    "release": "beta",
+    "description": "Collect logs and metrics from ActiveMQ instances with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/activemq/activemq-0.3.0.zip",
+    "path": "/package/activemq/0.3.0",
+    "icons": [
+      {
+        "src": "/img/activemq.svg",
+        "path": "/package/activemq/0.3.0/img/activemq.svg",
+        "title": "activemq",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "activemq",
+        "title": "ActiveMQ logs and metrics",
+        "description": "Collect logs and metrics from ActiveMQ instances"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "web"
+    ],
+    "signature_path": "/epr/activemq/activemq-0.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "activemq.audit",
+        "title": "ActiveMQ audit logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "activemq.broker",
+        "title": "ActiveMQ broker metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "activemq.log",
+        "title": "ActiveMQ log logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "activemq.queue",
+        "title": "ActiveMQ queue metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "activemq.topic",
+        "title": "ActiveMQ topic metrics"
+      }
+    ]
+  },
+  {
+    "name": "akamai",
+    "title": "Akamai",
+    "version": "2.28.0",
+    "release": "ga",
+    "description": "Collect logs from Akamai with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/akamai/akamai-2.28.0.zip",
+    "path": "/package/akamai/2.28.0",
+    "icons": [
+      {
+        "src": "/img/akamai_logo.svg",
+        "path": "/package/akamai/2.28.0/img/akamai_logo.svg",
+        "title": "Akamai",
+        "size": "409×167",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "akamai",
+        "title": "Akamai logs",
+        "description": "Collect SIEM logs from Akamai"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.13.0 || ^9.0.0"
+      }
+    },
+    "owner": {
+      "type": "community",
+      "github": "elastic/security-service-integrations"
+    },
+    "categories": [
+      "security",
+      "cdn_security"
+    ],
+    "signature_path": "/epr/akamai/akamai-2.28.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "akamai.siem",
+        "title": "Akamai SIEM Logs"
+      }
+    ]
+  },
+  {
+    "name": "apache",
+    "title": "Apache HTTP Server",
+    "version": "1.3.5",
+    "release": "ga",
+    "description": "Collect logs and metrics from Apache servers with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/apache/apache-1.3.5.zip",
+    "path": "/package/apache/1.3.5",
+    "icons": [
+      {
+        "src": "/img/logo_apache.svg",
+        "path": "/package/apache/1.3.5/img/logo_apache.svg",
+        "title": "Apache Logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "apache",
+        "title": "Apache logs and metrics",
+        "description": "Collect logs and metrics from Apache instances"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "web"
+    ],
+    "signature_path": "/epr/apache/apache-1.3.5.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "apache.access",
+        "title": "Apache access logs",
+        "deprecated": {
+          "since": "1.3.5",
+          "description": "This data stream is deprecated"
+        }
+      },
+      {
+        "type": "logs",
+        "dataset": "apache.error",
+        "title": "Apache error logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apache.status",
+        "title": "Apache status metrics"
+      }
+    ],
+    "deprecated": {
+      "since": "1.3.0",
+      "description": "This package is deprecated"
+    }
+  },
+  {
+    "name": "apm",
+    "title": "Elastic APM",
+    "version": "8.2.0",
+    "release": "ga",
+    "description": "Ingest APM data",
+    "type": "integration",
+    "download": "/epr/apm/apm-8.2.0.zip",
+    "path": "/package/apm/8.2.0",
+    "icons": [
+      {
+        "src": "/img/logo_apm.svg",
+        "path": "/package/apm/8.2.0/img/logo_apm.svg",
+        "title": "APM Logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "apmserver",
+        "title": "Elastic APM Integration",
+        "description": "Elastic APM Integration"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.2.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/apm-server"
+    },
+    "categories": [
+      "elastic_stack",
+      "monitoring"
+    ],
+    "signature_path": "/epr/apm/apm-8.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "apm.app",
+        "title": "APM application logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.app",
+        "title": "APM application metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "apm.error",
+        "title": "APM errors"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.internal",
+        "title": "APM internal metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.profiling",
+        "title": "APM profiles"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm.rum",
+        "title": "APM RUM traces"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm.sampled",
+        "title": "APM tail-sampled traces"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm",
+        "title": "APM traces"
+      }
+    ]
+  },
+  {
+    "name": "atlassian_bitbucket",
+    "title": "Atlassian Bitbucket",
+    "version": "1.2.1",
+    "release": "ga",
+    "description": "Collect logs from Atlassian Bitbucket with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.2.1.zip",
+    "path": "/package/atlassian_bitbucket/1.2.1",
+    "icons": [
+      {
+        "src": "/img/bitbucket-logo.svg",
+        "path": "/package/atlassian_bitbucket/1.2.1/img/bitbucket-logo.svg",
+        "title": "Bitbucket Logo",
+        "size": "625x564",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "audit",
+        "title": "Audit Logs",
+        "description": "Collect audit logs from Atlassian Bitbucket with Elastic Agent."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security",
+      "web"
+    ],
+    "signature_path": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_bitbucket.audit",
+        "title": "Bitbucket Audit Logs"
+      }
+    ]
+  },
+  {
+    "name": "atlassian_confluence",
+    "title": "Atlassian Confluence",
+    "version": "1.3.0",
+    "release": "ga",
+    "description": "Collect logs from Atlassian Confluence with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/atlassian_confluence/atlassian_confluence-1.3.0.zip",
+    "path": "/package/atlassian_confluence/1.3.0",
+    "icons": [
+      {
+        "src": "/img/confluence-logo.svg",
+        "path": "/package/atlassian_confluence/1.3.0/img/confluence-logo.svg",
+        "title": "Confluence Logo",
+        "size": "400x400",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "audit",
+        "title": "Audit Logs",
+        "description": "Collect audit logs from Atlassian Confluence with Elastic Agent."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security",
+      "web"
+    ],
+    "signature_path": "/epr/atlassian_confluence/atlassian_confluence-1.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_confluence.audit",
+        "title": "Confluence Audit Logs"
+      }
+    ]
+  },
+  {
+    "name": "atlassian_jira",
+    "title": "Atlassian Jira",
+    "version": "1.3.0",
+    "release": "ga",
+    "description": "Collect logs from Atlassian Jira with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/atlassian_jira/atlassian_jira-1.3.0.zip",
+    "path": "/package/atlassian_jira/1.3.0",
+    "icons": [
+      {
+        "src": "/img/jira-software-logo.svg",
+        "path": "/package/atlassian_jira/1.3.0/img/jira-software-logo.svg",
+        "title": "Jira Software Logo",
+        "size": "590x625",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "audit",
+        "title": "Audit Logs",
+        "description": "Collect audit logs from Atlassian Jira with Elastic Agent."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security",
+      "web"
+    ],
+    "signature_path": "/epr/atlassian_jira/atlassian_jira-1.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_jira.audit",
+        "title": "Jira Audit Logs"
+      }
+    ]
+  },
+  {
+    "name": "auditd",
+    "title": "Auditd Logs",
+    "version": "3.1.0",
+    "release": "ga",
+    "description": "Collect logs from Linux audit daemon with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/auditd/auditd-3.1.0.zip",
+    "path": "/package/auditd/3.1.0",
+    "icons": [
+      {
+        "src": "/img/linux.svg",
+        "path": "/package/auditd/3.1.0/img/linux.svg",
+        "title": "linux",
+        "size": "299x354",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "auditd",
+        "title": "Auditd logs",
+        "description": "Collect logs from Auditd instances"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "os_system"
+    ],
+    "signature_path": "/epr/auditd/auditd-3.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "auditd.log",
+        "title": "Auditd logs"
+      }
+    ]
+  },
+  {
+    "name": "auditd_manager",
+    "title": "Auditd Manager",
+    "version": "1.0.0",
+    "release": "ga",
+    "description": "The Auditd Manager Integration receives audit events from the Linux Audit Framework that is a part of the Linux kernel.",
+    "type": "integration",
+    "download": "/epr/auditd_manager/auditd_manager-1.0.0.zip",
+    "path": "/package/auditd_manager/1.0.0",
+    "icons": [
+      {
+        "src": "/img/linux.svg",
+        "path": "/package/auditd_manager/1.0.0/img/linux.svg",
+        "title": "linux",
+        "size": "299x354",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "auditd",
+        "title": "Auditd",
+        "description": "Collect auditd events"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.2.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "os_system",
+      "security"
+    ],
+    "signature_path": "/epr/auditd_manager/auditd_manager-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "auditd_manager.auditd",
+        "title": "Auditd Manager"
+      }
+    ]
+  },
+  {
+    "name": "auth0",
+    "title": "Auth0 Log Streams Integration",
+    "version": "1.0.0",
+    "release": "ga",
+    "description": "Collect logs from Auth0 with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/auth0/auth0-1.0.0.zip",
+    "path": "/package/auth0/1.0.0",
+    "icons": [
+      {
+        "src": "/img/auth0-logo.svg",
+        "path": "/package/auth0/1.0.0/img/auth0-logo.svg",
+        "title": "Auth0 logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "auth0_events",
+        "title": "Auth0 log stream events via Webhooks",
+        "description": "Collect Auth0 log streams events via Webhooks."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "cloud",
+      "network",
+      "security"
+    ],
+    "signature_path": "/epr/auth0/auth0-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "auth0.logs",
+        "title": "Auth0 logs via Webhooks"
+      }
+    ]
+  },
+  {
     "name": "aws",
     "title": "AWS",
     "version": "1.16.4",
@@ -649,6 +1181,51 @@
     ]
   },
   {
+    "name": "aws_logs",
+    "title": "Custom AWS Logs",
+    "version": "0.2.1",
+    "release": "beta",
+    "description": "Collect raw logs from AWS S3 or CloudWatch with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/aws_logs/aws_logs-0.2.1.zip",
+    "path": "/package/aws_logs/0.2.1",
+    "icons": [
+      {
+        "src": "/img/icon.svg",
+        "path": "/package/aws_logs/0.2.1/img/icon.svg",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "aws_logs",
+        "title": "Custom AWS Logs",
+        "description": "Collect raw logs from AWS S3 or CloudWatch with Elastic Agent."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/obs-cloud-monitoring"
+    },
+    "categories": [
+      "custom",
+      "cloud",
+      "aws"
+    ],
+    "signature_path": "/epr/aws_logs/aws_logs-0.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "aws_logs.generic",
+        "title": "Custom logs from AWS"
+      }
+    ]
+  },
+  {
     "name": "awsfargate",
     "title": "AWS Fargate",
     "version": "0.1.1",
@@ -692,835 +1269,6 @@
         "type": "metrics",
         "dataset": "awsfargate.task_stats",
         "title": "AWS Fargate task_stats metrics"
-      }
-    ]
-  },
-  {
-    "name": "ti_abusech",
-    "title": "AbuseCH",
-    "version": "1.2.3",
-    "release": "ga",
-    "description": "Collect threat intelligence from AbuseCH API with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/ti_abusech/ti_abusech-1.2.3.zip",
-    "path": "/package/ti_abusech/1.2.3",
-    "icons": [
-      {
-        "src": "/img/abusech2.svg",
-        "path": "/package/ti_abusech/1.2.3/img/abusech2.svg",
-        "title": "AbuseCH",
-        "size": "512x512",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "ti_abusech",
-        "title": "AbuseCH API",
-        "description": "Collect threat intelligence from the AbuseCH API"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/ti_abusech/ti_abusech-1.2.3.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ti_abusech.malware",
-        "title": "AbuseCH Malware logs"
-      },
-      {
-        "type": "logs",
-        "dataset": "ti_abusech.malwarebazaar",
-        "title": "AbuseCH MalwareBazaar logs"
-      },
-      {
-        "type": "logs",
-        "dataset": "ti_abusech.url",
-        "title": "AbuseCH URL logs"
-      }
-    ]
-  },
-  {
-    "name": "activemq",
-    "title": "ActiveMQ",
-    "version": "0.3.0",
-    "release": "beta",
-    "description": "Collect logs and metrics from ActiveMQ instances with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/activemq/activemq-0.3.0.zip",
-    "path": "/package/activemq/0.3.0",
-    "icons": [
-      {
-        "src": "/img/activemq.svg",
-        "path": "/package/activemq/0.3.0/img/activemq.svg",
-        "title": "activemq",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "activemq",
-        "title": "ActiveMQ logs and metrics",
-        "description": "Collect logs and metrics from ActiveMQ instances"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "web"
-    ],
-    "signature_path": "/epr/activemq/activemq-0.3.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "activemq.audit",
-        "title": "ActiveMQ audit logs"
-      },
-      {
-        "type": "metrics",
-        "dataset": "activemq.broker",
-        "title": "ActiveMQ broker metrics"
-      },
-      {
-        "type": "logs",
-        "dataset": "activemq.log",
-        "title": "ActiveMQ log logs"
-      },
-      {
-        "type": "metrics",
-        "dataset": "activemq.queue",
-        "title": "ActiveMQ queue metrics"
-      },
-      {
-        "type": "metrics",
-        "dataset": "activemq.topic",
-        "title": "ActiveMQ topic metrics"
-      }
-    ]
-  },
-  {
-    "name": "akamai",
-    "title": "Akamai",
-    "version": "2.28.0",
-    "release": "ga",
-    "description": "Collect logs from Akamai with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/akamai/akamai-2.28.0.zip",
-    "path": "/package/akamai/2.28.0",
-    "icons": [
-      {
-        "src": "/img/akamai_logo.svg",
-        "path": "/package/akamai/2.28.0/img/akamai_logo.svg",
-        "title": "Akamai",
-        "size": "409×167",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "akamai",
-        "title": "Akamai logs",
-        "description": "Collect SIEM logs from Akamai"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.13.0 || ^9.0.0"
-      }
-    },
-    "owner": {
-      "type": "community",
-      "github": "elastic/security-service-integrations"
-    },
-    "categories": [
-      "security",
-      "cdn_security"
-    ],
-    "signature_path": "/epr/akamai/akamai-2.28.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "akamai.siem",
-        "title": "Akamai SIEM Logs"
-      }
-    ]
-  },
-  {
-    "name": "ti_otx",
-    "title": "AlienVault OTX",
-    "version": "1.2.2",
-    "release": "ga",
-    "description": "Collect threat intelligence from AlienVault OTX with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/ti_otx/ti_otx-1.2.2.zip",
-    "path": "/package/ti_otx/1.2.2",
-    "icons": [
-      {
-        "src": "/img/otx.svg",
-        "path": "/package/ti_otx/1.2.2/img/otx.svg",
-        "title": "Alienvault OTX",
-        "size": "216x216",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "ti_otx",
-        "title": "Alienvault OTX",
-        "description": "Collect threat intelligence from the Alienvault OTX"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/ti_otx/ti_otx-1.2.2.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ti_otx.threat",
-        "title": "Alienvault OTX logs"
-      }
-    ]
-  },
-  {
-    "name": "ti_anomali",
-    "title": "Anomali",
-    "version": "1.2.3",
-    "release": "ga",
-    "description": "Collect threat intelligence from Anomali APIs with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/ti_anomali/ti_anomali-1.2.3.zip",
-    "path": "/package/ti_anomali/1.2.3",
-    "icons": [
-      {
-        "src": "/img/anomali.svg",
-        "path": "/package/ti_anomali/1.2.3/img/anomali.svg",
-        "title": "Anomali",
-        "size": "216x216",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "ti_anomali",
-        "title": "Anomali",
-        "description": "Collect threat intelligence from the Anomali Limo API and Anomali Threatstream."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/ti_anomali/ti_anomali-1.2.3.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ti_anomali.limo",
-        "title": "Anomali Limo"
-      },
-      {
-        "type": "logs",
-        "dataset": "ti_anomali.threatstream",
-        "title": "Anomali Threatstream"
-      }
-    ]
-  },
-  {
-    "name": "apache",
-    "title": "Apache HTTP Server",
-    "version": "1.3.5",
-    "release": "ga",
-    "description": "Collect logs and metrics from Apache servers with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/apache/apache-1.3.5.zip",
-    "path": "/package/apache/1.3.5",
-    "icons": [
-      {
-        "src": "/img/logo_apache.svg",
-        "path": "/package/apache/1.3.5/img/logo_apache.svg",
-        "title": "Apache Logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "apache",
-        "title": "Apache logs and metrics",
-        "description": "Collect logs and metrics from Apache instances"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "web"
-    ],
-    "signature_path": "/epr/apache/apache-1.3.5.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "apache.access",
-        "title": "Apache access logs",
-        "deprecated": {
-          "since": "1.3.5",
-          "description": "This data stream is deprecated"
-        }
-      },
-      {
-        "type": "logs",
-        "dataset": "apache.error",
-        "title": "Apache error logs"
-      },
-      {
-        "type": "metrics",
-        "dataset": "apache.status",
-        "title": "Apache status metrics"
-      }
-    ],
-    "deprecated": {
-      "since": "1.3.0",
-      "description": "This package is deprecated"
-    }
-  },
-  {
-    "name": "tomcat",
-    "title": "Apache Tomcat",
-    "version": "1.3.1",
-    "release": "ga",
-    "description": "Collect and parse logs from Apache Tomcat servers with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/tomcat/tomcat-1.3.1.zip",
-    "path": "/package/tomcat/1.3.1",
-    "icons": [
-      {
-        "src": "/img/logo.svg",
-        "path": "/package/tomcat/1.3.1/img/logo.svg",
-        "title": "Apache Tomcat logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "log",
-        "title": "Apache Tomcat",
-        "description": "Collect Apache Tomcat logs from syslog or a file."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.1 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "web",
-      "security"
-    ],
-    "signature_path": "/epr/tomcat/tomcat-1.3.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "tomcat.log",
-        "title": "Apache Tomcat logs"
-      }
-    ]
-  },
-  {
-    "name": "netscout",
-    "title": "Arbor Peakflow SP Logs",
-    "version": "0.7.0",
-    "release": "experimental",
-    "description": "Collect and parse logs from Netscout Arbor Peakflow SP with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/netscout/netscout-0.7.0.zip",
-    "path": "/package/netscout/0.7.0",
-    "icons": [
-      {
-        "src": "/img/logo.svg",
-        "path": "/package/netscout/0.7.0/img/logo.svg",
-        "title": "Arbor Peakflow SP logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "sightline",
-        "title": "Arbor Peakflow SP",
-        "description": "Collect Arbor Peakflow SP logs from syslog or a file."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.1 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/netscout/netscout-0.7.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "netscout.sightline",
-        "title": "Arbor Peakflow SP logs"
-      }
-    ]
-  },
-  {
-    "name": "atlassian_bitbucket",
-    "title": "Atlassian Bitbucket",
-    "version": "1.2.1",
-    "release": "ga",
-    "description": "Collect logs from Atlassian Bitbucket with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.2.1.zip",
-    "path": "/package/atlassian_bitbucket/1.2.1",
-    "icons": [
-      {
-        "src": "/img/bitbucket-logo.svg",
-        "path": "/package/atlassian_bitbucket/1.2.1/img/bitbucket-logo.svg",
-        "title": "Bitbucket Logo",
-        "size": "625x564",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "audit",
-        "title": "Audit Logs",
-        "description": "Collect audit logs from Atlassian Bitbucket with Elastic Agent."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security",
-      "web"
-    ],
-    "signature_path": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.2.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "atlassian_bitbucket.audit",
-        "title": "Bitbucket Audit Logs"
-      }
-    ]
-  },
-  {
-    "name": "atlassian_confluence",
-    "title": "Atlassian Confluence",
-    "version": "1.3.0",
-    "release": "ga",
-    "description": "Collect logs from Atlassian Confluence with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/atlassian_confluence/atlassian_confluence-1.3.0.zip",
-    "path": "/package/atlassian_confluence/1.3.0",
-    "icons": [
-      {
-        "src": "/img/confluence-logo.svg",
-        "path": "/package/atlassian_confluence/1.3.0/img/confluence-logo.svg",
-        "title": "Confluence Logo",
-        "size": "400x400",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "audit",
-        "title": "Audit Logs",
-        "description": "Collect audit logs from Atlassian Confluence with Elastic Agent."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security",
-      "web"
-    ],
-    "signature_path": "/epr/atlassian_confluence/atlassian_confluence-1.3.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "atlassian_confluence.audit",
-        "title": "Confluence Audit Logs"
-      }
-    ]
-  },
-  {
-    "name": "atlassian_jira",
-    "title": "Atlassian Jira",
-    "version": "1.3.0",
-    "release": "ga",
-    "description": "Collect logs from Atlassian Jira with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/atlassian_jira/atlassian_jira-1.3.0.zip",
-    "path": "/package/atlassian_jira/1.3.0",
-    "icons": [
-      {
-        "src": "/img/jira-software-logo.svg",
-        "path": "/package/atlassian_jira/1.3.0/img/jira-software-logo.svg",
-        "title": "Jira Software Logo",
-        "size": "590x625",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "audit",
-        "title": "Audit Logs",
-        "description": "Collect audit logs from Atlassian Jira with Elastic Agent."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security",
-      "web"
-    ],
-    "signature_path": "/epr/atlassian_jira/atlassian_jira-1.3.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "atlassian_jira.audit",
-        "title": "Jira Audit Logs"
-      }
-    ]
-  },
-  {
-    "name": "auditd",
-    "title": "Auditd Logs",
-    "version": "3.1.0",
-    "release": "ga",
-    "description": "Collect logs from Linux audit daemon with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/auditd/auditd-3.1.0.zip",
-    "path": "/package/auditd/3.1.0",
-    "icons": [
-      {
-        "src": "/img/linux.svg",
-        "path": "/package/auditd/3.1.0/img/linux.svg",
-        "title": "linux",
-        "size": "299x354",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "auditd",
-        "title": "Auditd logs",
-        "description": "Collect logs from Auditd instances"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "os_system"
-    ],
-    "signature_path": "/epr/auditd/auditd-3.1.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "auditd.log",
-        "title": "Auditd logs"
-      }
-    ]
-  },
-  {
-    "name": "auditd_manager",
-    "title": "Auditd Manager",
-    "version": "1.0.0",
-    "release": "ga",
-    "description": "The Auditd Manager Integration receives audit events from the Linux Audit Framework that is a part of the Linux kernel.",
-    "type": "integration",
-    "download": "/epr/auditd_manager/auditd_manager-1.0.0.zip",
-    "path": "/package/auditd_manager/1.0.0",
-    "icons": [
-      {
-        "src": "/img/linux.svg",
-        "path": "/package/auditd_manager/1.0.0/img/linux.svg",
-        "title": "linux",
-        "size": "299x354",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "auditd",
-        "title": "Auditd",
-        "description": "Collect auditd events"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.2.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "os_system",
-      "security"
-    ],
-    "signature_path": "/epr/auditd_manager/auditd_manager-1.0.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "auditd_manager.auditd",
-        "title": "Auditd Manager"
-      }
-    ]
-  },
-  {
-    "name": "auth0",
-    "title": "Auth0 Log Streams Integration",
-    "version": "1.0.0",
-    "release": "ga",
-    "description": "Collect logs from Auth0 with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/auth0/auth0-1.0.0.zip",
-    "path": "/package/auth0/1.0.0",
-    "icons": [
-      {
-        "src": "/img/auth0-logo.svg",
-        "path": "/package/auth0/1.0.0/img/auth0-logo.svg",
-        "title": "Auth0 logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "auth0_events",
-        "title": "Auth0 log stream events via Webhooks",
-        "description": "Collect Auth0 log streams events via Webhooks."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "cloud",
-      "network",
-      "security"
-    ],
-    "signature_path": "/epr/auth0/auth0-1.0.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "auth0.logs",
-        "title": "Auth0 logs via Webhooks"
-      }
-    ]
-  },
-  {
-    "name": "azure_application_insights",
-    "title": "Azure Application Insights Metrics Overview",
-    "version": "1.0.1",
-    "release": "ga",
-    "description": "Collect application insights metrics from Azure Monitor with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/azure_application_insights/azure_application_insights-1.0.1.zip",
-    "path": "/package/azure_application_insights/1.0.1",
-    "icons": [
-      {
-        "src": "/img/app_insights.png",
-        "path": "/package/azure_application_insights/1.0.1/img/app_insights.png",
-        "title": "logo docker",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "app_insights",
-        "title": "Azure Application Insights Metrics",
-        "description": "Collect application insights metrics from Azure Monitor with Elastic Agent.",
-        "icons": [
-          {
-            "src": "/img//app_insights.png",
-            "path": "/package/azure_application_insights/1.0.1/img/app_insights.png",
-            "title": "logo azure",
-            "size": "32x32",
-            "type": "image/svg+xml"
-          }
-        ],
-        "data_streams": [
-          "app_insights"
-        ]
-      },
-      {
-        "name": "app_state",
-        "title": "Azure Application State Insights Metrics",
-        "description": "Collect application state related metrics from Azure Monitor with Elastic Agent.",
-        "icons": [
-          {
-            "src": "/img/application_insights_blue.png",
-            "path": "/package/azure_application_insights/1.0.1/img/application_insights_blue.png",
-            "title": "logo azure",
-            "size": "32x32",
-            "type": "image/svg+xml"
-          }
-        ],
-        "data_streams": [
-          "app_state"
-        ]
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "azure",
-      "web"
-    ],
-    "signature_path": "/epr/azure_application_insights/azure_application_insights-1.0.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "metrics",
-        "dataset": "azure.app_insights",
-        "title": "Azure Application Insights"
-      },
-      {
-        "type": "metrics",
-        "dataset": "azure.app_state",
-        "title": "Azure Application State"
-      }
-    ]
-  },
-  {
-    "name": "azure_billing",
-    "title": "Azure Billing Metrics",
-    "version": "1.0.1",
-    "release": "ga",
-    "description": "Collect billing metrics with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/azure_billing/azure_billing-1.0.1.zip",
-    "path": "/package/azure_billing/1.0.1",
-    "icons": [
-      {
-        "src": "/img/billing.png",
-        "path": "/package/azure_billing/1.0.1/img/billing.png",
-        "title": "logo docker",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "billing",
-        "title": "Azure Billing Metrics",
-        "description": "Collect billing information with Elastic Agent.",
-        "icons": [
-          {
-            "src": "/img//billing.png",
-            "path": "/package/azure_billing/1.0.1/img/billing.png",
-            "title": "logo azure",
-            "size": "32x32",
-            "type": "image/svg+xml"
-          }
-        ],
-        "data_streams": [
-          "billing"
-        ]
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.15.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "azure"
-    ],
-    "signature_path": "/epr/azure_billing/azure_billing-1.0.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "metrics",
-        "dataset": "azure.billing",
-        "title": "Azure Billing Metrics"
       }
     ]
   },
@@ -1675,6 +1423,143 @@
         "type": "logs",
         "dataset": "azure.springcloudlogs",
         "title": "Azure Spring Cloud Logs"
+      }
+    ]
+  },
+  {
+    "name": "azure_application_insights",
+    "title": "Azure Application Insights Metrics Overview",
+    "version": "1.0.1",
+    "release": "ga",
+    "description": "Collect application insights metrics from Azure Monitor with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/azure_application_insights/azure_application_insights-1.0.1.zip",
+    "path": "/package/azure_application_insights/1.0.1",
+    "icons": [
+      {
+        "src": "/img/app_insights.png",
+        "path": "/package/azure_application_insights/1.0.1/img/app_insights.png",
+        "title": "logo docker",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "app_insights",
+        "title": "Azure Application Insights Metrics",
+        "description": "Collect application insights metrics from Azure Monitor with Elastic Agent.",
+        "icons": [
+          {
+            "src": "/img//app_insights.png",
+            "path": "/package/azure_application_insights/1.0.1/img/app_insights.png",
+            "title": "logo azure",
+            "size": "32x32",
+            "type": "image/svg+xml"
+          }
+        ],
+        "data_streams": [
+          "app_insights"
+        ]
+      },
+      {
+        "name": "app_state",
+        "title": "Azure Application State Insights Metrics",
+        "description": "Collect application state related metrics from Azure Monitor with Elastic Agent.",
+        "icons": [
+          {
+            "src": "/img/application_insights_blue.png",
+            "path": "/package/azure_application_insights/1.0.1/img/application_insights_blue.png",
+            "title": "logo azure",
+            "size": "32x32",
+            "type": "image/svg+xml"
+          }
+        ],
+        "data_streams": [
+          "app_state"
+        ]
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "azure",
+      "web"
+    ],
+    "signature_path": "/epr/azure_application_insights/azure_application_insights-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "azure.app_insights",
+        "title": "Azure Application Insights"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.app_state",
+        "title": "Azure Application State"
+      }
+    ]
+  },
+  {
+    "name": "azure_billing",
+    "title": "Azure Billing Metrics",
+    "version": "1.0.1",
+    "release": "ga",
+    "description": "Collect billing metrics with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/azure_billing/azure_billing-1.0.1.zip",
+    "path": "/package/azure_billing/1.0.1",
+    "icons": [
+      {
+        "src": "/img/billing.png",
+        "path": "/package/azure_billing/1.0.1/img/billing.png",
+        "title": "logo docker",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "billing",
+        "title": "Azure Billing Metrics",
+        "description": "Collect billing information with Elastic Agent.",
+        "icons": [
+          {
+            "src": "/img//billing.png",
+            "path": "/package/azure_billing/1.0.1/img/billing.png",
+            "title": "logo azure",
+            "size": "32x32",
+            "type": "image/svg+xml"
+          }
+        ],
+        "data_streams": [
+          "billing"
+        ]
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.15.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "azure"
+    ],
+    "signature_path": "/epr/azure_billing/azure_billing-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "azure.billing",
+        "title": "Azure Billing Metrics"
       }
     ]
   },
@@ -1979,85 +1864,112 @@
     ]
   },
   {
-    "name": "cef",
-    "title": "CEF Logs",
-    "version": "2.0.0",
+    "name": "carbon_black_cloud",
+    "title": "VMware Carbon Black Cloud",
+    "version": "1.0.2",
     "release": "ga",
-    "description": "Collect logs from CEF Logs with Elastic Agent.",
+    "description": "Collect logs from VMWare Carbon Black Cloud with Elastic Agent.",
     "type": "integration",
-    "download": "/epr/cef/cef-2.0.0.zip",
-    "path": "/package/cef/2.0.0",
-    "policy_templates": [
-      {
-        "name": "cef",
-        "title": "CEF logs",
-        "description": "Collect logs from CEF instances"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "network",
-      "security"
-    ],
-    "signature_path": "/epr/cef/cef-2.0.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "cef.log",
-        "title": "CEF log logs"
-      }
-    ]
-  },
-  {
-    "name": "cloud_security_posture",
-    "title": "CIS Kubernetes Benchmark",
-    "version": "0.0.14",
-    "release": "experimental",
-    "description": "Check Kubernetes cluster compliance with the Kubernetes CIS benchmark.",
-    "type": "integration",
-    "download": "/epr/cloud_security_posture/cloud_security_posture-0.0.14.zip",
-    "path": "/package/cloud_security_posture/0.0.14",
+    "download": "/epr/carbon_black_cloud/carbon_black_cloud-1.0.2.zip",
+    "path": "/package/carbon_black_cloud/1.0.2",
     "icons": [
       {
-        "src": "/img/cis-kubernetes-benchmark-logo.svg",
-        "path": "/package/cloud_security_posture/0.0.14/img/cis-kubernetes-benchmark-logo.svg",
-        "title": "CIS Kubernetes Benchmark logo",
+        "src": "/img/carbon_black_cloud-logo.svg",
+        "path": "/package/carbon_black_cloud/1.0.2/img/carbon_black_cloud-logo.svg",
+        "title": "Carbon Black Cloud logo",
         "size": "32x32",
         "type": "image/svg+xml"
       }
     ],
     "policy_templates": [
       {
-        "name": "kspm",
-        "title": "CIS Kubernetes Benchmark",
-        "description": "Check Kubernetes cluster compliance with the Kubernetes CIS benchmark."
+        "name": "carbon_black_cloud",
+        "title": "Carbon Black Cloud",
+        "description": "Collect Logs from Carbon Black Cloud"
       }
     ],
     "conditions": {
       "kibana": {
-        "version": "^8.3.0"
+        "version": "^7.17.0 || ^8.0.0"
       }
     },
     "owner": {
-      "github": "elastic/cloud-security-posture"
+      "github": "elastic/security-external-integrations"
     },
     "categories": [
-      "containers",
-      "kubernetes"
+      "security"
     ],
-    "signature_path": "/epr/cloud_security_posture/cloud_security_posture-0.0.14.zip.sig",
+    "signature_path": "/epr/carbon_black_cloud/carbon_black_cloud-1.0.2.zip.sig",
     "data_streams": [
       {
         "type": "logs",
-        "dataset": "cloud_security_posture.findings",
-        "title": "Findings"
+        "dataset": "carbon_black_cloud.alert",
+        "title": "Alert"
+      },
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.asset_vulnerability_summary",
+        "title": "Asset Vulnerability Summary"
+      },
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.audit",
+        "title": "Audit"
+      },
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.endpoint_event",
+        "title": "Endpoint Event"
+      },
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.watchlist_hit",
+        "title": "Watchlist Hit"
+      }
+    ]
+  },
+  {
+    "name": "carbonblack_edr",
+    "title": "VMware Carbon Black EDR",
+    "version": "1.2.0",
+    "release": "ga",
+    "description": "Collect logs from VMware Carbon Black EDR with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/carbonblack_edr/carbonblack_edr-1.2.0.zip",
+    "path": "/package/carbonblack_edr/1.2.0",
+    "icons": [
+      {
+        "src": "/img/carbon-black-logo.svg",
+        "path": "/package/carbonblack_edr/1.2.0/img/carbon-black-logo.svg",
+        "title": "VMWare Carbon Black",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "log",
+        "title": "Carbon Black EDR logs",
+        "description": "Collect logs from Carbon Black EDR"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/carbonblack_edr/carbonblack_edr-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "carbonblack_edr.log",
+        "title": "Carbon Black EDR logs"
       }
     ]
   },
@@ -2109,6 +2021,43 @@
         "type": "metrics",
         "dataset": "cassandra.metrics",
         "title": "metrics"
+      }
+    ]
+  },
+  {
+    "name": "cef",
+    "title": "CEF Logs",
+    "version": "2.0.0",
+    "release": "ga",
+    "description": "Collect logs from CEF Logs with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/cef/cef-2.0.0.zip",
+    "path": "/package/cef/2.0.0",
+    "policy_templates": [
+      {
+        "name": "cef",
+        "title": "CEF logs",
+        "description": "Collect logs from CEF instances"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "network",
+      "security"
+    ],
+    "signature_path": "/epr/cef/cef-2.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cef.log",
+        "title": "CEF log logs"
       }
     ]
   },
@@ -2706,6 +2655,52 @@
     ]
   },
   {
+    "name": "cloud_security_posture",
+    "title": "CIS Kubernetes Benchmark",
+    "version": "0.0.14",
+    "release": "experimental",
+    "description": "Check Kubernetes cluster compliance with the Kubernetes CIS benchmark.",
+    "type": "integration",
+    "download": "/epr/cloud_security_posture/cloud_security_posture-0.0.14.zip",
+    "path": "/package/cloud_security_posture/0.0.14",
+    "icons": [
+      {
+        "src": "/img/cis-kubernetes-benchmark-logo.svg",
+        "path": "/package/cloud_security_posture/0.0.14/img/cis-kubernetes-benchmark-logo.svg",
+        "title": "CIS Kubernetes Benchmark logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "kspm",
+        "title": "CIS Kubernetes Benchmark",
+        "description": "Check Kubernetes cluster compliance with the Kubernetes CIS benchmark."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.3.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/cloud-security-posture"
+    },
+    "categories": [
+      "containers",
+      "kubernetes"
+    ],
+    "signature_path": "/epr/cloud_security_posture/cloud_security_posture-0.0.14.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cloud_security_posture.findings",
+        "title": "Findings"
+      }
+    ]
+  },
+  {
     "name": "cloudflare",
     "title": "Cloudflare",
     "version": "2.0.0",
@@ -2866,389 +2861,6 @@
     ]
   },
   {
-    "name": "aws_logs",
-    "title": "Custom AWS Logs",
-    "version": "0.2.1",
-    "release": "beta",
-    "description": "Collect raw logs from AWS S3 or CloudWatch with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/aws_logs/aws_logs-0.2.1.zip",
-    "path": "/package/aws_logs/0.2.1",
-    "icons": [
-      {
-        "src": "/img/icon.svg",
-        "path": "/package/aws_logs/0.2.1/img/icon.svg",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "aws_logs",
-        "title": "Custom AWS Logs",
-        "description": "Collect raw logs from AWS S3 or CloudWatch with Elastic Agent."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/obs-cloud-monitoring"
-    },
-    "categories": [
-      "custom",
-      "cloud",
-      "aws"
-    ],
-    "signature_path": "/epr/aws_logs/aws_logs-0.2.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "aws_logs.generic",
-        "title": "Custom logs from AWS"
-      }
-    ]
-  },
-  {
-    "name": "gcp_pubsub",
-    "title": "Custom Google Pub/Sub Logs",
-    "version": "1.0.0",
-    "release": "ga",
-    "description": "Collect Logs from Google Pub/Sub topics",
-    "type": "integration",
-    "download": "/epr/gcp_pubsub/gcp_pubsub-1.0.0.zip",
-    "path": "/package/gcp_pubsub/1.0.0",
-    "icons": [
-      {
-        "src": "/img/logo_gcp.svg",
-        "path": "/package/gcp_pubsub/1.0.0/img/logo_gcp.svg",
-        "title": "logo gcp",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "gcp",
-        "title": "Custom Google Pub/Sub Logs",
-        "description": "Collect Logs from Google Pub/Sub topics"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "google_cloud",
-      "cloud",
-      "custom"
-    ],
-    "signature_path": "/epr/gcp_pubsub/gcp_pubsub-1.0.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "gcp_pubsub.generic",
-        "title": "Custom Google Pub/Sub Logs"
-      }
-    ]
-  },
-  {
-    "name": "http_endpoint",
-    "title": "Custom HTTP Endpoint Logs",
-    "version": "1.0.1",
-    "release": "ga",
-    "description": "Collect JSON data from listening HTTP port with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/http_endpoint/http_endpoint-1.0.1.zip",
-    "path": "/package/http_endpoint/1.0.1",
-    "icons": [
-      {
-        "src": "/img/icon.svg",
-        "path": "/package/http_endpoint/1.0.1/img/icon.svg",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "http_endpoint",
-        "title": "Custom HTTP Endpoint Logs",
-        "description": "Collect JSON data from listening HTTP port with Elastic Agent."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "signature_path": "/epr/http_endpoint/http_endpoint-1.0.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "http_endpoint.generic",
-        "title": "Custom HTTP Endpoint Logs"
-      }
-    ]
-  },
-  {
-    "name": "httpjson",
-    "title": "Custom HTTPJSON Input",
-    "version": "1.1.1",
-    "release": "ga",
-    "description": "Collect custom data from REST API's with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/httpjson/httpjson-1.1.1.zip",
-    "path": "/package/httpjson/1.1.1",
-    "policy_templates": [
-      {
-        "name": "generic",
-        "title": "Custom HTTPJSON Input",
-        "description": "Collect custom data from REST API's"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "signature_path": "/epr/httpjson/httpjson-1.1.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "httpjson.generic",
-        "title": "Custom HTTPJSON Input"
-      }
-    ]
-  },
-  {
-    "name": "journald",
-    "title": "Custom Journald logs",
-    "version": "0.0.2",
-    "release": "experimental",
-    "description": "Collect logs from journald with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/journald/journald-0.0.2.zip",
-    "path": "/package/journald/0.0.2",
-    "icons": [
-      {
-        "src": "/img/systemd-logo.svg",
-        "path": "/package/journald/0.0.2/img/systemd-logo.svg",
-        "title": "systemd logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "logs",
-        "title": "Journald",
-        "description": "Collect sample logs"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "signature_path": "/epr/journald/journald-0.0.2.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "journald.log",
-        "title": "Journald Log"
-      }
-    ]
-  },
-  {
-    "name": "log",
-    "title": "Custom Logs",
-    "version": "1.0.0",
-    "release": "ga",
-    "description": "Collect custom logs with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/log/log-1.0.0.zip",
-    "path": "/package/log/1.0.0",
-    "icons": [
-      {
-        "src": "/img/icon.svg",
-        "path": "/package/log/1.0.0/img/icon.svg",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "logs",
-        "title": "Custom logs",
-        "description": "Collect your custom log files."
-      }
-    ],
-    "owner": {
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "signature_path": "/epr/log/log-1.0.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "log.log",
-        "title": "Log Dataset"
-      }
-    ]
-  },
-  {
-    "name": "tcp",
-    "title": "Custom TCP Logs",
-    "version": "1.0.0",
-    "release": "ga",
-    "description": "Collect raw TCP data from listening TCP port with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/tcp/tcp-1.0.0.zip",
-    "path": "/package/tcp/1.0.0",
-    "icons": [
-      {
-        "src": "/img/icon.svg",
-        "path": "/package/tcp/1.0.0/img/icon.svg",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "tcp",
-        "title": "Custom TCP Logs",
-        "description": "Collect raw TCP data from listening TCP port with Elastic Agent."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "signature_path": "/epr/tcp/tcp-1.0.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "tcp.generic",
-        "title": "Custom TCP Logs"
-      }
-    ]
-  },
-  {
-    "name": "udp",
-    "title": "Custom UDP Logs",
-    "version": "1.0.1",
-    "release": "ga",
-    "description": "Collect raw UDP data from listening UDP port with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/udp/udp-1.0.1.zip",
-    "path": "/package/udp/1.0.1",
-    "icons": [
-      {
-        "src": "/img/icon.svg",
-        "path": "/package/udp/1.0.1/img/icon.svg",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "udp",
-        "title": "Custom UDP Logs",
-        "description": "Collect raw UDP data from listening UDP port with Elastic Agent."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "signature_path": "/epr/udp/udp-1.0.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "udp.generic",
-        "title": "Custom UDP Logs"
-      }
-    ]
-  },
-  {
-    "name": "winlog",
-    "title": "Custom Windows Event Logs",
-    "version": "1.4.0",
-    "release": "ga",
-    "description": "Collect and parse logs from any Windows event log channel with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/winlog/winlog-1.4.0.zip",
-    "path": "/package/winlog/1.4.0",
-    "icons": [
-      {
-        "src": "/img/logo_windows.svg",
-        "path": "/package/winlog/1.4.0/img/logo_windows.svg",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "winlogs",
-        "title": "Custom Windows event logs",
-        "description": "Collect your custom Windows event logs."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "signature_path": "/epr/winlog/winlog-1.4.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "winlog.winlog",
-        "title": "Custom Windows Event Log Dataset"
-      }
-    ]
-  },
-  {
     "name": "cyberark",
     "title": "CyberArk",
     "version": "0.4.4",
@@ -3335,52 +2947,6 @@
         "type": "logs",
         "dataset": "cyberarkpas.audit",
         "title": "CyberArk PAS audit logs"
-      }
-    ]
-  },
-  {
-    "name": "ti_cybersixgill",
-    "title": "Cybersixgill",
-    "version": "1.3.2",
-    "release": "ga",
-    "description": "This Elastic integration collects threat intelligence from Cybersixgill",
-    "type": "integration",
-    "download": "/epr/ti_cybersixgill/ti_cybersixgill-1.3.2.zip",
-    "path": "/package/ti_cybersixgill/1.3.2",
-    "icons": [
-      {
-        "src": "/img/cybersixgill.svg",
-        "path": "/package/ti_cybersixgill/1.3.2/img/cybersixgill.svg",
-        "title": "Cybersixgill",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "cybersixgill",
-        "title": "Cybersixgill Threat Intel",
-        "description": "Collect Threat Intel from Cybersixgill"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security",
-      "productivity"
-    ],
-    "signature_path": "/epr/ti_cybersixgill/ti_cybersixgill-1.3.2.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ti_cybersixgill.threat",
-        "title": "Cybersixgill Darkfeed Logs"
       }
     ]
   },
@@ -3636,87 +3202,6 @@
     ]
   },
   {
-    "name": "apm",
-    "title": "Elastic APM",
-    "version": "8.2.0",
-    "release": "ga",
-    "description": "Ingest APM data",
-    "type": "integration",
-    "download": "/epr/apm/apm-8.2.0.zip",
-    "path": "/package/apm/8.2.0",
-    "icons": [
-      {
-        "src": "/img/logo_apm.svg",
-        "path": "/package/apm/8.2.0/img/logo_apm.svg",
-        "title": "APM Logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "apmserver",
-        "title": "Elastic APM Integration",
-        "description": "Elastic APM Integration"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.2.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/apm-server"
-    },
-    "categories": [
-      "elastic_stack",
-      "monitoring"
-    ],
-    "signature_path": "/epr/apm/apm-8.2.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "apm.app",
-        "title": "APM application logs"
-      },
-      {
-        "type": "metrics",
-        "dataset": "apm.app",
-        "title": "APM application metrics"
-      },
-      {
-        "type": "logs",
-        "dataset": "apm.error",
-        "title": "APM errors"
-      },
-      {
-        "type": "metrics",
-        "dataset": "apm.internal",
-        "title": "APM internal metrics"
-      },
-      {
-        "type": "metrics",
-        "dataset": "apm.profiling",
-        "title": "APM profiles"
-      },
-      {
-        "type": "traces",
-        "dataset": "apm.rum",
-        "title": "APM RUM traces"
-      },
-      {
-        "type": "traces",
-        "dataset": "apm.sampled",
-        "title": "APM tail-sampled traces"
-      },
-      {
-        "type": "traces",
-        "dataset": "apm",
-        "title": "APM traces"
-      }
-    ]
-  },
-  {
     "name": "elastic_agent",
     "title": "Elastic Agent",
     "version": "1.3.1",
@@ -3846,77 +3331,6 @@
         "type": "metrics",
         "dataset": "elastic_agent.packetbeat",
         "title": "Elastic Agent"
-      }
-    ]
-  },
-  {
-    "name": "synthetics",
-    "title": "Elastic Synthetics",
-    "version": "0.9.2",
-    "release": "beta",
-    "description": "Monitor the availability of your services with Elastic Synthetics.",
-    "type": "integration",
-    "download": "/epr/synthetics/synthetics-0.9.2.zip",
-    "path": "/package/synthetics/0.9.2",
-    "icons": [
-      {
-        "src": "/img/uptime-logo-color-64px.svg",
-        "path": "/package/synthetics/0.9.2/img/uptime-logo-color-64px.svg",
-        "size": "16x16",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "synthetics",
-        "title": "Elastic Synthetics",
-        "description": "Perform synthetic health checks on network endpoints."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.1.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/uptime"
-    },
-    "categories": [
-      "elastic_stack",
-      "monitoring",
-      "web"
-    ],
-    "signature_path": "/epr/synthetics/synthetics-0.9.2.zip.sig",
-    "data_streams": [
-      {
-        "type": "synthetics",
-        "dataset": "browser",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "browser.network",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "browser.screenshot",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "http",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "icmp",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "tcp",
-        "title": "synthetic monitor check"
       }
     ]
   },
@@ -4390,51 +3804,6 @@
     ]
   },
   {
-    "name": "github",
-    "title": "GitHub",
-    "version": "1.0.0",
-    "release": "ga",
-    "description": "Collect events from GitHub with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/github/github-1.0.0.zip",
-    "path": "/package/github/1.0.0",
-    "icons": [
-      {
-        "src": "/img/github.svg",
-        "path": "/package/github/1.0.0/img/github.svg",
-        "title": "GitHub",
-        "size": "1024x1024",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "github",
-        "title": "GitHub logs",
-        "description": "Collect logs from GitHub"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/github/github-1.0.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "github.audit",
-        "title": "GitHub Audit Logs"
-      }
-    ]
-  },
-  {
     "name": "gcp",
     "title": "Google Cloud Platform",
     "version": "1.9.0",
@@ -4498,47 +3867,94 @@
     ]
   },
   {
-    "name": "santa",
-    "title": "Google Santa Logs",
-    "version": "2.0.1",
+    "name": "gcp_pubsub",
+    "title": "Custom Google Pub/Sub Logs",
+    "version": "1.0.0",
     "release": "ga",
-    "description": "Collect and parse logs from Google Santa instances with Elastic Agent.",
+    "description": "Collect Logs from Google Pub/Sub topics",
     "type": "integration",
-    "download": "/epr/santa/santa-2.0.1.zip",
-    "path": "/package/santa/2.0.1",
+    "download": "/epr/gcp_pubsub/gcp_pubsub-1.0.0.zip",
+    "path": "/package/gcp_pubsub/1.0.0",
     "icons": [
       {
-        "src": "/img/icon.svg",
-        "path": "/package/santa/2.0.1/img/icon.svg",
-        "title": "Google Santa",
+        "src": "/img/logo_gcp.svg",
+        "path": "/package/gcp_pubsub/1.0.0/img/logo_gcp.svg",
+        "title": "logo gcp",
+        "size": "32x32",
         "type": "image/svg+xml"
       }
     ],
     "policy_templates": [
       {
-        "name": "santa",
-        "title": "Google Santa logs",
-        "description": "Collect logs from Google Santa instances"
+        "name": "gcp",
+        "title": "Custom Google Pub/Sub Logs",
+        "description": "Collect Logs from Google Pub/Sub topics"
       }
     ],
     "conditions": {
       "kibana": {
-        "version": "^7.17.0 || ^8.0.0"
+        "version": "^7.16.0 || ^8.0.0"
       }
     },
     "owner": {
       "github": "elastic/security-external-integrations"
     },
     "categories": [
-      "security",
-      "os_system"
+      "google_cloud",
+      "cloud",
+      "custom"
     ],
-    "signature_path": "/epr/santa/santa-2.0.1.zip.sig",
+    "signature_path": "/epr/gcp_pubsub/gcp_pubsub-1.0.0.zip.sig",
     "data_streams": [
       {
         "type": "logs",
-        "dataset": "santa.log",
-        "title": "Google Santa log logs"
+        "dataset": "gcp_pubsub.generic",
+        "title": "Custom Google Pub/Sub Logs"
+      }
+    ]
+  },
+  {
+    "name": "github",
+    "title": "GitHub",
+    "version": "1.0.0",
+    "release": "ga",
+    "description": "Collect events from GitHub with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/github/github-1.0.0.zip",
+    "path": "/package/github/1.0.0",
+    "icons": [
+      {
+        "src": "/img/github.svg",
+        "path": "/package/github/1.0.0/img/github.svg",
+        "title": "GitHub",
+        "size": "1024x1024",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "github",
+        "title": "GitHub logs",
+        "description": "Collect logs from GitHub"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/github/github-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "github.audit",
+        "title": "GitHub Audit Logs"
       }
     ]
   },
@@ -4774,6 +4190,85 @@
     ]
   },
   {
+    "name": "http_endpoint",
+    "title": "Custom HTTP Endpoint Logs",
+    "version": "1.0.1",
+    "release": "ga",
+    "description": "Collect JSON data from listening HTTP port with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/http_endpoint/http_endpoint-1.0.1.zip",
+    "path": "/package/http_endpoint/1.0.1",
+    "icons": [
+      {
+        "src": "/img/icon.svg",
+        "path": "/package/http_endpoint/1.0.1/img/icon.svg",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "http_endpoint",
+        "title": "Custom HTTP Endpoint Logs",
+        "description": "Collect JSON data from listening HTTP port with Elastic Agent."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "signature_path": "/epr/http_endpoint/http_endpoint-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "http_endpoint.generic",
+        "title": "Custom HTTP Endpoint Logs"
+      }
+    ]
+  },
+  {
+    "name": "httpjson",
+    "title": "Custom HTTPJSON Input",
+    "version": "1.1.1",
+    "release": "ga",
+    "description": "Collect custom data from REST API's with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/httpjson/httpjson-1.1.1.zip",
+    "path": "/package/httpjson/1.1.1",
+    "policy_templates": [
+      {
+        "name": "generic",
+        "title": "Custom HTTPJSON Input",
+        "description": "Collect custom data from REST API's"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "signature_path": "/epr/httpjson/httpjson-1.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "httpjson.generic",
+        "title": "Custom HTTPJSON Input"
+      }
+    ]
+  },
+  {
     "name": "iis",
     "title": "IIS",
     "version": "0.8.0",
@@ -4967,48 +4462,47 @@
     ]
   },
   {
-    "name": "juniper_junos",
-    "title": "Juniper JunOS",
-    "version": "0.1.1",
+    "name": "journald",
+    "title": "Custom Journald logs",
+    "version": "0.0.2",
     "release": "experimental",
-    "description": "Collect logs from Juniper JunOS with Elastic Agent.",
+    "description": "Collect logs from journald with Elastic Agent.",
     "type": "integration",
-    "download": "/epr/juniper_junos/juniper_junos-0.1.1.zip",
-    "path": "/package/juniper_junos/0.1.1",
+    "download": "/epr/journald/journald-0.0.2.zip",
+    "path": "/package/journald/0.0.2",
     "icons": [
       {
-        "src": "/img/logo.svg",
-        "path": "/package/juniper_junos/0.1.1/img/logo.svg",
-        "title": "Juniper logo",
+        "src": "/img/systemd-logo.svg",
+        "path": "/package/journald/0.0.2/img/systemd-logo.svg",
+        "title": "systemd logo",
         "size": "32x32",
         "type": "image/svg+xml"
       }
     ],
     "policy_templates": [
       {
-        "name": "juniper",
-        "title": "Juniper JunOS logs",
-        "description": "Collect Juniper JunOS logs from syslog or a file."
+        "name": "logs",
+        "title": "Journald",
+        "description": "Collect sample logs"
       }
     ],
     "conditions": {
       "kibana": {
-        "version": "^8.0.0"
+        "version": "^7.16.0"
       }
     },
     "owner": {
-      "github": "elastic/security-external-integrations"
+      "github": "elastic/integrations"
     },
     "categories": [
-      "network",
-      "security"
+      "custom"
     ],
-    "signature_path": "/epr/juniper_junos/juniper_junos-0.1.1.zip.sig",
+    "signature_path": "/epr/journald/journald-0.0.2.zip.sig",
     "data_streams": [
       {
         "type": "logs",
-        "dataset": "juniper_junos.log",
-        "title": "Juniper JUNOS logs"
+        "dataset": "journald.log",
+        "title": "Journald Log"
       }
     ]
   },
@@ -5065,6 +4559,52 @@
         "type": "logs",
         "dataset": "juniper.srx",
         "title": "Juniper SRX logs"
+      }
+    ]
+  },
+  {
+    "name": "juniper_junos",
+    "title": "Juniper JunOS",
+    "version": "0.1.1",
+    "release": "experimental",
+    "description": "Collect logs from Juniper JunOS with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/juniper_junos/juniper_junos-0.1.1.zip",
+    "path": "/package/juniper_junos/0.1.1",
+    "icons": [
+      {
+        "src": "/img/logo.svg",
+        "path": "/package/juniper_junos/0.1.1/img/logo.svg",
+        "title": "Juniper logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "juniper",
+        "title": "Juniper JunOS logs",
+        "description": "Collect Juniper JunOS logs from syslog or a file."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "network",
+      "security"
+    ],
+    "signature_path": "/epr/juniper_junos/juniper_junos-0.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "juniper_junos.log",
+        "title": "Juniper JUNOS logs"
       }
     ]
   },
@@ -5784,6 +5324,44 @@
     ]
   },
   {
+    "name": "log",
+    "title": "Custom Logs",
+    "version": "1.0.0",
+    "release": "ga",
+    "description": "Collect custom logs with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/log/log-1.0.0.zip",
+    "path": "/package/log/1.0.0",
+    "icons": [
+      {
+        "src": "/img/icon.svg",
+        "path": "/package/log/1.0.0/img/icon.svg",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "logs",
+        "title": "Custom logs",
+        "description": "Collect your custom log files."
+      }
+    ],
+    "owner": {
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "signature_path": "/epr/log/log-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "log.log",
+        "title": "Log Dataset"
+      }
+    ]
+  },
+  {
     "name": "logstash",
     "title": "Logstash",
     "version": "1.1.0",
@@ -5844,37 +5422,6 @@
     ]
   },
   {
-    "name": "problemchild",
-    "title": "LotL Attack Detection",
-    "version": "0.0.2",
-    "release": "experimental",
-    "description": "The ProblemChild framework is used to detect living off the land activity. Requires a Platinum subscription.",
-    "type": "integration",
-    "download": "/epr/problemchild/problemchild-0.0.2.zip",
-    "path": "/package/problemchild/0.0.2",
-    "icons": [
-      {
-        "src": "/img/icon-machine-learning.svg",
-        "path": "/package/problemchild/0.0.2/img/icon-machine-learning.svg",
-        "title": "Sample logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/ml-ui"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/problemchild/problemchild-0.0.2.zip.sig"
-  },
-  {
     "name": "m365_defender",
     "title": "M365 Defender Logs",
     "version": "1.0.3",
@@ -5918,51 +5465,6 @@
         "type": "logs",
         "dataset": "m365_defender.log",
         "title": "M365 Defender Logs"
-      }
-    ]
-  },
-  {
-    "name": "ti_misp",
-    "title": "MISP",
-    "version": "1.2.2",
-    "release": "ga",
-    "description": "This Elastic integration collects events from MISP",
-    "type": "integration",
-    "download": "/epr/ti_misp/ti_misp-1.2.2.zip",
-    "path": "/package/ti_misp/1.2.2",
-    "icons": [
-      {
-        "src": "/img/misp.svg",
-        "path": "/package/ti_misp/1.2.2/img/misp.svg",
-        "title": "MISP",
-        "size": "216x216",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "ti_misp",
-        "title": "MISP",
-        "description": "Collect threat intelligence from the MISP API."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/ti_misp/ti_misp-1.2.2.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ti_misp.threat",
-        "title": "MISP"
       }
     ]
   },
@@ -6065,51 +5567,6 @@
     ]
   },
   {
-    "name": "microsoft_dhcp",
-    "title": "Microsoft DHCP",
-    "version": "1.3.1",
-    "release": "ga",
-    "description": "Collect logs from Microsoft DHCP with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/microsoft_dhcp/microsoft_dhcp-1.3.1.zip",
-    "path": "/package/microsoft_dhcp/1.3.1",
-    "icons": [
-      {
-        "src": "/img/logo.svg",
-        "path": "/package/microsoft_dhcp/1.3.1/img/logo.svg",
-        "title": "Microsoft logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "microsoft_dhcp",
-        "title": "Microsoft DHCP",
-        "description": "Collect Microsoft DHCP logs."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "network"
-    ],
-    "signature_path": "/epr/microsoft_dhcp/microsoft_dhcp-1.3.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "microsoft_dhcp.log",
-        "title": "Microsoft DHCP Logs"
-      }
-    ]
-  },
-  {
     "name": "microsoft_defender_endpoint",
     "title": "Microsoft Defender for Endpoint",
     "version": "2.1.0",
@@ -6153,6 +5610,51 @@
         "type": "logs",
         "dataset": "microsoft_defender_endpoint.log",
         "title": "Microsoft Defender for Endpoint logs"
+      }
+    ]
+  },
+  {
+    "name": "microsoft_dhcp",
+    "title": "Microsoft DHCP",
+    "version": "1.3.1",
+    "release": "ga",
+    "description": "Collect logs from Microsoft DHCP with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/microsoft_dhcp/microsoft_dhcp-1.3.1.zip",
+    "path": "/package/microsoft_dhcp/1.3.1",
+    "icons": [
+      {
+        "src": "/img/logo.svg",
+        "path": "/package/microsoft_dhcp/1.3.1/img/logo.svg",
+        "title": "Microsoft logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "microsoft_dhcp",
+        "title": "Microsoft DHCP",
+        "description": "Collect Microsoft DHCP logs."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "network"
+    ],
+    "signature_path": "/epr/microsoft_dhcp/microsoft_dhcp-1.3.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "microsoft_dhcp.log",
+        "title": "Microsoft DHCP Logs"
       }
     ]
   },
@@ -6538,6 +6040,51 @@
         "type": "logs",
         "dataset": "netflow.log",
         "title": "NetFlow logs"
+      }
+    ]
+  },
+  {
+    "name": "netscout",
+    "title": "Arbor Peakflow SP Logs",
+    "version": "0.7.0",
+    "release": "experimental",
+    "description": "Collect and parse logs from Netscout Arbor Peakflow SP with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/netscout/netscout-0.7.0.zip",
+    "path": "/package/netscout/0.7.0",
+    "icons": [
+      {
+        "src": "/img/logo.svg",
+        "path": "/package/netscout/0.7.0/img/logo.svg",
+        "title": "Arbor Peakflow SP logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "sightline",
+        "title": "Arbor Peakflow SP",
+        "description": "Collect Arbor Peakflow SP logs from syslog or a file."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.1 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/netscout/netscout-0.7.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "netscout.sightline",
+        "title": "Arbor Peakflow SP logs"
       }
     ]
   },
@@ -7039,6 +6586,51 @@
     ]
   },
   {
+    "name": "panw",
+    "title": "Palo Alto Networks Logs",
+    "version": "1.5.3",
+    "release": "ga",
+    "description": "Collect PAN-OS firewall monitoring logs from Palo Alto Networks devices with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/panw/panw-1.5.3.zip",
+    "path": "/package/panw/1.5.3",
+    "icons": [
+      {
+        "src": "/img/logo-integrations-paloalto-networks.svg",
+        "path": "/package/panw/1.5.3/img/logo-integrations-paloalto-networks.svg",
+        "title": "Palo Alto Networks",
+        "size": "216x216",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "panw",
+        "title": "Palo Alto Networks PAN-OS firewall logs",
+        "description": "Collect logs from Palo Alto Networks PAN-OS firewall"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/panw/panw-1.5.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "panw.panos",
+        "title": "Palo Alto Networks PAN-OS firewall logs"
+      }
+    ]
+  },
+  {
     "name": "panw_cortex_xdr",
     "title": "Palo Alto Cortex XDR Logs",
     "version": "1.1.1",
@@ -7084,47 +6676,48 @@
     ]
   },
   {
-    "name": "panw",
-    "title": "Palo Alto Networks Logs",
-    "version": "1.5.3",
-    "release": "ga",
-    "description": "Collect PAN-OS firewall monitoring logs from Palo Alto Networks devices with Elastic Agent.",
+    "name": "pfsense",
+    "title": "pfSense Logs",
+    "version": "0.3.1",
+    "release": "experimental",
+    "description": "Collect and parse logs from pfSense devices with Elastic Agent.",
     "type": "integration",
-    "download": "/epr/panw/panw-1.5.3.zip",
-    "path": "/package/panw/1.5.3",
+    "download": "/epr/pfsense/pfsense-0.3.1.zip",
+    "path": "/package/pfsense/0.3.1",
     "icons": [
       {
-        "src": "/img/logo-integrations-paloalto-networks.svg",
-        "path": "/package/panw/1.5.3/img/logo-integrations-paloalto-networks.svg",
-        "title": "Palo Alto Networks",
-        "size": "216x216",
+        "src": "/img/pfsense.svg",
+        "path": "/package/pfsense/0.3.1/img/pfsense.svg",
+        "title": "pfsense",
+        "size": "512x143",
         "type": "image/svg+xml"
       }
     ],
     "policy_templates": [
       {
-        "name": "panw",
-        "title": "Palo Alto Networks PAN-OS firewall logs",
-        "description": "Collect logs from Palo Alto Networks PAN-OS firewall"
+        "name": "pfsense",
+        "title": "pfSense logs",
+        "description": "Collect logs from pfSense systems"
       }
     ],
     "conditions": {
       "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
+        "version": "^7.15.0 || ^8.0.0"
       }
     },
     "owner": {
       "github": "elastic/security-external-integrations"
     },
     "categories": [
+      "network",
       "security"
     ],
-    "signature_path": "/epr/panw/panw-1.5.3.zip.sig",
+    "signature_path": "/epr/pfsense/pfsense-0.3.1.zip.sig",
     "data_streams": [
       {
         "type": "logs",
-        "dataset": "panw.panos",
-        "title": "Palo Alto Networks PAN-OS firewall logs"
+        "dataset": "pfsense.log",
+        "title": "pfSense log logs"
       }
     ]
   },
@@ -7194,40 +6787,35 @@
     ]
   },
   {
-    "name": "security_detection_engine",
-    "title": "Prebuilt Security Detection Rules",
-    "version": "1.0.2",
-    "release": "ga",
-    "description": "Prebuilt detection rules for Elastic Security",
+    "name": "problemchild",
+    "title": "LotL Attack Detection",
+    "version": "0.0.2",
+    "release": "experimental",
+    "description": "The ProblemChild framework is used to detect living off the land activity. Requires a Platinum subscription.",
     "type": "integration",
-    "download": "/epr/security_detection_engine/security_detection_engine-1.0.2.zip",
-    "path": "/package/security_detection_engine/1.0.2",
+    "download": "/epr/problemchild/problemchild-0.0.2.zip",
+    "path": "/package/problemchild/0.0.2",
     "icons": [
       {
-        "src": "/img/security-logo-color-64px.svg",
-        "path": "/package/security_detection_engine/1.0.2/img/security-logo-color-64px.svg",
-        "size": "16x16",
+        "src": "/img/icon-machine-learning.svg",
+        "path": "/package/problemchild/0.0.2/img/icon-machine-learning.svg",
+        "title": "Sample logo",
+        "size": "32x32",
         "type": "image/svg+xml"
       }
     ],
     "conditions": {
       "kibana": {
         "version": "^8.0.0"
-      },
-      "elastic": {
-        "subscription": "basic",
-        "capabilities": [
-          "security"
-        ]
       }
     },
     "owner": {
-      "github": "elastic/protections"
+      "github": "elastic/ml-ui"
     },
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/security_detection_engine/security_detection_engine-1.0.2.zip.sig"
+    "signature_path": "/epr/problemchild/problemchild-0.0.2.zip.sig"
   },
   {
     "name": "prometheus",
@@ -7532,51 +7120,6 @@
     ]
   },
   {
-    "name": "ti_recordedfuture",
-    "title": "Recorded Future",
-    "version": "0.1.2",
-    "release": "beta",
-    "description": "Collect threat intelligence from Recorded Future with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/ti_recordedfuture/ti_recordedfuture-0.1.2.zip",
-    "path": "/package/ti_recordedfuture/0.1.2",
-    "icons": [
-      {
-        "src": "/img/logo.svg",
-        "path": "/package/ti_recordedfuture/0.1.2/img/logo.svg",
-        "title": "Recorded Future",
-        "size": "216x216",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "ti_recordedfuture",
-        "title": "Recorded Future",
-        "description": "Collect threat intelligence from Recorded Future."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/ti_recordedfuture/ti_recordedfuture-0.1.2.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ti_recordedfuture.threat",
-        "title": "Recorded Future"
-      }
-    ]
-  },
-  {
     "name": "redis",
     "title": "Redis",
     "version": "1.2.0",
@@ -7643,114 +7186,85 @@
     ]
   },
   {
-    "name": "sql",
-    "title": "SQL Input",
-    "version": "0.5.0",
-    "release": "beta",
-    "description": "Collects Metrics by Quering on SQL Databases",
-    "type": "input",
-    "download": "/epr/sql/sql-0.5.0.zip",
-    "path": "/package/sql/0.5.0",
-    "icons": [
-      {
-        "src": "/img/sql-server-icon.svg",
-        "path": "/package/sql/0.5.0/img/sql-server-icon.svg",
-        "title": "SQL logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "sql",
-        "title": "SQL Metrics",
-        "description": "Collects Metrics by Quering on SQL Databases",
-        "deprecated": {
-          "since": "0.5.0",
-          "description": "This policy is deprecated"
-        }
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.13.0"
-      },
-      "elastic": {
-        "subscription": "basic"
-      }
-    },
-    "owner": {
-      "github": "elastic/obs-infraobs-integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "signature_path": "/epr/sql/sql-0.5.0.zip.sig",
-    "deprecated": {
-      "since": "0.5.0",
-      "description": "This package is deprecated"
-    }
-  },
-  {
-    "name": "stan",
-    "title": "STAN",
-    "version": "1.2.0",
+    "name": "santa",
+    "title": "Google Santa Logs",
+    "version": "2.0.1",
     "release": "ga",
-    "description": "Collect logs and metrics from STAN servers with Elastic Agent.",
+    "description": "Collect and parse logs from Google Santa instances with Elastic Agent.",
     "type": "integration",
-    "download": "/epr/stan/stan-1.2.0.zip",
-    "path": "/package/stan/1.2.0",
+    "download": "/epr/santa/santa-2.0.1.zip",
+    "path": "/package/santa/2.0.1",
     "icons": [
       {
-        "src": "/img/stan.svg",
-        "path": "/package/stan/1.2.0/img/stan.svg",
-        "title": "STAN Logo",
-        "size": "32x32",
+        "src": "/img/icon.svg",
+        "path": "/package/santa/2.0.1/img/icon.svg",
+        "title": "Google Santa",
         "type": "image/svg+xml"
       }
     ],
     "policy_templates": [
       {
-        "name": "stan",
-        "title": "STAN Logs and Metrics",
-        "description": "Collect logs and metrics from STAN instances"
+        "name": "santa",
+        "title": "Google Santa logs",
+        "description": "Collect logs from Google Santa instances"
       }
     ],
     "conditions": {
       "kibana": {
-        "version": "^7.14.0 || ^8.0.0"
+        "version": "^7.17.0 || ^8.0.0"
       }
     },
     "owner": {
-      "github": "elastic/integrations"
+      "github": "elastic/security-external-integrations"
     },
     "categories": [
-      "message_queue",
-      "kubernetes"
+      "security",
+      "os_system"
     ],
-    "signature_path": "/epr/stan/stan-1.2.0.zip.sig",
+    "signature_path": "/epr/santa/santa-2.0.1.zip.sig",
     "data_streams": [
       {
-        "type": "metrics",
-        "dataset": "stan.channels",
-        "title": "Stan channels metrics"
-      },
-      {
         "type": "logs",
-        "dataset": "stan.log",
-        "title": "STAN logs"
-      },
-      {
-        "type": "metrics",
-        "dataset": "stan.stats",
-        "title": "Stan stats metrics"
-      },
-      {
-        "type": "metrics",
-        "dataset": "stan.subscriptions",
-        "title": "Stan subscriptions metrics"
+        "dataset": "santa.log",
+        "title": "Google Santa log logs"
       }
     ]
+  },
+  {
+    "name": "security_detection_engine",
+    "title": "Prebuilt Security Detection Rules",
+    "version": "1.0.2",
+    "release": "ga",
+    "description": "Prebuilt detection rules for Elastic Security",
+    "type": "integration",
+    "download": "/epr/security_detection_engine/security_detection_engine-1.0.2.zip",
+    "path": "/package/security_detection_engine/1.0.2",
+    "icons": [
+      {
+        "src": "/img/security-logo-color-64px.svg",
+        "path": "/package/security_detection_engine/1.0.2/img/security-logo-color-64px.svg",
+        "size": "16x16",
+        "type": "image/svg+xml"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      },
+      "elastic": {
+        "subscription": "basic",
+        "capabilities": [
+          "security"
+        ]
+      }
+    },
+    "owner": {
+      "github": "elastic/protections"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/security_detection_engine/security_detection_engine-1.0.2.zip.sig"
   },
   {
     "name": "snort",
@@ -7945,6 +7459,55 @@
     ]
   },
   {
+    "name": "sql",
+    "title": "SQL Input",
+    "version": "0.5.0",
+    "release": "beta",
+    "description": "Collects Metrics by Quering on SQL Databases",
+    "type": "input",
+    "download": "/epr/sql/sql-0.5.0.zip",
+    "path": "/package/sql/0.5.0",
+    "icons": [
+      {
+        "src": "/img/sql-server-icon.svg",
+        "path": "/package/sql/0.5.0/img/sql-server-icon.svg",
+        "title": "SQL logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "sql",
+        "title": "SQL Metrics",
+        "description": "Collects Metrics by Quering on SQL Databases",
+        "deprecated": {
+          "since": "0.5.0",
+          "description": "This policy is deprecated"
+        }
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.13.0"
+      },
+      "elastic": {
+        "subscription": "basic"
+      }
+    },
+    "owner": {
+      "github": "elastic/obs-infraobs-integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "signature_path": "/epr/sql/sql-0.5.0.zip.sig",
+    "deprecated": {
+      "since": "0.5.0",
+      "description": "This package is deprecated"
+    }
+  },
+  {
     "name": "squid",
     "title": "Squid Logs",
     "version": "0.7.0",
@@ -7977,6 +7540,67 @@
         "type": "logs",
         "dataset": "squid.log",
         "title": "Squid logs"
+      }
+    ]
+  },
+  {
+    "name": "stan",
+    "title": "STAN",
+    "version": "1.2.0",
+    "release": "ga",
+    "description": "Collect logs and metrics from STAN servers with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/stan/stan-1.2.0.zip",
+    "path": "/package/stan/1.2.0",
+    "icons": [
+      {
+        "src": "/img/stan.svg",
+        "path": "/package/stan/1.2.0/img/stan.svg",
+        "title": "STAN Logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "stan",
+        "title": "STAN Logs and Metrics",
+        "description": "Collect logs and metrics from STAN instances"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "message_queue",
+      "kubernetes"
+    ],
+    "signature_path": "/epr/stan/stan-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "stan.channels",
+        "title": "Stan channels metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "stan.log",
+        "title": "STAN logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "stan.stats",
+        "title": "Stan stats metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "stan.subscriptions",
+        "title": "Stan subscriptions metrics"
       }
     ]
   },
@@ -8114,6 +7738,77 @@
     ]
   },
   {
+    "name": "synthetics",
+    "title": "Elastic Synthetics",
+    "version": "0.9.2",
+    "release": "beta",
+    "description": "Monitor the availability of your services with Elastic Synthetics.",
+    "type": "integration",
+    "download": "/epr/synthetics/synthetics-0.9.2.zip",
+    "path": "/package/synthetics/0.9.2",
+    "icons": [
+      {
+        "src": "/img/uptime-logo-color-64px.svg",
+        "path": "/package/synthetics/0.9.2/img/uptime-logo-color-64px.svg",
+        "size": "16x16",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "synthetics",
+        "title": "Elastic Synthetics",
+        "description": "Perform synthetic health checks on network endpoints."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.1.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/uptime"
+    },
+    "categories": [
+      "elastic_stack",
+      "monitoring",
+      "web"
+    ],
+    "signature_path": "/epr/synthetics/synthetics-0.9.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "synthetics",
+        "dataset": "browser",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "browser.network",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "browser.screenshot",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "http",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "icmp",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "tcp",
+        "title": "synthetic monitor check"
+      }
+    ]
+  },
+  {
     "name": "system",
     "title": "System",
     "version": "1.6.4",
@@ -8240,6 +7935,49 @@
     ]
   },
   {
+    "name": "tcp",
+    "title": "Custom TCP Logs",
+    "version": "1.0.0",
+    "release": "ga",
+    "description": "Collect raw TCP data from listening TCP port with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/tcp/tcp-1.0.0.zip",
+    "path": "/package/tcp/1.0.0",
+    "icons": [
+      {
+        "src": "/img/icon.svg",
+        "path": "/package/tcp/1.0.0/img/icon.svg",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "tcp",
+        "title": "Custom TCP Logs",
+        "description": "Collect raw TCP data from listening TCP port with Elastic Agent."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "signature_path": "/epr/tcp/tcp-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "tcp.generic",
+        "title": "Custom TCP Logs"
+      }
+    ]
+  },
+  {
     "name": "tenable_sc",
     "title": "Tenable.sc",
     "version": "1.1.1",
@@ -8295,6 +8033,292 @@
     ]
   },
   {
+    "name": "ti_abusech",
+    "title": "AbuseCH",
+    "version": "1.2.3",
+    "release": "ga",
+    "description": "Collect threat intelligence from AbuseCH API with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/ti_abusech/ti_abusech-1.2.3.zip",
+    "path": "/package/ti_abusech/1.2.3",
+    "icons": [
+      {
+        "src": "/img/abusech2.svg",
+        "path": "/package/ti_abusech/1.2.3/img/abusech2.svg",
+        "title": "AbuseCH",
+        "size": "512x512",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "ti_abusech",
+        "title": "AbuseCH API",
+        "description": "Collect threat intelligence from the AbuseCH API"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/ti_abusech/ti_abusech-1.2.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_abusech.malware",
+        "title": "AbuseCH Malware logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "ti_abusech.malwarebazaar",
+        "title": "AbuseCH MalwareBazaar logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "ti_abusech.url",
+        "title": "AbuseCH URL logs"
+      }
+    ]
+  },
+  {
+    "name": "ti_anomali",
+    "title": "Anomali",
+    "version": "1.2.3",
+    "release": "ga",
+    "description": "Collect threat intelligence from Anomali APIs with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/ti_anomali/ti_anomali-1.2.3.zip",
+    "path": "/package/ti_anomali/1.2.3",
+    "icons": [
+      {
+        "src": "/img/anomali.svg",
+        "path": "/package/ti_anomali/1.2.3/img/anomali.svg",
+        "title": "Anomali",
+        "size": "216x216",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "ti_anomali",
+        "title": "Anomali",
+        "description": "Collect threat intelligence from the Anomali Limo API and Anomali Threatstream."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/ti_anomali/ti_anomali-1.2.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_anomali.limo",
+        "title": "Anomali Limo"
+      },
+      {
+        "type": "logs",
+        "dataset": "ti_anomali.threatstream",
+        "title": "Anomali Threatstream"
+      }
+    ]
+  },
+  {
+    "name": "ti_cybersixgill",
+    "title": "Cybersixgill",
+    "version": "1.3.2",
+    "release": "ga",
+    "description": "This Elastic integration collects threat intelligence from Cybersixgill",
+    "type": "integration",
+    "download": "/epr/ti_cybersixgill/ti_cybersixgill-1.3.2.zip",
+    "path": "/package/ti_cybersixgill/1.3.2",
+    "icons": [
+      {
+        "src": "/img/cybersixgill.svg",
+        "path": "/package/ti_cybersixgill/1.3.2/img/cybersixgill.svg",
+        "title": "Cybersixgill",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "cybersixgill",
+        "title": "Cybersixgill Threat Intel",
+        "description": "Collect Threat Intel from Cybersixgill"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security",
+      "productivity"
+    ],
+    "signature_path": "/epr/ti_cybersixgill/ti_cybersixgill-1.3.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_cybersixgill.threat",
+        "title": "Cybersixgill Darkfeed Logs"
+      }
+    ]
+  },
+  {
+    "name": "ti_misp",
+    "title": "MISP",
+    "version": "1.2.2",
+    "release": "ga",
+    "description": "This Elastic integration collects events from MISP",
+    "type": "integration",
+    "download": "/epr/ti_misp/ti_misp-1.2.2.zip",
+    "path": "/package/ti_misp/1.2.2",
+    "icons": [
+      {
+        "src": "/img/misp.svg",
+        "path": "/package/ti_misp/1.2.2/img/misp.svg",
+        "title": "MISP",
+        "size": "216x216",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "ti_misp",
+        "title": "MISP",
+        "description": "Collect threat intelligence from the MISP API."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/ti_misp/ti_misp-1.2.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_misp.threat",
+        "title": "MISP"
+      }
+    ]
+  },
+  {
+    "name": "ti_otx",
+    "title": "AlienVault OTX",
+    "version": "1.2.2",
+    "release": "ga",
+    "description": "Collect threat intelligence from AlienVault OTX with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/ti_otx/ti_otx-1.2.2.zip",
+    "path": "/package/ti_otx/1.2.2",
+    "icons": [
+      {
+        "src": "/img/otx.svg",
+        "path": "/package/ti_otx/1.2.2/img/otx.svg",
+        "title": "Alienvault OTX",
+        "size": "216x216",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "ti_otx",
+        "title": "Alienvault OTX",
+        "description": "Collect threat intelligence from the Alienvault OTX"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/ti_otx/ti_otx-1.2.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_otx.threat",
+        "title": "Alienvault OTX logs"
+      }
+    ]
+  },
+  {
+    "name": "ti_recordedfuture",
+    "title": "Recorded Future",
+    "version": "0.1.2",
+    "release": "beta",
+    "description": "Collect threat intelligence from Recorded Future with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/ti_recordedfuture/ti_recordedfuture-0.1.2.zip",
+    "path": "/package/ti_recordedfuture/0.1.2",
+    "icons": [
+      {
+        "src": "/img/logo.svg",
+        "path": "/package/ti_recordedfuture/0.1.2/img/logo.svg",
+        "title": "Recorded Future",
+        "size": "216x216",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "ti_recordedfuture",
+        "title": "Recorded Future",
+        "description": "Collect threat intelligence from Recorded Future."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/ti_recordedfuture/ti_recordedfuture-0.1.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_recordedfuture.threat",
+        "title": "Recorded Future"
+      }
+    ]
+  },
+  {
     "name": "ti_threatq",
     "title": "ThreatQuotient",
     "version": "1.2.2",
@@ -8336,6 +8360,52 @@
         "type": "logs",
         "dataset": "ti_threatq.threat",
         "title": "ThreatQ"
+      }
+    ]
+  },
+  {
+    "name": "tomcat",
+    "title": "Apache Tomcat",
+    "version": "1.3.1",
+    "release": "ga",
+    "description": "Collect and parse logs from Apache Tomcat servers with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/tomcat/tomcat-1.3.1.zip",
+    "path": "/package/tomcat/1.3.1",
+    "icons": [
+      {
+        "src": "/img/logo.svg",
+        "path": "/package/tomcat/1.3.1/img/logo.svg",
+        "title": "Apache Tomcat logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "log",
+        "title": "Apache Tomcat",
+        "description": "Collect Apache Tomcat logs from syslog or a file."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.1 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "web",
+      "security"
+    ],
+    "signature_path": "/epr/tomcat/tomcat-1.3.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "tomcat.log",
+        "title": "Apache Tomcat logs"
       }
     ]
   },
@@ -8391,112 +8461,45 @@
     ]
   },
   {
-    "name": "carbon_black_cloud",
-    "title": "VMware Carbon Black Cloud",
-    "version": "1.0.2",
+    "name": "udp",
+    "title": "Custom UDP Logs",
+    "version": "1.0.1",
     "release": "ga",
-    "description": "Collect logs from VMWare Carbon Black Cloud with Elastic Agent.",
+    "description": "Collect raw UDP data from listening UDP port with Elastic Agent.",
     "type": "integration",
-    "download": "/epr/carbon_black_cloud/carbon_black_cloud-1.0.2.zip",
-    "path": "/package/carbon_black_cloud/1.0.2",
+    "download": "/epr/udp/udp-1.0.1.zip",
+    "path": "/package/udp/1.0.1",
     "icons": [
       {
-        "src": "/img/carbon_black_cloud-logo.svg",
-        "path": "/package/carbon_black_cloud/1.0.2/img/carbon_black_cloud-logo.svg",
-        "title": "Carbon Black Cloud logo",
-        "size": "32x32",
+        "src": "/img/icon.svg",
+        "path": "/package/udp/1.0.1/img/icon.svg",
         "type": "image/svg+xml"
       }
     ],
     "policy_templates": [
       {
-        "name": "carbon_black_cloud",
-        "title": "Carbon Black Cloud",
-        "description": "Collect Logs from Carbon Black Cloud"
+        "name": "udp",
+        "title": "Custom UDP Logs",
+        "description": "Collect raw UDP data from listening UDP port with Elastic Agent."
       }
     ],
     "conditions": {
       "kibana": {
-        "version": "^7.17.0 || ^8.0.0"
+        "version": "^7.16.0 || ^8.0.0"
       }
     },
     "owner": {
       "github": "elastic/security-external-integrations"
     },
     "categories": [
-      "security"
+      "custom"
     ],
-    "signature_path": "/epr/carbon_black_cloud/carbon_black_cloud-1.0.2.zip.sig",
+    "signature_path": "/epr/udp/udp-1.0.1.zip.sig",
     "data_streams": [
       {
         "type": "logs",
-        "dataset": "carbon_black_cloud.alert",
-        "title": "Alert"
-      },
-      {
-        "type": "logs",
-        "dataset": "carbon_black_cloud.asset_vulnerability_summary",
-        "title": "Asset Vulnerability Summary"
-      },
-      {
-        "type": "logs",
-        "dataset": "carbon_black_cloud.audit",
-        "title": "Audit"
-      },
-      {
-        "type": "logs",
-        "dataset": "carbon_black_cloud.endpoint_event",
-        "title": "Endpoint Event"
-      },
-      {
-        "type": "logs",
-        "dataset": "carbon_black_cloud.watchlist_hit",
-        "title": "Watchlist Hit"
-      }
-    ]
-  },
-  {
-    "name": "carbonblack_edr",
-    "title": "VMware Carbon Black EDR",
-    "version": "1.2.0",
-    "release": "ga",
-    "description": "Collect logs from VMware Carbon Black EDR with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/carbonblack_edr/carbonblack_edr-1.2.0.zip",
-    "path": "/package/carbonblack_edr/1.2.0",
-    "icons": [
-      {
-        "src": "/img/carbon-black-logo.svg",
-        "path": "/package/carbonblack_edr/1.2.0/img/carbon-black-logo.svg",
-        "title": "VMWare Carbon Black",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "log",
-        "title": "Carbon Black EDR logs",
-        "description": "Collect logs from Carbon Black EDR"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/carbonblack_edr/carbonblack_edr-1.2.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "carbonblack_edr.log",
-        "title": "Carbon Black EDR logs"
+        "dataset": "udp.generic",
+        "title": "Custom UDP Logs"
       }
     ]
   },
@@ -8629,6 +8632,49 @@
         "type": "logs",
         "dataset": "windows.sysmon_operational",
         "title": "Windows Sysmon/Operational events"
+      }
+    ]
+  },
+  {
+    "name": "winlog",
+    "title": "Custom Windows Event Logs",
+    "version": "1.4.0",
+    "release": "ga",
+    "description": "Collect and parse logs from any Windows event log channel with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/winlog/winlog-1.4.0.zip",
+    "path": "/package/winlog/1.4.0",
+    "icons": [
+      {
+        "src": "/img/logo_windows.svg",
+        "path": "/package/winlog/1.4.0/img/logo_windows.svg",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "winlogs",
+        "title": "Custom Windows event logs",
+        "description": "Collect your custom Windows event logs."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "signature_path": "/epr/winlog/winlog-1.4.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "winlog.winlog",
+        "title": "Custom Windows Event Log Dataset"
       }
     ]
   },
@@ -9018,6 +9064,52 @@
     ]
   },
   {
+    "name": "zscaler",
+    "title": "Zscaler NSS Logs",
+    "version": "0.5.1",
+    "release": "experimental",
+    "description": "Deprecated. Use the Zscaler ZIA integration instead.",
+    "type": "integration",
+    "download": "/epr/zscaler/zscaler-0.5.1.zip",
+    "path": "/package/zscaler/0.5.1",
+    "icons": [
+      {
+        "src": "/img/logo.svg",
+        "path": "/package/zscaler/0.5.1/img/logo.svg",
+        "title": "Zscaler NSS logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "zia",
+        "title": "Zscaler NSS",
+        "description": "Collect Zscaler NSS logs from syslog or a file."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.1"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "network",
+      "security"
+    ],
+    "signature_path": "/epr/zscaler/zscaler-0.5.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "zscaler.zia",
+        "title": "Zscaler NSS logs"
+      }
+    ]
+  },
+  {
     "name": "zscaler_zia",
     "title": "Zscaler Internet Access",
     "version": "0.1.3",
@@ -9083,52 +9175,6 @@
     ]
   },
   {
-    "name": "zscaler",
-    "title": "Zscaler NSS Logs",
-    "version": "0.5.1",
-    "release": "experimental",
-    "description": "Deprecated. Use the Zscaler ZIA integration instead.",
-    "type": "integration",
-    "download": "/epr/zscaler/zscaler-0.5.1.zip",
-    "path": "/package/zscaler/0.5.1",
-    "icons": [
-      {
-        "src": "/img/logo.svg",
-        "path": "/package/zscaler/0.5.1/img/logo.svg",
-        "title": "Zscaler NSS logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "zia",
-        "title": "Zscaler NSS",
-        "description": "Collect Zscaler NSS logs from syslog or a file."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.1"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "network",
-      "security"
-    ],
-    "signature_path": "/epr/zscaler/zscaler-0.5.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "zscaler.zia",
-        "title": "Zscaler NSS logs"
-      }
-    ]
-  },
-  {
     "name": "zscaler_zpa",
     "title": "Zscaler Private Access",
     "version": "0.1.2",
@@ -9190,52 +9236,6 @@
         "type": "logs",
         "dataset": "zscaler_zpa.user_status",
         "title": "User Status Logs"
-      }
-    ]
-  },
-  {
-    "name": "pfsense",
-    "title": "pfSense Logs",
-    "version": "0.3.1",
-    "release": "experimental",
-    "description": "Collect and parse logs from pfSense devices with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/pfsense/pfsense-0.3.1.zip",
-    "path": "/package/pfsense/0.3.1",
-    "icons": [
-      {
-        "src": "/img/pfsense.svg",
-        "path": "/package/pfsense/0.3.1/img/pfsense.svg",
-        "title": "pfsense",
-        "size": "512x143",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "pfsense",
-        "title": "pfSense logs",
-        "description": "Collect logs from pfSense systems"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.15.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "network",
-      "security"
-    ],
-    "signature_path": "/epr/pfsense/pfsense-0.3.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "pfsense.log",
-        "title": "pfSense log logs"
       }
     ]
   }

--- a/testdata/generated/storage-indexer/search-prerelease-capabilities-none.json
+++ b/testdata/generated/storage-indexer/search-prerelease-capabilities-none.json
@@ -54,6 +54,538 @@
     ]
   },
   {
+    "name": "activemq",
+    "title": "ActiveMQ",
+    "version": "0.3.0",
+    "release": "beta",
+    "description": "Collect logs and metrics from ActiveMQ instances with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/activemq/activemq-0.3.0.zip",
+    "path": "/package/activemq/0.3.0",
+    "icons": [
+      {
+        "src": "/img/activemq.svg",
+        "path": "/package/activemq/0.3.0/img/activemq.svg",
+        "title": "activemq",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "activemq",
+        "title": "ActiveMQ logs and metrics",
+        "description": "Collect logs and metrics from ActiveMQ instances"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "web"
+    ],
+    "signature_path": "/epr/activemq/activemq-0.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "activemq.audit",
+        "title": "ActiveMQ audit logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "activemq.broker",
+        "title": "ActiveMQ broker metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "activemq.log",
+        "title": "ActiveMQ log logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "activemq.queue",
+        "title": "ActiveMQ queue metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "activemq.topic",
+        "title": "ActiveMQ topic metrics"
+      }
+    ]
+  },
+  {
+    "name": "akamai",
+    "title": "Akamai",
+    "version": "2.28.0",
+    "release": "ga",
+    "description": "Collect logs from Akamai with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/akamai/akamai-2.28.0.zip",
+    "path": "/package/akamai/2.28.0",
+    "icons": [
+      {
+        "src": "/img/akamai_logo.svg",
+        "path": "/package/akamai/2.28.0/img/akamai_logo.svg",
+        "title": "Akamai",
+        "size": "409×167",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "akamai",
+        "title": "Akamai logs",
+        "description": "Collect SIEM logs from Akamai"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.13.0 || ^9.0.0"
+      }
+    },
+    "owner": {
+      "type": "community",
+      "github": "elastic/security-service-integrations"
+    },
+    "categories": [
+      "security",
+      "cdn_security"
+    ],
+    "signature_path": "/epr/akamai/akamai-2.28.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "akamai.siem",
+        "title": "Akamai SIEM Logs"
+      }
+    ]
+  },
+  {
+    "name": "apache",
+    "title": "Apache HTTP Server",
+    "version": "1.3.5",
+    "release": "ga",
+    "description": "Collect logs and metrics from Apache servers with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/apache/apache-1.3.5.zip",
+    "path": "/package/apache/1.3.5",
+    "icons": [
+      {
+        "src": "/img/logo_apache.svg",
+        "path": "/package/apache/1.3.5/img/logo_apache.svg",
+        "title": "Apache Logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "apache",
+        "title": "Apache logs and metrics",
+        "description": "Collect logs and metrics from Apache instances"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "web"
+    ],
+    "signature_path": "/epr/apache/apache-1.3.5.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "apache.access",
+        "title": "Apache access logs",
+        "deprecated": {
+          "since": "1.3.5",
+          "description": "This data stream is deprecated"
+        }
+      },
+      {
+        "type": "logs",
+        "dataset": "apache.error",
+        "title": "Apache error logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apache.status",
+        "title": "Apache status metrics"
+      }
+    ],
+    "deprecated": {
+      "since": "1.3.0",
+      "description": "This package is deprecated"
+    }
+  },
+  {
+    "name": "apm",
+    "title": "Elastic APM",
+    "version": "8.2.0",
+    "release": "ga",
+    "description": "Ingest APM data",
+    "type": "integration",
+    "download": "/epr/apm/apm-8.2.0.zip",
+    "path": "/package/apm/8.2.0",
+    "icons": [
+      {
+        "src": "/img/logo_apm.svg",
+        "path": "/package/apm/8.2.0/img/logo_apm.svg",
+        "title": "APM Logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "apmserver",
+        "title": "Elastic APM Integration",
+        "description": "Elastic APM Integration"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.2.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/apm-server"
+    },
+    "categories": [
+      "elastic_stack",
+      "monitoring"
+    ],
+    "signature_path": "/epr/apm/apm-8.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "apm.app",
+        "title": "APM application logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.app",
+        "title": "APM application metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "apm.error",
+        "title": "APM errors"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.internal",
+        "title": "APM internal metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.profiling",
+        "title": "APM profiles"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm.rum",
+        "title": "APM RUM traces"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm.sampled",
+        "title": "APM tail-sampled traces"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm",
+        "title": "APM traces"
+      }
+    ]
+  },
+  {
+    "name": "atlassian_bitbucket",
+    "title": "Atlassian Bitbucket",
+    "version": "1.2.1",
+    "release": "ga",
+    "description": "Collect logs from Atlassian Bitbucket with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.2.1.zip",
+    "path": "/package/atlassian_bitbucket/1.2.1",
+    "icons": [
+      {
+        "src": "/img/bitbucket-logo.svg",
+        "path": "/package/atlassian_bitbucket/1.2.1/img/bitbucket-logo.svg",
+        "title": "Bitbucket Logo",
+        "size": "625x564",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "audit",
+        "title": "Audit Logs",
+        "description": "Collect audit logs from Atlassian Bitbucket with Elastic Agent."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security",
+      "web"
+    ],
+    "signature_path": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_bitbucket.audit",
+        "title": "Bitbucket Audit Logs"
+      }
+    ]
+  },
+  {
+    "name": "atlassian_confluence",
+    "title": "Atlassian Confluence",
+    "version": "1.3.0",
+    "release": "ga",
+    "description": "Collect logs from Atlassian Confluence with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/atlassian_confluence/atlassian_confluence-1.3.0.zip",
+    "path": "/package/atlassian_confluence/1.3.0",
+    "icons": [
+      {
+        "src": "/img/confluence-logo.svg",
+        "path": "/package/atlassian_confluence/1.3.0/img/confluence-logo.svg",
+        "title": "Confluence Logo",
+        "size": "400x400",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "audit",
+        "title": "Audit Logs",
+        "description": "Collect audit logs from Atlassian Confluence with Elastic Agent."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security",
+      "web"
+    ],
+    "signature_path": "/epr/atlassian_confluence/atlassian_confluence-1.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_confluence.audit",
+        "title": "Confluence Audit Logs"
+      }
+    ]
+  },
+  {
+    "name": "atlassian_jira",
+    "title": "Atlassian Jira",
+    "version": "1.3.0",
+    "release": "ga",
+    "description": "Collect logs from Atlassian Jira with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/atlassian_jira/atlassian_jira-1.3.0.zip",
+    "path": "/package/atlassian_jira/1.3.0",
+    "icons": [
+      {
+        "src": "/img/jira-software-logo.svg",
+        "path": "/package/atlassian_jira/1.3.0/img/jira-software-logo.svg",
+        "title": "Jira Software Logo",
+        "size": "590x625",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "audit",
+        "title": "Audit Logs",
+        "description": "Collect audit logs from Atlassian Jira with Elastic Agent."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security",
+      "web"
+    ],
+    "signature_path": "/epr/atlassian_jira/atlassian_jira-1.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_jira.audit",
+        "title": "Jira Audit Logs"
+      }
+    ]
+  },
+  {
+    "name": "auditd",
+    "title": "Auditd Logs",
+    "version": "3.1.0",
+    "release": "ga",
+    "description": "Collect logs from Linux audit daemon with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/auditd/auditd-3.1.0.zip",
+    "path": "/package/auditd/3.1.0",
+    "icons": [
+      {
+        "src": "/img/linux.svg",
+        "path": "/package/auditd/3.1.0/img/linux.svg",
+        "title": "linux",
+        "size": "299x354",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "auditd",
+        "title": "Auditd logs",
+        "description": "Collect logs from Auditd instances"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "os_system"
+    ],
+    "signature_path": "/epr/auditd/auditd-3.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "auditd.log",
+        "title": "Auditd logs"
+      }
+    ]
+  },
+  {
+    "name": "auditd_manager",
+    "title": "Auditd Manager",
+    "version": "1.0.0",
+    "release": "ga",
+    "description": "The Auditd Manager Integration receives audit events from the Linux Audit Framework that is a part of the Linux kernel.",
+    "type": "integration",
+    "download": "/epr/auditd_manager/auditd_manager-1.0.0.zip",
+    "path": "/package/auditd_manager/1.0.0",
+    "icons": [
+      {
+        "src": "/img/linux.svg",
+        "path": "/package/auditd_manager/1.0.0/img/linux.svg",
+        "title": "linux",
+        "size": "299x354",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "auditd",
+        "title": "Auditd",
+        "description": "Collect auditd events"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.2.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "os_system",
+      "security"
+    ],
+    "signature_path": "/epr/auditd_manager/auditd_manager-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "auditd_manager.auditd",
+        "title": "Auditd Manager"
+      }
+    ]
+  },
+  {
+    "name": "auth0",
+    "title": "Auth0 Log Streams Integration",
+    "version": "1.0.0",
+    "release": "ga",
+    "description": "Collect logs from Auth0 with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/auth0/auth0-1.0.0.zip",
+    "path": "/package/auth0/1.0.0",
+    "icons": [
+      {
+        "src": "/img/auth0-logo.svg",
+        "path": "/package/auth0/1.0.0/img/auth0-logo.svg",
+        "title": "Auth0 logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "auth0_events",
+        "title": "Auth0 log stream events via Webhooks",
+        "description": "Collect Auth0 log streams events via Webhooks."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "cloud",
+      "network",
+      "security"
+    ],
+    "signature_path": "/epr/auth0/auth0-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "auth0.logs",
+        "title": "Auth0 logs via Webhooks"
+      }
+    ]
+  },
+  {
     "name": "aws",
     "title": "AWS",
     "version": "1.16.4",
@@ -649,6 +1181,51 @@
     ]
   },
   {
+    "name": "aws_logs",
+    "title": "Custom AWS Logs",
+    "version": "0.2.1",
+    "release": "beta",
+    "description": "Collect raw logs from AWS S3 or CloudWatch with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/aws_logs/aws_logs-0.2.1.zip",
+    "path": "/package/aws_logs/0.2.1",
+    "icons": [
+      {
+        "src": "/img/icon.svg",
+        "path": "/package/aws_logs/0.2.1/img/icon.svg",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "aws_logs",
+        "title": "Custom AWS Logs",
+        "description": "Collect raw logs from AWS S3 or CloudWatch with Elastic Agent."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/obs-cloud-monitoring"
+    },
+    "categories": [
+      "custom",
+      "cloud",
+      "aws"
+    ],
+    "signature_path": "/epr/aws_logs/aws_logs-0.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "aws_logs.generic",
+        "title": "Custom logs from AWS"
+      }
+    ]
+  },
+  {
     "name": "awsfargate",
     "title": "AWS Fargate",
     "version": "0.1.1",
@@ -692,835 +1269,6 @@
         "type": "metrics",
         "dataset": "awsfargate.task_stats",
         "title": "AWS Fargate task_stats metrics"
-      }
-    ]
-  },
-  {
-    "name": "ti_abusech",
-    "title": "AbuseCH",
-    "version": "1.2.3",
-    "release": "ga",
-    "description": "Collect threat intelligence from AbuseCH API with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/ti_abusech/ti_abusech-1.2.3.zip",
-    "path": "/package/ti_abusech/1.2.3",
-    "icons": [
-      {
-        "src": "/img/abusech2.svg",
-        "path": "/package/ti_abusech/1.2.3/img/abusech2.svg",
-        "title": "AbuseCH",
-        "size": "512x512",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "ti_abusech",
-        "title": "AbuseCH API",
-        "description": "Collect threat intelligence from the AbuseCH API"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/ti_abusech/ti_abusech-1.2.3.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ti_abusech.malware",
-        "title": "AbuseCH Malware logs"
-      },
-      {
-        "type": "logs",
-        "dataset": "ti_abusech.malwarebazaar",
-        "title": "AbuseCH MalwareBazaar logs"
-      },
-      {
-        "type": "logs",
-        "dataset": "ti_abusech.url",
-        "title": "AbuseCH URL logs"
-      }
-    ]
-  },
-  {
-    "name": "activemq",
-    "title": "ActiveMQ",
-    "version": "0.3.0",
-    "release": "beta",
-    "description": "Collect logs and metrics from ActiveMQ instances with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/activemq/activemq-0.3.0.zip",
-    "path": "/package/activemq/0.3.0",
-    "icons": [
-      {
-        "src": "/img/activemq.svg",
-        "path": "/package/activemq/0.3.0/img/activemq.svg",
-        "title": "activemq",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "activemq",
-        "title": "ActiveMQ logs and metrics",
-        "description": "Collect logs and metrics from ActiveMQ instances"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "web"
-    ],
-    "signature_path": "/epr/activemq/activemq-0.3.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "activemq.audit",
-        "title": "ActiveMQ audit logs"
-      },
-      {
-        "type": "metrics",
-        "dataset": "activemq.broker",
-        "title": "ActiveMQ broker metrics"
-      },
-      {
-        "type": "logs",
-        "dataset": "activemq.log",
-        "title": "ActiveMQ log logs"
-      },
-      {
-        "type": "metrics",
-        "dataset": "activemq.queue",
-        "title": "ActiveMQ queue metrics"
-      },
-      {
-        "type": "metrics",
-        "dataset": "activemq.topic",
-        "title": "ActiveMQ topic metrics"
-      }
-    ]
-  },
-  {
-    "name": "akamai",
-    "title": "Akamai",
-    "version": "2.28.0",
-    "release": "ga",
-    "description": "Collect logs from Akamai with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/akamai/akamai-2.28.0.zip",
-    "path": "/package/akamai/2.28.0",
-    "icons": [
-      {
-        "src": "/img/akamai_logo.svg",
-        "path": "/package/akamai/2.28.0/img/akamai_logo.svg",
-        "title": "Akamai",
-        "size": "409×167",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "akamai",
-        "title": "Akamai logs",
-        "description": "Collect SIEM logs from Akamai"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.13.0 || ^9.0.0"
-      }
-    },
-    "owner": {
-      "type": "community",
-      "github": "elastic/security-service-integrations"
-    },
-    "categories": [
-      "security",
-      "cdn_security"
-    ],
-    "signature_path": "/epr/akamai/akamai-2.28.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "akamai.siem",
-        "title": "Akamai SIEM Logs"
-      }
-    ]
-  },
-  {
-    "name": "ti_otx",
-    "title": "AlienVault OTX",
-    "version": "1.2.2",
-    "release": "ga",
-    "description": "Collect threat intelligence from AlienVault OTX with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/ti_otx/ti_otx-1.2.2.zip",
-    "path": "/package/ti_otx/1.2.2",
-    "icons": [
-      {
-        "src": "/img/otx.svg",
-        "path": "/package/ti_otx/1.2.2/img/otx.svg",
-        "title": "Alienvault OTX",
-        "size": "216x216",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "ti_otx",
-        "title": "Alienvault OTX",
-        "description": "Collect threat intelligence from the Alienvault OTX"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/ti_otx/ti_otx-1.2.2.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ti_otx.threat",
-        "title": "Alienvault OTX logs"
-      }
-    ]
-  },
-  {
-    "name": "ti_anomali",
-    "title": "Anomali",
-    "version": "1.2.3",
-    "release": "ga",
-    "description": "Collect threat intelligence from Anomali APIs with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/ti_anomali/ti_anomali-1.2.3.zip",
-    "path": "/package/ti_anomali/1.2.3",
-    "icons": [
-      {
-        "src": "/img/anomali.svg",
-        "path": "/package/ti_anomali/1.2.3/img/anomali.svg",
-        "title": "Anomali",
-        "size": "216x216",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "ti_anomali",
-        "title": "Anomali",
-        "description": "Collect threat intelligence from the Anomali Limo API and Anomali Threatstream."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/ti_anomali/ti_anomali-1.2.3.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ti_anomali.limo",
-        "title": "Anomali Limo"
-      },
-      {
-        "type": "logs",
-        "dataset": "ti_anomali.threatstream",
-        "title": "Anomali Threatstream"
-      }
-    ]
-  },
-  {
-    "name": "apache",
-    "title": "Apache HTTP Server",
-    "version": "1.3.5",
-    "release": "ga",
-    "description": "Collect logs and metrics from Apache servers with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/apache/apache-1.3.5.zip",
-    "path": "/package/apache/1.3.5",
-    "icons": [
-      {
-        "src": "/img/logo_apache.svg",
-        "path": "/package/apache/1.3.5/img/logo_apache.svg",
-        "title": "Apache Logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "apache",
-        "title": "Apache logs and metrics",
-        "description": "Collect logs and metrics from Apache instances"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "web"
-    ],
-    "signature_path": "/epr/apache/apache-1.3.5.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "apache.access",
-        "title": "Apache access logs",
-        "deprecated": {
-          "since": "1.3.5",
-          "description": "This data stream is deprecated"
-        }
-      },
-      {
-        "type": "logs",
-        "dataset": "apache.error",
-        "title": "Apache error logs"
-      },
-      {
-        "type": "metrics",
-        "dataset": "apache.status",
-        "title": "Apache status metrics"
-      }
-    ],
-    "deprecated": {
-      "since": "1.3.0",
-      "description": "This package is deprecated"
-    }
-  },
-  {
-    "name": "tomcat",
-    "title": "Apache Tomcat",
-    "version": "1.3.1",
-    "release": "ga",
-    "description": "Collect and parse logs from Apache Tomcat servers with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/tomcat/tomcat-1.3.1.zip",
-    "path": "/package/tomcat/1.3.1",
-    "icons": [
-      {
-        "src": "/img/logo.svg",
-        "path": "/package/tomcat/1.3.1/img/logo.svg",
-        "title": "Apache Tomcat logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "log",
-        "title": "Apache Tomcat",
-        "description": "Collect Apache Tomcat logs from syslog or a file."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.1 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "web",
-      "security"
-    ],
-    "signature_path": "/epr/tomcat/tomcat-1.3.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "tomcat.log",
-        "title": "Apache Tomcat logs"
-      }
-    ]
-  },
-  {
-    "name": "netscout",
-    "title": "Arbor Peakflow SP Logs",
-    "version": "0.7.0",
-    "release": "experimental",
-    "description": "Collect and parse logs from Netscout Arbor Peakflow SP with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/netscout/netscout-0.7.0.zip",
-    "path": "/package/netscout/0.7.0",
-    "icons": [
-      {
-        "src": "/img/logo.svg",
-        "path": "/package/netscout/0.7.0/img/logo.svg",
-        "title": "Arbor Peakflow SP logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "sightline",
-        "title": "Arbor Peakflow SP",
-        "description": "Collect Arbor Peakflow SP logs from syslog or a file."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.1 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/netscout/netscout-0.7.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "netscout.sightline",
-        "title": "Arbor Peakflow SP logs"
-      }
-    ]
-  },
-  {
-    "name": "atlassian_bitbucket",
-    "title": "Atlassian Bitbucket",
-    "version": "1.2.1",
-    "release": "ga",
-    "description": "Collect logs from Atlassian Bitbucket with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.2.1.zip",
-    "path": "/package/atlassian_bitbucket/1.2.1",
-    "icons": [
-      {
-        "src": "/img/bitbucket-logo.svg",
-        "path": "/package/atlassian_bitbucket/1.2.1/img/bitbucket-logo.svg",
-        "title": "Bitbucket Logo",
-        "size": "625x564",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "audit",
-        "title": "Audit Logs",
-        "description": "Collect audit logs from Atlassian Bitbucket with Elastic Agent."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security",
-      "web"
-    ],
-    "signature_path": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.2.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "atlassian_bitbucket.audit",
-        "title": "Bitbucket Audit Logs"
-      }
-    ]
-  },
-  {
-    "name": "atlassian_confluence",
-    "title": "Atlassian Confluence",
-    "version": "1.3.0",
-    "release": "ga",
-    "description": "Collect logs from Atlassian Confluence with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/atlassian_confluence/atlassian_confluence-1.3.0.zip",
-    "path": "/package/atlassian_confluence/1.3.0",
-    "icons": [
-      {
-        "src": "/img/confluence-logo.svg",
-        "path": "/package/atlassian_confluence/1.3.0/img/confluence-logo.svg",
-        "title": "Confluence Logo",
-        "size": "400x400",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "audit",
-        "title": "Audit Logs",
-        "description": "Collect audit logs from Atlassian Confluence with Elastic Agent."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security",
-      "web"
-    ],
-    "signature_path": "/epr/atlassian_confluence/atlassian_confluence-1.3.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "atlassian_confluence.audit",
-        "title": "Confluence Audit Logs"
-      }
-    ]
-  },
-  {
-    "name": "atlassian_jira",
-    "title": "Atlassian Jira",
-    "version": "1.3.0",
-    "release": "ga",
-    "description": "Collect logs from Atlassian Jira with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/atlassian_jira/atlassian_jira-1.3.0.zip",
-    "path": "/package/atlassian_jira/1.3.0",
-    "icons": [
-      {
-        "src": "/img/jira-software-logo.svg",
-        "path": "/package/atlassian_jira/1.3.0/img/jira-software-logo.svg",
-        "title": "Jira Software Logo",
-        "size": "590x625",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "audit",
-        "title": "Audit Logs",
-        "description": "Collect audit logs from Atlassian Jira with Elastic Agent."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security",
-      "web"
-    ],
-    "signature_path": "/epr/atlassian_jira/atlassian_jira-1.3.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "atlassian_jira.audit",
-        "title": "Jira Audit Logs"
-      }
-    ]
-  },
-  {
-    "name": "auditd",
-    "title": "Auditd Logs",
-    "version": "3.1.0",
-    "release": "ga",
-    "description": "Collect logs from Linux audit daemon with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/auditd/auditd-3.1.0.zip",
-    "path": "/package/auditd/3.1.0",
-    "icons": [
-      {
-        "src": "/img/linux.svg",
-        "path": "/package/auditd/3.1.0/img/linux.svg",
-        "title": "linux",
-        "size": "299x354",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "auditd",
-        "title": "Auditd logs",
-        "description": "Collect logs from Auditd instances"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "os_system"
-    ],
-    "signature_path": "/epr/auditd/auditd-3.1.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "auditd.log",
-        "title": "Auditd logs"
-      }
-    ]
-  },
-  {
-    "name": "auditd_manager",
-    "title": "Auditd Manager",
-    "version": "1.0.0",
-    "release": "ga",
-    "description": "The Auditd Manager Integration receives audit events from the Linux Audit Framework that is a part of the Linux kernel.",
-    "type": "integration",
-    "download": "/epr/auditd_manager/auditd_manager-1.0.0.zip",
-    "path": "/package/auditd_manager/1.0.0",
-    "icons": [
-      {
-        "src": "/img/linux.svg",
-        "path": "/package/auditd_manager/1.0.0/img/linux.svg",
-        "title": "linux",
-        "size": "299x354",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "auditd",
-        "title": "Auditd",
-        "description": "Collect auditd events"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.2.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "os_system",
-      "security"
-    ],
-    "signature_path": "/epr/auditd_manager/auditd_manager-1.0.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "auditd_manager.auditd",
-        "title": "Auditd Manager"
-      }
-    ]
-  },
-  {
-    "name": "auth0",
-    "title": "Auth0 Log Streams Integration",
-    "version": "1.0.0",
-    "release": "ga",
-    "description": "Collect logs from Auth0 with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/auth0/auth0-1.0.0.zip",
-    "path": "/package/auth0/1.0.0",
-    "icons": [
-      {
-        "src": "/img/auth0-logo.svg",
-        "path": "/package/auth0/1.0.0/img/auth0-logo.svg",
-        "title": "Auth0 logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "auth0_events",
-        "title": "Auth0 log stream events via Webhooks",
-        "description": "Collect Auth0 log streams events via Webhooks."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "cloud",
-      "network",
-      "security"
-    ],
-    "signature_path": "/epr/auth0/auth0-1.0.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "auth0.logs",
-        "title": "Auth0 logs via Webhooks"
-      }
-    ]
-  },
-  {
-    "name": "azure_application_insights",
-    "title": "Azure Application Insights Metrics Overview",
-    "version": "1.0.1",
-    "release": "ga",
-    "description": "Collect application insights metrics from Azure Monitor with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/azure_application_insights/azure_application_insights-1.0.1.zip",
-    "path": "/package/azure_application_insights/1.0.1",
-    "icons": [
-      {
-        "src": "/img/app_insights.png",
-        "path": "/package/azure_application_insights/1.0.1/img/app_insights.png",
-        "title": "logo docker",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "app_insights",
-        "title": "Azure Application Insights Metrics",
-        "description": "Collect application insights metrics from Azure Monitor with Elastic Agent.",
-        "icons": [
-          {
-            "src": "/img//app_insights.png",
-            "path": "/package/azure_application_insights/1.0.1/img/app_insights.png",
-            "title": "logo azure",
-            "size": "32x32",
-            "type": "image/svg+xml"
-          }
-        ],
-        "data_streams": [
-          "app_insights"
-        ]
-      },
-      {
-        "name": "app_state",
-        "title": "Azure Application State Insights Metrics",
-        "description": "Collect application state related metrics from Azure Monitor with Elastic Agent.",
-        "icons": [
-          {
-            "src": "/img/application_insights_blue.png",
-            "path": "/package/azure_application_insights/1.0.1/img/application_insights_blue.png",
-            "title": "logo azure",
-            "size": "32x32",
-            "type": "image/svg+xml"
-          }
-        ],
-        "data_streams": [
-          "app_state"
-        ]
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "azure",
-      "web"
-    ],
-    "signature_path": "/epr/azure_application_insights/azure_application_insights-1.0.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "metrics",
-        "dataset": "azure.app_insights",
-        "title": "Azure Application Insights"
-      },
-      {
-        "type": "metrics",
-        "dataset": "azure.app_state",
-        "title": "Azure Application State"
-      }
-    ]
-  },
-  {
-    "name": "azure_billing",
-    "title": "Azure Billing Metrics",
-    "version": "1.0.1",
-    "release": "ga",
-    "description": "Collect billing metrics with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/azure_billing/azure_billing-1.0.1.zip",
-    "path": "/package/azure_billing/1.0.1",
-    "icons": [
-      {
-        "src": "/img/billing.png",
-        "path": "/package/azure_billing/1.0.1/img/billing.png",
-        "title": "logo docker",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "billing",
-        "title": "Azure Billing Metrics",
-        "description": "Collect billing information with Elastic Agent.",
-        "icons": [
-          {
-            "src": "/img//billing.png",
-            "path": "/package/azure_billing/1.0.1/img/billing.png",
-            "title": "logo azure",
-            "size": "32x32",
-            "type": "image/svg+xml"
-          }
-        ],
-        "data_streams": [
-          "billing"
-        ]
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.15.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "azure"
-    ],
-    "signature_path": "/epr/azure_billing/azure_billing-1.0.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "metrics",
-        "dataset": "azure.billing",
-        "title": "Azure Billing Metrics"
       }
     ]
   },
@@ -1675,6 +1423,143 @@
         "type": "logs",
         "dataset": "azure.springcloudlogs",
         "title": "Azure Spring Cloud Logs"
+      }
+    ]
+  },
+  {
+    "name": "azure_application_insights",
+    "title": "Azure Application Insights Metrics Overview",
+    "version": "1.0.1",
+    "release": "ga",
+    "description": "Collect application insights metrics from Azure Monitor with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/azure_application_insights/azure_application_insights-1.0.1.zip",
+    "path": "/package/azure_application_insights/1.0.1",
+    "icons": [
+      {
+        "src": "/img/app_insights.png",
+        "path": "/package/azure_application_insights/1.0.1/img/app_insights.png",
+        "title": "logo docker",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "app_insights",
+        "title": "Azure Application Insights Metrics",
+        "description": "Collect application insights metrics from Azure Monitor with Elastic Agent.",
+        "icons": [
+          {
+            "src": "/img//app_insights.png",
+            "path": "/package/azure_application_insights/1.0.1/img/app_insights.png",
+            "title": "logo azure",
+            "size": "32x32",
+            "type": "image/svg+xml"
+          }
+        ],
+        "data_streams": [
+          "app_insights"
+        ]
+      },
+      {
+        "name": "app_state",
+        "title": "Azure Application State Insights Metrics",
+        "description": "Collect application state related metrics from Azure Monitor with Elastic Agent.",
+        "icons": [
+          {
+            "src": "/img/application_insights_blue.png",
+            "path": "/package/azure_application_insights/1.0.1/img/application_insights_blue.png",
+            "title": "logo azure",
+            "size": "32x32",
+            "type": "image/svg+xml"
+          }
+        ],
+        "data_streams": [
+          "app_state"
+        ]
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "azure",
+      "web"
+    ],
+    "signature_path": "/epr/azure_application_insights/azure_application_insights-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "azure.app_insights",
+        "title": "Azure Application Insights"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.app_state",
+        "title": "Azure Application State"
+      }
+    ]
+  },
+  {
+    "name": "azure_billing",
+    "title": "Azure Billing Metrics",
+    "version": "1.0.1",
+    "release": "ga",
+    "description": "Collect billing metrics with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/azure_billing/azure_billing-1.0.1.zip",
+    "path": "/package/azure_billing/1.0.1",
+    "icons": [
+      {
+        "src": "/img/billing.png",
+        "path": "/package/azure_billing/1.0.1/img/billing.png",
+        "title": "logo docker",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "billing",
+        "title": "Azure Billing Metrics",
+        "description": "Collect billing information with Elastic Agent.",
+        "icons": [
+          {
+            "src": "/img//billing.png",
+            "path": "/package/azure_billing/1.0.1/img/billing.png",
+            "title": "logo azure",
+            "size": "32x32",
+            "type": "image/svg+xml"
+          }
+        ],
+        "data_streams": [
+          "billing"
+        ]
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.15.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "azure"
+    ],
+    "signature_path": "/epr/azure_billing/azure_billing-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "azure.billing",
+        "title": "Azure Billing Metrics"
       }
     ]
   },
@@ -1979,85 +1864,112 @@
     ]
   },
   {
-    "name": "cef",
-    "title": "CEF Logs",
-    "version": "2.0.0",
+    "name": "carbon_black_cloud",
+    "title": "VMware Carbon Black Cloud",
+    "version": "1.0.2",
     "release": "ga",
-    "description": "Collect logs from CEF Logs with Elastic Agent.",
+    "description": "Collect logs from VMWare Carbon Black Cloud with Elastic Agent.",
     "type": "integration",
-    "download": "/epr/cef/cef-2.0.0.zip",
-    "path": "/package/cef/2.0.0",
-    "policy_templates": [
-      {
-        "name": "cef",
-        "title": "CEF logs",
-        "description": "Collect logs from CEF instances"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "network",
-      "security"
-    ],
-    "signature_path": "/epr/cef/cef-2.0.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "cef.log",
-        "title": "CEF log logs"
-      }
-    ]
-  },
-  {
-    "name": "cloud_security_posture",
-    "title": "CIS Kubernetes Benchmark",
-    "version": "0.0.14",
-    "release": "experimental",
-    "description": "Check Kubernetes cluster compliance with the Kubernetes CIS benchmark.",
-    "type": "integration",
-    "download": "/epr/cloud_security_posture/cloud_security_posture-0.0.14.zip",
-    "path": "/package/cloud_security_posture/0.0.14",
+    "download": "/epr/carbon_black_cloud/carbon_black_cloud-1.0.2.zip",
+    "path": "/package/carbon_black_cloud/1.0.2",
     "icons": [
       {
-        "src": "/img/cis-kubernetes-benchmark-logo.svg",
-        "path": "/package/cloud_security_posture/0.0.14/img/cis-kubernetes-benchmark-logo.svg",
-        "title": "CIS Kubernetes Benchmark logo",
+        "src": "/img/carbon_black_cloud-logo.svg",
+        "path": "/package/carbon_black_cloud/1.0.2/img/carbon_black_cloud-logo.svg",
+        "title": "Carbon Black Cloud logo",
         "size": "32x32",
         "type": "image/svg+xml"
       }
     ],
     "policy_templates": [
       {
-        "name": "kspm",
-        "title": "CIS Kubernetes Benchmark",
-        "description": "Check Kubernetes cluster compliance with the Kubernetes CIS benchmark."
+        "name": "carbon_black_cloud",
+        "title": "Carbon Black Cloud",
+        "description": "Collect Logs from Carbon Black Cloud"
       }
     ],
     "conditions": {
       "kibana": {
-        "version": "^8.3.0"
+        "version": "^7.17.0 || ^8.0.0"
       }
     },
     "owner": {
-      "github": "elastic/cloud-security-posture"
+      "github": "elastic/security-external-integrations"
     },
     "categories": [
-      "containers",
-      "kubernetes"
+      "security"
     ],
-    "signature_path": "/epr/cloud_security_posture/cloud_security_posture-0.0.14.zip.sig",
+    "signature_path": "/epr/carbon_black_cloud/carbon_black_cloud-1.0.2.zip.sig",
     "data_streams": [
       {
         "type": "logs",
-        "dataset": "cloud_security_posture.findings",
-        "title": "Findings"
+        "dataset": "carbon_black_cloud.alert",
+        "title": "Alert"
+      },
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.asset_vulnerability_summary",
+        "title": "Asset Vulnerability Summary"
+      },
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.audit",
+        "title": "Audit"
+      },
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.endpoint_event",
+        "title": "Endpoint Event"
+      },
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.watchlist_hit",
+        "title": "Watchlist Hit"
+      }
+    ]
+  },
+  {
+    "name": "carbonblack_edr",
+    "title": "VMware Carbon Black EDR",
+    "version": "1.2.0",
+    "release": "ga",
+    "description": "Collect logs from VMware Carbon Black EDR with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/carbonblack_edr/carbonblack_edr-1.2.0.zip",
+    "path": "/package/carbonblack_edr/1.2.0",
+    "icons": [
+      {
+        "src": "/img/carbon-black-logo.svg",
+        "path": "/package/carbonblack_edr/1.2.0/img/carbon-black-logo.svg",
+        "title": "VMWare Carbon Black",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "log",
+        "title": "Carbon Black EDR logs",
+        "description": "Collect logs from Carbon Black EDR"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/carbonblack_edr/carbonblack_edr-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "carbonblack_edr.log",
+        "title": "Carbon Black EDR logs"
       }
     ]
   },
@@ -2109,6 +2021,43 @@
         "type": "metrics",
         "dataset": "cassandra.metrics",
         "title": "metrics"
+      }
+    ]
+  },
+  {
+    "name": "cef",
+    "title": "CEF Logs",
+    "version": "2.0.0",
+    "release": "ga",
+    "description": "Collect logs from CEF Logs with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/cef/cef-2.0.0.zip",
+    "path": "/package/cef/2.0.0",
+    "policy_templates": [
+      {
+        "name": "cef",
+        "title": "CEF logs",
+        "description": "Collect logs from CEF instances"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "network",
+      "security"
+    ],
+    "signature_path": "/epr/cef/cef-2.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cef.log",
+        "title": "CEF log logs"
       }
     ]
   },
@@ -2706,6 +2655,52 @@
     ]
   },
   {
+    "name": "cloud_security_posture",
+    "title": "CIS Kubernetes Benchmark",
+    "version": "0.0.14",
+    "release": "experimental",
+    "description": "Check Kubernetes cluster compliance with the Kubernetes CIS benchmark.",
+    "type": "integration",
+    "download": "/epr/cloud_security_posture/cloud_security_posture-0.0.14.zip",
+    "path": "/package/cloud_security_posture/0.0.14",
+    "icons": [
+      {
+        "src": "/img/cis-kubernetes-benchmark-logo.svg",
+        "path": "/package/cloud_security_posture/0.0.14/img/cis-kubernetes-benchmark-logo.svg",
+        "title": "CIS Kubernetes Benchmark logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "kspm",
+        "title": "CIS Kubernetes Benchmark",
+        "description": "Check Kubernetes cluster compliance with the Kubernetes CIS benchmark."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.3.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/cloud-security-posture"
+    },
+    "categories": [
+      "containers",
+      "kubernetes"
+    ],
+    "signature_path": "/epr/cloud_security_posture/cloud_security_posture-0.0.14.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cloud_security_posture.findings",
+        "title": "Findings"
+      }
+    ]
+  },
+  {
     "name": "cloudflare",
     "title": "Cloudflare",
     "version": "2.0.0",
@@ -2866,389 +2861,6 @@
     ]
   },
   {
-    "name": "aws_logs",
-    "title": "Custom AWS Logs",
-    "version": "0.2.1",
-    "release": "beta",
-    "description": "Collect raw logs from AWS S3 or CloudWatch with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/aws_logs/aws_logs-0.2.1.zip",
-    "path": "/package/aws_logs/0.2.1",
-    "icons": [
-      {
-        "src": "/img/icon.svg",
-        "path": "/package/aws_logs/0.2.1/img/icon.svg",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "aws_logs",
-        "title": "Custom AWS Logs",
-        "description": "Collect raw logs from AWS S3 or CloudWatch with Elastic Agent."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/obs-cloud-monitoring"
-    },
-    "categories": [
-      "custom",
-      "cloud",
-      "aws"
-    ],
-    "signature_path": "/epr/aws_logs/aws_logs-0.2.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "aws_logs.generic",
-        "title": "Custom logs from AWS"
-      }
-    ]
-  },
-  {
-    "name": "gcp_pubsub",
-    "title": "Custom Google Pub/Sub Logs",
-    "version": "1.0.0",
-    "release": "ga",
-    "description": "Collect Logs from Google Pub/Sub topics",
-    "type": "integration",
-    "download": "/epr/gcp_pubsub/gcp_pubsub-1.0.0.zip",
-    "path": "/package/gcp_pubsub/1.0.0",
-    "icons": [
-      {
-        "src": "/img/logo_gcp.svg",
-        "path": "/package/gcp_pubsub/1.0.0/img/logo_gcp.svg",
-        "title": "logo gcp",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "gcp",
-        "title": "Custom Google Pub/Sub Logs",
-        "description": "Collect Logs from Google Pub/Sub topics"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "google_cloud",
-      "cloud",
-      "custom"
-    ],
-    "signature_path": "/epr/gcp_pubsub/gcp_pubsub-1.0.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "gcp_pubsub.generic",
-        "title": "Custom Google Pub/Sub Logs"
-      }
-    ]
-  },
-  {
-    "name": "http_endpoint",
-    "title": "Custom HTTP Endpoint Logs",
-    "version": "1.0.1",
-    "release": "ga",
-    "description": "Collect JSON data from listening HTTP port with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/http_endpoint/http_endpoint-1.0.1.zip",
-    "path": "/package/http_endpoint/1.0.1",
-    "icons": [
-      {
-        "src": "/img/icon.svg",
-        "path": "/package/http_endpoint/1.0.1/img/icon.svg",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "http_endpoint",
-        "title": "Custom HTTP Endpoint Logs",
-        "description": "Collect JSON data from listening HTTP port with Elastic Agent."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "signature_path": "/epr/http_endpoint/http_endpoint-1.0.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "http_endpoint.generic",
-        "title": "Custom HTTP Endpoint Logs"
-      }
-    ]
-  },
-  {
-    "name": "httpjson",
-    "title": "Custom HTTPJSON Input",
-    "version": "1.1.1",
-    "release": "ga",
-    "description": "Collect custom data from REST API's with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/httpjson/httpjson-1.1.1.zip",
-    "path": "/package/httpjson/1.1.1",
-    "policy_templates": [
-      {
-        "name": "generic",
-        "title": "Custom HTTPJSON Input",
-        "description": "Collect custom data from REST API's"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "signature_path": "/epr/httpjson/httpjson-1.1.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "httpjson.generic",
-        "title": "Custom HTTPJSON Input"
-      }
-    ]
-  },
-  {
-    "name": "journald",
-    "title": "Custom Journald logs",
-    "version": "0.0.2",
-    "release": "experimental",
-    "description": "Collect logs from journald with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/journald/journald-0.0.2.zip",
-    "path": "/package/journald/0.0.2",
-    "icons": [
-      {
-        "src": "/img/systemd-logo.svg",
-        "path": "/package/journald/0.0.2/img/systemd-logo.svg",
-        "title": "systemd logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "logs",
-        "title": "Journald",
-        "description": "Collect sample logs"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "signature_path": "/epr/journald/journald-0.0.2.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "journald.log",
-        "title": "Journald Log"
-      }
-    ]
-  },
-  {
-    "name": "log",
-    "title": "Custom Logs",
-    "version": "1.0.0",
-    "release": "ga",
-    "description": "Collect custom logs with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/log/log-1.0.0.zip",
-    "path": "/package/log/1.0.0",
-    "icons": [
-      {
-        "src": "/img/icon.svg",
-        "path": "/package/log/1.0.0/img/icon.svg",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "logs",
-        "title": "Custom logs",
-        "description": "Collect your custom log files."
-      }
-    ],
-    "owner": {
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "signature_path": "/epr/log/log-1.0.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "log.log",
-        "title": "Log Dataset"
-      }
-    ]
-  },
-  {
-    "name": "tcp",
-    "title": "Custom TCP Logs",
-    "version": "1.0.0",
-    "release": "ga",
-    "description": "Collect raw TCP data from listening TCP port with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/tcp/tcp-1.0.0.zip",
-    "path": "/package/tcp/1.0.0",
-    "icons": [
-      {
-        "src": "/img/icon.svg",
-        "path": "/package/tcp/1.0.0/img/icon.svg",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "tcp",
-        "title": "Custom TCP Logs",
-        "description": "Collect raw TCP data from listening TCP port with Elastic Agent."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "signature_path": "/epr/tcp/tcp-1.0.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "tcp.generic",
-        "title": "Custom TCP Logs"
-      }
-    ]
-  },
-  {
-    "name": "udp",
-    "title": "Custom UDP Logs",
-    "version": "1.0.1",
-    "release": "ga",
-    "description": "Collect raw UDP data from listening UDP port with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/udp/udp-1.0.1.zip",
-    "path": "/package/udp/1.0.1",
-    "icons": [
-      {
-        "src": "/img/icon.svg",
-        "path": "/package/udp/1.0.1/img/icon.svg",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "udp",
-        "title": "Custom UDP Logs",
-        "description": "Collect raw UDP data from listening UDP port with Elastic Agent."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "signature_path": "/epr/udp/udp-1.0.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "udp.generic",
-        "title": "Custom UDP Logs"
-      }
-    ]
-  },
-  {
-    "name": "winlog",
-    "title": "Custom Windows Event Logs",
-    "version": "1.4.0",
-    "release": "ga",
-    "description": "Collect and parse logs from any Windows event log channel with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/winlog/winlog-1.4.0.zip",
-    "path": "/package/winlog/1.4.0",
-    "icons": [
-      {
-        "src": "/img/logo_windows.svg",
-        "path": "/package/winlog/1.4.0/img/logo_windows.svg",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "winlogs",
-        "title": "Custom Windows event logs",
-        "description": "Collect your custom Windows event logs."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "signature_path": "/epr/winlog/winlog-1.4.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "winlog.winlog",
-        "title": "Custom Windows Event Log Dataset"
-      }
-    ]
-  },
-  {
     "name": "cyberark",
     "title": "CyberArk",
     "version": "0.4.4",
@@ -3335,52 +2947,6 @@
         "type": "logs",
         "dataset": "cyberarkpas.audit",
         "title": "CyberArk PAS audit logs"
-      }
-    ]
-  },
-  {
-    "name": "ti_cybersixgill",
-    "title": "Cybersixgill",
-    "version": "1.3.2",
-    "release": "ga",
-    "description": "This Elastic integration collects threat intelligence from Cybersixgill",
-    "type": "integration",
-    "download": "/epr/ti_cybersixgill/ti_cybersixgill-1.3.2.zip",
-    "path": "/package/ti_cybersixgill/1.3.2",
-    "icons": [
-      {
-        "src": "/img/cybersixgill.svg",
-        "path": "/package/ti_cybersixgill/1.3.2/img/cybersixgill.svg",
-        "title": "Cybersixgill",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "cybersixgill",
-        "title": "Cybersixgill Threat Intel",
-        "description": "Collect Threat Intel from Cybersixgill"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security",
-      "productivity"
-    ],
-    "signature_path": "/epr/ti_cybersixgill/ti_cybersixgill-1.3.2.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ti_cybersixgill.threat",
-        "title": "Cybersixgill Darkfeed Logs"
       }
     ]
   },
@@ -3636,87 +3202,6 @@
     ]
   },
   {
-    "name": "apm",
-    "title": "Elastic APM",
-    "version": "8.2.0",
-    "release": "ga",
-    "description": "Ingest APM data",
-    "type": "integration",
-    "download": "/epr/apm/apm-8.2.0.zip",
-    "path": "/package/apm/8.2.0",
-    "icons": [
-      {
-        "src": "/img/logo_apm.svg",
-        "path": "/package/apm/8.2.0/img/logo_apm.svg",
-        "title": "APM Logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "apmserver",
-        "title": "Elastic APM Integration",
-        "description": "Elastic APM Integration"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.2.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/apm-server"
-    },
-    "categories": [
-      "elastic_stack",
-      "monitoring"
-    ],
-    "signature_path": "/epr/apm/apm-8.2.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "apm.app",
-        "title": "APM application logs"
-      },
-      {
-        "type": "metrics",
-        "dataset": "apm.app",
-        "title": "APM application metrics"
-      },
-      {
-        "type": "logs",
-        "dataset": "apm.error",
-        "title": "APM errors"
-      },
-      {
-        "type": "metrics",
-        "dataset": "apm.internal",
-        "title": "APM internal metrics"
-      },
-      {
-        "type": "metrics",
-        "dataset": "apm.profiling",
-        "title": "APM profiles"
-      },
-      {
-        "type": "traces",
-        "dataset": "apm.rum",
-        "title": "APM RUM traces"
-      },
-      {
-        "type": "traces",
-        "dataset": "apm.sampled",
-        "title": "APM tail-sampled traces"
-      },
-      {
-        "type": "traces",
-        "dataset": "apm",
-        "title": "APM traces"
-      }
-    ]
-  },
-  {
     "name": "elastic_agent",
     "title": "Elastic Agent",
     "version": "1.3.1",
@@ -3846,77 +3331,6 @@
         "type": "metrics",
         "dataset": "elastic_agent.packetbeat",
         "title": "Elastic Agent"
-      }
-    ]
-  },
-  {
-    "name": "synthetics",
-    "title": "Elastic Synthetics",
-    "version": "0.9.2",
-    "release": "beta",
-    "description": "Monitor the availability of your services with Elastic Synthetics.",
-    "type": "integration",
-    "download": "/epr/synthetics/synthetics-0.9.2.zip",
-    "path": "/package/synthetics/0.9.2",
-    "icons": [
-      {
-        "src": "/img/uptime-logo-color-64px.svg",
-        "path": "/package/synthetics/0.9.2/img/uptime-logo-color-64px.svg",
-        "size": "16x16",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "synthetics",
-        "title": "Elastic Synthetics",
-        "description": "Perform synthetic health checks on network endpoints."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.1.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/uptime"
-    },
-    "categories": [
-      "elastic_stack",
-      "monitoring",
-      "web"
-    ],
-    "signature_path": "/epr/synthetics/synthetics-0.9.2.zip.sig",
-    "data_streams": [
-      {
-        "type": "synthetics",
-        "dataset": "browser",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "browser.network",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "browser.screenshot",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "http",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "icmp",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "tcp",
-        "title": "synthetic monitor check"
       }
     ]
   },
@@ -4390,51 +3804,6 @@
     ]
   },
   {
-    "name": "github",
-    "title": "GitHub",
-    "version": "1.0.0",
-    "release": "ga",
-    "description": "Collect events from GitHub with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/github/github-1.0.0.zip",
-    "path": "/package/github/1.0.0",
-    "icons": [
-      {
-        "src": "/img/github.svg",
-        "path": "/package/github/1.0.0/img/github.svg",
-        "title": "GitHub",
-        "size": "1024x1024",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "github",
-        "title": "GitHub logs",
-        "description": "Collect logs from GitHub"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/github/github-1.0.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "github.audit",
-        "title": "GitHub Audit Logs"
-      }
-    ]
-  },
-  {
     "name": "gcp",
     "title": "Google Cloud Platform",
     "version": "1.9.0",
@@ -4498,47 +3867,94 @@
     ]
   },
   {
-    "name": "santa",
-    "title": "Google Santa Logs",
-    "version": "2.0.1",
+    "name": "gcp_pubsub",
+    "title": "Custom Google Pub/Sub Logs",
+    "version": "1.0.0",
     "release": "ga",
-    "description": "Collect and parse logs from Google Santa instances with Elastic Agent.",
+    "description": "Collect Logs from Google Pub/Sub topics",
     "type": "integration",
-    "download": "/epr/santa/santa-2.0.1.zip",
-    "path": "/package/santa/2.0.1",
+    "download": "/epr/gcp_pubsub/gcp_pubsub-1.0.0.zip",
+    "path": "/package/gcp_pubsub/1.0.0",
     "icons": [
       {
-        "src": "/img/icon.svg",
-        "path": "/package/santa/2.0.1/img/icon.svg",
-        "title": "Google Santa",
+        "src": "/img/logo_gcp.svg",
+        "path": "/package/gcp_pubsub/1.0.0/img/logo_gcp.svg",
+        "title": "logo gcp",
+        "size": "32x32",
         "type": "image/svg+xml"
       }
     ],
     "policy_templates": [
       {
-        "name": "santa",
-        "title": "Google Santa logs",
-        "description": "Collect logs from Google Santa instances"
+        "name": "gcp",
+        "title": "Custom Google Pub/Sub Logs",
+        "description": "Collect Logs from Google Pub/Sub topics"
       }
     ],
     "conditions": {
       "kibana": {
-        "version": "^7.17.0 || ^8.0.0"
+        "version": "^7.16.0 || ^8.0.0"
       }
     },
     "owner": {
       "github": "elastic/security-external-integrations"
     },
     "categories": [
-      "security",
-      "os_system"
+      "google_cloud",
+      "cloud",
+      "custom"
     ],
-    "signature_path": "/epr/santa/santa-2.0.1.zip.sig",
+    "signature_path": "/epr/gcp_pubsub/gcp_pubsub-1.0.0.zip.sig",
     "data_streams": [
       {
         "type": "logs",
-        "dataset": "santa.log",
-        "title": "Google Santa log logs"
+        "dataset": "gcp_pubsub.generic",
+        "title": "Custom Google Pub/Sub Logs"
+      }
+    ]
+  },
+  {
+    "name": "github",
+    "title": "GitHub",
+    "version": "1.0.0",
+    "release": "ga",
+    "description": "Collect events from GitHub with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/github/github-1.0.0.zip",
+    "path": "/package/github/1.0.0",
+    "icons": [
+      {
+        "src": "/img/github.svg",
+        "path": "/package/github/1.0.0/img/github.svg",
+        "title": "GitHub",
+        "size": "1024x1024",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "github",
+        "title": "GitHub logs",
+        "description": "Collect logs from GitHub"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/github/github-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "github.audit",
+        "title": "GitHub Audit Logs"
       }
     ]
   },
@@ -4774,6 +4190,85 @@
     ]
   },
   {
+    "name": "http_endpoint",
+    "title": "Custom HTTP Endpoint Logs",
+    "version": "1.0.1",
+    "release": "ga",
+    "description": "Collect JSON data from listening HTTP port with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/http_endpoint/http_endpoint-1.0.1.zip",
+    "path": "/package/http_endpoint/1.0.1",
+    "icons": [
+      {
+        "src": "/img/icon.svg",
+        "path": "/package/http_endpoint/1.0.1/img/icon.svg",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "http_endpoint",
+        "title": "Custom HTTP Endpoint Logs",
+        "description": "Collect JSON data from listening HTTP port with Elastic Agent."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "signature_path": "/epr/http_endpoint/http_endpoint-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "http_endpoint.generic",
+        "title": "Custom HTTP Endpoint Logs"
+      }
+    ]
+  },
+  {
+    "name": "httpjson",
+    "title": "Custom HTTPJSON Input",
+    "version": "1.1.1",
+    "release": "ga",
+    "description": "Collect custom data from REST API's with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/httpjson/httpjson-1.1.1.zip",
+    "path": "/package/httpjson/1.1.1",
+    "policy_templates": [
+      {
+        "name": "generic",
+        "title": "Custom HTTPJSON Input",
+        "description": "Collect custom data from REST API's"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "signature_path": "/epr/httpjson/httpjson-1.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "httpjson.generic",
+        "title": "Custom HTTPJSON Input"
+      }
+    ]
+  },
+  {
     "name": "iis",
     "title": "IIS",
     "version": "0.8.0",
@@ -4967,48 +4462,47 @@
     ]
   },
   {
-    "name": "juniper_junos",
-    "title": "Juniper JunOS",
-    "version": "0.1.1",
+    "name": "journald",
+    "title": "Custom Journald logs",
+    "version": "0.0.2",
     "release": "experimental",
-    "description": "Collect logs from Juniper JunOS with Elastic Agent.",
+    "description": "Collect logs from journald with Elastic Agent.",
     "type": "integration",
-    "download": "/epr/juniper_junos/juniper_junos-0.1.1.zip",
-    "path": "/package/juniper_junos/0.1.1",
+    "download": "/epr/journald/journald-0.0.2.zip",
+    "path": "/package/journald/0.0.2",
     "icons": [
       {
-        "src": "/img/logo.svg",
-        "path": "/package/juniper_junos/0.1.1/img/logo.svg",
-        "title": "Juniper logo",
+        "src": "/img/systemd-logo.svg",
+        "path": "/package/journald/0.0.2/img/systemd-logo.svg",
+        "title": "systemd logo",
         "size": "32x32",
         "type": "image/svg+xml"
       }
     ],
     "policy_templates": [
       {
-        "name": "juniper",
-        "title": "Juniper JunOS logs",
-        "description": "Collect Juniper JunOS logs from syslog or a file."
+        "name": "logs",
+        "title": "Journald",
+        "description": "Collect sample logs"
       }
     ],
     "conditions": {
       "kibana": {
-        "version": "^8.0.0"
+        "version": "^7.16.0"
       }
     },
     "owner": {
-      "github": "elastic/security-external-integrations"
+      "github": "elastic/integrations"
     },
     "categories": [
-      "network",
-      "security"
+      "custom"
     ],
-    "signature_path": "/epr/juniper_junos/juniper_junos-0.1.1.zip.sig",
+    "signature_path": "/epr/journald/journald-0.0.2.zip.sig",
     "data_streams": [
       {
         "type": "logs",
-        "dataset": "juniper_junos.log",
-        "title": "Juniper JUNOS logs"
+        "dataset": "journald.log",
+        "title": "Journald Log"
       }
     ]
   },
@@ -5065,6 +4559,52 @@
         "type": "logs",
         "dataset": "juniper.srx",
         "title": "Juniper SRX logs"
+      }
+    ]
+  },
+  {
+    "name": "juniper_junos",
+    "title": "Juniper JunOS",
+    "version": "0.1.1",
+    "release": "experimental",
+    "description": "Collect logs from Juniper JunOS with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/juniper_junos/juniper_junos-0.1.1.zip",
+    "path": "/package/juniper_junos/0.1.1",
+    "icons": [
+      {
+        "src": "/img/logo.svg",
+        "path": "/package/juniper_junos/0.1.1/img/logo.svg",
+        "title": "Juniper logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "juniper",
+        "title": "Juniper JunOS logs",
+        "description": "Collect Juniper JunOS logs from syslog or a file."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "network",
+      "security"
+    ],
+    "signature_path": "/epr/juniper_junos/juniper_junos-0.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "juniper_junos.log",
+        "title": "Juniper JUNOS logs"
       }
     ]
   },
@@ -5784,6 +5324,44 @@
     ]
   },
   {
+    "name": "log",
+    "title": "Custom Logs",
+    "version": "1.0.0",
+    "release": "ga",
+    "description": "Collect custom logs with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/log/log-1.0.0.zip",
+    "path": "/package/log/1.0.0",
+    "icons": [
+      {
+        "src": "/img/icon.svg",
+        "path": "/package/log/1.0.0/img/icon.svg",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "logs",
+        "title": "Custom logs",
+        "description": "Collect your custom log files."
+      }
+    ],
+    "owner": {
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "signature_path": "/epr/log/log-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "log.log",
+        "title": "Log Dataset"
+      }
+    ]
+  },
+  {
     "name": "logstash",
     "title": "Logstash",
     "version": "1.1.0",
@@ -5844,37 +5422,6 @@
     ]
   },
   {
-    "name": "problemchild",
-    "title": "LotL Attack Detection",
-    "version": "0.0.2",
-    "release": "experimental",
-    "description": "The ProblemChild framework is used to detect living off the land activity. Requires a Platinum subscription.",
-    "type": "integration",
-    "download": "/epr/problemchild/problemchild-0.0.2.zip",
-    "path": "/package/problemchild/0.0.2",
-    "icons": [
-      {
-        "src": "/img/icon-machine-learning.svg",
-        "path": "/package/problemchild/0.0.2/img/icon-machine-learning.svg",
-        "title": "Sample logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/ml-ui"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/problemchild/problemchild-0.0.2.zip.sig"
-  },
-  {
     "name": "m365_defender",
     "title": "M365 Defender Logs",
     "version": "1.0.3",
@@ -5918,51 +5465,6 @@
         "type": "logs",
         "dataset": "m365_defender.log",
         "title": "M365 Defender Logs"
-      }
-    ]
-  },
-  {
-    "name": "ti_misp",
-    "title": "MISP",
-    "version": "1.2.2",
-    "release": "ga",
-    "description": "This Elastic integration collects events from MISP",
-    "type": "integration",
-    "download": "/epr/ti_misp/ti_misp-1.2.2.zip",
-    "path": "/package/ti_misp/1.2.2",
-    "icons": [
-      {
-        "src": "/img/misp.svg",
-        "path": "/package/ti_misp/1.2.2/img/misp.svg",
-        "title": "MISP",
-        "size": "216x216",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "ti_misp",
-        "title": "MISP",
-        "description": "Collect threat intelligence from the MISP API."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/ti_misp/ti_misp-1.2.2.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ti_misp.threat",
-        "title": "MISP"
       }
     ]
   },
@@ -6065,51 +5567,6 @@
     ]
   },
   {
-    "name": "microsoft_dhcp",
-    "title": "Microsoft DHCP",
-    "version": "1.3.1",
-    "release": "ga",
-    "description": "Collect logs from Microsoft DHCP with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/microsoft_dhcp/microsoft_dhcp-1.3.1.zip",
-    "path": "/package/microsoft_dhcp/1.3.1",
-    "icons": [
-      {
-        "src": "/img/logo.svg",
-        "path": "/package/microsoft_dhcp/1.3.1/img/logo.svg",
-        "title": "Microsoft logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "microsoft_dhcp",
-        "title": "Microsoft DHCP",
-        "description": "Collect Microsoft DHCP logs."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "network"
-    ],
-    "signature_path": "/epr/microsoft_dhcp/microsoft_dhcp-1.3.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "microsoft_dhcp.log",
-        "title": "Microsoft DHCP Logs"
-      }
-    ]
-  },
-  {
     "name": "microsoft_defender_endpoint",
     "title": "Microsoft Defender for Endpoint",
     "version": "2.1.0",
@@ -6153,6 +5610,51 @@
         "type": "logs",
         "dataset": "microsoft_defender_endpoint.log",
         "title": "Microsoft Defender for Endpoint logs"
+      }
+    ]
+  },
+  {
+    "name": "microsoft_dhcp",
+    "title": "Microsoft DHCP",
+    "version": "1.3.1",
+    "release": "ga",
+    "description": "Collect logs from Microsoft DHCP with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/microsoft_dhcp/microsoft_dhcp-1.3.1.zip",
+    "path": "/package/microsoft_dhcp/1.3.1",
+    "icons": [
+      {
+        "src": "/img/logo.svg",
+        "path": "/package/microsoft_dhcp/1.3.1/img/logo.svg",
+        "title": "Microsoft logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "microsoft_dhcp",
+        "title": "Microsoft DHCP",
+        "description": "Collect Microsoft DHCP logs."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "network"
+    ],
+    "signature_path": "/epr/microsoft_dhcp/microsoft_dhcp-1.3.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "microsoft_dhcp.log",
+        "title": "Microsoft DHCP Logs"
       }
     ]
   },
@@ -6538,6 +6040,51 @@
         "type": "logs",
         "dataset": "netflow.log",
         "title": "NetFlow logs"
+      }
+    ]
+  },
+  {
+    "name": "netscout",
+    "title": "Arbor Peakflow SP Logs",
+    "version": "0.7.0",
+    "release": "experimental",
+    "description": "Collect and parse logs from Netscout Arbor Peakflow SP with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/netscout/netscout-0.7.0.zip",
+    "path": "/package/netscout/0.7.0",
+    "icons": [
+      {
+        "src": "/img/logo.svg",
+        "path": "/package/netscout/0.7.0/img/logo.svg",
+        "title": "Arbor Peakflow SP logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "sightline",
+        "title": "Arbor Peakflow SP",
+        "description": "Collect Arbor Peakflow SP logs from syslog or a file."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.1 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/netscout/netscout-0.7.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "netscout.sightline",
+        "title": "Arbor Peakflow SP logs"
       }
     ]
   },
@@ -7039,6 +6586,51 @@
     ]
   },
   {
+    "name": "panw",
+    "title": "Palo Alto Networks Logs",
+    "version": "1.5.3",
+    "release": "ga",
+    "description": "Collect PAN-OS firewall monitoring logs from Palo Alto Networks devices with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/panw/panw-1.5.3.zip",
+    "path": "/package/panw/1.5.3",
+    "icons": [
+      {
+        "src": "/img/logo-integrations-paloalto-networks.svg",
+        "path": "/package/panw/1.5.3/img/logo-integrations-paloalto-networks.svg",
+        "title": "Palo Alto Networks",
+        "size": "216x216",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "panw",
+        "title": "Palo Alto Networks PAN-OS firewall logs",
+        "description": "Collect logs from Palo Alto Networks PAN-OS firewall"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/panw/panw-1.5.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "panw.panos",
+        "title": "Palo Alto Networks PAN-OS firewall logs"
+      }
+    ]
+  },
+  {
     "name": "panw_cortex_xdr",
     "title": "Palo Alto Cortex XDR Logs",
     "version": "1.1.1",
@@ -7084,47 +6676,48 @@
     ]
   },
   {
-    "name": "panw",
-    "title": "Palo Alto Networks Logs",
-    "version": "1.5.3",
-    "release": "ga",
-    "description": "Collect PAN-OS firewall monitoring logs from Palo Alto Networks devices with Elastic Agent.",
+    "name": "pfsense",
+    "title": "pfSense Logs",
+    "version": "0.3.1",
+    "release": "experimental",
+    "description": "Collect and parse logs from pfSense devices with Elastic Agent.",
     "type": "integration",
-    "download": "/epr/panw/panw-1.5.3.zip",
-    "path": "/package/panw/1.5.3",
+    "download": "/epr/pfsense/pfsense-0.3.1.zip",
+    "path": "/package/pfsense/0.3.1",
     "icons": [
       {
-        "src": "/img/logo-integrations-paloalto-networks.svg",
-        "path": "/package/panw/1.5.3/img/logo-integrations-paloalto-networks.svg",
-        "title": "Palo Alto Networks",
-        "size": "216x216",
+        "src": "/img/pfsense.svg",
+        "path": "/package/pfsense/0.3.1/img/pfsense.svg",
+        "title": "pfsense",
+        "size": "512x143",
         "type": "image/svg+xml"
       }
     ],
     "policy_templates": [
       {
-        "name": "panw",
-        "title": "Palo Alto Networks PAN-OS firewall logs",
-        "description": "Collect logs from Palo Alto Networks PAN-OS firewall"
+        "name": "pfsense",
+        "title": "pfSense logs",
+        "description": "Collect logs from pfSense systems"
       }
     ],
     "conditions": {
       "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
+        "version": "^7.15.0 || ^8.0.0"
       }
     },
     "owner": {
       "github": "elastic/security-external-integrations"
     },
     "categories": [
+      "network",
       "security"
     ],
-    "signature_path": "/epr/panw/panw-1.5.3.zip.sig",
+    "signature_path": "/epr/pfsense/pfsense-0.3.1.zip.sig",
     "data_streams": [
       {
         "type": "logs",
-        "dataset": "panw.panos",
-        "title": "Palo Alto Networks PAN-OS firewall logs"
+        "dataset": "pfsense.log",
+        "title": "pfSense log logs"
       }
     ]
   },
@@ -7194,34 +6787,35 @@
     ]
   },
   {
-    "name": "security_detection_engine",
-    "title": "Prebuilt Security Detection Rules",
-    "version": "0.16.2",
-    "release": "ga",
-    "description": "Prebuilt detection rules for Elastic Security",
+    "name": "problemchild",
+    "title": "LotL Attack Detection",
+    "version": "0.0.2",
+    "release": "experimental",
+    "description": "The ProblemChild framework is used to detect living off the land activity. Requires a Platinum subscription.",
     "type": "integration",
-    "download": "/epr/security_detection_engine/security_detection_engine-0.16.2.zip",
-    "path": "/package/security_detection_engine/0.16.2",
+    "download": "/epr/problemchild/problemchild-0.0.2.zip",
+    "path": "/package/problemchild/0.0.2",
     "icons": [
       {
-        "src": "/img/security-logo-color-64px.svg",
-        "path": "/package/security_detection_engine/0.16.2/img/security-logo-color-64px.svg",
-        "size": "16x16",
+        "src": "/img/icon-machine-learning.svg",
+        "path": "/package/problemchild/0.0.2/img/icon-machine-learning.svg",
+        "title": "Sample logo",
+        "size": "32x32",
         "type": "image/svg+xml"
       }
     ],
     "conditions": {
       "kibana": {
-        "version": "^7.16.0"
+        "version": "^8.0.0"
       }
     },
     "owner": {
-      "github": "elastic/protections"
+      "github": "elastic/ml-ui"
     },
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/security_detection_engine/security_detection_engine-0.16.2.zip.sig"
+    "signature_path": "/epr/problemchild/problemchild-0.0.2.zip.sig"
   },
   {
     "name": "prometheus",
@@ -7526,51 +7120,6 @@
     ]
   },
   {
-    "name": "ti_recordedfuture",
-    "title": "Recorded Future",
-    "version": "0.1.2",
-    "release": "beta",
-    "description": "Collect threat intelligence from Recorded Future with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/ti_recordedfuture/ti_recordedfuture-0.1.2.zip",
-    "path": "/package/ti_recordedfuture/0.1.2",
-    "icons": [
-      {
-        "src": "/img/logo.svg",
-        "path": "/package/ti_recordedfuture/0.1.2/img/logo.svg",
-        "title": "Recorded Future",
-        "size": "216x216",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "ti_recordedfuture",
-        "title": "Recorded Future",
-        "description": "Collect threat intelligence from Recorded Future."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/ti_recordedfuture/ti_recordedfuture-0.1.2.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ti_recordedfuture.threat",
-        "title": "Recorded Future"
-      }
-    ]
-  },
-  {
     "name": "redis",
     "title": "Redis",
     "version": "1.2.0",
@@ -7637,114 +7186,79 @@
     ]
   },
   {
-    "name": "sql",
-    "title": "SQL Input",
-    "version": "0.5.0",
-    "release": "beta",
-    "description": "Collects Metrics by Quering on SQL Databases",
-    "type": "input",
-    "download": "/epr/sql/sql-0.5.0.zip",
-    "path": "/package/sql/0.5.0",
-    "icons": [
-      {
-        "src": "/img/sql-server-icon.svg",
-        "path": "/package/sql/0.5.0/img/sql-server-icon.svg",
-        "title": "SQL logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "sql",
-        "title": "SQL Metrics",
-        "description": "Collects Metrics by Quering on SQL Databases",
-        "deprecated": {
-          "since": "0.5.0",
-          "description": "This policy is deprecated"
-        }
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.13.0"
-      },
-      "elastic": {
-        "subscription": "basic"
-      }
-    },
-    "owner": {
-      "github": "elastic/obs-infraobs-integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "signature_path": "/epr/sql/sql-0.5.0.zip.sig",
-    "deprecated": {
-      "since": "0.5.0",
-      "description": "This package is deprecated"
-    }
-  },
-  {
-    "name": "stan",
-    "title": "STAN",
-    "version": "1.2.0",
+    "name": "santa",
+    "title": "Google Santa Logs",
+    "version": "2.0.1",
     "release": "ga",
-    "description": "Collect logs and metrics from STAN servers with Elastic Agent.",
+    "description": "Collect and parse logs from Google Santa instances with Elastic Agent.",
     "type": "integration",
-    "download": "/epr/stan/stan-1.2.0.zip",
-    "path": "/package/stan/1.2.0",
+    "download": "/epr/santa/santa-2.0.1.zip",
+    "path": "/package/santa/2.0.1",
     "icons": [
       {
-        "src": "/img/stan.svg",
-        "path": "/package/stan/1.2.0/img/stan.svg",
-        "title": "STAN Logo",
-        "size": "32x32",
+        "src": "/img/icon.svg",
+        "path": "/package/santa/2.0.1/img/icon.svg",
+        "title": "Google Santa",
         "type": "image/svg+xml"
       }
     ],
     "policy_templates": [
       {
-        "name": "stan",
-        "title": "STAN Logs and Metrics",
-        "description": "Collect logs and metrics from STAN instances"
+        "name": "santa",
+        "title": "Google Santa logs",
+        "description": "Collect logs from Google Santa instances"
       }
     ],
     "conditions": {
       "kibana": {
-        "version": "^7.14.0 || ^8.0.0"
+        "version": "^7.17.0 || ^8.0.0"
       }
     },
     "owner": {
-      "github": "elastic/integrations"
+      "github": "elastic/security-external-integrations"
     },
     "categories": [
-      "message_queue",
-      "kubernetes"
+      "security",
+      "os_system"
     ],
-    "signature_path": "/epr/stan/stan-1.2.0.zip.sig",
+    "signature_path": "/epr/santa/santa-2.0.1.zip.sig",
     "data_streams": [
       {
-        "type": "metrics",
-        "dataset": "stan.channels",
-        "title": "Stan channels metrics"
-      },
-      {
         "type": "logs",
-        "dataset": "stan.log",
-        "title": "STAN logs"
-      },
-      {
-        "type": "metrics",
-        "dataset": "stan.stats",
-        "title": "Stan stats metrics"
-      },
-      {
-        "type": "metrics",
-        "dataset": "stan.subscriptions",
-        "title": "Stan subscriptions metrics"
+        "dataset": "santa.log",
+        "title": "Google Santa log logs"
       }
     ]
+  },
+  {
+    "name": "security_detection_engine",
+    "title": "Prebuilt Security Detection Rules",
+    "version": "0.16.2",
+    "release": "ga",
+    "description": "Prebuilt detection rules for Elastic Security",
+    "type": "integration",
+    "download": "/epr/security_detection_engine/security_detection_engine-0.16.2.zip",
+    "path": "/package/security_detection_engine/0.16.2",
+    "icons": [
+      {
+        "src": "/img/security-logo-color-64px.svg",
+        "path": "/package/security_detection_engine/0.16.2/img/security-logo-color-64px.svg",
+        "size": "16x16",
+        "type": "image/svg+xml"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/protections"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/security_detection_engine/security_detection_engine-0.16.2.zip.sig"
   },
   {
     "name": "snort",
@@ -7939,6 +7453,55 @@
     ]
   },
   {
+    "name": "sql",
+    "title": "SQL Input",
+    "version": "0.5.0",
+    "release": "beta",
+    "description": "Collects Metrics by Quering on SQL Databases",
+    "type": "input",
+    "download": "/epr/sql/sql-0.5.0.zip",
+    "path": "/package/sql/0.5.0",
+    "icons": [
+      {
+        "src": "/img/sql-server-icon.svg",
+        "path": "/package/sql/0.5.0/img/sql-server-icon.svg",
+        "title": "SQL logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "sql",
+        "title": "SQL Metrics",
+        "description": "Collects Metrics by Quering on SQL Databases",
+        "deprecated": {
+          "since": "0.5.0",
+          "description": "This policy is deprecated"
+        }
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.13.0"
+      },
+      "elastic": {
+        "subscription": "basic"
+      }
+    },
+    "owner": {
+      "github": "elastic/obs-infraobs-integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "signature_path": "/epr/sql/sql-0.5.0.zip.sig",
+    "deprecated": {
+      "since": "0.5.0",
+      "description": "This package is deprecated"
+    }
+  },
+  {
     "name": "squid",
     "title": "Squid Logs",
     "version": "0.7.0",
@@ -7971,6 +7534,67 @@
         "type": "logs",
         "dataset": "squid.log",
         "title": "Squid logs"
+      }
+    ]
+  },
+  {
+    "name": "stan",
+    "title": "STAN",
+    "version": "1.2.0",
+    "release": "ga",
+    "description": "Collect logs and metrics from STAN servers with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/stan/stan-1.2.0.zip",
+    "path": "/package/stan/1.2.0",
+    "icons": [
+      {
+        "src": "/img/stan.svg",
+        "path": "/package/stan/1.2.0/img/stan.svg",
+        "title": "STAN Logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "stan",
+        "title": "STAN Logs and Metrics",
+        "description": "Collect logs and metrics from STAN instances"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "message_queue",
+      "kubernetes"
+    ],
+    "signature_path": "/epr/stan/stan-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "stan.channels",
+        "title": "Stan channels metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "stan.log",
+        "title": "STAN logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "stan.stats",
+        "title": "Stan stats metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "stan.subscriptions",
+        "title": "Stan subscriptions metrics"
       }
     ]
   },
@@ -8108,6 +7732,77 @@
     ]
   },
   {
+    "name": "synthetics",
+    "title": "Elastic Synthetics",
+    "version": "0.9.2",
+    "release": "beta",
+    "description": "Monitor the availability of your services with Elastic Synthetics.",
+    "type": "integration",
+    "download": "/epr/synthetics/synthetics-0.9.2.zip",
+    "path": "/package/synthetics/0.9.2",
+    "icons": [
+      {
+        "src": "/img/uptime-logo-color-64px.svg",
+        "path": "/package/synthetics/0.9.2/img/uptime-logo-color-64px.svg",
+        "size": "16x16",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "synthetics",
+        "title": "Elastic Synthetics",
+        "description": "Perform synthetic health checks on network endpoints."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.1.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/uptime"
+    },
+    "categories": [
+      "elastic_stack",
+      "monitoring",
+      "web"
+    ],
+    "signature_path": "/epr/synthetics/synthetics-0.9.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "synthetics",
+        "dataset": "browser",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "browser.network",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "browser.screenshot",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "http",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "icmp",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "tcp",
+        "title": "synthetic monitor check"
+      }
+    ]
+  },
+  {
     "name": "system",
     "title": "System",
     "version": "1.6.4",
@@ -8234,6 +7929,49 @@
     ]
   },
   {
+    "name": "tcp",
+    "title": "Custom TCP Logs",
+    "version": "1.0.0",
+    "release": "ga",
+    "description": "Collect raw TCP data from listening TCP port with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/tcp/tcp-1.0.0.zip",
+    "path": "/package/tcp/1.0.0",
+    "icons": [
+      {
+        "src": "/img/icon.svg",
+        "path": "/package/tcp/1.0.0/img/icon.svg",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "tcp",
+        "title": "Custom TCP Logs",
+        "description": "Collect raw TCP data from listening TCP port with Elastic Agent."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "signature_path": "/epr/tcp/tcp-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "tcp.generic",
+        "title": "Custom TCP Logs"
+      }
+    ]
+  },
+  {
     "name": "tenable_sc",
     "title": "Tenable.sc",
     "version": "1.1.1",
@@ -8289,6 +8027,292 @@
     ]
   },
   {
+    "name": "ti_abusech",
+    "title": "AbuseCH",
+    "version": "1.2.3",
+    "release": "ga",
+    "description": "Collect threat intelligence from AbuseCH API with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/ti_abusech/ti_abusech-1.2.3.zip",
+    "path": "/package/ti_abusech/1.2.3",
+    "icons": [
+      {
+        "src": "/img/abusech2.svg",
+        "path": "/package/ti_abusech/1.2.3/img/abusech2.svg",
+        "title": "AbuseCH",
+        "size": "512x512",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "ti_abusech",
+        "title": "AbuseCH API",
+        "description": "Collect threat intelligence from the AbuseCH API"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/ti_abusech/ti_abusech-1.2.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_abusech.malware",
+        "title": "AbuseCH Malware logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "ti_abusech.malwarebazaar",
+        "title": "AbuseCH MalwareBazaar logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "ti_abusech.url",
+        "title": "AbuseCH URL logs"
+      }
+    ]
+  },
+  {
+    "name": "ti_anomali",
+    "title": "Anomali",
+    "version": "1.2.3",
+    "release": "ga",
+    "description": "Collect threat intelligence from Anomali APIs with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/ti_anomali/ti_anomali-1.2.3.zip",
+    "path": "/package/ti_anomali/1.2.3",
+    "icons": [
+      {
+        "src": "/img/anomali.svg",
+        "path": "/package/ti_anomali/1.2.3/img/anomali.svg",
+        "title": "Anomali",
+        "size": "216x216",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "ti_anomali",
+        "title": "Anomali",
+        "description": "Collect threat intelligence from the Anomali Limo API and Anomali Threatstream."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/ti_anomali/ti_anomali-1.2.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_anomali.limo",
+        "title": "Anomali Limo"
+      },
+      {
+        "type": "logs",
+        "dataset": "ti_anomali.threatstream",
+        "title": "Anomali Threatstream"
+      }
+    ]
+  },
+  {
+    "name": "ti_cybersixgill",
+    "title": "Cybersixgill",
+    "version": "1.3.2",
+    "release": "ga",
+    "description": "This Elastic integration collects threat intelligence from Cybersixgill",
+    "type": "integration",
+    "download": "/epr/ti_cybersixgill/ti_cybersixgill-1.3.2.zip",
+    "path": "/package/ti_cybersixgill/1.3.2",
+    "icons": [
+      {
+        "src": "/img/cybersixgill.svg",
+        "path": "/package/ti_cybersixgill/1.3.2/img/cybersixgill.svg",
+        "title": "Cybersixgill",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "cybersixgill",
+        "title": "Cybersixgill Threat Intel",
+        "description": "Collect Threat Intel from Cybersixgill"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security",
+      "productivity"
+    ],
+    "signature_path": "/epr/ti_cybersixgill/ti_cybersixgill-1.3.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_cybersixgill.threat",
+        "title": "Cybersixgill Darkfeed Logs"
+      }
+    ]
+  },
+  {
+    "name": "ti_misp",
+    "title": "MISP",
+    "version": "1.2.2",
+    "release": "ga",
+    "description": "This Elastic integration collects events from MISP",
+    "type": "integration",
+    "download": "/epr/ti_misp/ti_misp-1.2.2.zip",
+    "path": "/package/ti_misp/1.2.2",
+    "icons": [
+      {
+        "src": "/img/misp.svg",
+        "path": "/package/ti_misp/1.2.2/img/misp.svg",
+        "title": "MISP",
+        "size": "216x216",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "ti_misp",
+        "title": "MISP",
+        "description": "Collect threat intelligence from the MISP API."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/ti_misp/ti_misp-1.2.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_misp.threat",
+        "title": "MISP"
+      }
+    ]
+  },
+  {
+    "name": "ti_otx",
+    "title": "AlienVault OTX",
+    "version": "1.2.2",
+    "release": "ga",
+    "description": "Collect threat intelligence from AlienVault OTX with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/ti_otx/ti_otx-1.2.2.zip",
+    "path": "/package/ti_otx/1.2.2",
+    "icons": [
+      {
+        "src": "/img/otx.svg",
+        "path": "/package/ti_otx/1.2.2/img/otx.svg",
+        "title": "Alienvault OTX",
+        "size": "216x216",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "ti_otx",
+        "title": "Alienvault OTX",
+        "description": "Collect threat intelligence from the Alienvault OTX"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/ti_otx/ti_otx-1.2.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_otx.threat",
+        "title": "Alienvault OTX logs"
+      }
+    ]
+  },
+  {
+    "name": "ti_recordedfuture",
+    "title": "Recorded Future",
+    "version": "0.1.2",
+    "release": "beta",
+    "description": "Collect threat intelligence from Recorded Future with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/ti_recordedfuture/ti_recordedfuture-0.1.2.zip",
+    "path": "/package/ti_recordedfuture/0.1.2",
+    "icons": [
+      {
+        "src": "/img/logo.svg",
+        "path": "/package/ti_recordedfuture/0.1.2/img/logo.svg",
+        "title": "Recorded Future",
+        "size": "216x216",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "ti_recordedfuture",
+        "title": "Recorded Future",
+        "description": "Collect threat intelligence from Recorded Future."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/ti_recordedfuture/ti_recordedfuture-0.1.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_recordedfuture.threat",
+        "title": "Recorded Future"
+      }
+    ]
+  },
+  {
     "name": "ti_threatq",
     "title": "ThreatQuotient",
     "version": "1.2.2",
@@ -8330,6 +8354,52 @@
         "type": "logs",
         "dataset": "ti_threatq.threat",
         "title": "ThreatQ"
+      }
+    ]
+  },
+  {
+    "name": "tomcat",
+    "title": "Apache Tomcat",
+    "version": "1.3.1",
+    "release": "ga",
+    "description": "Collect and parse logs from Apache Tomcat servers with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/tomcat/tomcat-1.3.1.zip",
+    "path": "/package/tomcat/1.3.1",
+    "icons": [
+      {
+        "src": "/img/logo.svg",
+        "path": "/package/tomcat/1.3.1/img/logo.svg",
+        "title": "Apache Tomcat logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "log",
+        "title": "Apache Tomcat",
+        "description": "Collect Apache Tomcat logs from syslog or a file."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.1 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "web",
+      "security"
+    ],
+    "signature_path": "/epr/tomcat/tomcat-1.3.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "tomcat.log",
+        "title": "Apache Tomcat logs"
       }
     ]
   },
@@ -8385,112 +8455,45 @@
     ]
   },
   {
-    "name": "carbon_black_cloud",
-    "title": "VMware Carbon Black Cloud",
-    "version": "1.0.2",
+    "name": "udp",
+    "title": "Custom UDP Logs",
+    "version": "1.0.1",
     "release": "ga",
-    "description": "Collect logs from VMWare Carbon Black Cloud with Elastic Agent.",
+    "description": "Collect raw UDP data from listening UDP port with Elastic Agent.",
     "type": "integration",
-    "download": "/epr/carbon_black_cloud/carbon_black_cloud-1.0.2.zip",
-    "path": "/package/carbon_black_cloud/1.0.2",
+    "download": "/epr/udp/udp-1.0.1.zip",
+    "path": "/package/udp/1.0.1",
     "icons": [
       {
-        "src": "/img/carbon_black_cloud-logo.svg",
-        "path": "/package/carbon_black_cloud/1.0.2/img/carbon_black_cloud-logo.svg",
-        "title": "Carbon Black Cloud logo",
-        "size": "32x32",
+        "src": "/img/icon.svg",
+        "path": "/package/udp/1.0.1/img/icon.svg",
         "type": "image/svg+xml"
       }
     ],
     "policy_templates": [
       {
-        "name": "carbon_black_cloud",
-        "title": "Carbon Black Cloud",
-        "description": "Collect Logs from Carbon Black Cloud"
+        "name": "udp",
+        "title": "Custom UDP Logs",
+        "description": "Collect raw UDP data from listening UDP port with Elastic Agent."
       }
     ],
     "conditions": {
       "kibana": {
-        "version": "^7.17.0 || ^8.0.0"
+        "version": "^7.16.0 || ^8.0.0"
       }
     },
     "owner": {
       "github": "elastic/security-external-integrations"
     },
     "categories": [
-      "security"
+      "custom"
     ],
-    "signature_path": "/epr/carbon_black_cloud/carbon_black_cloud-1.0.2.zip.sig",
+    "signature_path": "/epr/udp/udp-1.0.1.zip.sig",
     "data_streams": [
       {
         "type": "logs",
-        "dataset": "carbon_black_cloud.alert",
-        "title": "Alert"
-      },
-      {
-        "type": "logs",
-        "dataset": "carbon_black_cloud.asset_vulnerability_summary",
-        "title": "Asset Vulnerability Summary"
-      },
-      {
-        "type": "logs",
-        "dataset": "carbon_black_cloud.audit",
-        "title": "Audit"
-      },
-      {
-        "type": "logs",
-        "dataset": "carbon_black_cloud.endpoint_event",
-        "title": "Endpoint Event"
-      },
-      {
-        "type": "logs",
-        "dataset": "carbon_black_cloud.watchlist_hit",
-        "title": "Watchlist Hit"
-      }
-    ]
-  },
-  {
-    "name": "carbonblack_edr",
-    "title": "VMware Carbon Black EDR",
-    "version": "1.2.0",
-    "release": "ga",
-    "description": "Collect logs from VMware Carbon Black EDR with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/carbonblack_edr/carbonblack_edr-1.2.0.zip",
-    "path": "/package/carbonblack_edr/1.2.0",
-    "icons": [
-      {
-        "src": "/img/carbon-black-logo.svg",
-        "path": "/package/carbonblack_edr/1.2.0/img/carbon-black-logo.svg",
-        "title": "VMWare Carbon Black",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "log",
-        "title": "Carbon Black EDR logs",
-        "description": "Collect logs from Carbon Black EDR"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/carbonblack_edr/carbonblack_edr-1.2.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "carbonblack_edr.log",
-        "title": "Carbon Black EDR logs"
+        "dataset": "udp.generic",
+        "title": "Custom UDP Logs"
       }
     ]
   },
@@ -8623,6 +8626,49 @@
         "type": "logs",
         "dataset": "windows.sysmon_operational",
         "title": "Windows Sysmon/Operational events"
+      }
+    ]
+  },
+  {
+    "name": "winlog",
+    "title": "Custom Windows Event Logs",
+    "version": "1.4.0",
+    "release": "ga",
+    "description": "Collect and parse logs from any Windows event log channel with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/winlog/winlog-1.4.0.zip",
+    "path": "/package/winlog/1.4.0",
+    "icons": [
+      {
+        "src": "/img/logo_windows.svg",
+        "path": "/package/winlog/1.4.0/img/logo_windows.svg",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "winlogs",
+        "title": "Custom Windows event logs",
+        "description": "Collect your custom Windows event logs."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "signature_path": "/epr/winlog/winlog-1.4.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "winlog.winlog",
+        "title": "Custom Windows Event Log Dataset"
       }
     ]
   },
@@ -9012,6 +9058,52 @@
     ]
   },
   {
+    "name": "zscaler",
+    "title": "Zscaler NSS Logs",
+    "version": "0.5.1",
+    "release": "experimental",
+    "description": "Deprecated. Use the Zscaler ZIA integration instead.",
+    "type": "integration",
+    "download": "/epr/zscaler/zscaler-0.5.1.zip",
+    "path": "/package/zscaler/0.5.1",
+    "icons": [
+      {
+        "src": "/img/logo.svg",
+        "path": "/package/zscaler/0.5.1/img/logo.svg",
+        "title": "Zscaler NSS logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "zia",
+        "title": "Zscaler NSS",
+        "description": "Collect Zscaler NSS logs from syslog or a file."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.1"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "network",
+      "security"
+    ],
+    "signature_path": "/epr/zscaler/zscaler-0.5.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "zscaler.zia",
+        "title": "Zscaler NSS logs"
+      }
+    ]
+  },
+  {
     "name": "zscaler_zia",
     "title": "Zscaler Internet Access",
     "version": "0.1.3",
@@ -9077,52 +9169,6 @@
     ]
   },
   {
-    "name": "zscaler",
-    "title": "Zscaler NSS Logs",
-    "version": "0.5.1",
-    "release": "experimental",
-    "description": "Deprecated. Use the Zscaler ZIA integration instead.",
-    "type": "integration",
-    "download": "/epr/zscaler/zscaler-0.5.1.zip",
-    "path": "/package/zscaler/0.5.1",
-    "icons": [
-      {
-        "src": "/img/logo.svg",
-        "path": "/package/zscaler/0.5.1/img/logo.svg",
-        "title": "Zscaler NSS logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "zia",
-        "title": "Zscaler NSS",
-        "description": "Collect Zscaler NSS logs from syslog or a file."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.1"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "network",
-      "security"
-    ],
-    "signature_path": "/epr/zscaler/zscaler-0.5.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "zscaler.zia",
-        "title": "Zscaler NSS logs"
-      }
-    ]
-  },
-  {
     "name": "zscaler_zpa",
     "title": "Zscaler Private Access",
     "version": "0.1.2",
@@ -9184,52 +9230,6 @@
         "type": "logs",
         "dataset": "zscaler_zpa.user_status",
         "title": "User Status Logs"
-      }
-    ]
-  },
-  {
-    "name": "pfsense",
-    "title": "pfSense Logs",
-    "version": "0.3.1",
-    "release": "experimental",
-    "description": "Collect and parse logs from pfSense devices with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/pfsense/pfsense-0.3.1.zip",
-    "path": "/package/pfsense/0.3.1",
-    "icons": [
-      {
-        "src": "/img/pfsense.svg",
-        "path": "/package/pfsense/0.3.1/img/pfsense.svg",
-        "title": "pfsense",
-        "size": "512x143",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "pfsense",
-        "title": "pfSense logs",
-        "description": "Collect logs from pfSense systems"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.15.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "network",
-      "security"
-    ],
-    "signature_path": "/epr/pfsense/pfsense-0.3.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "pfsense.log",
-        "title": "pfSense log logs"
       }
     ]
   }

--- a/testdata/generated/storage-indexer/search-prerelease-capabilities-observability-security.json
+++ b/testdata/generated/storage-indexer/search-prerelease-capabilities-observability-security.json
@@ -54,6 +54,538 @@
     ]
   },
   {
+    "name": "activemq",
+    "title": "ActiveMQ",
+    "version": "0.3.0",
+    "release": "beta",
+    "description": "Collect logs and metrics from ActiveMQ instances with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/activemq/activemq-0.3.0.zip",
+    "path": "/package/activemq/0.3.0",
+    "icons": [
+      {
+        "src": "/img/activemq.svg",
+        "path": "/package/activemq/0.3.0/img/activemq.svg",
+        "title": "activemq",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "activemq",
+        "title": "ActiveMQ logs and metrics",
+        "description": "Collect logs and metrics from ActiveMQ instances"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "web"
+    ],
+    "signature_path": "/epr/activemq/activemq-0.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "activemq.audit",
+        "title": "ActiveMQ audit logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "activemq.broker",
+        "title": "ActiveMQ broker metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "activemq.log",
+        "title": "ActiveMQ log logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "activemq.queue",
+        "title": "ActiveMQ queue metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "activemq.topic",
+        "title": "ActiveMQ topic metrics"
+      }
+    ]
+  },
+  {
+    "name": "akamai",
+    "title": "Akamai",
+    "version": "2.28.0",
+    "release": "ga",
+    "description": "Collect logs from Akamai with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/akamai/akamai-2.28.0.zip",
+    "path": "/package/akamai/2.28.0",
+    "icons": [
+      {
+        "src": "/img/akamai_logo.svg",
+        "path": "/package/akamai/2.28.0/img/akamai_logo.svg",
+        "title": "Akamai",
+        "size": "409×167",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "akamai",
+        "title": "Akamai logs",
+        "description": "Collect SIEM logs from Akamai"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.13.0 || ^9.0.0"
+      }
+    },
+    "owner": {
+      "type": "community",
+      "github": "elastic/security-service-integrations"
+    },
+    "categories": [
+      "security",
+      "cdn_security"
+    ],
+    "signature_path": "/epr/akamai/akamai-2.28.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "akamai.siem",
+        "title": "Akamai SIEM Logs"
+      }
+    ]
+  },
+  {
+    "name": "apache",
+    "title": "Apache HTTP Server",
+    "version": "1.3.5",
+    "release": "ga",
+    "description": "Collect logs and metrics from Apache servers with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/apache/apache-1.3.5.zip",
+    "path": "/package/apache/1.3.5",
+    "icons": [
+      {
+        "src": "/img/logo_apache.svg",
+        "path": "/package/apache/1.3.5/img/logo_apache.svg",
+        "title": "Apache Logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "apache",
+        "title": "Apache logs and metrics",
+        "description": "Collect logs and metrics from Apache instances"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "web"
+    ],
+    "signature_path": "/epr/apache/apache-1.3.5.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "apache.access",
+        "title": "Apache access logs",
+        "deprecated": {
+          "since": "1.3.5",
+          "description": "This data stream is deprecated"
+        }
+      },
+      {
+        "type": "logs",
+        "dataset": "apache.error",
+        "title": "Apache error logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apache.status",
+        "title": "Apache status metrics"
+      }
+    ],
+    "deprecated": {
+      "since": "1.3.0",
+      "description": "This package is deprecated"
+    }
+  },
+  {
+    "name": "apm",
+    "title": "Elastic APM",
+    "version": "8.2.0",
+    "release": "ga",
+    "description": "Ingest APM data",
+    "type": "integration",
+    "download": "/epr/apm/apm-8.2.0.zip",
+    "path": "/package/apm/8.2.0",
+    "icons": [
+      {
+        "src": "/img/logo_apm.svg",
+        "path": "/package/apm/8.2.0/img/logo_apm.svg",
+        "title": "APM Logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "apmserver",
+        "title": "Elastic APM Integration",
+        "description": "Elastic APM Integration"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.2.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/apm-server"
+    },
+    "categories": [
+      "elastic_stack",
+      "monitoring"
+    ],
+    "signature_path": "/epr/apm/apm-8.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "apm.app",
+        "title": "APM application logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.app",
+        "title": "APM application metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "apm.error",
+        "title": "APM errors"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.internal",
+        "title": "APM internal metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.profiling",
+        "title": "APM profiles"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm.rum",
+        "title": "APM RUM traces"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm.sampled",
+        "title": "APM tail-sampled traces"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm",
+        "title": "APM traces"
+      }
+    ]
+  },
+  {
+    "name": "atlassian_bitbucket",
+    "title": "Atlassian Bitbucket",
+    "version": "1.2.1",
+    "release": "ga",
+    "description": "Collect logs from Atlassian Bitbucket with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.2.1.zip",
+    "path": "/package/atlassian_bitbucket/1.2.1",
+    "icons": [
+      {
+        "src": "/img/bitbucket-logo.svg",
+        "path": "/package/atlassian_bitbucket/1.2.1/img/bitbucket-logo.svg",
+        "title": "Bitbucket Logo",
+        "size": "625x564",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "audit",
+        "title": "Audit Logs",
+        "description": "Collect audit logs from Atlassian Bitbucket with Elastic Agent."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security",
+      "web"
+    ],
+    "signature_path": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_bitbucket.audit",
+        "title": "Bitbucket Audit Logs"
+      }
+    ]
+  },
+  {
+    "name": "atlassian_confluence",
+    "title": "Atlassian Confluence",
+    "version": "1.3.0",
+    "release": "ga",
+    "description": "Collect logs from Atlassian Confluence with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/atlassian_confluence/atlassian_confluence-1.3.0.zip",
+    "path": "/package/atlassian_confluence/1.3.0",
+    "icons": [
+      {
+        "src": "/img/confluence-logo.svg",
+        "path": "/package/atlassian_confluence/1.3.0/img/confluence-logo.svg",
+        "title": "Confluence Logo",
+        "size": "400x400",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "audit",
+        "title": "Audit Logs",
+        "description": "Collect audit logs from Atlassian Confluence with Elastic Agent."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security",
+      "web"
+    ],
+    "signature_path": "/epr/atlassian_confluence/atlassian_confluence-1.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_confluence.audit",
+        "title": "Confluence Audit Logs"
+      }
+    ]
+  },
+  {
+    "name": "atlassian_jira",
+    "title": "Atlassian Jira",
+    "version": "1.3.0",
+    "release": "ga",
+    "description": "Collect logs from Atlassian Jira with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/atlassian_jira/atlassian_jira-1.3.0.zip",
+    "path": "/package/atlassian_jira/1.3.0",
+    "icons": [
+      {
+        "src": "/img/jira-software-logo.svg",
+        "path": "/package/atlassian_jira/1.3.0/img/jira-software-logo.svg",
+        "title": "Jira Software Logo",
+        "size": "590x625",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "audit",
+        "title": "Audit Logs",
+        "description": "Collect audit logs from Atlassian Jira with Elastic Agent."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security",
+      "web"
+    ],
+    "signature_path": "/epr/atlassian_jira/atlassian_jira-1.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_jira.audit",
+        "title": "Jira Audit Logs"
+      }
+    ]
+  },
+  {
+    "name": "auditd",
+    "title": "Auditd Logs",
+    "version": "3.1.0",
+    "release": "ga",
+    "description": "Collect logs from Linux audit daemon with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/auditd/auditd-3.1.0.zip",
+    "path": "/package/auditd/3.1.0",
+    "icons": [
+      {
+        "src": "/img/linux.svg",
+        "path": "/package/auditd/3.1.0/img/linux.svg",
+        "title": "linux",
+        "size": "299x354",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "auditd",
+        "title": "Auditd logs",
+        "description": "Collect logs from Auditd instances"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "os_system"
+    ],
+    "signature_path": "/epr/auditd/auditd-3.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "auditd.log",
+        "title": "Auditd logs"
+      }
+    ]
+  },
+  {
+    "name": "auditd_manager",
+    "title": "Auditd Manager",
+    "version": "1.0.0",
+    "release": "ga",
+    "description": "The Auditd Manager Integration receives audit events from the Linux Audit Framework that is a part of the Linux kernel.",
+    "type": "integration",
+    "download": "/epr/auditd_manager/auditd_manager-1.0.0.zip",
+    "path": "/package/auditd_manager/1.0.0",
+    "icons": [
+      {
+        "src": "/img/linux.svg",
+        "path": "/package/auditd_manager/1.0.0/img/linux.svg",
+        "title": "linux",
+        "size": "299x354",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "auditd",
+        "title": "Auditd",
+        "description": "Collect auditd events"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.2.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "os_system",
+      "security"
+    ],
+    "signature_path": "/epr/auditd_manager/auditd_manager-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "auditd_manager.auditd",
+        "title": "Auditd Manager"
+      }
+    ]
+  },
+  {
+    "name": "auth0",
+    "title": "Auth0 Log Streams Integration",
+    "version": "1.0.0",
+    "release": "ga",
+    "description": "Collect logs from Auth0 with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/auth0/auth0-1.0.0.zip",
+    "path": "/package/auth0/1.0.0",
+    "icons": [
+      {
+        "src": "/img/auth0-logo.svg",
+        "path": "/package/auth0/1.0.0/img/auth0-logo.svg",
+        "title": "Auth0 logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "auth0_events",
+        "title": "Auth0 log stream events via Webhooks",
+        "description": "Collect Auth0 log streams events via Webhooks."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "cloud",
+      "network",
+      "security"
+    ],
+    "signature_path": "/epr/auth0/auth0-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "auth0.logs",
+        "title": "Auth0 logs via Webhooks"
+      }
+    ]
+  },
+  {
     "name": "aws",
     "title": "AWS",
     "version": "1.16.4",
@@ -649,6 +1181,51 @@
     ]
   },
   {
+    "name": "aws_logs",
+    "title": "Custom AWS Logs",
+    "version": "0.2.1",
+    "release": "beta",
+    "description": "Collect raw logs from AWS S3 or CloudWatch with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/aws_logs/aws_logs-0.2.1.zip",
+    "path": "/package/aws_logs/0.2.1",
+    "icons": [
+      {
+        "src": "/img/icon.svg",
+        "path": "/package/aws_logs/0.2.1/img/icon.svg",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "aws_logs",
+        "title": "Custom AWS Logs",
+        "description": "Collect raw logs from AWS S3 or CloudWatch with Elastic Agent."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/obs-cloud-monitoring"
+    },
+    "categories": [
+      "custom",
+      "cloud",
+      "aws"
+    ],
+    "signature_path": "/epr/aws_logs/aws_logs-0.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "aws_logs.generic",
+        "title": "Custom logs from AWS"
+      }
+    ]
+  },
+  {
     "name": "awsfargate",
     "title": "AWS Fargate",
     "version": "0.1.1",
@@ -692,835 +1269,6 @@
         "type": "metrics",
         "dataset": "awsfargate.task_stats",
         "title": "AWS Fargate task_stats metrics"
-      }
-    ]
-  },
-  {
-    "name": "ti_abusech",
-    "title": "AbuseCH",
-    "version": "1.2.3",
-    "release": "ga",
-    "description": "Collect threat intelligence from AbuseCH API with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/ti_abusech/ti_abusech-1.2.3.zip",
-    "path": "/package/ti_abusech/1.2.3",
-    "icons": [
-      {
-        "src": "/img/abusech2.svg",
-        "path": "/package/ti_abusech/1.2.3/img/abusech2.svg",
-        "title": "AbuseCH",
-        "size": "512x512",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "ti_abusech",
-        "title": "AbuseCH API",
-        "description": "Collect threat intelligence from the AbuseCH API"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/ti_abusech/ti_abusech-1.2.3.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ti_abusech.malware",
-        "title": "AbuseCH Malware logs"
-      },
-      {
-        "type": "logs",
-        "dataset": "ti_abusech.malwarebazaar",
-        "title": "AbuseCH MalwareBazaar logs"
-      },
-      {
-        "type": "logs",
-        "dataset": "ti_abusech.url",
-        "title": "AbuseCH URL logs"
-      }
-    ]
-  },
-  {
-    "name": "activemq",
-    "title": "ActiveMQ",
-    "version": "0.3.0",
-    "release": "beta",
-    "description": "Collect logs and metrics from ActiveMQ instances with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/activemq/activemq-0.3.0.zip",
-    "path": "/package/activemq/0.3.0",
-    "icons": [
-      {
-        "src": "/img/activemq.svg",
-        "path": "/package/activemq/0.3.0/img/activemq.svg",
-        "title": "activemq",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "activemq",
-        "title": "ActiveMQ logs and metrics",
-        "description": "Collect logs and metrics from ActiveMQ instances"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "web"
-    ],
-    "signature_path": "/epr/activemq/activemq-0.3.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "activemq.audit",
-        "title": "ActiveMQ audit logs"
-      },
-      {
-        "type": "metrics",
-        "dataset": "activemq.broker",
-        "title": "ActiveMQ broker metrics"
-      },
-      {
-        "type": "logs",
-        "dataset": "activemq.log",
-        "title": "ActiveMQ log logs"
-      },
-      {
-        "type": "metrics",
-        "dataset": "activemq.queue",
-        "title": "ActiveMQ queue metrics"
-      },
-      {
-        "type": "metrics",
-        "dataset": "activemq.topic",
-        "title": "ActiveMQ topic metrics"
-      }
-    ]
-  },
-  {
-    "name": "akamai",
-    "title": "Akamai",
-    "version": "2.28.0",
-    "release": "ga",
-    "description": "Collect logs from Akamai with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/akamai/akamai-2.28.0.zip",
-    "path": "/package/akamai/2.28.0",
-    "icons": [
-      {
-        "src": "/img/akamai_logo.svg",
-        "path": "/package/akamai/2.28.0/img/akamai_logo.svg",
-        "title": "Akamai",
-        "size": "409×167",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "akamai",
-        "title": "Akamai logs",
-        "description": "Collect SIEM logs from Akamai"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.13.0 || ^9.0.0"
-      }
-    },
-    "owner": {
-      "type": "community",
-      "github": "elastic/security-service-integrations"
-    },
-    "categories": [
-      "security",
-      "cdn_security"
-    ],
-    "signature_path": "/epr/akamai/akamai-2.28.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "akamai.siem",
-        "title": "Akamai SIEM Logs"
-      }
-    ]
-  },
-  {
-    "name": "ti_otx",
-    "title": "AlienVault OTX",
-    "version": "1.2.2",
-    "release": "ga",
-    "description": "Collect threat intelligence from AlienVault OTX with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/ti_otx/ti_otx-1.2.2.zip",
-    "path": "/package/ti_otx/1.2.2",
-    "icons": [
-      {
-        "src": "/img/otx.svg",
-        "path": "/package/ti_otx/1.2.2/img/otx.svg",
-        "title": "Alienvault OTX",
-        "size": "216x216",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "ti_otx",
-        "title": "Alienvault OTX",
-        "description": "Collect threat intelligence from the Alienvault OTX"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/ti_otx/ti_otx-1.2.2.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ti_otx.threat",
-        "title": "Alienvault OTX logs"
-      }
-    ]
-  },
-  {
-    "name": "ti_anomali",
-    "title": "Anomali",
-    "version": "1.2.3",
-    "release": "ga",
-    "description": "Collect threat intelligence from Anomali APIs with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/ti_anomali/ti_anomali-1.2.3.zip",
-    "path": "/package/ti_anomali/1.2.3",
-    "icons": [
-      {
-        "src": "/img/anomali.svg",
-        "path": "/package/ti_anomali/1.2.3/img/anomali.svg",
-        "title": "Anomali",
-        "size": "216x216",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "ti_anomali",
-        "title": "Anomali",
-        "description": "Collect threat intelligence from the Anomali Limo API and Anomali Threatstream."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/ti_anomali/ti_anomali-1.2.3.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ti_anomali.limo",
-        "title": "Anomali Limo"
-      },
-      {
-        "type": "logs",
-        "dataset": "ti_anomali.threatstream",
-        "title": "Anomali Threatstream"
-      }
-    ]
-  },
-  {
-    "name": "apache",
-    "title": "Apache HTTP Server",
-    "version": "1.3.5",
-    "release": "ga",
-    "description": "Collect logs and metrics from Apache servers with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/apache/apache-1.3.5.zip",
-    "path": "/package/apache/1.3.5",
-    "icons": [
-      {
-        "src": "/img/logo_apache.svg",
-        "path": "/package/apache/1.3.5/img/logo_apache.svg",
-        "title": "Apache Logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "apache",
-        "title": "Apache logs and metrics",
-        "description": "Collect logs and metrics from Apache instances"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "web"
-    ],
-    "signature_path": "/epr/apache/apache-1.3.5.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "apache.access",
-        "title": "Apache access logs",
-        "deprecated": {
-          "since": "1.3.5",
-          "description": "This data stream is deprecated"
-        }
-      },
-      {
-        "type": "logs",
-        "dataset": "apache.error",
-        "title": "Apache error logs"
-      },
-      {
-        "type": "metrics",
-        "dataset": "apache.status",
-        "title": "Apache status metrics"
-      }
-    ],
-    "deprecated": {
-      "since": "1.3.0",
-      "description": "This package is deprecated"
-    }
-  },
-  {
-    "name": "tomcat",
-    "title": "Apache Tomcat",
-    "version": "1.3.1",
-    "release": "ga",
-    "description": "Collect and parse logs from Apache Tomcat servers with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/tomcat/tomcat-1.3.1.zip",
-    "path": "/package/tomcat/1.3.1",
-    "icons": [
-      {
-        "src": "/img/logo.svg",
-        "path": "/package/tomcat/1.3.1/img/logo.svg",
-        "title": "Apache Tomcat logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "log",
-        "title": "Apache Tomcat",
-        "description": "Collect Apache Tomcat logs from syslog or a file."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.1 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "web",
-      "security"
-    ],
-    "signature_path": "/epr/tomcat/tomcat-1.3.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "tomcat.log",
-        "title": "Apache Tomcat logs"
-      }
-    ]
-  },
-  {
-    "name": "netscout",
-    "title": "Arbor Peakflow SP Logs",
-    "version": "0.7.0",
-    "release": "experimental",
-    "description": "Collect and parse logs from Netscout Arbor Peakflow SP with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/netscout/netscout-0.7.0.zip",
-    "path": "/package/netscout/0.7.0",
-    "icons": [
-      {
-        "src": "/img/logo.svg",
-        "path": "/package/netscout/0.7.0/img/logo.svg",
-        "title": "Arbor Peakflow SP logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "sightline",
-        "title": "Arbor Peakflow SP",
-        "description": "Collect Arbor Peakflow SP logs from syslog or a file."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.1 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/netscout/netscout-0.7.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "netscout.sightline",
-        "title": "Arbor Peakflow SP logs"
-      }
-    ]
-  },
-  {
-    "name": "atlassian_bitbucket",
-    "title": "Atlassian Bitbucket",
-    "version": "1.2.1",
-    "release": "ga",
-    "description": "Collect logs from Atlassian Bitbucket with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.2.1.zip",
-    "path": "/package/atlassian_bitbucket/1.2.1",
-    "icons": [
-      {
-        "src": "/img/bitbucket-logo.svg",
-        "path": "/package/atlassian_bitbucket/1.2.1/img/bitbucket-logo.svg",
-        "title": "Bitbucket Logo",
-        "size": "625x564",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "audit",
-        "title": "Audit Logs",
-        "description": "Collect audit logs from Atlassian Bitbucket with Elastic Agent."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security",
-      "web"
-    ],
-    "signature_path": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.2.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "atlassian_bitbucket.audit",
-        "title": "Bitbucket Audit Logs"
-      }
-    ]
-  },
-  {
-    "name": "atlassian_confluence",
-    "title": "Atlassian Confluence",
-    "version": "1.3.0",
-    "release": "ga",
-    "description": "Collect logs from Atlassian Confluence with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/atlassian_confluence/atlassian_confluence-1.3.0.zip",
-    "path": "/package/atlassian_confluence/1.3.0",
-    "icons": [
-      {
-        "src": "/img/confluence-logo.svg",
-        "path": "/package/atlassian_confluence/1.3.0/img/confluence-logo.svg",
-        "title": "Confluence Logo",
-        "size": "400x400",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "audit",
-        "title": "Audit Logs",
-        "description": "Collect audit logs from Atlassian Confluence with Elastic Agent."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security",
-      "web"
-    ],
-    "signature_path": "/epr/atlassian_confluence/atlassian_confluence-1.3.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "atlassian_confluence.audit",
-        "title": "Confluence Audit Logs"
-      }
-    ]
-  },
-  {
-    "name": "atlassian_jira",
-    "title": "Atlassian Jira",
-    "version": "1.3.0",
-    "release": "ga",
-    "description": "Collect logs from Atlassian Jira with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/atlassian_jira/atlassian_jira-1.3.0.zip",
-    "path": "/package/atlassian_jira/1.3.0",
-    "icons": [
-      {
-        "src": "/img/jira-software-logo.svg",
-        "path": "/package/atlassian_jira/1.3.0/img/jira-software-logo.svg",
-        "title": "Jira Software Logo",
-        "size": "590x625",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "audit",
-        "title": "Audit Logs",
-        "description": "Collect audit logs from Atlassian Jira with Elastic Agent."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security",
-      "web"
-    ],
-    "signature_path": "/epr/atlassian_jira/atlassian_jira-1.3.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "atlassian_jira.audit",
-        "title": "Jira Audit Logs"
-      }
-    ]
-  },
-  {
-    "name": "auditd",
-    "title": "Auditd Logs",
-    "version": "3.1.0",
-    "release": "ga",
-    "description": "Collect logs from Linux audit daemon with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/auditd/auditd-3.1.0.zip",
-    "path": "/package/auditd/3.1.0",
-    "icons": [
-      {
-        "src": "/img/linux.svg",
-        "path": "/package/auditd/3.1.0/img/linux.svg",
-        "title": "linux",
-        "size": "299x354",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "auditd",
-        "title": "Auditd logs",
-        "description": "Collect logs from Auditd instances"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "os_system"
-    ],
-    "signature_path": "/epr/auditd/auditd-3.1.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "auditd.log",
-        "title": "Auditd logs"
-      }
-    ]
-  },
-  {
-    "name": "auditd_manager",
-    "title": "Auditd Manager",
-    "version": "1.0.0",
-    "release": "ga",
-    "description": "The Auditd Manager Integration receives audit events from the Linux Audit Framework that is a part of the Linux kernel.",
-    "type": "integration",
-    "download": "/epr/auditd_manager/auditd_manager-1.0.0.zip",
-    "path": "/package/auditd_manager/1.0.0",
-    "icons": [
-      {
-        "src": "/img/linux.svg",
-        "path": "/package/auditd_manager/1.0.0/img/linux.svg",
-        "title": "linux",
-        "size": "299x354",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "auditd",
-        "title": "Auditd",
-        "description": "Collect auditd events"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.2.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "os_system",
-      "security"
-    ],
-    "signature_path": "/epr/auditd_manager/auditd_manager-1.0.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "auditd_manager.auditd",
-        "title": "Auditd Manager"
-      }
-    ]
-  },
-  {
-    "name": "auth0",
-    "title": "Auth0 Log Streams Integration",
-    "version": "1.0.0",
-    "release": "ga",
-    "description": "Collect logs from Auth0 with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/auth0/auth0-1.0.0.zip",
-    "path": "/package/auth0/1.0.0",
-    "icons": [
-      {
-        "src": "/img/auth0-logo.svg",
-        "path": "/package/auth0/1.0.0/img/auth0-logo.svg",
-        "title": "Auth0 logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "auth0_events",
-        "title": "Auth0 log stream events via Webhooks",
-        "description": "Collect Auth0 log streams events via Webhooks."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "cloud",
-      "network",
-      "security"
-    ],
-    "signature_path": "/epr/auth0/auth0-1.0.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "auth0.logs",
-        "title": "Auth0 logs via Webhooks"
-      }
-    ]
-  },
-  {
-    "name": "azure_application_insights",
-    "title": "Azure Application Insights Metrics Overview",
-    "version": "1.0.1",
-    "release": "ga",
-    "description": "Collect application insights metrics from Azure Monitor with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/azure_application_insights/azure_application_insights-1.0.1.zip",
-    "path": "/package/azure_application_insights/1.0.1",
-    "icons": [
-      {
-        "src": "/img/app_insights.png",
-        "path": "/package/azure_application_insights/1.0.1/img/app_insights.png",
-        "title": "logo docker",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "app_insights",
-        "title": "Azure Application Insights Metrics",
-        "description": "Collect application insights metrics from Azure Monitor with Elastic Agent.",
-        "icons": [
-          {
-            "src": "/img//app_insights.png",
-            "path": "/package/azure_application_insights/1.0.1/img/app_insights.png",
-            "title": "logo azure",
-            "size": "32x32",
-            "type": "image/svg+xml"
-          }
-        ],
-        "data_streams": [
-          "app_insights"
-        ]
-      },
-      {
-        "name": "app_state",
-        "title": "Azure Application State Insights Metrics",
-        "description": "Collect application state related metrics from Azure Monitor with Elastic Agent.",
-        "icons": [
-          {
-            "src": "/img/application_insights_blue.png",
-            "path": "/package/azure_application_insights/1.0.1/img/application_insights_blue.png",
-            "title": "logo azure",
-            "size": "32x32",
-            "type": "image/svg+xml"
-          }
-        ],
-        "data_streams": [
-          "app_state"
-        ]
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "azure",
-      "web"
-    ],
-    "signature_path": "/epr/azure_application_insights/azure_application_insights-1.0.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "metrics",
-        "dataset": "azure.app_insights",
-        "title": "Azure Application Insights"
-      },
-      {
-        "type": "metrics",
-        "dataset": "azure.app_state",
-        "title": "Azure Application State"
-      }
-    ]
-  },
-  {
-    "name": "azure_billing",
-    "title": "Azure Billing Metrics",
-    "version": "1.0.1",
-    "release": "ga",
-    "description": "Collect billing metrics with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/azure_billing/azure_billing-1.0.1.zip",
-    "path": "/package/azure_billing/1.0.1",
-    "icons": [
-      {
-        "src": "/img/billing.png",
-        "path": "/package/azure_billing/1.0.1/img/billing.png",
-        "title": "logo docker",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "billing",
-        "title": "Azure Billing Metrics",
-        "description": "Collect billing information with Elastic Agent.",
-        "icons": [
-          {
-            "src": "/img//billing.png",
-            "path": "/package/azure_billing/1.0.1/img/billing.png",
-            "title": "logo azure",
-            "size": "32x32",
-            "type": "image/svg+xml"
-          }
-        ],
-        "data_streams": [
-          "billing"
-        ]
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.15.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "azure"
-    ],
-    "signature_path": "/epr/azure_billing/azure_billing-1.0.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "metrics",
-        "dataset": "azure.billing",
-        "title": "Azure Billing Metrics"
       }
     ]
   },
@@ -1675,6 +1423,143 @@
         "type": "logs",
         "dataset": "azure.springcloudlogs",
         "title": "Azure Spring Cloud Logs"
+      }
+    ]
+  },
+  {
+    "name": "azure_application_insights",
+    "title": "Azure Application Insights Metrics Overview",
+    "version": "1.0.1",
+    "release": "ga",
+    "description": "Collect application insights metrics from Azure Monitor with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/azure_application_insights/azure_application_insights-1.0.1.zip",
+    "path": "/package/azure_application_insights/1.0.1",
+    "icons": [
+      {
+        "src": "/img/app_insights.png",
+        "path": "/package/azure_application_insights/1.0.1/img/app_insights.png",
+        "title": "logo docker",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "app_insights",
+        "title": "Azure Application Insights Metrics",
+        "description": "Collect application insights metrics from Azure Monitor with Elastic Agent.",
+        "icons": [
+          {
+            "src": "/img//app_insights.png",
+            "path": "/package/azure_application_insights/1.0.1/img/app_insights.png",
+            "title": "logo azure",
+            "size": "32x32",
+            "type": "image/svg+xml"
+          }
+        ],
+        "data_streams": [
+          "app_insights"
+        ]
+      },
+      {
+        "name": "app_state",
+        "title": "Azure Application State Insights Metrics",
+        "description": "Collect application state related metrics from Azure Monitor with Elastic Agent.",
+        "icons": [
+          {
+            "src": "/img/application_insights_blue.png",
+            "path": "/package/azure_application_insights/1.0.1/img/application_insights_blue.png",
+            "title": "logo azure",
+            "size": "32x32",
+            "type": "image/svg+xml"
+          }
+        ],
+        "data_streams": [
+          "app_state"
+        ]
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "azure",
+      "web"
+    ],
+    "signature_path": "/epr/azure_application_insights/azure_application_insights-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "azure.app_insights",
+        "title": "Azure Application Insights"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.app_state",
+        "title": "Azure Application State"
+      }
+    ]
+  },
+  {
+    "name": "azure_billing",
+    "title": "Azure Billing Metrics",
+    "version": "1.0.1",
+    "release": "ga",
+    "description": "Collect billing metrics with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/azure_billing/azure_billing-1.0.1.zip",
+    "path": "/package/azure_billing/1.0.1",
+    "icons": [
+      {
+        "src": "/img/billing.png",
+        "path": "/package/azure_billing/1.0.1/img/billing.png",
+        "title": "logo docker",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "billing",
+        "title": "Azure Billing Metrics",
+        "description": "Collect billing information with Elastic Agent.",
+        "icons": [
+          {
+            "src": "/img//billing.png",
+            "path": "/package/azure_billing/1.0.1/img/billing.png",
+            "title": "logo azure",
+            "size": "32x32",
+            "type": "image/svg+xml"
+          }
+        ],
+        "data_streams": [
+          "billing"
+        ]
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.15.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "azure"
+    ],
+    "signature_path": "/epr/azure_billing/azure_billing-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "azure.billing",
+        "title": "Azure Billing Metrics"
       }
     ]
   },
@@ -1979,85 +1864,112 @@
     ]
   },
   {
-    "name": "cef",
-    "title": "CEF Logs",
-    "version": "2.0.0",
+    "name": "carbon_black_cloud",
+    "title": "VMware Carbon Black Cloud",
+    "version": "1.0.2",
     "release": "ga",
-    "description": "Collect logs from CEF Logs with Elastic Agent.",
+    "description": "Collect logs from VMWare Carbon Black Cloud with Elastic Agent.",
     "type": "integration",
-    "download": "/epr/cef/cef-2.0.0.zip",
-    "path": "/package/cef/2.0.0",
-    "policy_templates": [
-      {
-        "name": "cef",
-        "title": "CEF logs",
-        "description": "Collect logs from CEF instances"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "network",
-      "security"
-    ],
-    "signature_path": "/epr/cef/cef-2.0.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "cef.log",
-        "title": "CEF log logs"
-      }
-    ]
-  },
-  {
-    "name": "cloud_security_posture",
-    "title": "CIS Kubernetes Benchmark",
-    "version": "0.0.14",
-    "release": "experimental",
-    "description": "Check Kubernetes cluster compliance with the Kubernetes CIS benchmark.",
-    "type": "integration",
-    "download": "/epr/cloud_security_posture/cloud_security_posture-0.0.14.zip",
-    "path": "/package/cloud_security_posture/0.0.14",
+    "download": "/epr/carbon_black_cloud/carbon_black_cloud-1.0.2.zip",
+    "path": "/package/carbon_black_cloud/1.0.2",
     "icons": [
       {
-        "src": "/img/cis-kubernetes-benchmark-logo.svg",
-        "path": "/package/cloud_security_posture/0.0.14/img/cis-kubernetes-benchmark-logo.svg",
-        "title": "CIS Kubernetes Benchmark logo",
+        "src": "/img/carbon_black_cloud-logo.svg",
+        "path": "/package/carbon_black_cloud/1.0.2/img/carbon_black_cloud-logo.svg",
+        "title": "Carbon Black Cloud logo",
         "size": "32x32",
         "type": "image/svg+xml"
       }
     ],
     "policy_templates": [
       {
-        "name": "kspm",
-        "title": "CIS Kubernetes Benchmark",
-        "description": "Check Kubernetes cluster compliance with the Kubernetes CIS benchmark."
+        "name": "carbon_black_cloud",
+        "title": "Carbon Black Cloud",
+        "description": "Collect Logs from Carbon Black Cloud"
       }
     ],
     "conditions": {
       "kibana": {
-        "version": "^8.3.0"
+        "version": "^7.17.0 || ^8.0.0"
       }
     },
     "owner": {
-      "github": "elastic/cloud-security-posture"
+      "github": "elastic/security-external-integrations"
     },
     "categories": [
-      "containers",
-      "kubernetes"
+      "security"
     ],
-    "signature_path": "/epr/cloud_security_posture/cloud_security_posture-0.0.14.zip.sig",
+    "signature_path": "/epr/carbon_black_cloud/carbon_black_cloud-1.0.2.zip.sig",
     "data_streams": [
       {
         "type": "logs",
-        "dataset": "cloud_security_posture.findings",
-        "title": "Findings"
+        "dataset": "carbon_black_cloud.alert",
+        "title": "Alert"
+      },
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.asset_vulnerability_summary",
+        "title": "Asset Vulnerability Summary"
+      },
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.audit",
+        "title": "Audit"
+      },
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.endpoint_event",
+        "title": "Endpoint Event"
+      },
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.watchlist_hit",
+        "title": "Watchlist Hit"
+      }
+    ]
+  },
+  {
+    "name": "carbonblack_edr",
+    "title": "VMware Carbon Black EDR",
+    "version": "1.2.0",
+    "release": "ga",
+    "description": "Collect logs from VMware Carbon Black EDR with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/carbonblack_edr/carbonblack_edr-1.2.0.zip",
+    "path": "/package/carbonblack_edr/1.2.0",
+    "icons": [
+      {
+        "src": "/img/carbon-black-logo.svg",
+        "path": "/package/carbonblack_edr/1.2.0/img/carbon-black-logo.svg",
+        "title": "VMWare Carbon Black",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "log",
+        "title": "Carbon Black EDR logs",
+        "description": "Collect logs from Carbon Black EDR"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/carbonblack_edr/carbonblack_edr-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "carbonblack_edr.log",
+        "title": "Carbon Black EDR logs"
       }
     ]
   },
@@ -2109,6 +2021,43 @@
         "type": "metrics",
         "dataset": "cassandra.metrics",
         "title": "metrics"
+      }
+    ]
+  },
+  {
+    "name": "cef",
+    "title": "CEF Logs",
+    "version": "2.0.0",
+    "release": "ga",
+    "description": "Collect logs from CEF Logs with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/cef/cef-2.0.0.zip",
+    "path": "/package/cef/2.0.0",
+    "policy_templates": [
+      {
+        "name": "cef",
+        "title": "CEF logs",
+        "description": "Collect logs from CEF instances"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "network",
+      "security"
+    ],
+    "signature_path": "/epr/cef/cef-2.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cef.log",
+        "title": "CEF log logs"
       }
     ]
   },
@@ -2706,6 +2655,52 @@
     ]
   },
   {
+    "name": "cloud_security_posture",
+    "title": "CIS Kubernetes Benchmark",
+    "version": "0.0.14",
+    "release": "experimental",
+    "description": "Check Kubernetes cluster compliance with the Kubernetes CIS benchmark.",
+    "type": "integration",
+    "download": "/epr/cloud_security_posture/cloud_security_posture-0.0.14.zip",
+    "path": "/package/cloud_security_posture/0.0.14",
+    "icons": [
+      {
+        "src": "/img/cis-kubernetes-benchmark-logo.svg",
+        "path": "/package/cloud_security_posture/0.0.14/img/cis-kubernetes-benchmark-logo.svg",
+        "title": "CIS Kubernetes Benchmark logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "kspm",
+        "title": "CIS Kubernetes Benchmark",
+        "description": "Check Kubernetes cluster compliance with the Kubernetes CIS benchmark."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.3.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/cloud-security-posture"
+    },
+    "categories": [
+      "containers",
+      "kubernetes"
+    ],
+    "signature_path": "/epr/cloud_security_posture/cloud_security_posture-0.0.14.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cloud_security_posture.findings",
+        "title": "Findings"
+      }
+    ]
+  },
+  {
     "name": "cloudflare",
     "title": "Cloudflare",
     "version": "2.0.0",
@@ -2866,389 +2861,6 @@
     ]
   },
   {
-    "name": "aws_logs",
-    "title": "Custom AWS Logs",
-    "version": "0.2.1",
-    "release": "beta",
-    "description": "Collect raw logs from AWS S3 or CloudWatch with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/aws_logs/aws_logs-0.2.1.zip",
-    "path": "/package/aws_logs/0.2.1",
-    "icons": [
-      {
-        "src": "/img/icon.svg",
-        "path": "/package/aws_logs/0.2.1/img/icon.svg",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "aws_logs",
-        "title": "Custom AWS Logs",
-        "description": "Collect raw logs from AWS S3 or CloudWatch with Elastic Agent."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/obs-cloud-monitoring"
-    },
-    "categories": [
-      "custom",
-      "cloud",
-      "aws"
-    ],
-    "signature_path": "/epr/aws_logs/aws_logs-0.2.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "aws_logs.generic",
-        "title": "Custom logs from AWS"
-      }
-    ]
-  },
-  {
-    "name": "gcp_pubsub",
-    "title": "Custom Google Pub/Sub Logs",
-    "version": "1.0.0",
-    "release": "ga",
-    "description": "Collect Logs from Google Pub/Sub topics",
-    "type": "integration",
-    "download": "/epr/gcp_pubsub/gcp_pubsub-1.0.0.zip",
-    "path": "/package/gcp_pubsub/1.0.0",
-    "icons": [
-      {
-        "src": "/img/logo_gcp.svg",
-        "path": "/package/gcp_pubsub/1.0.0/img/logo_gcp.svg",
-        "title": "logo gcp",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "gcp",
-        "title": "Custom Google Pub/Sub Logs",
-        "description": "Collect Logs from Google Pub/Sub topics"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "google_cloud",
-      "cloud",
-      "custom"
-    ],
-    "signature_path": "/epr/gcp_pubsub/gcp_pubsub-1.0.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "gcp_pubsub.generic",
-        "title": "Custom Google Pub/Sub Logs"
-      }
-    ]
-  },
-  {
-    "name": "http_endpoint",
-    "title": "Custom HTTP Endpoint Logs",
-    "version": "1.0.1",
-    "release": "ga",
-    "description": "Collect JSON data from listening HTTP port with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/http_endpoint/http_endpoint-1.0.1.zip",
-    "path": "/package/http_endpoint/1.0.1",
-    "icons": [
-      {
-        "src": "/img/icon.svg",
-        "path": "/package/http_endpoint/1.0.1/img/icon.svg",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "http_endpoint",
-        "title": "Custom HTTP Endpoint Logs",
-        "description": "Collect JSON data from listening HTTP port with Elastic Agent."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "signature_path": "/epr/http_endpoint/http_endpoint-1.0.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "http_endpoint.generic",
-        "title": "Custom HTTP Endpoint Logs"
-      }
-    ]
-  },
-  {
-    "name": "httpjson",
-    "title": "Custom HTTPJSON Input",
-    "version": "1.1.1",
-    "release": "ga",
-    "description": "Collect custom data from REST API's with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/httpjson/httpjson-1.1.1.zip",
-    "path": "/package/httpjson/1.1.1",
-    "policy_templates": [
-      {
-        "name": "generic",
-        "title": "Custom HTTPJSON Input",
-        "description": "Collect custom data from REST API's"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "signature_path": "/epr/httpjson/httpjson-1.1.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "httpjson.generic",
-        "title": "Custom HTTPJSON Input"
-      }
-    ]
-  },
-  {
-    "name": "journald",
-    "title": "Custom Journald logs",
-    "version": "0.0.2",
-    "release": "experimental",
-    "description": "Collect logs from journald with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/journald/journald-0.0.2.zip",
-    "path": "/package/journald/0.0.2",
-    "icons": [
-      {
-        "src": "/img/systemd-logo.svg",
-        "path": "/package/journald/0.0.2/img/systemd-logo.svg",
-        "title": "systemd logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "logs",
-        "title": "Journald",
-        "description": "Collect sample logs"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "signature_path": "/epr/journald/journald-0.0.2.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "journald.log",
-        "title": "Journald Log"
-      }
-    ]
-  },
-  {
-    "name": "log",
-    "title": "Custom Logs",
-    "version": "1.0.0",
-    "release": "ga",
-    "description": "Collect custom logs with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/log/log-1.0.0.zip",
-    "path": "/package/log/1.0.0",
-    "icons": [
-      {
-        "src": "/img/icon.svg",
-        "path": "/package/log/1.0.0/img/icon.svg",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "logs",
-        "title": "Custom logs",
-        "description": "Collect your custom log files."
-      }
-    ],
-    "owner": {
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "signature_path": "/epr/log/log-1.0.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "log.log",
-        "title": "Log Dataset"
-      }
-    ]
-  },
-  {
-    "name": "tcp",
-    "title": "Custom TCP Logs",
-    "version": "1.0.0",
-    "release": "ga",
-    "description": "Collect raw TCP data from listening TCP port with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/tcp/tcp-1.0.0.zip",
-    "path": "/package/tcp/1.0.0",
-    "icons": [
-      {
-        "src": "/img/icon.svg",
-        "path": "/package/tcp/1.0.0/img/icon.svg",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "tcp",
-        "title": "Custom TCP Logs",
-        "description": "Collect raw TCP data from listening TCP port with Elastic Agent."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "signature_path": "/epr/tcp/tcp-1.0.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "tcp.generic",
-        "title": "Custom TCP Logs"
-      }
-    ]
-  },
-  {
-    "name": "udp",
-    "title": "Custom UDP Logs",
-    "version": "1.0.1",
-    "release": "ga",
-    "description": "Collect raw UDP data from listening UDP port with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/udp/udp-1.0.1.zip",
-    "path": "/package/udp/1.0.1",
-    "icons": [
-      {
-        "src": "/img/icon.svg",
-        "path": "/package/udp/1.0.1/img/icon.svg",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "udp",
-        "title": "Custom UDP Logs",
-        "description": "Collect raw UDP data from listening UDP port with Elastic Agent."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "signature_path": "/epr/udp/udp-1.0.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "udp.generic",
-        "title": "Custom UDP Logs"
-      }
-    ]
-  },
-  {
-    "name": "winlog",
-    "title": "Custom Windows Event Logs",
-    "version": "1.4.0",
-    "release": "ga",
-    "description": "Collect and parse logs from any Windows event log channel with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/winlog/winlog-1.4.0.zip",
-    "path": "/package/winlog/1.4.0",
-    "icons": [
-      {
-        "src": "/img/logo_windows.svg",
-        "path": "/package/winlog/1.4.0/img/logo_windows.svg",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "winlogs",
-        "title": "Custom Windows event logs",
-        "description": "Collect your custom Windows event logs."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "signature_path": "/epr/winlog/winlog-1.4.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "winlog.winlog",
-        "title": "Custom Windows Event Log Dataset"
-      }
-    ]
-  },
-  {
     "name": "cyberark",
     "title": "CyberArk",
     "version": "0.4.4",
@@ -3335,52 +2947,6 @@
         "type": "logs",
         "dataset": "cyberarkpas.audit",
         "title": "CyberArk PAS audit logs"
-      }
-    ]
-  },
-  {
-    "name": "ti_cybersixgill",
-    "title": "Cybersixgill",
-    "version": "1.3.2",
-    "release": "ga",
-    "description": "This Elastic integration collects threat intelligence from Cybersixgill",
-    "type": "integration",
-    "download": "/epr/ti_cybersixgill/ti_cybersixgill-1.3.2.zip",
-    "path": "/package/ti_cybersixgill/1.3.2",
-    "icons": [
-      {
-        "src": "/img/cybersixgill.svg",
-        "path": "/package/ti_cybersixgill/1.3.2/img/cybersixgill.svg",
-        "title": "Cybersixgill",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "cybersixgill",
-        "title": "Cybersixgill Threat Intel",
-        "description": "Collect Threat Intel from Cybersixgill"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security",
-      "productivity"
-    ],
-    "signature_path": "/epr/ti_cybersixgill/ti_cybersixgill-1.3.2.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ti_cybersixgill.threat",
-        "title": "Cybersixgill Darkfeed Logs"
       }
     ]
   },
@@ -3636,87 +3202,6 @@
     ]
   },
   {
-    "name": "apm",
-    "title": "Elastic APM",
-    "version": "8.2.0",
-    "release": "ga",
-    "description": "Ingest APM data",
-    "type": "integration",
-    "download": "/epr/apm/apm-8.2.0.zip",
-    "path": "/package/apm/8.2.0",
-    "icons": [
-      {
-        "src": "/img/logo_apm.svg",
-        "path": "/package/apm/8.2.0/img/logo_apm.svg",
-        "title": "APM Logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "apmserver",
-        "title": "Elastic APM Integration",
-        "description": "Elastic APM Integration"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.2.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/apm-server"
-    },
-    "categories": [
-      "elastic_stack",
-      "monitoring"
-    ],
-    "signature_path": "/epr/apm/apm-8.2.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "apm.app",
-        "title": "APM application logs"
-      },
-      {
-        "type": "metrics",
-        "dataset": "apm.app",
-        "title": "APM application metrics"
-      },
-      {
-        "type": "logs",
-        "dataset": "apm.error",
-        "title": "APM errors"
-      },
-      {
-        "type": "metrics",
-        "dataset": "apm.internal",
-        "title": "APM internal metrics"
-      },
-      {
-        "type": "metrics",
-        "dataset": "apm.profiling",
-        "title": "APM profiles"
-      },
-      {
-        "type": "traces",
-        "dataset": "apm.rum",
-        "title": "APM RUM traces"
-      },
-      {
-        "type": "traces",
-        "dataset": "apm.sampled",
-        "title": "APM tail-sampled traces"
-      },
-      {
-        "type": "traces",
-        "dataset": "apm",
-        "title": "APM traces"
-      }
-    ]
-  },
-  {
     "name": "elastic_agent",
     "title": "Elastic Agent",
     "version": "1.3.1",
@@ -3846,77 +3331,6 @@
         "type": "metrics",
         "dataset": "elastic_agent.packetbeat",
         "title": "Elastic Agent"
-      }
-    ]
-  },
-  {
-    "name": "synthetics",
-    "title": "Elastic Synthetics",
-    "version": "0.9.2",
-    "release": "beta",
-    "description": "Monitor the availability of your services with Elastic Synthetics.",
-    "type": "integration",
-    "download": "/epr/synthetics/synthetics-0.9.2.zip",
-    "path": "/package/synthetics/0.9.2",
-    "icons": [
-      {
-        "src": "/img/uptime-logo-color-64px.svg",
-        "path": "/package/synthetics/0.9.2/img/uptime-logo-color-64px.svg",
-        "size": "16x16",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "synthetics",
-        "title": "Elastic Synthetics",
-        "description": "Perform synthetic health checks on network endpoints."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.1.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/uptime"
-    },
-    "categories": [
-      "elastic_stack",
-      "monitoring",
-      "web"
-    ],
-    "signature_path": "/epr/synthetics/synthetics-0.9.2.zip.sig",
-    "data_streams": [
-      {
-        "type": "synthetics",
-        "dataset": "browser",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "browser.network",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "browser.screenshot",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "http",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "icmp",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "tcp",
-        "title": "synthetic monitor check"
       }
     ]
   },
@@ -4390,51 +3804,6 @@
     ]
   },
   {
-    "name": "github",
-    "title": "GitHub",
-    "version": "1.0.0",
-    "release": "ga",
-    "description": "Collect events from GitHub with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/github/github-1.0.0.zip",
-    "path": "/package/github/1.0.0",
-    "icons": [
-      {
-        "src": "/img/github.svg",
-        "path": "/package/github/1.0.0/img/github.svg",
-        "title": "GitHub",
-        "size": "1024x1024",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "github",
-        "title": "GitHub logs",
-        "description": "Collect logs from GitHub"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/github/github-1.0.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "github.audit",
-        "title": "GitHub Audit Logs"
-      }
-    ]
-  },
-  {
     "name": "gcp",
     "title": "Google Cloud Platform",
     "version": "1.9.0",
@@ -4498,47 +3867,94 @@
     ]
   },
   {
-    "name": "santa",
-    "title": "Google Santa Logs",
-    "version": "2.0.1",
+    "name": "gcp_pubsub",
+    "title": "Custom Google Pub/Sub Logs",
+    "version": "1.0.0",
     "release": "ga",
-    "description": "Collect and parse logs from Google Santa instances with Elastic Agent.",
+    "description": "Collect Logs from Google Pub/Sub topics",
     "type": "integration",
-    "download": "/epr/santa/santa-2.0.1.zip",
-    "path": "/package/santa/2.0.1",
+    "download": "/epr/gcp_pubsub/gcp_pubsub-1.0.0.zip",
+    "path": "/package/gcp_pubsub/1.0.0",
     "icons": [
       {
-        "src": "/img/icon.svg",
-        "path": "/package/santa/2.0.1/img/icon.svg",
-        "title": "Google Santa",
+        "src": "/img/logo_gcp.svg",
+        "path": "/package/gcp_pubsub/1.0.0/img/logo_gcp.svg",
+        "title": "logo gcp",
+        "size": "32x32",
         "type": "image/svg+xml"
       }
     ],
     "policy_templates": [
       {
-        "name": "santa",
-        "title": "Google Santa logs",
-        "description": "Collect logs from Google Santa instances"
+        "name": "gcp",
+        "title": "Custom Google Pub/Sub Logs",
+        "description": "Collect Logs from Google Pub/Sub topics"
       }
     ],
     "conditions": {
       "kibana": {
-        "version": "^7.17.0 || ^8.0.0"
+        "version": "^7.16.0 || ^8.0.0"
       }
     },
     "owner": {
       "github": "elastic/security-external-integrations"
     },
     "categories": [
-      "security",
-      "os_system"
+      "google_cloud",
+      "cloud",
+      "custom"
     ],
-    "signature_path": "/epr/santa/santa-2.0.1.zip.sig",
+    "signature_path": "/epr/gcp_pubsub/gcp_pubsub-1.0.0.zip.sig",
     "data_streams": [
       {
         "type": "logs",
-        "dataset": "santa.log",
-        "title": "Google Santa log logs"
+        "dataset": "gcp_pubsub.generic",
+        "title": "Custom Google Pub/Sub Logs"
+      }
+    ]
+  },
+  {
+    "name": "github",
+    "title": "GitHub",
+    "version": "1.0.0",
+    "release": "ga",
+    "description": "Collect events from GitHub with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/github/github-1.0.0.zip",
+    "path": "/package/github/1.0.0",
+    "icons": [
+      {
+        "src": "/img/github.svg",
+        "path": "/package/github/1.0.0/img/github.svg",
+        "title": "GitHub",
+        "size": "1024x1024",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "github",
+        "title": "GitHub logs",
+        "description": "Collect logs from GitHub"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/github/github-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "github.audit",
+        "title": "GitHub Audit Logs"
       }
     ]
   },
@@ -4774,6 +4190,85 @@
     ]
   },
   {
+    "name": "http_endpoint",
+    "title": "Custom HTTP Endpoint Logs",
+    "version": "1.0.1",
+    "release": "ga",
+    "description": "Collect JSON data from listening HTTP port with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/http_endpoint/http_endpoint-1.0.1.zip",
+    "path": "/package/http_endpoint/1.0.1",
+    "icons": [
+      {
+        "src": "/img/icon.svg",
+        "path": "/package/http_endpoint/1.0.1/img/icon.svg",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "http_endpoint",
+        "title": "Custom HTTP Endpoint Logs",
+        "description": "Collect JSON data from listening HTTP port with Elastic Agent."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "signature_path": "/epr/http_endpoint/http_endpoint-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "http_endpoint.generic",
+        "title": "Custom HTTP Endpoint Logs"
+      }
+    ]
+  },
+  {
+    "name": "httpjson",
+    "title": "Custom HTTPJSON Input",
+    "version": "1.1.1",
+    "release": "ga",
+    "description": "Collect custom data from REST API's with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/httpjson/httpjson-1.1.1.zip",
+    "path": "/package/httpjson/1.1.1",
+    "policy_templates": [
+      {
+        "name": "generic",
+        "title": "Custom HTTPJSON Input",
+        "description": "Collect custom data from REST API's"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "signature_path": "/epr/httpjson/httpjson-1.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "httpjson.generic",
+        "title": "Custom HTTPJSON Input"
+      }
+    ]
+  },
+  {
     "name": "iis",
     "title": "IIS",
     "version": "0.8.0",
@@ -4967,48 +4462,47 @@
     ]
   },
   {
-    "name": "juniper_junos",
-    "title": "Juniper JunOS",
-    "version": "0.1.1",
+    "name": "journald",
+    "title": "Custom Journald logs",
+    "version": "0.0.2",
     "release": "experimental",
-    "description": "Collect logs from Juniper JunOS with Elastic Agent.",
+    "description": "Collect logs from journald with Elastic Agent.",
     "type": "integration",
-    "download": "/epr/juniper_junos/juniper_junos-0.1.1.zip",
-    "path": "/package/juniper_junos/0.1.1",
+    "download": "/epr/journald/journald-0.0.2.zip",
+    "path": "/package/journald/0.0.2",
     "icons": [
       {
-        "src": "/img/logo.svg",
-        "path": "/package/juniper_junos/0.1.1/img/logo.svg",
-        "title": "Juniper logo",
+        "src": "/img/systemd-logo.svg",
+        "path": "/package/journald/0.0.2/img/systemd-logo.svg",
+        "title": "systemd logo",
         "size": "32x32",
         "type": "image/svg+xml"
       }
     ],
     "policy_templates": [
       {
-        "name": "juniper",
-        "title": "Juniper JunOS logs",
-        "description": "Collect Juniper JunOS logs from syslog or a file."
+        "name": "logs",
+        "title": "Journald",
+        "description": "Collect sample logs"
       }
     ],
     "conditions": {
       "kibana": {
-        "version": "^8.0.0"
+        "version": "^7.16.0"
       }
     },
     "owner": {
-      "github": "elastic/security-external-integrations"
+      "github": "elastic/integrations"
     },
     "categories": [
-      "network",
-      "security"
+      "custom"
     ],
-    "signature_path": "/epr/juniper_junos/juniper_junos-0.1.1.zip.sig",
+    "signature_path": "/epr/journald/journald-0.0.2.zip.sig",
     "data_streams": [
       {
         "type": "logs",
-        "dataset": "juniper_junos.log",
-        "title": "Juniper JUNOS logs"
+        "dataset": "journald.log",
+        "title": "Journald Log"
       }
     ]
   },
@@ -5065,6 +4559,52 @@
         "type": "logs",
         "dataset": "juniper.srx",
         "title": "Juniper SRX logs"
+      }
+    ]
+  },
+  {
+    "name": "juniper_junos",
+    "title": "Juniper JunOS",
+    "version": "0.1.1",
+    "release": "experimental",
+    "description": "Collect logs from Juniper JunOS with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/juniper_junos/juniper_junos-0.1.1.zip",
+    "path": "/package/juniper_junos/0.1.1",
+    "icons": [
+      {
+        "src": "/img/logo.svg",
+        "path": "/package/juniper_junos/0.1.1/img/logo.svg",
+        "title": "Juniper logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "juniper",
+        "title": "Juniper JunOS logs",
+        "description": "Collect Juniper JunOS logs from syslog or a file."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "network",
+      "security"
+    ],
+    "signature_path": "/epr/juniper_junos/juniper_junos-0.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "juniper_junos.log",
+        "title": "Juniper JUNOS logs"
       }
     ]
   },
@@ -5784,6 +5324,44 @@
     ]
   },
   {
+    "name": "log",
+    "title": "Custom Logs",
+    "version": "1.0.0",
+    "release": "ga",
+    "description": "Collect custom logs with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/log/log-1.0.0.zip",
+    "path": "/package/log/1.0.0",
+    "icons": [
+      {
+        "src": "/img/icon.svg",
+        "path": "/package/log/1.0.0/img/icon.svg",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "logs",
+        "title": "Custom logs",
+        "description": "Collect your custom log files."
+      }
+    ],
+    "owner": {
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "signature_path": "/epr/log/log-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "log.log",
+        "title": "Log Dataset"
+      }
+    ]
+  },
+  {
     "name": "logstash",
     "title": "Logstash",
     "version": "1.1.0",
@@ -5844,37 +5422,6 @@
     ]
   },
   {
-    "name": "problemchild",
-    "title": "LotL Attack Detection",
-    "version": "0.0.2",
-    "release": "experimental",
-    "description": "The ProblemChild framework is used to detect living off the land activity. Requires a Platinum subscription.",
-    "type": "integration",
-    "download": "/epr/problemchild/problemchild-0.0.2.zip",
-    "path": "/package/problemchild/0.0.2",
-    "icons": [
-      {
-        "src": "/img/icon-machine-learning.svg",
-        "path": "/package/problemchild/0.0.2/img/icon-machine-learning.svg",
-        "title": "Sample logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/ml-ui"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/problemchild/problemchild-0.0.2.zip.sig"
-  },
-  {
     "name": "m365_defender",
     "title": "M365 Defender Logs",
     "version": "1.0.3",
@@ -5918,51 +5465,6 @@
         "type": "logs",
         "dataset": "m365_defender.log",
         "title": "M365 Defender Logs"
-      }
-    ]
-  },
-  {
-    "name": "ti_misp",
-    "title": "MISP",
-    "version": "1.2.2",
-    "release": "ga",
-    "description": "This Elastic integration collects events from MISP",
-    "type": "integration",
-    "download": "/epr/ti_misp/ti_misp-1.2.2.zip",
-    "path": "/package/ti_misp/1.2.2",
-    "icons": [
-      {
-        "src": "/img/misp.svg",
-        "path": "/package/ti_misp/1.2.2/img/misp.svg",
-        "title": "MISP",
-        "size": "216x216",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "ti_misp",
-        "title": "MISP",
-        "description": "Collect threat intelligence from the MISP API."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/ti_misp/ti_misp-1.2.2.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ti_misp.threat",
-        "title": "MISP"
       }
     ]
   },
@@ -6065,51 +5567,6 @@
     ]
   },
   {
-    "name": "microsoft_dhcp",
-    "title": "Microsoft DHCP",
-    "version": "1.3.1",
-    "release": "ga",
-    "description": "Collect logs from Microsoft DHCP with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/microsoft_dhcp/microsoft_dhcp-1.3.1.zip",
-    "path": "/package/microsoft_dhcp/1.3.1",
-    "icons": [
-      {
-        "src": "/img/logo.svg",
-        "path": "/package/microsoft_dhcp/1.3.1/img/logo.svg",
-        "title": "Microsoft logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "microsoft_dhcp",
-        "title": "Microsoft DHCP",
-        "description": "Collect Microsoft DHCP logs."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "network"
-    ],
-    "signature_path": "/epr/microsoft_dhcp/microsoft_dhcp-1.3.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "microsoft_dhcp.log",
-        "title": "Microsoft DHCP Logs"
-      }
-    ]
-  },
-  {
     "name": "microsoft_defender_endpoint",
     "title": "Microsoft Defender for Endpoint",
     "version": "2.1.0",
@@ -6153,6 +5610,51 @@
         "type": "logs",
         "dataset": "microsoft_defender_endpoint.log",
         "title": "Microsoft Defender for Endpoint logs"
+      }
+    ]
+  },
+  {
+    "name": "microsoft_dhcp",
+    "title": "Microsoft DHCP",
+    "version": "1.3.1",
+    "release": "ga",
+    "description": "Collect logs from Microsoft DHCP with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/microsoft_dhcp/microsoft_dhcp-1.3.1.zip",
+    "path": "/package/microsoft_dhcp/1.3.1",
+    "icons": [
+      {
+        "src": "/img/logo.svg",
+        "path": "/package/microsoft_dhcp/1.3.1/img/logo.svg",
+        "title": "Microsoft logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "microsoft_dhcp",
+        "title": "Microsoft DHCP",
+        "description": "Collect Microsoft DHCP logs."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "network"
+    ],
+    "signature_path": "/epr/microsoft_dhcp/microsoft_dhcp-1.3.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "microsoft_dhcp.log",
+        "title": "Microsoft DHCP Logs"
       }
     ]
   },
@@ -6538,6 +6040,51 @@
         "type": "logs",
         "dataset": "netflow.log",
         "title": "NetFlow logs"
+      }
+    ]
+  },
+  {
+    "name": "netscout",
+    "title": "Arbor Peakflow SP Logs",
+    "version": "0.7.0",
+    "release": "experimental",
+    "description": "Collect and parse logs from Netscout Arbor Peakflow SP with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/netscout/netscout-0.7.0.zip",
+    "path": "/package/netscout/0.7.0",
+    "icons": [
+      {
+        "src": "/img/logo.svg",
+        "path": "/package/netscout/0.7.0/img/logo.svg",
+        "title": "Arbor Peakflow SP logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "sightline",
+        "title": "Arbor Peakflow SP",
+        "description": "Collect Arbor Peakflow SP logs from syslog or a file."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.1 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/netscout/netscout-0.7.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "netscout.sightline",
+        "title": "Arbor Peakflow SP logs"
       }
     ]
   },
@@ -7039,6 +6586,51 @@
     ]
   },
   {
+    "name": "panw",
+    "title": "Palo Alto Networks Logs",
+    "version": "1.5.3",
+    "release": "ga",
+    "description": "Collect PAN-OS firewall monitoring logs from Palo Alto Networks devices with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/panw/panw-1.5.3.zip",
+    "path": "/package/panw/1.5.3",
+    "icons": [
+      {
+        "src": "/img/logo-integrations-paloalto-networks.svg",
+        "path": "/package/panw/1.5.3/img/logo-integrations-paloalto-networks.svg",
+        "title": "Palo Alto Networks",
+        "size": "216x216",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "panw",
+        "title": "Palo Alto Networks PAN-OS firewall logs",
+        "description": "Collect logs from Palo Alto Networks PAN-OS firewall"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/panw/panw-1.5.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "panw.panos",
+        "title": "Palo Alto Networks PAN-OS firewall logs"
+      }
+    ]
+  },
+  {
     "name": "panw_cortex_xdr",
     "title": "Palo Alto Cortex XDR Logs",
     "version": "1.1.1",
@@ -7084,47 +6676,48 @@
     ]
   },
   {
-    "name": "panw",
-    "title": "Palo Alto Networks Logs",
-    "version": "1.5.3",
-    "release": "ga",
-    "description": "Collect PAN-OS firewall monitoring logs from Palo Alto Networks devices with Elastic Agent.",
+    "name": "pfsense",
+    "title": "pfSense Logs",
+    "version": "0.3.1",
+    "release": "experimental",
+    "description": "Collect and parse logs from pfSense devices with Elastic Agent.",
     "type": "integration",
-    "download": "/epr/panw/panw-1.5.3.zip",
-    "path": "/package/panw/1.5.3",
+    "download": "/epr/pfsense/pfsense-0.3.1.zip",
+    "path": "/package/pfsense/0.3.1",
     "icons": [
       {
-        "src": "/img/logo-integrations-paloalto-networks.svg",
-        "path": "/package/panw/1.5.3/img/logo-integrations-paloalto-networks.svg",
-        "title": "Palo Alto Networks",
-        "size": "216x216",
+        "src": "/img/pfsense.svg",
+        "path": "/package/pfsense/0.3.1/img/pfsense.svg",
+        "title": "pfsense",
+        "size": "512x143",
         "type": "image/svg+xml"
       }
     ],
     "policy_templates": [
       {
-        "name": "panw",
-        "title": "Palo Alto Networks PAN-OS firewall logs",
-        "description": "Collect logs from Palo Alto Networks PAN-OS firewall"
+        "name": "pfsense",
+        "title": "pfSense logs",
+        "description": "Collect logs from pfSense systems"
       }
     ],
     "conditions": {
       "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
+        "version": "^7.15.0 || ^8.0.0"
       }
     },
     "owner": {
       "github": "elastic/security-external-integrations"
     },
     "categories": [
+      "network",
       "security"
     ],
-    "signature_path": "/epr/panw/panw-1.5.3.zip.sig",
+    "signature_path": "/epr/pfsense/pfsense-0.3.1.zip.sig",
     "data_streams": [
       {
         "type": "logs",
-        "dataset": "panw.panos",
-        "title": "Palo Alto Networks PAN-OS firewall logs"
+        "dataset": "pfsense.log",
+        "title": "pfSense log logs"
       }
     ]
   },
@@ -7194,40 +6787,35 @@
     ]
   },
   {
-    "name": "security_detection_engine",
-    "title": "Prebuilt Security Detection Rules",
-    "version": "1.0.2",
-    "release": "ga",
-    "description": "Prebuilt detection rules for Elastic Security",
+    "name": "problemchild",
+    "title": "LotL Attack Detection",
+    "version": "0.0.2",
+    "release": "experimental",
+    "description": "The ProblemChild framework is used to detect living off the land activity. Requires a Platinum subscription.",
     "type": "integration",
-    "download": "/epr/security_detection_engine/security_detection_engine-1.0.2.zip",
-    "path": "/package/security_detection_engine/1.0.2",
+    "download": "/epr/problemchild/problemchild-0.0.2.zip",
+    "path": "/package/problemchild/0.0.2",
     "icons": [
       {
-        "src": "/img/security-logo-color-64px.svg",
-        "path": "/package/security_detection_engine/1.0.2/img/security-logo-color-64px.svg",
-        "size": "16x16",
+        "src": "/img/icon-machine-learning.svg",
+        "path": "/package/problemchild/0.0.2/img/icon-machine-learning.svg",
+        "title": "Sample logo",
+        "size": "32x32",
         "type": "image/svg+xml"
       }
     ],
     "conditions": {
       "kibana": {
         "version": "^8.0.0"
-      },
-      "elastic": {
-        "subscription": "basic",
-        "capabilities": [
-          "security"
-        ]
       }
     },
     "owner": {
-      "github": "elastic/protections"
+      "github": "elastic/ml-ui"
     },
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/security_detection_engine/security_detection_engine-1.0.2.zip.sig"
+    "signature_path": "/epr/problemchild/problemchild-0.0.2.zip.sig"
   },
   {
     "name": "prometheus",
@@ -7532,51 +7120,6 @@
     ]
   },
   {
-    "name": "ti_recordedfuture",
-    "title": "Recorded Future",
-    "version": "0.1.2",
-    "release": "beta",
-    "description": "Collect threat intelligence from Recorded Future with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/ti_recordedfuture/ti_recordedfuture-0.1.2.zip",
-    "path": "/package/ti_recordedfuture/0.1.2",
-    "icons": [
-      {
-        "src": "/img/logo.svg",
-        "path": "/package/ti_recordedfuture/0.1.2/img/logo.svg",
-        "title": "Recorded Future",
-        "size": "216x216",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "ti_recordedfuture",
-        "title": "Recorded Future",
-        "description": "Collect threat intelligence from Recorded Future."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/ti_recordedfuture/ti_recordedfuture-0.1.2.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ti_recordedfuture.threat",
-        "title": "Recorded Future"
-      }
-    ]
-  },
-  {
     "name": "redis",
     "title": "Redis",
     "version": "1.2.0",
@@ -7643,114 +7186,85 @@
     ]
   },
   {
-    "name": "sql",
-    "title": "SQL Input",
-    "version": "0.5.0",
-    "release": "beta",
-    "description": "Collects Metrics by Quering on SQL Databases",
-    "type": "input",
-    "download": "/epr/sql/sql-0.5.0.zip",
-    "path": "/package/sql/0.5.0",
-    "icons": [
-      {
-        "src": "/img/sql-server-icon.svg",
-        "path": "/package/sql/0.5.0/img/sql-server-icon.svg",
-        "title": "SQL logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "sql",
-        "title": "SQL Metrics",
-        "description": "Collects Metrics by Quering on SQL Databases",
-        "deprecated": {
-          "since": "0.5.0",
-          "description": "This policy is deprecated"
-        }
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.13.0"
-      },
-      "elastic": {
-        "subscription": "basic"
-      }
-    },
-    "owner": {
-      "github": "elastic/obs-infraobs-integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "signature_path": "/epr/sql/sql-0.5.0.zip.sig",
-    "deprecated": {
-      "since": "0.5.0",
-      "description": "This package is deprecated"
-    }
-  },
-  {
-    "name": "stan",
-    "title": "STAN",
-    "version": "1.2.0",
+    "name": "santa",
+    "title": "Google Santa Logs",
+    "version": "2.0.1",
     "release": "ga",
-    "description": "Collect logs and metrics from STAN servers with Elastic Agent.",
+    "description": "Collect and parse logs from Google Santa instances with Elastic Agent.",
     "type": "integration",
-    "download": "/epr/stan/stan-1.2.0.zip",
-    "path": "/package/stan/1.2.0",
+    "download": "/epr/santa/santa-2.0.1.zip",
+    "path": "/package/santa/2.0.1",
     "icons": [
       {
-        "src": "/img/stan.svg",
-        "path": "/package/stan/1.2.0/img/stan.svg",
-        "title": "STAN Logo",
-        "size": "32x32",
+        "src": "/img/icon.svg",
+        "path": "/package/santa/2.0.1/img/icon.svg",
+        "title": "Google Santa",
         "type": "image/svg+xml"
       }
     ],
     "policy_templates": [
       {
-        "name": "stan",
-        "title": "STAN Logs and Metrics",
-        "description": "Collect logs and metrics from STAN instances"
+        "name": "santa",
+        "title": "Google Santa logs",
+        "description": "Collect logs from Google Santa instances"
       }
     ],
     "conditions": {
       "kibana": {
-        "version": "^7.14.0 || ^8.0.0"
+        "version": "^7.17.0 || ^8.0.0"
       }
     },
     "owner": {
-      "github": "elastic/integrations"
+      "github": "elastic/security-external-integrations"
     },
     "categories": [
-      "message_queue",
-      "kubernetes"
+      "security",
+      "os_system"
     ],
-    "signature_path": "/epr/stan/stan-1.2.0.zip.sig",
+    "signature_path": "/epr/santa/santa-2.0.1.zip.sig",
     "data_streams": [
       {
-        "type": "metrics",
-        "dataset": "stan.channels",
-        "title": "Stan channels metrics"
-      },
-      {
         "type": "logs",
-        "dataset": "stan.log",
-        "title": "STAN logs"
-      },
-      {
-        "type": "metrics",
-        "dataset": "stan.stats",
-        "title": "Stan stats metrics"
-      },
-      {
-        "type": "metrics",
-        "dataset": "stan.subscriptions",
-        "title": "Stan subscriptions metrics"
+        "dataset": "santa.log",
+        "title": "Google Santa log logs"
       }
     ]
+  },
+  {
+    "name": "security_detection_engine",
+    "title": "Prebuilt Security Detection Rules",
+    "version": "1.0.2",
+    "release": "ga",
+    "description": "Prebuilt detection rules for Elastic Security",
+    "type": "integration",
+    "download": "/epr/security_detection_engine/security_detection_engine-1.0.2.zip",
+    "path": "/package/security_detection_engine/1.0.2",
+    "icons": [
+      {
+        "src": "/img/security-logo-color-64px.svg",
+        "path": "/package/security_detection_engine/1.0.2/img/security-logo-color-64px.svg",
+        "size": "16x16",
+        "type": "image/svg+xml"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      },
+      "elastic": {
+        "subscription": "basic",
+        "capabilities": [
+          "security"
+        ]
+      }
+    },
+    "owner": {
+      "github": "elastic/protections"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/security_detection_engine/security_detection_engine-1.0.2.zip.sig"
   },
   {
     "name": "snort",
@@ -7945,6 +7459,55 @@
     ]
   },
   {
+    "name": "sql",
+    "title": "SQL Input",
+    "version": "0.5.0",
+    "release": "beta",
+    "description": "Collects Metrics by Quering on SQL Databases",
+    "type": "input",
+    "download": "/epr/sql/sql-0.5.0.zip",
+    "path": "/package/sql/0.5.0",
+    "icons": [
+      {
+        "src": "/img/sql-server-icon.svg",
+        "path": "/package/sql/0.5.0/img/sql-server-icon.svg",
+        "title": "SQL logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "sql",
+        "title": "SQL Metrics",
+        "description": "Collects Metrics by Quering on SQL Databases",
+        "deprecated": {
+          "since": "0.5.0",
+          "description": "This policy is deprecated"
+        }
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.13.0"
+      },
+      "elastic": {
+        "subscription": "basic"
+      }
+    },
+    "owner": {
+      "github": "elastic/obs-infraobs-integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "signature_path": "/epr/sql/sql-0.5.0.zip.sig",
+    "deprecated": {
+      "since": "0.5.0",
+      "description": "This package is deprecated"
+    }
+  },
+  {
     "name": "squid",
     "title": "Squid Logs",
     "version": "0.7.0",
@@ -7977,6 +7540,67 @@
         "type": "logs",
         "dataset": "squid.log",
         "title": "Squid logs"
+      }
+    ]
+  },
+  {
+    "name": "stan",
+    "title": "STAN",
+    "version": "1.2.0",
+    "release": "ga",
+    "description": "Collect logs and metrics from STAN servers with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/stan/stan-1.2.0.zip",
+    "path": "/package/stan/1.2.0",
+    "icons": [
+      {
+        "src": "/img/stan.svg",
+        "path": "/package/stan/1.2.0/img/stan.svg",
+        "title": "STAN Logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "stan",
+        "title": "STAN Logs and Metrics",
+        "description": "Collect logs and metrics from STAN instances"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "message_queue",
+      "kubernetes"
+    ],
+    "signature_path": "/epr/stan/stan-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "stan.channels",
+        "title": "Stan channels metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "stan.log",
+        "title": "STAN logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "stan.stats",
+        "title": "Stan stats metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "stan.subscriptions",
+        "title": "Stan subscriptions metrics"
       }
     ]
   },
@@ -8114,6 +7738,77 @@
     ]
   },
   {
+    "name": "synthetics",
+    "title": "Elastic Synthetics",
+    "version": "0.9.2",
+    "release": "beta",
+    "description": "Monitor the availability of your services with Elastic Synthetics.",
+    "type": "integration",
+    "download": "/epr/synthetics/synthetics-0.9.2.zip",
+    "path": "/package/synthetics/0.9.2",
+    "icons": [
+      {
+        "src": "/img/uptime-logo-color-64px.svg",
+        "path": "/package/synthetics/0.9.2/img/uptime-logo-color-64px.svg",
+        "size": "16x16",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "synthetics",
+        "title": "Elastic Synthetics",
+        "description": "Perform synthetic health checks on network endpoints."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.1.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/uptime"
+    },
+    "categories": [
+      "elastic_stack",
+      "monitoring",
+      "web"
+    ],
+    "signature_path": "/epr/synthetics/synthetics-0.9.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "synthetics",
+        "dataset": "browser",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "browser.network",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "browser.screenshot",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "http",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "icmp",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "tcp",
+        "title": "synthetic monitor check"
+      }
+    ]
+  },
+  {
     "name": "system",
     "title": "System",
     "version": "1.6.4",
@@ -8240,6 +7935,49 @@
     ]
   },
   {
+    "name": "tcp",
+    "title": "Custom TCP Logs",
+    "version": "1.0.0",
+    "release": "ga",
+    "description": "Collect raw TCP data from listening TCP port with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/tcp/tcp-1.0.0.zip",
+    "path": "/package/tcp/1.0.0",
+    "icons": [
+      {
+        "src": "/img/icon.svg",
+        "path": "/package/tcp/1.0.0/img/icon.svg",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "tcp",
+        "title": "Custom TCP Logs",
+        "description": "Collect raw TCP data from listening TCP port with Elastic Agent."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "signature_path": "/epr/tcp/tcp-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "tcp.generic",
+        "title": "Custom TCP Logs"
+      }
+    ]
+  },
+  {
     "name": "tenable_sc",
     "title": "Tenable.sc",
     "version": "1.1.1",
@@ -8295,6 +8033,292 @@
     ]
   },
   {
+    "name": "ti_abusech",
+    "title": "AbuseCH",
+    "version": "1.2.3",
+    "release": "ga",
+    "description": "Collect threat intelligence from AbuseCH API with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/ti_abusech/ti_abusech-1.2.3.zip",
+    "path": "/package/ti_abusech/1.2.3",
+    "icons": [
+      {
+        "src": "/img/abusech2.svg",
+        "path": "/package/ti_abusech/1.2.3/img/abusech2.svg",
+        "title": "AbuseCH",
+        "size": "512x512",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "ti_abusech",
+        "title": "AbuseCH API",
+        "description": "Collect threat intelligence from the AbuseCH API"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/ti_abusech/ti_abusech-1.2.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_abusech.malware",
+        "title": "AbuseCH Malware logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "ti_abusech.malwarebazaar",
+        "title": "AbuseCH MalwareBazaar logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "ti_abusech.url",
+        "title": "AbuseCH URL logs"
+      }
+    ]
+  },
+  {
+    "name": "ti_anomali",
+    "title": "Anomali",
+    "version": "1.2.3",
+    "release": "ga",
+    "description": "Collect threat intelligence from Anomali APIs with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/ti_anomali/ti_anomali-1.2.3.zip",
+    "path": "/package/ti_anomali/1.2.3",
+    "icons": [
+      {
+        "src": "/img/anomali.svg",
+        "path": "/package/ti_anomali/1.2.3/img/anomali.svg",
+        "title": "Anomali",
+        "size": "216x216",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "ti_anomali",
+        "title": "Anomali",
+        "description": "Collect threat intelligence from the Anomali Limo API and Anomali Threatstream."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/ti_anomali/ti_anomali-1.2.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_anomali.limo",
+        "title": "Anomali Limo"
+      },
+      {
+        "type": "logs",
+        "dataset": "ti_anomali.threatstream",
+        "title": "Anomali Threatstream"
+      }
+    ]
+  },
+  {
+    "name": "ti_cybersixgill",
+    "title": "Cybersixgill",
+    "version": "1.3.2",
+    "release": "ga",
+    "description": "This Elastic integration collects threat intelligence from Cybersixgill",
+    "type": "integration",
+    "download": "/epr/ti_cybersixgill/ti_cybersixgill-1.3.2.zip",
+    "path": "/package/ti_cybersixgill/1.3.2",
+    "icons": [
+      {
+        "src": "/img/cybersixgill.svg",
+        "path": "/package/ti_cybersixgill/1.3.2/img/cybersixgill.svg",
+        "title": "Cybersixgill",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "cybersixgill",
+        "title": "Cybersixgill Threat Intel",
+        "description": "Collect Threat Intel from Cybersixgill"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security",
+      "productivity"
+    ],
+    "signature_path": "/epr/ti_cybersixgill/ti_cybersixgill-1.3.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_cybersixgill.threat",
+        "title": "Cybersixgill Darkfeed Logs"
+      }
+    ]
+  },
+  {
+    "name": "ti_misp",
+    "title": "MISP",
+    "version": "1.2.2",
+    "release": "ga",
+    "description": "This Elastic integration collects events from MISP",
+    "type": "integration",
+    "download": "/epr/ti_misp/ti_misp-1.2.2.zip",
+    "path": "/package/ti_misp/1.2.2",
+    "icons": [
+      {
+        "src": "/img/misp.svg",
+        "path": "/package/ti_misp/1.2.2/img/misp.svg",
+        "title": "MISP",
+        "size": "216x216",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "ti_misp",
+        "title": "MISP",
+        "description": "Collect threat intelligence from the MISP API."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/ti_misp/ti_misp-1.2.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_misp.threat",
+        "title": "MISP"
+      }
+    ]
+  },
+  {
+    "name": "ti_otx",
+    "title": "AlienVault OTX",
+    "version": "1.2.2",
+    "release": "ga",
+    "description": "Collect threat intelligence from AlienVault OTX with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/ti_otx/ti_otx-1.2.2.zip",
+    "path": "/package/ti_otx/1.2.2",
+    "icons": [
+      {
+        "src": "/img/otx.svg",
+        "path": "/package/ti_otx/1.2.2/img/otx.svg",
+        "title": "Alienvault OTX",
+        "size": "216x216",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "ti_otx",
+        "title": "Alienvault OTX",
+        "description": "Collect threat intelligence from the Alienvault OTX"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/ti_otx/ti_otx-1.2.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_otx.threat",
+        "title": "Alienvault OTX logs"
+      }
+    ]
+  },
+  {
+    "name": "ti_recordedfuture",
+    "title": "Recorded Future",
+    "version": "0.1.2",
+    "release": "beta",
+    "description": "Collect threat intelligence from Recorded Future with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/ti_recordedfuture/ti_recordedfuture-0.1.2.zip",
+    "path": "/package/ti_recordedfuture/0.1.2",
+    "icons": [
+      {
+        "src": "/img/logo.svg",
+        "path": "/package/ti_recordedfuture/0.1.2/img/logo.svg",
+        "title": "Recorded Future",
+        "size": "216x216",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "ti_recordedfuture",
+        "title": "Recorded Future",
+        "description": "Collect threat intelligence from Recorded Future."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/ti_recordedfuture/ti_recordedfuture-0.1.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_recordedfuture.threat",
+        "title": "Recorded Future"
+      }
+    ]
+  },
+  {
     "name": "ti_threatq",
     "title": "ThreatQuotient",
     "version": "1.2.2",
@@ -8336,6 +8360,52 @@
         "type": "logs",
         "dataset": "ti_threatq.threat",
         "title": "ThreatQ"
+      }
+    ]
+  },
+  {
+    "name": "tomcat",
+    "title": "Apache Tomcat",
+    "version": "1.3.1",
+    "release": "ga",
+    "description": "Collect and parse logs from Apache Tomcat servers with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/tomcat/tomcat-1.3.1.zip",
+    "path": "/package/tomcat/1.3.1",
+    "icons": [
+      {
+        "src": "/img/logo.svg",
+        "path": "/package/tomcat/1.3.1/img/logo.svg",
+        "title": "Apache Tomcat logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "log",
+        "title": "Apache Tomcat",
+        "description": "Collect Apache Tomcat logs from syslog or a file."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.1 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "web",
+      "security"
+    ],
+    "signature_path": "/epr/tomcat/tomcat-1.3.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "tomcat.log",
+        "title": "Apache Tomcat logs"
       }
     ]
   },
@@ -8391,112 +8461,45 @@
     ]
   },
   {
-    "name": "carbon_black_cloud",
-    "title": "VMware Carbon Black Cloud",
-    "version": "1.0.2",
+    "name": "udp",
+    "title": "Custom UDP Logs",
+    "version": "1.0.1",
     "release": "ga",
-    "description": "Collect logs from VMWare Carbon Black Cloud with Elastic Agent.",
+    "description": "Collect raw UDP data from listening UDP port with Elastic Agent.",
     "type": "integration",
-    "download": "/epr/carbon_black_cloud/carbon_black_cloud-1.0.2.zip",
-    "path": "/package/carbon_black_cloud/1.0.2",
+    "download": "/epr/udp/udp-1.0.1.zip",
+    "path": "/package/udp/1.0.1",
     "icons": [
       {
-        "src": "/img/carbon_black_cloud-logo.svg",
-        "path": "/package/carbon_black_cloud/1.0.2/img/carbon_black_cloud-logo.svg",
-        "title": "Carbon Black Cloud logo",
-        "size": "32x32",
+        "src": "/img/icon.svg",
+        "path": "/package/udp/1.0.1/img/icon.svg",
         "type": "image/svg+xml"
       }
     ],
     "policy_templates": [
       {
-        "name": "carbon_black_cloud",
-        "title": "Carbon Black Cloud",
-        "description": "Collect Logs from Carbon Black Cloud"
+        "name": "udp",
+        "title": "Custom UDP Logs",
+        "description": "Collect raw UDP data from listening UDP port with Elastic Agent."
       }
     ],
     "conditions": {
       "kibana": {
-        "version": "^7.17.0 || ^8.0.0"
+        "version": "^7.16.0 || ^8.0.0"
       }
     },
     "owner": {
       "github": "elastic/security-external-integrations"
     },
     "categories": [
-      "security"
+      "custom"
     ],
-    "signature_path": "/epr/carbon_black_cloud/carbon_black_cloud-1.0.2.zip.sig",
+    "signature_path": "/epr/udp/udp-1.0.1.zip.sig",
     "data_streams": [
       {
         "type": "logs",
-        "dataset": "carbon_black_cloud.alert",
-        "title": "Alert"
-      },
-      {
-        "type": "logs",
-        "dataset": "carbon_black_cloud.asset_vulnerability_summary",
-        "title": "Asset Vulnerability Summary"
-      },
-      {
-        "type": "logs",
-        "dataset": "carbon_black_cloud.audit",
-        "title": "Audit"
-      },
-      {
-        "type": "logs",
-        "dataset": "carbon_black_cloud.endpoint_event",
-        "title": "Endpoint Event"
-      },
-      {
-        "type": "logs",
-        "dataset": "carbon_black_cloud.watchlist_hit",
-        "title": "Watchlist Hit"
-      }
-    ]
-  },
-  {
-    "name": "carbonblack_edr",
-    "title": "VMware Carbon Black EDR",
-    "version": "1.2.0",
-    "release": "ga",
-    "description": "Collect logs from VMware Carbon Black EDR with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/carbonblack_edr/carbonblack_edr-1.2.0.zip",
-    "path": "/package/carbonblack_edr/1.2.0",
-    "icons": [
-      {
-        "src": "/img/carbon-black-logo.svg",
-        "path": "/package/carbonblack_edr/1.2.0/img/carbon-black-logo.svg",
-        "title": "VMWare Carbon Black",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "log",
-        "title": "Carbon Black EDR logs",
-        "description": "Collect logs from Carbon Black EDR"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/carbonblack_edr/carbonblack_edr-1.2.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "carbonblack_edr.log",
-        "title": "Carbon Black EDR logs"
+        "dataset": "udp.generic",
+        "title": "Custom UDP Logs"
       }
     ]
   },
@@ -8629,6 +8632,49 @@
         "type": "logs",
         "dataset": "windows.sysmon_operational",
         "title": "Windows Sysmon/Operational events"
+      }
+    ]
+  },
+  {
+    "name": "winlog",
+    "title": "Custom Windows Event Logs",
+    "version": "1.4.0",
+    "release": "ga",
+    "description": "Collect and parse logs from any Windows event log channel with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/winlog/winlog-1.4.0.zip",
+    "path": "/package/winlog/1.4.0",
+    "icons": [
+      {
+        "src": "/img/logo_windows.svg",
+        "path": "/package/winlog/1.4.0/img/logo_windows.svg",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "winlogs",
+        "title": "Custom Windows event logs",
+        "description": "Collect your custom Windows event logs."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "signature_path": "/epr/winlog/winlog-1.4.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "winlog.winlog",
+        "title": "Custom Windows Event Log Dataset"
       }
     ]
   },
@@ -9018,6 +9064,52 @@
     ]
   },
   {
+    "name": "zscaler",
+    "title": "Zscaler NSS Logs",
+    "version": "0.5.1",
+    "release": "experimental",
+    "description": "Deprecated. Use the Zscaler ZIA integration instead.",
+    "type": "integration",
+    "download": "/epr/zscaler/zscaler-0.5.1.zip",
+    "path": "/package/zscaler/0.5.1",
+    "icons": [
+      {
+        "src": "/img/logo.svg",
+        "path": "/package/zscaler/0.5.1/img/logo.svg",
+        "title": "Zscaler NSS logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "zia",
+        "title": "Zscaler NSS",
+        "description": "Collect Zscaler NSS logs from syslog or a file."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.1"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "network",
+      "security"
+    ],
+    "signature_path": "/epr/zscaler/zscaler-0.5.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "zscaler.zia",
+        "title": "Zscaler NSS logs"
+      }
+    ]
+  },
+  {
     "name": "zscaler_zia",
     "title": "Zscaler Internet Access",
     "version": "0.1.3",
@@ -9083,52 +9175,6 @@
     ]
   },
   {
-    "name": "zscaler",
-    "title": "Zscaler NSS Logs",
-    "version": "0.5.1",
-    "release": "experimental",
-    "description": "Deprecated. Use the Zscaler ZIA integration instead.",
-    "type": "integration",
-    "download": "/epr/zscaler/zscaler-0.5.1.zip",
-    "path": "/package/zscaler/0.5.1",
-    "icons": [
-      {
-        "src": "/img/logo.svg",
-        "path": "/package/zscaler/0.5.1/img/logo.svg",
-        "title": "Zscaler NSS logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "zia",
-        "title": "Zscaler NSS",
-        "description": "Collect Zscaler NSS logs from syslog or a file."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.1"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "network",
-      "security"
-    ],
-    "signature_path": "/epr/zscaler/zscaler-0.5.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "zscaler.zia",
-        "title": "Zscaler NSS logs"
-      }
-    ]
-  },
-  {
     "name": "zscaler_zpa",
     "title": "Zscaler Private Access",
     "version": "0.1.2",
@@ -9190,52 +9236,6 @@
         "type": "logs",
         "dataset": "zscaler_zpa.user_status",
         "title": "User Status Logs"
-      }
-    ]
-  },
-  {
-    "name": "pfsense",
-    "title": "pfSense Logs",
-    "version": "0.3.1",
-    "release": "experimental",
-    "description": "Collect and parse logs from pfSense devices with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/pfsense/pfsense-0.3.1.zip",
-    "path": "/package/pfsense/0.3.1",
-    "icons": [
-      {
-        "src": "/img/pfsense.svg",
-        "path": "/package/pfsense/0.3.1/img/pfsense.svg",
-        "title": "pfsense",
-        "size": "512x143",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "pfsense",
-        "title": "pfSense logs",
-        "description": "Collect logs from pfSense systems"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.15.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "network",
-      "security"
-    ],
-    "signature_path": "/epr/pfsense/pfsense-0.3.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "pfsense.log",
-        "title": "pfSense log logs"
       }
     ]
   }

--- a/testdata/generated/storage-indexer/search-spec-max-2.10.0.json
+++ b/testdata/generated/storage-indexer/search-spec-max-2.10.0.json
@@ -54,6 +54,539 @@
     ]
   },
   {
+    "name": "activemq",
+    "title": "ActiveMQ",
+    "version": "0.3.0",
+    "release": "beta",
+    "description": "Collect logs and metrics from ActiveMQ instances with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/activemq/activemq-0.3.0.zip",
+    "path": "/package/activemq/0.3.0",
+    "icons": [
+      {
+        "src": "/img/activemq.svg",
+        "path": "/package/activemq/0.3.0/img/activemq.svg",
+        "title": "activemq",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "activemq",
+        "title": "ActiveMQ logs and metrics",
+        "description": "Collect logs and metrics from ActiveMQ instances"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "web"
+    ],
+    "signature_path": "/epr/activemq/activemq-0.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "activemq.audit",
+        "title": "ActiveMQ audit logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "activemq.broker",
+        "title": "ActiveMQ broker metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "activemq.log",
+        "title": "ActiveMQ log logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "activemq.queue",
+        "title": "ActiveMQ queue metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "activemq.topic",
+        "title": "ActiveMQ topic metrics"
+      }
+    ]
+  },
+  {
+    "name": "akamai",
+    "title": "Akamai",
+    "version": "1.0.0",
+    "release": "ga",
+    "description": "Akamai Integration",
+    "type": "integration",
+    "download": "/epr/akamai/akamai-1.0.0.zip",
+    "path": "/package/akamai/1.0.0",
+    "icons": [
+      {
+        "src": "/img/akamai_logo.svg",
+        "path": "/package/akamai/1.0.0/img/akamai_logo.svg",
+        "title": "Akamai",
+        "size": "409×167",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "akamai",
+        "title": "Akamai logs",
+        "description": "Collect SIEM logs from Akamai"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security",
+      "network",
+      "web",
+      "cloud"
+    ],
+    "signature_path": "/epr/akamai/akamai-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "akamai.siem",
+        "title": "Akamai SIEM Logs"
+      }
+    ]
+  },
+  {
+    "name": "apache",
+    "title": "Apache HTTP Server",
+    "version": "1.3.5",
+    "release": "ga",
+    "description": "Collect logs and metrics from Apache servers with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/apache/apache-1.3.5.zip",
+    "path": "/package/apache/1.3.5",
+    "icons": [
+      {
+        "src": "/img/logo_apache.svg",
+        "path": "/package/apache/1.3.5/img/logo_apache.svg",
+        "title": "Apache Logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "apache",
+        "title": "Apache logs and metrics",
+        "description": "Collect logs and metrics from Apache instances"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "web"
+    ],
+    "signature_path": "/epr/apache/apache-1.3.5.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "apache.access",
+        "title": "Apache access logs",
+        "deprecated": {
+          "since": "1.3.5",
+          "description": "This data stream is deprecated"
+        }
+      },
+      {
+        "type": "logs",
+        "dataset": "apache.error",
+        "title": "Apache error logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apache.status",
+        "title": "Apache status metrics"
+      }
+    ],
+    "deprecated": {
+      "since": "1.3.0",
+      "description": "This package is deprecated"
+    }
+  },
+  {
+    "name": "apm",
+    "title": "Elastic APM",
+    "version": "8.2.0",
+    "release": "ga",
+    "description": "Ingest APM data",
+    "type": "integration",
+    "download": "/epr/apm/apm-8.2.0.zip",
+    "path": "/package/apm/8.2.0",
+    "icons": [
+      {
+        "src": "/img/logo_apm.svg",
+        "path": "/package/apm/8.2.0/img/logo_apm.svg",
+        "title": "APM Logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "apmserver",
+        "title": "Elastic APM Integration",
+        "description": "Elastic APM Integration"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.2.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/apm-server"
+    },
+    "categories": [
+      "elastic_stack",
+      "monitoring"
+    ],
+    "signature_path": "/epr/apm/apm-8.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "apm.app",
+        "title": "APM application logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.app",
+        "title": "APM application metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "apm.error",
+        "title": "APM errors"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.internal",
+        "title": "APM internal metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.profiling",
+        "title": "APM profiles"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm.rum",
+        "title": "APM RUM traces"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm.sampled",
+        "title": "APM tail-sampled traces"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm",
+        "title": "APM traces"
+      }
+    ]
+  },
+  {
+    "name": "atlassian_bitbucket",
+    "title": "Atlassian Bitbucket",
+    "version": "1.2.1",
+    "release": "ga",
+    "description": "Collect logs from Atlassian Bitbucket with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.2.1.zip",
+    "path": "/package/atlassian_bitbucket/1.2.1",
+    "icons": [
+      {
+        "src": "/img/bitbucket-logo.svg",
+        "path": "/package/atlassian_bitbucket/1.2.1/img/bitbucket-logo.svg",
+        "title": "Bitbucket Logo",
+        "size": "625x564",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "audit",
+        "title": "Audit Logs",
+        "description": "Collect audit logs from Atlassian Bitbucket with Elastic Agent."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security",
+      "web"
+    ],
+    "signature_path": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_bitbucket.audit",
+        "title": "Bitbucket Audit Logs"
+      }
+    ]
+  },
+  {
+    "name": "atlassian_confluence",
+    "title": "Atlassian Confluence",
+    "version": "1.3.0",
+    "release": "ga",
+    "description": "Collect logs from Atlassian Confluence with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/atlassian_confluence/atlassian_confluence-1.3.0.zip",
+    "path": "/package/atlassian_confluence/1.3.0",
+    "icons": [
+      {
+        "src": "/img/confluence-logo.svg",
+        "path": "/package/atlassian_confluence/1.3.0/img/confluence-logo.svg",
+        "title": "Confluence Logo",
+        "size": "400x400",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "audit",
+        "title": "Audit Logs",
+        "description": "Collect audit logs from Atlassian Confluence with Elastic Agent."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security",
+      "web"
+    ],
+    "signature_path": "/epr/atlassian_confluence/atlassian_confluence-1.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_confluence.audit",
+        "title": "Confluence Audit Logs"
+      }
+    ]
+  },
+  {
+    "name": "atlassian_jira",
+    "title": "Atlassian Jira",
+    "version": "1.3.0",
+    "release": "ga",
+    "description": "Collect logs from Atlassian Jira with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/atlassian_jira/atlassian_jira-1.3.0.zip",
+    "path": "/package/atlassian_jira/1.3.0",
+    "icons": [
+      {
+        "src": "/img/jira-software-logo.svg",
+        "path": "/package/atlassian_jira/1.3.0/img/jira-software-logo.svg",
+        "title": "Jira Software Logo",
+        "size": "590x625",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "audit",
+        "title": "Audit Logs",
+        "description": "Collect audit logs from Atlassian Jira with Elastic Agent."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security",
+      "web"
+    ],
+    "signature_path": "/epr/atlassian_jira/atlassian_jira-1.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_jira.audit",
+        "title": "Jira Audit Logs"
+      }
+    ]
+  },
+  {
+    "name": "auditd",
+    "title": "Auditd Logs",
+    "version": "3.1.0",
+    "release": "ga",
+    "description": "Collect logs from Linux audit daemon with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/auditd/auditd-3.1.0.zip",
+    "path": "/package/auditd/3.1.0",
+    "icons": [
+      {
+        "src": "/img/linux.svg",
+        "path": "/package/auditd/3.1.0/img/linux.svg",
+        "title": "linux",
+        "size": "299x354",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "auditd",
+        "title": "Auditd logs",
+        "description": "Collect logs from Auditd instances"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "os_system"
+    ],
+    "signature_path": "/epr/auditd/auditd-3.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "auditd.log",
+        "title": "Auditd logs"
+      }
+    ]
+  },
+  {
+    "name": "auditd_manager",
+    "title": "Auditd Manager",
+    "version": "1.0.0",
+    "release": "ga",
+    "description": "The Auditd Manager Integration receives audit events from the Linux Audit Framework that is a part of the Linux kernel.",
+    "type": "integration",
+    "download": "/epr/auditd_manager/auditd_manager-1.0.0.zip",
+    "path": "/package/auditd_manager/1.0.0",
+    "icons": [
+      {
+        "src": "/img/linux.svg",
+        "path": "/package/auditd_manager/1.0.0/img/linux.svg",
+        "title": "linux",
+        "size": "299x354",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "auditd",
+        "title": "Auditd",
+        "description": "Collect auditd events"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.2.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "os_system",
+      "security"
+    ],
+    "signature_path": "/epr/auditd_manager/auditd_manager-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "auditd_manager.auditd",
+        "title": "Auditd Manager"
+      }
+    ]
+  },
+  {
+    "name": "auth0",
+    "title": "Auth0 Log Streams Integration",
+    "version": "1.0.0",
+    "release": "ga",
+    "description": "Collect logs from Auth0 with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/auth0/auth0-1.0.0.zip",
+    "path": "/package/auth0/1.0.0",
+    "icons": [
+      {
+        "src": "/img/auth0-logo.svg",
+        "path": "/package/auth0/1.0.0/img/auth0-logo.svg",
+        "title": "Auth0 logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "auth0_events",
+        "title": "Auth0 log stream events via Webhooks",
+        "description": "Collect Auth0 log streams events via Webhooks."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "cloud",
+      "network",
+      "security"
+    ],
+    "signature_path": "/epr/auth0/auth0-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "auth0.logs",
+        "title": "Auth0 logs via Webhooks"
+      }
+    ]
+  },
+  {
     "name": "aws",
     "title": "AWS",
     "version": "1.16.4",
@@ -649,6 +1182,51 @@
     ]
   },
   {
+    "name": "aws_logs",
+    "title": "Custom AWS Logs",
+    "version": "0.2.1",
+    "release": "beta",
+    "description": "Collect raw logs from AWS S3 or CloudWatch with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/aws_logs/aws_logs-0.2.1.zip",
+    "path": "/package/aws_logs/0.2.1",
+    "icons": [
+      {
+        "src": "/img/icon.svg",
+        "path": "/package/aws_logs/0.2.1/img/icon.svg",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "aws_logs",
+        "title": "Custom AWS Logs",
+        "description": "Collect raw logs from AWS S3 or CloudWatch with Elastic Agent."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/obs-cloud-monitoring"
+    },
+    "categories": [
+      "custom",
+      "cloud",
+      "aws"
+    ],
+    "signature_path": "/epr/aws_logs/aws_logs-0.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "aws_logs.generic",
+        "title": "Custom logs from AWS"
+      }
+    ]
+  },
+  {
     "name": "awsfargate",
     "title": "AWS Fargate",
     "version": "0.1.1",
@@ -692,836 +1270,6 @@
         "type": "metrics",
         "dataset": "awsfargate.task_stats",
         "title": "AWS Fargate task_stats metrics"
-      }
-    ]
-  },
-  {
-    "name": "ti_abusech",
-    "title": "AbuseCH",
-    "version": "1.2.3",
-    "release": "ga",
-    "description": "Collect threat intelligence from AbuseCH API with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/ti_abusech/ti_abusech-1.2.3.zip",
-    "path": "/package/ti_abusech/1.2.3",
-    "icons": [
-      {
-        "src": "/img/abusech2.svg",
-        "path": "/package/ti_abusech/1.2.3/img/abusech2.svg",
-        "title": "AbuseCH",
-        "size": "512x512",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "ti_abusech",
-        "title": "AbuseCH API",
-        "description": "Collect threat intelligence from the AbuseCH API"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/ti_abusech/ti_abusech-1.2.3.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ti_abusech.malware",
-        "title": "AbuseCH Malware logs"
-      },
-      {
-        "type": "logs",
-        "dataset": "ti_abusech.malwarebazaar",
-        "title": "AbuseCH MalwareBazaar logs"
-      },
-      {
-        "type": "logs",
-        "dataset": "ti_abusech.url",
-        "title": "AbuseCH URL logs"
-      }
-    ]
-  },
-  {
-    "name": "activemq",
-    "title": "ActiveMQ",
-    "version": "0.3.0",
-    "release": "beta",
-    "description": "Collect logs and metrics from ActiveMQ instances with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/activemq/activemq-0.3.0.zip",
-    "path": "/package/activemq/0.3.0",
-    "icons": [
-      {
-        "src": "/img/activemq.svg",
-        "path": "/package/activemq/0.3.0/img/activemq.svg",
-        "title": "activemq",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "activemq",
-        "title": "ActiveMQ logs and metrics",
-        "description": "Collect logs and metrics from ActiveMQ instances"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "web"
-    ],
-    "signature_path": "/epr/activemq/activemq-0.3.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "activemq.audit",
-        "title": "ActiveMQ audit logs"
-      },
-      {
-        "type": "metrics",
-        "dataset": "activemq.broker",
-        "title": "ActiveMQ broker metrics"
-      },
-      {
-        "type": "logs",
-        "dataset": "activemq.log",
-        "title": "ActiveMQ log logs"
-      },
-      {
-        "type": "metrics",
-        "dataset": "activemq.queue",
-        "title": "ActiveMQ queue metrics"
-      },
-      {
-        "type": "metrics",
-        "dataset": "activemq.topic",
-        "title": "ActiveMQ topic metrics"
-      }
-    ]
-  },
-  {
-    "name": "akamai",
-    "title": "Akamai",
-    "version": "1.0.0",
-    "release": "ga",
-    "description": "Akamai Integration",
-    "type": "integration",
-    "download": "/epr/akamai/akamai-1.0.0.zip",
-    "path": "/package/akamai/1.0.0",
-    "icons": [
-      {
-        "src": "/img/akamai_logo.svg",
-        "path": "/package/akamai/1.0.0/img/akamai_logo.svg",
-        "title": "Akamai",
-        "size": "409×167",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "akamai",
-        "title": "Akamai logs",
-        "description": "Collect SIEM logs from Akamai"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security",
-      "network",
-      "web",
-      "cloud"
-    ],
-    "signature_path": "/epr/akamai/akamai-1.0.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "akamai.siem",
-        "title": "Akamai SIEM Logs"
-      }
-    ]
-  },
-  {
-    "name": "ti_otx",
-    "title": "AlienVault OTX",
-    "version": "1.2.2",
-    "release": "ga",
-    "description": "Collect threat intelligence from AlienVault OTX with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/ti_otx/ti_otx-1.2.2.zip",
-    "path": "/package/ti_otx/1.2.2",
-    "icons": [
-      {
-        "src": "/img/otx.svg",
-        "path": "/package/ti_otx/1.2.2/img/otx.svg",
-        "title": "Alienvault OTX",
-        "size": "216x216",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "ti_otx",
-        "title": "Alienvault OTX",
-        "description": "Collect threat intelligence from the Alienvault OTX"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/ti_otx/ti_otx-1.2.2.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ti_otx.threat",
-        "title": "Alienvault OTX logs"
-      }
-    ]
-  },
-  {
-    "name": "ti_anomali",
-    "title": "Anomali",
-    "version": "1.2.3",
-    "release": "ga",
-    "description": "Collect threat intelligence from Anomali APIs with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/ti_anomali/ti_anomali-1.2.3.zip",
-    "path": "/package/ti_anomali/1.2.3",
-    "icons": [
-      {
-        "src": "/img/anomali.svg",
-        "path": "/package/ti_anomali/1.2.3/img/anomali.svg",
-        "title": "Anomali",
-        "size": "216x216",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "ti_anomali",
-        "title": "Anomali",
-        "description": "Collect threat intelligence from the Anomali Limo API and Anomali Threatstream."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/ti_anomali/ti_anomali-1.2.3.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ti_anomali.limo",
-        "title": "Anomali Limo"
-      },
-      {
-        "type": "logs",
-        "dataset": "ti_anomali.threatstream",
-        "title": "Anomali Threatstream"
-      }
-    ]
-  },
-  {
-    "name": "apache",
-    "title": "Apache HTTP Server",
-    "version": "1.3.5",
-    "release": "ga",
-    "description": "Collect logs and metrics from Apache servers with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/apache/apache-1.3.5.zip",
-    "path": "/package/apache/1.3.5",
-    "icons": [
-      {
-        "src": "/img/logo_apache.svg",
-        "path": "/package/apache/1.3.5/img/logo_apache.svg",
-        "title": "Apache Logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "apache",
-        "title": "Apache logs and metrics",
-        "description": "Collect logs and metrics from Apache instances"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "web"
-    ],
-    "signature_path": "/epr/apache/apache-1.3.5.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "apache.access",
-        "title": "Apache access logs",
-        "deprecated": {
-          "since": "1.3.5",
-          "description": "This data stream is deprecated"
-        }
-      },
-      {
-        "type": "logs",
-        "dataset": "apache.error",
-        "title": "Apache error logs"
-      },
-      {
-        "type": "metrics",
-        "dataset": "apache.status",
-        "title": "Apache status metrics"
-      }
-    ],
-    "deprecated": {
-      "since": "1.3.0",
-      "description": "This package is deprecated"
-    }
-  },
-  {
-    "name": "tomcat",
-    "title": "Apache Tomcat",
-    "version": "1.3.1",
-    "release": "ga",
-    "description": "Collect and parse logs from Apache Tomcat servers with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/tomcat/tomcat-1.3.1.zip",
-    "path": "/package/tomcat/1.3.1",
-    "icons": [
-      {
-        "src": "/img/logo.svg",
-        "path": "/package/tomcat/1.3.1/img/logo.svg",
-        "title": "Apache Tomcat logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "log",
-        "title": "Apache Tomcat",
-        "description": "Collect Apache Tomcat logs from syslog or a file."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.1 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "web",
-      "security"
-    ],
-    "signature_path": "/epr/tomcat/tomcat-1.3.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "tomcat.log",
-        "title": "Apache Tomcat logs"
-      }
-    ]
-  },
-  {
-    "name": "netscout",
-    "title": "Arbor Peakflow SP Logs",
-    "version": "0.7.0",
-    "release": "experimental",
-    "description": "Collect and parse logs from Netscout Arbor Peakflow SP with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/netscout/netscout-0.7.0.zip",
-    "path": "/package/netscout/0.7.0",
-    "icons": [
-      {
-        "src": "/img/logo.svg",
-        "path": "/package/netscout/0.7.0/img/logo.svg",
-        "title": "Arbor Peakflow SP logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "sightline",
-        "title": "Arbor Peakflow SP",
-        "description": "Collect Arbor Peakflow SP logs from syslog or a file."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.1 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/netscout/netscout-0.7.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "netscout.sightline",
-        "title": "Arbor Peakflow SP logs"
-      }
-    ]
-  },
-  {
-    "name": "atlassian_bitbucket",
-    "title": "Atlassian Bitbucket",
-    "version": "1.2.1",
-    "release": "ga",
-    "description": "Collect logs from Atlassian Bitbucket with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.2.1.zip",
-    "path": "/package/atlassian_bitbucket/1.2.1",
-    "icons": [
-      {
-        "src": "/img/bitbucket-logo.svg",
-        "path": "/package/atlassian_bitbucket/1.2.1/img/bitbucket-logo.svg",
-        "title": "Bitbucket Logo",
-        "size": "625x564",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "audit",
-        "title": "Audit Logs",
-        "description": "Collect audit logs from Atlassian Bitbucket with Elastic Agent."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security",
-      "web"
-    ],
-    "signature_path": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.2.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "atlassian_bitbucket.audit",
-        "title": "Bitbucket Audit Logs"
-      }
-    ]
-  },
-  {
-    "name": "atlassian_confluence",
-    "title": "Atlassian Confluence",
-    "version": "1.3.0",
-    "release": "ga",
-    "description": "Collect logs from Atlassian Confluence with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/atlassian_confluence/atlassian_confluence-1.3.0.zip",
-    "path": "/package/atlassian_confluence/1.3.0",
-    "icons": [
-      {
-        "src": "/img/confluence-logo.svg",
-        "path": "/package/atlassian_confluence/1.3.0/img/confluence-logo.svg",
-        "title": "Confluence Logo",
-        "size": "400x400",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "audit",
-        "title": "Audit Logs",
-        "description": "Collect audit logs from Atlassian Confluence with Elastic Agent."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security",
-      "web"
-    ],
-    "signature_path": "/epr/atlassian_confluence/atlassian_confluence-1.3.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "atlassian_confluence.audit",
-        "title": "Confluence Audit Logs"
-      }
-    ]
-  },
-  {
-    "name": "atlassian_jira",
-    "title": "Atlassian Jira",
-    "version": "1.3.0",
-    "release": "ga",
-    "description": "Collect logs from Atlassian Jira with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/atlassian_jira/atlassian_jira-1.3.0.zip",
-    "path": "/package/atlassian_jira/1.3.0",
-    "icons": [
-      {
-        "src": "/img/jira-software-logo.svg",
-        "path": "/package/atlassian_jira/1.3.0/img/jira-software-logo.svg",
-        "title": "Jira Software Logo",
-        "size": "590x625",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "audit",
-        "title": "Audit Logs",
-        "description": "Collect audit logs from Atlassian Jira with Elastic Agent."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security",
-      "web"
-    ],
-    "signature_path": "/epr/atlassian_jira/atlassian_jira-1.3.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "atlassian_jira.audit",
-        "title": "Jira Audit Logs"
-      }
-    ]
-  },
-  {
-    "name": "auditd",
-    "title": "Auditd Logs",
-    "version": "3.1.0",
-    "release": "ga",
-    "description": "Collect logs from Linux audit daemon with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/auditd/auditd-3.1.0.zip",
-    "path": "/package/auditd/3.1.0",
-    "icons": [
-      {
-        "src": "/img/linux.svg",
-        "path": "/package/auditd/3.1.0/img/linux.svg",
-        "title": "linux",
-        "size": "299x354",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "auditd",
-        "title": "Auditd logs",
-        "description": "Collect logs from Auditd instances"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "os_system"
-    ],
-    "signature_path": "/epr/auditd/auditd-3.1.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "auditd.log",
-        "title": "Auditd logs"
-      }
-    ]
-  },
-  {
-    "name": "auditd_manager",
-    "title": "Auditd Manager",
-    "version": "1.0.0",
-    "release": "ga",
-    "description": "The Auditd Manager Integration receives audit events from the Linux Audit Framework that is a part of the Linux kernel.",
-    "type": "integration",
-    "download": "/epr/auditd_manager/auditd_manager-1.0.0.zip",
-    "path": "/package/auditd_manager/1.0.0",
-    "icons": [
-      {
-        "src": "/img/linux.svg",
-        "path": "/package/auditd_manager/1.0.0/img/linux.svg",
-        "title": "linux",
-        "size": "299x354",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "auditd",
-        "title": "Auditd",
-        "description": "Collect auditd events"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.2.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "os_system",
-      "security"
-    ],
-    "signature_path": "/epr/auditd_manager/auditd_manager-1.0.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "auditd_manager.auditd",
-        "title": "Auditd Manager"
-      }
-    ]
-  },
-  {
-    "name": "auth0",
-    "title": "Auth0 Log Streams Integration",
-    "version": "1.0.0",
-    "release": "ga",
-    "description": "Collect logs from Auth0 with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/auth0/auth0-1.0.0.zip",
-    "path": "/package/auth0/1.0.0",
-    "icons": [
-      {
-        "src": "/img/auth0-logo.svg",
-        "path": "/package/auth0/1.0.0/img/auth0-logo.svg",
-        "title": "Auth0 logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "auth0_events",
-        "title": "Auth0 log stream events via Webhooks",
-        "description": "Collect Auth0 log streams events via Webhooks."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "cloud",
-      "network",
-      "security"
-    ],
-    "signature_path": "/epr/auth0/auth0-1.0.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "auth0.logs",
-        "title": "Auth0 logs via Webhooks"
-      }
-    ]
-  },
-  {
-    "name": "azure_application_insights",
-    "title": "Azure Application Insights Metrics Overview",
-    "version": "1.0.1",
-    "release": "ga",
-    "description": "Collect application insights metrics from Azure Monitor with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/azure_application_insights/azure_application_insights-1.0.1.zip",
-    "path": "/package/azure_application_insights/1.0.1",
-    "icons": [
-      {
-        "src": "/img/app_insights.png",
-        "path": "/package/azure_application_insights/1.0.1/img/app_insights.png",
-        "title": "logo docker",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "app_insights",
-        "title": "Azure Application Insights Metrics",
-        "description": "Collect application insights metrics from Azure Monitor with Elastic Agent.",
-        "icons": [
-          {
-            "src": "/img//app_insights.png",
-            "path": "/package/azure_application_insights/1.0.1/img/app_insights.png",
-            "title": "logo azure",
-            "size": "32x32",
-            "type": "image/svg+xml"
-          }
-        ],
-        "data_streams": [
-          "app_insights"
-        ]
-      },
-      {
-        "name": "app_state",
-        "title": "Azure Application State Insights Metrics",
-        "description": "Collect application state related metrics from Azure Monitor with Elastic Agent.",
-        "icons": [
-          {
-            "src": "/img/application_insights_blue.png",
-            "path": "/package/azure_application_insights/1.0.1/img/application_insights_blue.png",
-            "title": "logo azure",
-            "size": "32x32",
-            "type": "image/svg+xml"
-          }
-        ],
-        "data_streams": [
-          "app_state"
-        ]
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "azure",
-      "web"
-    ],
-    "signature_path": "/epr/azure_application_insights/azure_application_insights-1.0.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "metrics",
-        "dataset": "azure.app_insights",
-        "title": "Azure Application Insights"
-      },
-      {
-        "type": "metrics",
-        "dataset": "azure.app_state",
-        "title": "Azure Application State"
-      }
-    ]
-  },
-  {
-    "name": "azure_billing",
-    "title": "Azure Billing Metrics",
-    "version": "1.0.1",
-    "release": "ga",
-    "description": "Collect billing metrics with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/azure_billing/azure_billing-1.0.1.zip",
-    "path": "/package/azure_billing/1.0.1",
-    "icons": [
-      {
-        "src": "/img/billing.png",
-        "path": "/package/azure_billing/1.0.1/img/billing.png",
-        "title": "logo docker",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "billing",
-        "title": "Azure Billing Metrics",
-        "description": "Collect billing information with Elastic Agent.",
-        "icons": [
-          {
-            "src": "/img//billing.png",
-            "path": "/package/azure_billing/1.0.1/img/billing.png",
-            "title": "logo azure",
-            "size": "32x32",
-            "type": "image/svg+xml"
-          }
-        ],
-        "data_streams": [
-          "billing"
-        ]
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.15.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "azure"
-    ],
-    "signature_path": "/epr/azure_billing/azure_billing-1.0.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "metrics",
-        "dataset": "azure.billing",
-        "title": "Azure Billing Metrics"
       }
     ]
   },
@@ -1676,6 +1424,143 @@
         "type": "logs",
         "dataset": "azure.springcloudlogs",
         "title": "Azure Spring Cloud Logs"
+      }
+    ]
+  },
+  {
+    "name": "azure_application_insights",
+    "title": "Azure Application Insights Metrics Overview",
+    "version": "1.0.1",
+    "release": "ga",
+    "description": "Collect application insights metrics from Azure Monitor with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/azure_application_insights/azure_application_insights-1.0.1.zip",
+    "path": "/package/azure_application_insights/1.0.1",
+    "icons": [
+      {
+        "src": "/img/app_insights.png",
+        "path": "/package/azure_application_insights/1.0.1/img/app_insights.png",
+        "title": "logo docker",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "app_insights",
+        "title": "Azure Application Insights Metrics",
+        "description": "Collect application insights metrics from Azure Monitor with Elastic Agent.",
+        "icons": [
+          {
+            "src": "/img//app_insights.png",
+            "path": "/package/azure_application_insights/1.0.1/img/app_insights.png",
+            "title": "logo azure",
+            "size": "32x32",
+            "type": "image/svg+xml"
+          }
+        ],
+        "data_streams": [
+          "app_insights"
+        ]
+      },
+      {
+        "name": "app_state",
+        "title": "Azure Application State Insights Metrics",
+        "description": "Collect application state related metrics from Azure Monitor with Elastic Agent.",
+        "icons": [
+          {
+            "src": "/img/application_insights_blue.png",
+            "path": "/package/azure_application_insights/1.0.1/img/application_insights_blue.png",
+            "title": "logo azure",
+            "size": "32x32",
+            "type": "image/svg+xml"
+          }
+        ],
+        "data_streams": [
+          "app_state"
+        ]
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "azure",
+      "web"
+    ],
+    "signature_path": "/epr/azure_application_insights/azure_application_insights-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "azure.app_insights",
+        "title": "Azure Application Insights"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.app_state",
+        "title": "Azure Application State"
+      }
+    ]
+  },
+  {
+    "name": "azure_billing",
+    "title": "Azure Billing Metrics",
+    "version": "1.0.1",
+    "release": "ga",
+    "description": "Collect billing metrics with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/azure_billing/azure_billing-1.0.1.zip",
+    "path": "/package/azure_billing/1.0.1",
+    "icons": [
+      {
+        "src": "/img/billing.png",
+        "path": "/package/azure_billing/1.0.1/img/billing.png",
+        "title": "logo docker",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "billing",
+        "title": "Azure Billing Metrics",
+        "description": "Collect billing information with Elastic Agent.",
+        "icons": [
+          {
+            "src": "/img//billing.png",
+            "path": "/package/azure_billing/1.0.1/img/billing.png",
+            "title": "logo azure",
+            "size": "32x32",
+            "type": "image/svg+xml"
+          }
+        ],
+        "data_streams": [
+          "billing"
+        ]
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.15.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "azure"
+    ],
+    "signature_path": "/epr/azure_billing/azure_billing-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "azure.billing",
+        "title": "Azure Billing Metrics"
       }
     ]
   },
@@ -1980,85 +1865,112 @@
     ]
   },
   {
-    "name": "cef",
-    "title": "CEF Logs",
-    "version": "2.0.0",
+    "name": "carbon_black_cloud",
+    "title": "VMware Carbon Black Cloud",
+    "version": "1.0.2",
     "release": "ga",
-    "description": "Collect logs from CEF Logs with Elastic Agent.",
+    "description": "Collect logs from VMWare Carbon Black Cloud with Elastic Agent.",
     "type": "integration",
-    "download": "/epr/cef/cef-2.0.0.zip",
-    "path": "/package/cef/2.0.0",
-    "policy_templates": [
-      {
-        "name": "cef",
-        "title": "CEF logs",
-        "description": "Collect logs from CEF instances"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "network",
-      "security"
-    ],
-    "signature_path": "/epr/cef/cef-2.0.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "cef.log",
-        "title": "CEF log logs"
-      }
-    ]
-  },
-  {
-    "name": "cloud_security_posture",
-    "title": "CIS Kubernetes Benchmark",
-    "version": "0.0.14",
-    "release": "experimental",
-    "description": "Check Kubernetes cluster compliance with the Kubernetes CIS benchmark.",
-    "type": "integration",
-    "download": "/epr/cloud_security_posture/cloud_security_posture-0.0.14.zip",
-    "path": "/package/cloud_security_posture/0.0.14",
+    "download": "/epr/carbon_black_cloud/carbon_black_cloud-1.0.2.zip",
+    "path": "/package/carbon_black_cloud/1.0.2",
     "icons": [
       {
-        "src": "/img/cis-kubernetes-benchmark-logo.svg",
-        "path": "/package/cloud_security_posture/0.0.14/img/cis-kubernetes-benchmark-logo.svg",
-        "title": "CIS Kubernetes Benchmark logo",
+        "src": "/img/carbon_black_cloud-logo.svg",
+        "path": "/package/carbon_black_cloud/1.0.2/img/carbon_black_cloud-logo.svg",
+        "title": "Carbon Black Cloud logo",
         "size": "32x32",
         "type": "image/svg+xml"
       }
     ],
     "policy_templates": [
       {
-        "name": "kspm",
-        "title": "CIS Kubernetes Benchmark",
-        "description": "Check Kubernetes cluster compliance with the Kubernetes CIS benchmark."
+        "name": "carbon_black_cloud",
+        "title": "Carbon Black Cloud",
+        "description": "Collect Logs from Carbon Black Cloud"
       }
     ],
     "conditions": {
       "kibana": {
-        "version": "^8.3.0"
+        "version": "^7.17.0 || ^8.0.0"
       }
     },
     "owner": {
-      "github": "elastic/cloud-security-posture"
+      "github": "elastic/security-external-integrations"
     },
     "categories": [
-      "containers",
-      "kubernetes"
+      "security"
     ],
-    "signature_path": "/epr/cloud_security_posture/cloud_security_posture-0.0.14.zip.sig",
+    "signature_path": "/epr/carbon_black_cloud/carbon_black_cloud-1.0.2.zip.sig",
     "data_streams": [
       {
         "type": "logs",
-        "dataset": "cloud_security_posture.findings",
-        "title": "Findings"
+        "dataset": "carbon_black_cloud.alert",
+        "title": "Alert"
+      },
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.asset_vulnerability_summary",
+        "title": "Asset Vulnerability Summary"
+      },
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.audit",
+        "title": "Audit"
+      },
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.endpoint_event",
+        "title": "Endpoint Event"
+      },
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.watchlist_hit",
+        "title": "Watchlist Hit"
+      }
+    ]
+  },
+  {
+    "name": "carbonblack_edr",
+    "title": "VMware Carbon Black EDR",
+    "version": "1.2.0",
+    "release": "ga",
+    "description": "Collect logs from VMware Carbon Black EDR with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/carbonblack_edr/carbonblack_edr-1.2.0.zip",
+    "path": "/package/carbonblack_edr/1.2.0",
+    "icons": [
+      {
+        "src": "/img/carbon-black-logo.svg",
+        "path": "/package/carbonblack_edr/1.2.0/img/carbon-black-logo.svg",
+        "title": "VMWare Carbon Black",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "log",
+        "title": "Carbon Black EDR logs",
+        "description": "Collect logs from Carbon Black EDR"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/carbonblack_edr/carbonblack_edr-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "carbonblack_edr.log",
+        "title": "Carbon Black EDR logs"
       }
     ]
   },
@@ -2110,6 +2022,43 @@
         "type": "metrics",
         "dataset": "cassandra.metrics",
         "title": "metrics"
+      }
+    ]
+  },
+  {
+    "name": "cef",
+    "title": "CEF Logs",
+    "version": "2.0.0",
+    "release": "ga",
+    "description": "Collect logs from CEF Logs with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/cef/cef-2.0.0.zip",
+    "path": "/package/cef/2.0.0",
+    "policy_templates": [
+      {
+        "name": "cef",
+        "title": "CEF logs",
+        "description": "Collect logs from CEF instances"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "network",
+      "security"
+    ],
+    "signature_path": "/epr/cef/cef-2.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cef.log",
+        "title": "CEF log logs"
       }
     ]
   },
@@ -2707,6 +2656,52 @@
     ]
   },
   {
+    "name": "cloud_security_posture",
+    "title": "CIS Kubernetes Benchmark",
+    "version": "0.0.14",
+    "release": "experimental",
+    "description": "Check Kubernetes cluster compliance with the Kubernetes CIS benchmark.",
+    "type": "integration",
+    "download": "/epr/cloud_security_posture/cloud_security_posture-0.0.14.zip",
+    "path": "/package/cloud_security_posture/0.0.14",
+    "icons": [
+      {
+        "src": "/img/cis-kubernetes-benchmark-logo.svg",
+        "path": "/package/cloud_security_posture/0.0.14/img/cis-kubernetes-benchmark-logo.svg",
+        "title": "CIS Kubernetes Benchmark logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "kspm",
+        "title": "CIS Kubernetes Benchmark",
+        "description": "Check Kubernetes cluster compliance with the Kubernetes CIS benchmark."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.3.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/cloud-security-posture"
+    },
+    "categories": [
+      "containers",
+      "kubernetes"
+    ],
+    "signature_path": "/epr/cloud_security_posture/cloud_security_posture-0.0.14.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cloud_security_posture.findings",
+        "title": "Findings"
+      }
+    ]
+  },
+  {
     "name": "cloudflare",
     "title": "Cloudflare",
     "version": "2.0.0",
@@ -2867,389 +2862,6 @@
     ]
   },
   {
-    "name": "aws_logs",
-    "title": "Custom AWS Logs",
-    "version": "0.2.1",
-    "release": "beta",
-    "description": "Collect raw logs from AWS S3 or CloudWatch with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/aws_logs/aws_logs-0.2.1.zip",
-    "path": "/package/aws_logs/0.2.1",
-    "icons": [
-      {
-        "src": "/img/icon.svg",
-        "path": "/package/aws_logs/0.2.1/img/icon.svg",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "aws_logs",
-        "title": "Custom AWS Logs",
-        "description": "Collect raw logs from AWS S3 or CloudWatch with Elastic Agent."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/obs-cloud-monitoring"
-    },
-    "categories": [
-      "custom",
-      "cloud",
-      "aws"
-    ],
-    "signature_path": "/epr/aws_logs/aws_logs-0.2.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "aws_logs.generic",
-        "title": "Custom logs from AWS"
-      }
-    ]
-  },
-  {
-    "name": "gcp_pubsub",
-    "title": "Custom Google Pub/Sub Logs",
-    "version": "1.0.0",
-    "release": "ga",
-    "description": "Collect Logs from Google Pub/Sub topics",
-    "type": "integration",
-    "download": "/epr/gcp_pubsub/gcp_pubsub-1.0.0.zip",
-    "path": "/package/gcp_pubsub/1.0.0",
-    "icons": [
-      {
-        "src": "/img/logo_gcp.svg",
-        "path": "/package/gcp_pubsub/1.0.0/img/logo_gcp.svg",
-        "title": "logo gcp",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "gcp",
-        "title": "Custom Google Pub/Sub Logs",
-        "description": "Collect Logs from Google Pub/Sub topics"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "google_cloud",
-      "cloud",
-      "custom"
-    ],
-    "signature_path": "/epr/gcp_pubsub/gcp_pubsub-1.0.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "gcp_pubsub.generic",
-        "title": "Custom Google Pub/Sub Logs"
-      }
-    ]
-  },
-  {
-    "name": "http_endpoint",
-    "title": "Custom HTTP Endpoint Logs",
-    "version": "1.0.1",
-    "release": "ga",
-    "description": "Collect JSON data from listening HTTP port with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/http_endpoint/http_endpoint-1.0.1.zip",
-    "path": "/package/http_endpoint/1.0.1",
-    "icons": [
-      {
-        "src": "/img/icon.svg",
-        "path": "/package/http_endpoint/1.0.1/img/icon.svg",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "http_endpoint",
-        "title": "Custom HTTP Endpoint Logs",
-        "description": "Collect JSON data from listening HTTP port with Elastic Agent."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "signature_path": "/epr/http_endpoint/http_endpoint-1.0.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "http_endpoint.generic",
-        "title": "Custom HTTP Endpoint Logs"
-      }
-    ]
-  },
-  {
-    "name": "httpjson",
-    "title": "Custom HTTPJSON Input",
-    "version": "1.1.1",
-    "release": "ga",
-    "description": "Collect custom data from REST API's with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/httpjson/httpjson-1.1.1.zip",
-    "path": "/package/httpjson/1.1.1",
-    "policy_templates": [
-      {
-        "name": "generic",
-        "title": "Custom HTTPJSON Input",
-        "description": "Collect custom data from REST API's"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "signature_path": "/epr/httpjson/httpjson-1.1.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "httpjson.generic",
-        "title": "Custom HTTPJSON Input"
-      }
-    ]
-  },
-  {
-    "name": "journald",
-    "title": "Custom Journald logs",
-    "version": "0.0.2",
-    "release": "experimental",
-    "description": "Collect logs from journald with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/journald/journald-0.0.2.zip",
-    "path": "/package/journald/0.0.2",
-    "icons": [
-      {
-        "src": "/img/systemd-logo.svg",
-        "path": "/package/journald/0.0.2/img/systemd-logo.svg",
-        "title": "systemd logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "logs",
-        "title": "Journald",
-        "description": "Collect sample logs"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "signature_path": "/epr/journald/journald-0.0.2.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "journald.log",
-        "title": "Journald Log"
-      }
-    ]
-  },
-  {
-    "name": "log",
-    "title": "Custom Logs",
-    "version": "1.0.0",
-    "release": "ga",
-    "description": "Collect custom logs with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/log/log-1.0.0.zip",
-    "path": "/package/log/1.0.0",
-    "icons": [
-      {
-        "src": "/img/icon.svg",
-        "path": "/package/log/1.0.0/img/icon.svg",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "logs",
-        "title": "Custom logs",
-        "description": "Collect your custom log files."
-      }
-    ],
-    "owner": {
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "signature_path": "/epr/log/log-1.0.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "log.log",
-        "title": "Log Dataset"
-      }
-    ]
-  },
-  {
-    "name": "tcp",
-    "title": "Custom TCP Logs",
-    "version": "1.0.0",
-    "release": "ga",
-    "description": "Collect raw TCP data from listening TCP port with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/tcp/tcp-1.0.0.zip",
-    "path": "/package/tcp/1.0.0",
-    "icons": [
-      {
-        "src": "/img/icon.svg",
-        "path": "/package/tcp/1.0.0/img/icon.svg",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "tcp",
-        "title": "Custom TCP Logs",
-        "description": "Collect raw TCP data from listening TCP port with Elastic Agent."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "signature_path": "/epr/tcp/tcp-1.0.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "tcp.generic",
-        "title": "Custom TCP Logs"
-      }
-    ]
-  },
-  {
-    "name": "udp",
-    "title": "Custom UDP Logs",
-    "version": "1.0.1",
-    "release": "ga",
-    "description": "Collect raw UDP data from listening UDP port with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/udp/udp-1.0.1.zip",
-    "path": "/package/udp/1.0.1",
-    "icons": [
-      {
-        "src": "/img/icon.svg",
-        "path": "/package/udp/1.0.1/img/icon.svg",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "udp",
-        "title": "Custom UDP Logs",
-        "description": "Collect raw UDP data from listening UDP port with Elastic Agent."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "signature_path": "/epr/udp/udp-1.0.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "udp.generic",
-        "title": "Custom UDP Logs"
-      }
-    ]
-  },
-  {
-    "name": "winlog",
-    "title": "Custom Windows Event Logs",
-    "version": "1.4.0",
-    "release": "ga",
-    "description": "Collect and parse logs from any Windows event log channel with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/winlog/winlog-1.4.0.zip",
-    "path": "/package/winlog/1.4.0",
-    "icons": [
-      {
-        "src": "/img/logo_windows.svg",
-        "path": "/package/winlog/1.4.0/img/logo_windows.svg",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "winlogs",
-        "title": "Custom Windows event logs",
-        "description": "Collect your custom Windows event logs."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "signature_path": "/epr/winlog/winlog-1.4.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "winlog.winlog",
-        "title": "Custom Windows Event Log Dataset"
-      }
-    ]
-  },
-  {
     "name": "cyberark",
     "title": "CyberArk",
     "version": "0.4.4",
@@ -3336,52 +2948,6 @@
         "type": "logs",
         "dataset": "cyberarkpas.audit",
         "title": "CyberArk PAS audit logs"
-      }
-    ]
-  },
-  {
-    "name": "ti_cybersixgill",
-    "title": "Cybersixgill",
-    "version": "1.3.2",
-    "release": "ga",
-    "description": "This Elastic integration collects threat intelligence from Cybersixgill",
-    "type": "integration",
-    "download": "/epr/ti_cybersixgill/ti_cybersixgill-1.3.2.zip",
-    "path": "/package/ti_cybersixgill/1.3.2",
-    "icons": [
-      {
-        "src": "/img/cybersixgill.svg",
-        "path": "/package/ti_cybersixgill/1.3.2/img/cybersixgill.svg",
-        "title": "Cybersixgill",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "cybersixgill",
-        "title": "Cybersixgill Threat Intel",
-        "description": "Collect Threat Intel from Cybersixgill"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security",
-      "productivity"
-    ],
-    "signature_path": "/epr/ti_cybersixgill/ti_cybersixgill-1.3.2.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ti_cybersixgill.threat",
-        "title": "Cybersixgill Darkfeed Logs"
       }
     ]
   },
@@ -3548,87 +3114,6 @@
     ]
   },
   {
-    "name": "apm",
-    "title": "Elastic APM",
-    "version": "8.2.0",
-    "release": "ga",
-    "description": "Ingest APM data",
-    "type": "integration",
-    "download": "/epr/apm/apm-8.2.0.zip",
-    "path": "/package/apm/8.2.0",
-    "icons": [
-      {
-        "src": "/img/logo_apm.svg",
-        "path": "/package/apm/8.2.0/img/logo_apm.svg",
-        "title": "APM Logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "apmserver",
-        "title": "Elastic APM Integration",
-        "description": "Elastic APM Integration"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.2.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/apm-server"
-    },
-    "categories": [
-      "elastic_stack",
-      "monitoring"
-    ],
-    "signature_path": "/epr/apm/apm-8.2.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "apm.app",
-        "title": "APM application logs"
-      },
-      {
-        "type": "metrics",
-        "dataset": "apm.app",
-        "title": "APM application metrics"
-      },
-      {
-        "type": "logs",
-        "dataset": "apm.error",
-        "title": "APM errors"
-      },
-      {
-        "type": "metrics",
-        "dataset": "apm.internal",
-        "title": "APM internal metrics"
-      },
-      {
-        "type": "metrics",
-        "dataset": "apm.profiling",
-        "title": "APM profiles"
-      },
-      {
-        "type": "traces",
-        "dataset": "apm.rum",
-        "title": "APM RUM traces"
-      },
-      {
-        "type": "traces",
-        "dataset": "apm.sampled",
-        "title": "APM tail-sampled traces"
-      },
-      {
-        "type": "traces",
-        "dataset": "apm",
-        "title": "APM traces"
-      }
-    ]
-  },
-  {
     "name": "elastic_agent",
     "title": "Elastic Agent",
     "version": "1.3.1",
@@ -3758,77 +3243,6 @@
         "type": "metrics",
         "dataset": "elastic_agent.packetbeat",
         "title": "Elastic Agent"
-      }
-    ]
-  },
-  {
-    "name": "synthetics",
-    "title": "Elastic Synthetics",
-    "version": "0.9.2",
-    "release": "beta",
-    "description": "Monitor the availability of your services with Elastic Synthetics.",
-    "type": "integration",
-    "download": "/epr/synthetics/synthetics-0.9.2.zip",
-    "path": "/package/synthetics/0.9.2",
-    "icons": [
-      {
-        "src": "/img/uptime-logo-color-64px.svg",
-        "path": "/package/synthetics/0.9.2/img/uptime-logo-color-64px.svg",
-        "size": "16x16",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "synthetics",
-        "title": "Elastic Synthetics",
-        "description": "Perform synthetic health checks on network endpoints."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.1.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/uptime"
-    },
-    "categories": [
-      "elastic_stack",
-      "monitoring",
-      "web"
-    ],
-    "signature_path": "/epr/synthetics/synthetics-0.9.2.zip.sig",
-    "data_streams": [
-      {
-        "type": "synthetics",
-        "dataset": "browser",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "browser.network",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "browser.screenshot",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "http",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "icmp",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "tcp",
-        "title": "synthetic monitor check"
       }
     ]
   },
@@ -4302,51 +3716,6 @@
     ]
   },
   {
-    "name": "github",
-    "title": "GitHub",
-    "version": "1.0.0",
-    "release": "ga",
-    "description": "Collect events from GitHub with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/github/github-1.0.0.zip",
-    "path": "/package/github/1.0.0",
-    "icons": [
-      {
-        "src": "/img/github.svg",
-        "path": "/package/github/1.0.0/img/github.svg",
-        "title": "GitHub",
-        "size": "1024x1024",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "github",
-        "title": "GitHub logs",
-        "description": "Collect logs from GitHub"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/github/github-1.0.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "github.audit",
-        "title": "GitHub Audit Logs"
-      }
-    ]
-  },
-  {
     "name": "gcp",
     "title": "Google Cloud Platform",
     "version": "1.9.0",
@@ -4410,47 +3779,94 @@
     ]
   },
   {
-    "name": "santa",
-    "title": "Google Santa Logs",
-    "version": "2.0.1",
+    "name": "gcp_pubsub",
+    "title": "Custom Google Pub/Sub Logs",
+    "version": "1.0.0",
     "release": "ga",
-    "description": "Collect and parse logs from Google Santa instances with Elastic Agent.",
+    "description": "Collect Logs from Google Pub/Sub topics",
     "type": "integration",
-    "download": "/epr/santa/santa-2.0.1.zip",
-    "path": "/package/santa/2.0.1",
+    "download": "/epr/gcp_pubsub/gcp_pubsub-1.0.0.zip",
+    "path": "/package/gcp_pubsub/1.0.0",
     "icons": [
       {
-        "src": "/img/icon.svg",
-        "path": "/package/santa/2.0.1/img/icon.svg",
-        "title": "Google Santa",
+        "src": "/img/logo_gcp.svg",
+        "path": "/package/gcp_pubsub/1.0.0/img/logo_gcp.svg",
+        "title": "logo gcp",
+        "size": "32x32",
         "type": "image/svg+xml"
       }
     ],
     "policy_templates": [
       {
-        "name": "santa",
-        "title": "Google Santa logs",
-        "description": "Collect logs from Google Santa instances"
+        "name": "gcp",
+        "title": "Custom Google Pub/Sub Logs",
+        "description": "Collect Logs from Google Pub/Sub topics"
       }
     ],
     "conditions": {
       "kibana": {
-        "version": "^7.17.0 || ^8.0.0"
+        "version": "^7.16.0 || ^8.0.0"
       }
     },
     "owner": {
       "github": "elastic/security-external-integrations"
     },
     "categories": [
-      "security",
-      "os_system"
+      "google_cloud",
+      "cloud",
+      "custom"
     ],
-    "signature_path": "/epr/santa/santa-2.0.1.zip.sig",
+    "signature_path": "/epr/gcp_pubsub/gcp_pubsub-1.0.0.zip.sig",
     "data_streams": [
       {
         "type": "logs",
-        "dataset": "santa.log",
-        "title": "Google Santa log logs"
+        "dataset": "gcp_pubsub.generic",
+        "title": "Custom Google Pub/Sub Logs"
+      }
+    ]
+  },
+  {
+    "name": "github",
+    "title": "GitHub",
+    "version": "1.0.0",
+    "release": "ga",
+    "description": "Collect events from GitHub with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/github/github-1.0.0.zip",
+    "path": "/package/github/1.0.0",
+    "icons": [
+      {
+        "src": "/img/github.svg",
+        "path": "/package/github/1.0.0/img/github.svg",
+        "title": "GitHub",
+        "size": "1024x1024",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "github",
+        "title": "GitHub logs",
+        "description": "Collect logs from GitHub"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/github/github-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "github.audit",
+        "title": "GitHub Audit Logs"
       }
     ]
   },
@@ -4686,6 +4102,85 @@
     ]
   },
   {
+    "name": "http_endpoint",
+    "title": "Custom HTTP Endpoint Logs",
+    "version": "1.0.1",
+    "release": "ga",
+    "description": "Collect JSON data from listening HTTP port with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/http_endpoint/http_endpoint-1.0.1.zip",
+    "path": "/package/http_endpoint/1.0.1",
+    "icons": [
+      {
+        "src": "/img/icon.svg",
+        "path": "/package/http_endpoint/1.0.1/img/icon.svg",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "http_endpoint",
+        "title": "Custom HTTP Endpoint Logs",
+        "description": "Collect JSON data from listening HTTP port with Elastic Agent."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "signature_path": "/epr/http_endpoint/http_endpoint-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "http_endpoint.generic",
+        "title": "Custom HTTP Endpoint Logs"
+      }
+    ]
+  },
+  {
+    "name": "httpjson",
+    "title": "Custom HTTPJSON Input",
+    "version": "1.1.1",
+    "release": "ga",
+    "description": "Collect custom data from REST API's with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/httpjson/httpjson-1.1.1.zip",
+    "path": "/package/httpjson/1.1.1",
+    "policy_templates": [
+      {
+        "name": "generic",
+        "title": "Custom HTTPJSON Input",
+        "description": "Collect custom data from REST API's"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "signature_path": "/epr/httpjson/httpjson-1.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "httpjson.generic",
+        "title": "Custom HTTPJSON Input"
+      }
+    ]
+  },
+  {
     "name": "iis",
     "title": "IIS",
     "version": "0.8.0",
@@ -4879,48 +4374,47 @@
     ]
   },
   {
-    "name": "juniper_junos",
-    "title": "Juniper JunOS",
-    "version": "0.1.1",
+    "name": "journald",
+    "title": "Custom Journald logs",
+    "version": "0.0.2",
     "release": "experimental",
-    "description": "Collect logs from Juniper JunOS with Elastic Agent.",
+    "description": "Collect logs from journald with Elastic Agent.",
     "type": "integration",
-    "download": "/epr/juniper_junos/juniper_junos-0.1.1.zip",
-    "path": "/package/juniper_junos/0.1.1",
+    "download": "/epr/journald/journald-0.0.2.zip",
+    "path": "/package/journald/0.0.2",
     "icons": [
       {
-        "src": "/img/logo.svg",
-        "path": "/package/juniper_junos/0.1.1/img/logo.svg",
-        "title": "Juniper logo",
+        "src": "/img/systemd-logo.svg",
+        "path": "/package/journald/0.0.2/img/systemd-logo.svg",
+        "title": "systemd logo",
         "size": "32x32",
         "type": "image/svg+xml"
       }
     ],
     "policy_templates": [
       {
-        "name": "juniper",
-        "title": "Juniper JunOS logs",
-        "description": "Collect Juniper JunOS logs from syslog or a file."
+        "name": "logs",
+        "title": "Journald",
+        "description": "Collect sample logs"
       }
     ],
     "conditions": {
       "kibana": {
-        "version": "^8.0.0"
+        "version": "^7.16.0"
       }
     },
     "owner": {
-      "github": "elastic/security-external-integrations"
+      "github": "elastic/integrations"
     },
     "categories": [
-      "network",
-      "security"
+      "custom"
     ],
-    "signature_path": "/epr/juniper_junos/juniper_junos-0.1.1.zip.sig",
+    "signature_path": "/epr/journald/journald-0.0.2.zip.sig",
     "data_streams": [
       {
         "type": "logs",
-        "dataset": "juniper_junos.log",
-        "title": "Juniper JUNOS logs"
+        "dataset": "journald.log",
+        "title": "Journald Log"
       }
     ]
   },
@@ -4977,6 +4471,52 @@
         "type": "logs",
         "dataset": "juniper.srx",
         "title": "Juniper SRX logs"
+      }
+    ]
+  },
+  {
+    "name": "juniper_junos",
+    "title": "Juniper JunOS",
+    "version": "0.1.1",
+    "release": "experimental",
+    "description": "Collect logs from Juniper JunOS with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/juniper_junos/juniper_junos-0.1.1.zip",
+    "path": "/package/juniper_junos/0.1.1",
+    "icons": [
+      {
+        "src": "/img/logo.svg",
+        "path": "/package/juniper_junos/0.1.1/img/logo.svg",
+        "title": "Juniper logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "juniper",
+        "title": "Juniper JunOS logs",
+        "description": "Collect Juniper JunOS logs from syslog or a file."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "network",
+      "security"
+    ],
+    "signature_path": "/epr/juniper_junos/juniper_junos-0.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "juniper_junos.log",
+        "title": "Juniper JUNOS logs"
       }
     ]
   },
@@ -5662,6 +5202,44 @@
     ]
   },
   {
+    "name": "log",
+    "title": "Custom Logs",
+    "version": "1.0.0",
+    "release": "ga",
+    "description": "Collect custom logs with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/log/log-1.0.0.zip",
+    "path": "/package/log/1.0.0",
+    "icons": [
+      {
+        "src": "/img/icon.svg",
+        "path": "/package/log/1.0.0/img/icon.svg",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "logs",
+        "title": "Custom logs",
+        "description": "Collect your custom log files."
+      }
+    ],
+    "owner": {
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "signature_path": "/epr/log/log-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "log.log",
+        "title": "Log Dataset"
+      }
+    ]
+  },
+  {
     "name": "logstash",
     "title": "Logstash",
     "version": "1.1.0",
@@ -5722,37 +5300,6 @@
     ]
   },
   {
-    "name": "problemchild",
-    "title": "LotL Attack Detection",
-    "version": "0.0.2",
-    "release": "experimental",
-    "description": "The ProblemChild framework is used to detect living off the land activity. Requires a Platinum subscription.",
-    "type": "integration",
-    "download": "/epr/problemchild/problemchild-0.0.2.zip",
-    "path": "/package/problemchild/0.0.2",
-    "icons": [
-      {
-        "src": "/img/icon-machine-learning.svg",
-        "path": "/package/problemchild/0.0.2/img/icon-machine-learning.svg",
-        "title": "Sample logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/ml-ui"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/problemchild/problemchild-0.0.2.zip.sig"
-  },
-  {
     "name": "m365_defender",
     "title": "M365 Defender Logs",
     "version": "1.0.3",
@@ -5796,51 +5343,6 @@
         "type": "logs",
         "dataset": "m365_defender.log",
         "title": "M365 Defender Logs"
-      }
-    ]
-  },
-  {
-    "name": "ti_misp",
-    "title": "MISP",
-    "version": "1.2.2",
-    "release": "ga",
-    "description": "This Elastic integration collects events from MISP",
-    "type": "integration",
-    "download": "/epr/ti_misp/ti_misp-1.2.2.zip",
-    "path": "/package/ti_misp/1.2.2",
-    "icons": [
-      {
-        "src": "/img/misp.svg",
-        "path": "/package/ti_misp/1.2.2/img/misp.svg",
-        "title": "MISP",
-        "size": "216x216",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "ti_misp",
-        "title": "MISP",
-        "description": "Collect threat intelligence from the MISP API."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/ti_misp/ti_misp-1.2.2.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ti_misp.threat",
-        "title": "MISP"
       }
     ]
   },
@@ -5943,51 +5445,6 @@
     ]
   },
   {
-    "name": "microsoft_dhcp",
-    "title": "Microsoft DHCP",
-    "version": "1.3.1",
-    "release": "ga",
-    "description": "Collect logs from Microsoft DHCP with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/microsoft_dhcp/microsoft_dhcp-1.3.1.zip",
-    "path": "/package/microsoft_dhcp/1.3.1",
-    "icons": [
-      {
-        "src": "/img/logo.svg",
-        "path": "/package/microsoft_dhcp/1.3.1/img/logo.svg",
-        "title": "Microsoft logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "microsoft_dhcp",
-        "title": "Microsoft DHCP",
-        "description": "Collect Microsoft DHCP logs."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "network"
-    ],
-    "signature_path": "/epr/microsoft_dhcp/microsoft_dhcp-1.3.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "microsoft_dhcp.log",
-        "title": "Microsoft DHCP Logs"
-      }
-    ]
-  },
-  {
     "name": "microsoft_defender_endpoint",
     "title": "Microsoft Defender for Endpoint",
     "version": "2.1.0",
@@ -6031,6 +5488,51 @@
         "type": "logs",
         "dataset": "microsoft_defender_endpoint.log",
         "title": "Microsoft Defender for Endpoint logs"
+      }
+    ]
+  },
+  {
+    "name": "microsoft_dhcp",
+    "title": "Microsoft DHCP",
+    "version": "1.3.1",
+    "release": "ga",
+    "description": "Collect logs from Microsoft DHCP with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/microsoft_dhcp/microsoft_dhcp-1.3.1.zip",
+    "path": "/package/microsoft_dhcp/1.3.1",
+    "icons": [
+      {
+        "src": "/img/logo.svg",
+        "path": "/package/microsoft_dhcp/1.3.1/img/logo.svg",
+        "title": "Microsoft logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "microsoft_dhcp",
+        "title": "Microsoft DHCP",
+        "description": "Collect Microsoft DHCP logs."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "network"
+    ],
+    "signature_path": "/epr/microsoft_dhcp/microsoft_dhcp-1.3.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "microsoft_dhcp.log",
+        "title": "Microsoft DHCP Logs"
       }
     ]
   },
@@ -6416,6 +5918,51 @@
         "type": "logs",
         "dataset": "netflow.log",
         "title": "NetFlow logs"
+      }
+    ]
+  },
+  {
+    "name": "netscout",
+    "title": "Arbor Peakflow SP Logs",
+    "version": "0.7.0",
+    "release": "experimental",
+    "description": "Collect and parse logs from Netscout Arbor Peakflow SP with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/netscout/netscout-0.7.0.zip",
+    "path": "/package/netscout/0.7.0",
+    "icons": [
+      {
+        "src": "/img/logo.svg",
+        "path": "/package/netscout/0.7.0/img/logo.svg",
+        "title": "Arbor Peakflow SP logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "sightline",
+        "title": "Arbor Peakflow SP",
+        "description": "Collect Arbor Peakflow SP logs from syslog or a file."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.1 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/netscout/netscout-0.7.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "netscout.sightline",
+        "title": "Arbor Peakflow SP logs"
       }
     ]
   },
@@ -6917,6 +6464,51 @@
     ]
   },
   {
+    "name": "panw",
+    "title": "Palo Alto Networks Logs",
+    "version": "1.5.3",
+    "release": "ga",
+    "description": "Collect PAN-OS firewall monitoring logs from Palo Alto Networks devices with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/panw/panw-1.5.3.zip",
+    "path": "/package/panw/1.5.3",
+    "icons": [
+      {
+        "src": "/img/logo-integrations-paloalto-networks.svg",
+        "path": "/package/panw/1.5.3/img/logo-integrations-paloalto-networks.svg",
+        "title": "Palo Alto Networks",
+        "size": "216x216",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "panw",
+        "title": "Palo Alto Networks PAN-OS firewall logs",
+        "description": "Collect logs from Palo Alto Networks PAN-OS firewall"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/panw/panw-1.5.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "panw.panos",
+        "title": "Palo Alto Networks PAN-OS firewall logs"
+      }
+    ]
+  },
+  {
     "name": "panw_cortex_xdr",
     "title": "Palo Alto Cortex XDR Logs",
     "version": "1.1.1",
@@ -6962,47 +6554,48 @@
     ]
   },
   {
-    "name": "panw",
-    "title": "Palo Alto Networks Logs",
-    "version": "1.5.3",
-    "release": "ga",
-    "description": "Collect PAN-OS firewall monitoring logs from Palo Alto Networks devices with Elastic Agent.",
+    "name": "pfsense",
+    "title": "pfSense Logs",
+    "version": "0.3.1",
+    "release": "experimental",
+    "description": "Collect and parse logs from pfSense devices with Elastic Agent.",
     "type": "integration",
-    "download": "/epr/panw/panw-1.5.3.zip",
-    "path": "/package/panw/1.5.3",
+    "download": "/epr/pfsense/pfsense-0.3.1.zip",
+    "path": "/package/pfsense/0.3.1",
     "icons": [
       {
-        "src": "/img/logo-integrations-paloalto-networks.svg",
-        "path": "/package/panw/1.5.3/img/logo-integrations-paloalto-networks.svg",
-        "title": "Palo Alto Networks",
-        "size": "216x216",
+        "src": "/img/pfsense.svg",
+        "path": "/package/pfsense/0.3.1/img/pfsense.svg",
+        "title": "pfsense",
+        "size": "512x143",
         "type": "image/svg+xml"
       }
     ],
     "policy_templates": [
       {
-        "name": "panw",
-        "title": "Palo Alto Networks PAN-OS firewall logs",
-        "description": "Collect logs from Palo Alto Networks PAN-OS firewall"
+        "name": "pfsense",
+        "title": "pfSense logs",
+        "description": "Collect logs from pfSense systems"
       }
     ],
     "conditions": {
       "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
+        "version": "^7.15.0 || ^8.0.0"
       }
     },
     "owner": {
       "github": "elastic/security-external-integrations"
     },
     "categories": [
+      "network",
       "security"
     ],
-    "signature_path": "/epr/panw/panw-1.5.3.zip.sig",
+    "signature_path": "/epr/pfsense/pfsense-0.3.1.zip.sig",
     "data_streams": [
       {
         "type": "logs",
-        "dataset": "panw.panos",
-        "title": "Palo Alto Networks PAN-OS firewall logs"
+        "dataset": "pfsense.log",
+        "title": "pfSense log logs"
       }
     ]
   },
@@ -7072,40 +6665,35 @@
     ]
   },
   {
-    "name": "security_detection_engine",
-    "title": "Prebuilt Security Detection Rules",
-    "version": "1.0.2",
-    "release": "ga",
-    "description": "Prebuilt detection rules for Elastic Security",
+    "name": "problemchild",
+    "title": "LotL Attack Detection",
+    "version": "0.0.2",
+    "release": "experimental",
+    "description": "The ProblemChild framework is used to detect living off the land activity. Requires a Platinum subscription.",
     "type": "integration",
-    "download": "/epr/security_detection_engine/security_detection_engine-1.0.2.zip",
-    "path": "/package/security_detection_engine/1.0.2",
+    "download": "/epr/problemchild/problemchild-0.0.2.zip",
+    "path": "/package/problemchild/0.0.2",
     "icons": [
       {
-        "src": "/img/security-logo-color-64px.svg",
-        "path": "/package/security_detection_engine/1.0.2/img/security-logo-color-64px.svg",
-        "size": "16x16",
+        "src": "/img/icon-machine-learning.svg",
+        "path": "/package/problemchild/0.0.2/img/icon-machine-learning.svg",
+        "title": "Sample logo",
+        "size": "32x32",
         "type": "image/svg+xml"
       }
     ],
     "conditions": {
       "kibana": {
         "version": "^8.0.0"
-      },
-      "elastic": {
-        "subscription": "basic",
-        "capabilities": [
-          "security"
-        ]
       }
     },
     "owner": {
-      "github": "elastic/protections"
+      "github": "elastic/ml-ui"
     },
     "categories": [
       "security"
     ],
-    "signature_path": "/epr/security_detection_engine/security_detection_engine-1.0.2.zip.sig"
+    "signature_path": "/epr/problemchild/problemchild-0.0.2.zip.sig"
   },
   {
     "name": "prometheus",
@@ -7410,51 +6998,6 @@
     ]
   },
   {
-    "name": "ti_recordedfuture",
-    "title": "Recorded Future",
-    "version": "0.1.2",
-    "release": "beta",
-    "description": "Collect threat intelligence from Recorded Future with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/ti_recordedfuture/ti_recordedfuture-0.1.2.zip",
-    "path": "/package/ti_recordedfuture/0.1.2",
-    "icons": [
-      {
-        "src": "/img/logo.svg",
-        "path": "/package/ti_recordedfuture/0.1.2/img/logo.svg",
-        "title": "Recorded Future",
-        "size": "216x216",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "ti_recordedfuture",
-        "title": "Recorded Future",
-        "description": "Collect threat intelligence from Recorded Future."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/ti_recordedfuture/ti_recordedfuture-0.1.2.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ti_recordedfuture.threat",
-        "title": "Recorded Future"
-      }
-    ]
-  },
-  {
     "name": "redis",
     "title": "Redis",
     "version": "1.2.0",
@@ -7521,114 +7064,85 @@
     ]
   },
   {
-    "name": "sql",
-    "title": "SQL Input",
-    "version": "0.5.0",
-    "release": "beta",
-    "description": "Collects Metrics by Quering on SQL Databases",
-    "type": "input",
-    "download": "/epr/sql/sql-0.5.0.zip",
-    "path": "/package/sql/0.5.0",
-    "icons": [
-      {
-        "src": "/img/sql-server-icon.svg",
-        "path": "/package/sql/0.5.0/img/sql-server-icon.svg",
-        "title": "SQL logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "sql",
-        "title": "SQL Metrics",
-        "description": "Collects Metrics by Quering on SQL Databases",
-        "deprecated": {
-          "since": "0.5.0",
-          "description": "This policy is deprecated"
-        }
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.13.0"
-      },
-      "elastic": {
-        "subscription": "basic"
-      }
-    },
-    "owner": {
-      "github": "elastic/obs-infraobs-integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "signature_path": "/epr/sql/sql-0.5.0.zip.sig",
-    "deprecated": {
-      "since": "0.5.0",
-      "description": "This package is deprecated"
-    }
-  },
-  {
-    "name": "stan",
-    "title": "STAN",
-    "version": "1.2.0",
+    "name": "santa",
+    "title": "Google Santa Logs",
+    "version": "2.0.1",
     "release": "ga",
-    "description": "Collect logs and metrics from STAN servers with Elastic Agent.",
+    "description": "Collect and parse logs from Google Santa instances with Elastic Agent.",
     "type": "integration",
-    "download": "/epr/stan/stan-1.2.0.zip",
-    "path": "/package/stan/1.2.0",
+    "download": "/epr/santa/santa-2.0.1.zip",
+    "path": "/package/santa/2.0.1",
     "icons": [
       {
-        "src": "/img/stan.svg",
-        "path": "/package/stan/1.2.0/img/stan.svg",
-        "title": "STAN Logo",
-        "size": "32x32",
+        "src": "/img/icon.svg",
+        "path": "/package/santa/2.0.1/img/icon.svg",
+        "title": "Google Santa",
         "type": "image/svg+xml"
       }
     ],
     "policy_templates": [
       {
-        "name": "stan",
-        "title": "STAN Logs and Metrics",
-        "description": "Collect logs and metrics from STAN instances"
+        "name": "santa",
+        "title": "Google Santa logs",
+        "description": "Collect logs from Google Santa instances"
       }
     ],
     "conditions": {
       "kibana": {
-        "version": "^7.14.0 || ^8.0.0"
+        "version": "^7.17.0 || ^8.0.0"
       }
     },
     "owner": {
-      "github": "elastic/integrations"
+      "github": "elastic/security-external-integrations"
     },
     "categories": [
-      "message_queue",
-      "kubernetes"
+      "security",
+      "os_system"
     ],
-    "signature_path": "/epr/stan/stan-1.2.0.zip.sig",
+    "signature_path": "/epr/santa/santa-2.0.1.zip.sig",
     "data_streams": [
       {
-        "type": "metrics",
-        "dataset": "stan.channels",
-        "title": "Stan channels metrics"
-      },
-      {
         "type": "logs",
-        "dataset": "stan.log",
-        "title": "STAN logs"
-      },
-      {
-        "type": "metrics",
-        "dataset": "stan.stats",
-        "title": "Stan stats metrics"
-      },
-      {
-        "type": "metrics",
-        "dataset": "stan.subscriptions",
-        "title": "Stan subscriptions metrics"
+        "dataset": "santa.log",
+        "title": "Google Santa log logs"
       }
     ]
+  },
+  {
+    "name": "security_detection_engine",
+    "title": "Prebuilt Security Detection Rules",
+    "version": "1.0.2",
+    "release": "ga",
+    "description": "Prebuilt detection rules for Elastic Security",
+    "type": "integration",
+    "download": "/epr/security_detection_engine/security_detection_engine-1.0.2.zip",
+    "path": "/package/security_detection_engine/1.0.2",
+    "icons": [
+      {
+        "src": "/img/security-logo-color-64px.svg",
+        "path": "/package/security_detection_engine/1.0.2/img/security-logo-color-64px.svg",
+        "size": "16x16",
+        "type": "image/svg+xml"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      },
+      "elastic": {
+        "subscription": "basic",
+        "capabilities": [
+          "security"
+        ]
+      }
+    },
+    "owner": {
+      "github": "elastic/protections"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/security_detection_engine/security_detection_engine-1.0.2.zip.sig"
   },
   {
     "name": "snort",
@@ -7823,6 +7337,55 @@
     ]
   },
   {
+    "name": "sql",
+    "title": "SQL Input",
+    "version": "0.5.0",
+    "release": "beta",
+    "description": "Collects Metrics by Quering on SQL Databases",
+    "type": "input",
+    "download": "/epr/sql/sql-0.5.0.zip",
+    "path": "/package/sql/0.5.0",
+    "icons": [
+      {
+        "src": "/img/sql-server-icon.svg",
+        "path": "/package/sql/0.5.0/img/sql-server-icon.svg",
+        "title": "SQL logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "sql",
+        "title": "SQL Metrics",
+        "description": "Collects Metrics by Quering on SQL Databases",
+        "deprecated": {
+          "since": "0.5.0",
+          "description": "This policy is deprecated"
+        }
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.13.0"
+      },
+      "elastic": {
+        "subscription": "basic"
+      }
+    },
+    "owner": {
+      "github": "elastic/obs-infraobs-integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "signature_path": "/epr/sql/sql-0.5.0.zip.sig",
+    "deprecated": {
+      "since": "0.5.0",
+      "description": "This package is deprecated"
+    }
+  },
+  {
     "name": "squid",
     "title": "Squid Logs",
     "version": "0.7.0",
@@ -7855,6 +7418,67 @@
         "type": "logs",
         "dataset": "squid.log",
         "title": "Squid logs"
+      }
+    ]
+  },
+  {
+    "name": "stan",
+    "title": "STAN",
+    "version": "1.2.0",
+    "release": "ga",
+    "description": "Collect logs and metrics from STAN servers with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/stan/stan-1.2.0.zip",
+    "path": "/package/stan/1.2.0",
+    "icons": [
+      {
+        "src": "/img/stan.svg",
+        "path": "/package/stan/1.2.0/img/stan.svg",
+        "title": "STAN Logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "stan",
+        "title": "STAN Logs and Metrics",
+        "description": "Collect logs and metrics from STAN instances"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "message_queue",
+      "kubernetes"
+    ],
+    "signature_path": "/epr/stan/stan-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "stan.channels",
+        "title": "Stan channels metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "stan.log",
+        "title": "STAN logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "stan.stats",
+        "title": "Stan stats metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "stan.subscriptions",
+        "title": "Stan subscriptions metrics"
       }
     ]
   },
@@ -7992,6 +7616,77 @@
     ]
   },
   {
+    "name": "synthetics",
+    "title": "Elastic Synthetics",
+    "version": "0.9.2",
+    "release": "beta",
+    "description": "Monitor the availability of your services with Elastic Synthetics.",
+    "type": "integration",
+    "download": "/epr/synthetics/synthetics-0.9.2.zip",
+    "path": "/package/synthetics/0.9.2",
+    "icons": [
+      {
+        "src": "/img/uptime-logo-color-64px.svg",
+        "path": "/package/synthetics/0.9.2/img/uptime-logo-color-64px.svg",
+        "size": "16x16",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "synthetics",
+        "title": "Elastic Synthetics",
+        "description": "Perform synthetic health checks on network endpoints."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.1.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/uptime"
+    },
+    "categories": [
+      "elastic_stack",
+      "monitoring",
+      "web"
+    ],
+    "signature_path": "/epr/synthetics/synthetics-0.9.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "synthetics",
+        "dataset": "browser",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "browser.network",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "browser.screenshot",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "http",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "icmp",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "tcp",
+        "title": "synthetic monitor check"
+      }
+    ]
+  },
+  {
     "name": "system",
     "title": "System",
     "version": "1.6.4",
@@ -8118,6 +7813,49 @@
     ]
   },
   {
+    "name": "tcp",
+    "title": "Custom TCP Logs",
+    "version": "1.0.0",
+    "release": "ga",
+    "description": "Collect raw TCP data from listening TCP port with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/tcp/tcp-1.0.0.zip",
+    "path": "/package/tcp/1.0.0",
+    "icons": [
+      {
+        "src": "/img/icon.svg",
+        "path": "/package/tcp/1.0.0/img/icon.svg",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "tcp",
+        "title": "Custom TCP Logs",
+        "description": "Collect raw TCP data from listening TCP port with Elastic Agent."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "signature_path": "/epr/tcp/tcp-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "tcp.generic",
+        "title": "Custom TCP Logs"
+      }
+    ]
+  },
+  {
     "name": "tenable_sc",
     "title": "Tenable.sc",
     "version": "1.1.1",
@@ -8173,6 +7911,292 @@
     ]
   },
   {
+    "name": "ti_abusech",
+    "title": "AbuseCH",
+    "version": "1.2.3",
+    "release": "ga",
+    "description": "Collect threat intelligence from AbuseCH API with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/ti_abusech/ti_abusech-1.2.3.zip",
+    "path": "/package/ti_abusech/1.2.3",
+    "icons": [
+      {
+        "src": "/img/abusech2.svg",
+        "path": "/package/ti_abusech/1.2.3/img/abusech2.svg",
+        "title": "AbuseCH",
+        "size": "512x512",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "ti_abusech",
+        "title": "AbuseCH API",
+        "description": "Collect threat intelligence from the AbuseCH API"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/ti_abusech/ti_abusech-1.2.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_abusech.malware",
+        "title": "AbuseCH Malware logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "ti_abusech.malwarebazaar",
+        "title": "AbuseCH MalwareBazaar logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "ti_abusech.url",
+        "title": "AbuseCH URL logs"
+      }
+    ]
+  },
+  {
+    "name": "ti_anomali",
+    "title": "Anomali",
+    "version": "1.2.3",
+    "release": "ga",
+    "description": "Collect threat intelligence from Anomali APIs with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/ti_anomali/ti_anomali-1.2.3.zip",
+    "path": "/package/ti_anomali/1.2.3",
+    "icons": [
+      {
+        "src": "/img/anomali.svg",
+        "path": "/package/ti_anomali/1.2.3/img/anomali.svg",
+        "title": "Anomali",
+        "size": "216x216",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "ti_anomali",
+        "title": "Anomali",
+        "description": "Collect threat intelligence from the Anomali Limo API and Anomali Threatstream."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/ti_anomali/ti_anomali-1.2.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_anomali.limo",
+        "title": "Anomali Limo"
+      },
+      {
+        "type": "logs",
+        "dataset": "ti_anomali.threatstream",
+        "title": "Anomali Threatstream"
+      }
+    ]
+  },
+  {
+    "name": "ti_cybersixgill",
+    "title": "Cybersixgill",
+    "version": "1.3.2",
+    "release": "ga",
+    "description": "This Elastic integration collects threat intelligence from Cybersixgill",
+    "type": "integration",
+    "download": "/epr/ti_cybersixgill/ti_cybersixgill-1.3.2.zip",
+    "path": "/package/ti_cybersixgill/1.3.2",
+    "icons": [
+      {
+        "src": "/img/cybersixgill.svg",
+        "path": "/package/ti_cybersixgill/1.3.2/img/cybersixgill.svg",
+        "title": "Cybersixgill",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "cybersixgill",
+        "title": "Cybersixgill Threat Intel",
+        "description": "Collect Threat Intel from Cybersixgill"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security",
+      "productivity"
+    ],
+    "signature_path": "/epr/ti_cybersixgill/ti_cybersixgill-1.3.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_cybersixgill.threat",
+        "title": "Cybersixgill Darkfeed Logs"
+      }
+    ]
+  },
+  {
+    "name": "ti_misp",
+    "title": "MISP",
+    "version": "1.2.2",
+    "release": "ga",
+    "description": "This Elastic integration collects events from MISP",
+    "type": "integration",
+    "download": "/epr/ti_misp/ti_misp-1.2.2.zip",
+    "path": "/package/ti_misp/1.2.2",
+    "icons": [
+      {
+        "src": "/img/misp.svg",
+        "path": "/package/ti_misp/1.2.2/img/misp.svg",
+        "title": "MISP",
+        "size": "216x216",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "ti_misp",
+        "title": "MISP",
+        "description": "Collect threat intelligence from the MISP API."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/ti_misp/ti_misp-1.2.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_misp.threat",
+        "title": "MISP"
+      }
+    ]
+  },
+  {
+    "name": "ti_otx",
+    "title": "AlienVault OTX",
+    "version": "1.2.2",
+    "release": "ga",
+    "description": "Collect threat intelligence from AlienVault OTX with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/ti_otx/ti_otx-1.2.2.zip",
+    "path": "/package/ti_otx/1.2.2",
+    "icons": [
+      {
+        "src": "/img/otx.svg",
+        "path": "/package/ti_otx/1.2.2/img/otx.svg",
+        "title": "Alienvault OTX",
+        "size": "216x216",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "ti_otx",
+        "title": "Alienvault OTX",
+        "description": "Collect threat intelligence from the Alienvault OTX"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/ti_otx/ti_otx-1.2.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_otx.threat",
+        "title": "Alienvault OTX logs"
+      }
+    ]
+  },
+  {
+    "name": "ti_recordedfuture",
+    "title": "Recorded Future",
+    "version": "0.1.2",
+    "release": "beta",
+    "description": "Collect threat intelligence from Recorded Future with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/ti_recordedfuture/ti_recordedfuture-0.1.2.zip",
+    "path": "/package/ti_recordedfuture/0.1.2",
+    "icons": [
+      {
+        "src": "/img/logo.svg",
+        "path": "/package/ti_recordedfuture/0.1.2/img/logo.svg",
+        "title": "Recorded Future",
+        "size": "216x216",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "ti_recordedfuture",
+        "title": "Recorded Future",
+        "description": "Collect threat intelligence from Recorded Future."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/ti_recordedfuture/ti_recordedfuture-0.1.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_recordedfuture.threat",
+        "title": "Recorded Future"
+      }
+    ]
+  },
+  {
     "name": "ti_threatq",
     "title": "ThreatQuotient",
     "version": "1.2.2",
@@ -8214,6 +8238,52 @@
         "type": "logs",
         "dataset": "ti_threatq.threat",
         "title": "ThreatQ"
+      }
+    ]
+  },
+  {
+    "name": "tomcat",
+    "title": "Apache Tomcat",
+    "version": "1.3.1",
+    "release": "ga",
+    "description": "Collect and parse logs from Apache Tomcat servers with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/tomcat/tomcat-1.3.1.zip",
+    "path": "/package/tomcat/1.3.1",
+    "icons": [
+      {
+        "src": "/img/logo.svg",
+        "path": "/package/tomcat/1.3.1/img/logo.svg",
+        "title": "Apache Tomcat logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "log",
+        "title": "Apache Tomcat",
+        "description": "Collect Apache Tomcat logs from syslog or a file."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.1 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "web",
+      "security"
+    ],
+    "signature_path": "/epr/tomcat/tomcat-1.3.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "tomcat.log",
+        "title": "Apache Tomcat logs"
       }
     ]
   },
@@ -8269,112 +8339,45 @@
     ]
   },
   {
-    "name": "carbon_black_cloud",
-    "title": "VMware Carbon Black Cloud",
-    "version": "1.0.2",
+    "name": "udp",
+    "title": "Custom UDP Logs",
+    "version": "1.0.1",
     "release": "ga",
-    "description": "Collect logs from VMWare Carbon Black Cloud with Elastic Agent.",
+    "description": "Collect raw UDP data from listening UDP port with Elastic Agent.",
     "type": "integration",
-    "download": "/epr/carbon_black_cloud/carbon_black_cloud-1.0.2.zip",
-    "path": "/package/carbon_black_cloud/1.0.2",
+    "download": "/epr/udp/udp-1.0.1.zip",
+    "path": "/package/udp/1.0.1",
     "icons": [
       {
-        "src": "/img/carbon_black_cloud-logo.svg",
-        "path": "/package/carbon_black_cloud/1.0.2/img/carbon_black_cloud-logo.svg",
-        "title": "Carbon Black Cloud logo",
-        "size": "32x32",
+        "src": "/img/icon.svg",
+        "path": "/package/udp/1.0.1/img/icon.svg",
         "type": "image/svg+xml"
       }
     ],
     "policy_templates": [
       {
-        "name": "carbon_black_cloud",
-        "title": "Carbon Black Cloud",
-        "description": "Collect Logs from Carbon Black Cloud"
+        "name": "udp",
+        "title": "Custom UDP Logs",
+        "description": "Collect raw UDP data from listening UDP port with Elastic Agent."
       }
     ],
     "conditions": {
       "kibana": {
-        "version": "^7.17.0 || ^8.0.0"
+        "version": "^7.16.0 || ^8.0.0"
       }
     },
     "owner": {
       "github": "elastic/security-external-integrations"
     },
     "categories": [
-      "security"
+      "custom"
     ],
-    "signature_path": "/epr/carbon_black_cloud/carbon_black_cloud-1.0.2.zip.sig",
+    "signature_path": "/epr/udp/udp-1.0.1.zip.sig",
     "data_streams": [
       {
         "type": "logs",
-        "dataset": "carbon_black_cloud.alert",
-        "title": "Alert"
-      },
-      {
-        "type": "logs",
-        "dataset": "carbon_black_cloud.asset_vulnerability_summary",
-        "title": "Asset Vulnerability Summary"
-      },
-      {
-        "type": "logs",
-        "dataset": "carbon_black_cloud.audit",
-        "title": "Audit"
-      },
-      {
-        "type": "logs",
-        "dataset": "carbon_black_cloud.endpoint_event",
-        "title": "Endpoint Event"
-      },
-      {
-        "type": "logs",
-        "dataset": "carbon_black_cloud.watchlist_hit",
-        "title": "Watchlist Hit"
-      }
-    ]
-  },
-  {
-    "name": "carbonblack_edr",
-    "title": "VMware Carbon Black EDR",
-    "version": "1.2.0",
-    "release": "ga",
-    "description": "Collect logs from VMware Carbon Black EDR with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/carbonblack_edr/carbonblack_edr-1.2.0.zip",
-    "path": "/package/carbonblack_edr/1.2.0",
-    "icons": [
-      {
-        "src": "/img/carbon-black-logo.svg",
-        "path": "/package/carbonblack_edr/1.2.0/img/carbon-black-logo.svg",
-        "title": "VMWare Carbon Black",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "log",
-        "title": "Carbon Black EDR logs",
-        "description": "Collect logs from Carbon Black EDR"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/carbonblack_edr/carbonblack_edr-1.2.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "carbonblack_edr.log",
-        "title": "Carbon Black EDR logs"
+        "dataset": "udp.generic",
+        "title": "Custom UDP Logs"
       }
     ]
   },
@@ -8507,6 +8510,49 @@
         "type": "logs",
         "dataset": "windows.sysmon_operational",
         "title": "Windows Sysmon/Operational events"
+      }
+    ]
+  },
+  {
+    "name": "winlog",
+    "title": "Custom Windows Event Logs",
+    "version": "1.4.0",
+    "release": "ga",
+    "description": "Collect and parse logs from any Windows event log channel with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/winlog/winlog-1.4.0.zip",
+    "path": "/package/winlog/1.4.0",
+    "icons": [
+      {
+        "src": "/img/logo_windows.svg",
+        "path": "/package/winlog/1.4.0/img/logo_windows.svg",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "winlogs",
+        "title": "Custom Windows event logs",
+        "description": "Collect your custom Windows event logs."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "signature_path": "/epr/winlog/winlog-1.4.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "winlog.winlog",
+        "title": "Custom Windows Event Log Dataset"
       }
     ]
   },
@@ -8896,6 +8942,52 @@
     ]
   },
   {
+    "name": "zscaler",
+    "title": "Zscaler NSS Logs",
+    "version": "0.5.1",
+    "release": "experimental",
+    "description": "Deprecated. Use the Zscaler ZIA integration instead.",
+    "type": "integration",
+    "download": "/epr/zscaler/zscaler-0.5.1.zip",
+    "path": "/package/zscaler/0.5.1",
+    "icons": [
+      {
+        "src": "/img/logo.svg",
+        "path": "/package/zscaler/0.5.1/img/logo.svg",
+        "title": "Zscaler NSS logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "zia",
+        "title": "Zscaler NSS",
+        "description": "Collect Zscaler NSS logs from syslog or a file."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.1"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "network",
+      "security"
+    ],
+    "signature_path": "/epr/zscaler/zscaler-0.5.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "zscaler.zia",
+        "title": "Zscaler NSS logs"
+      }
+    ]
+  },
+  {
     "name": "zscaler_zia",
     "title": "Zscaler Internet Access",
     "version": "0.1.3",
@@ -8961,52 +9053,6 @@
     ]
   },
   {
-    "name": "zscaler",
-    "title": "Zscaler NSS Logs",
-    "version": "0.5.1",
-    "release": "experimental",
-    "description": "Deprecated. Use the Zscaler ZIA integration instead.",
-    "type": "integration",
-    "download": "/epr/zscaler/zscaler-0.5.1.zip",
-    "path": "/package/zscaler/0.5.1",
-    "icons": [
-      {
-        "src": "/img/logo.svg",
-        "path": "/package/zscaler/0.5.1/img/logo.svg",
-        "title": "Zscaler NSS logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "zia",
-        "title": "Zscaler NSS",
-        "description": "Collect Zscaler NSS logs from syslog or a file."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.1"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "network",
-      "security"
-    ],
-    "signature_path": "/epr/zscaler/zscaler-0.5.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "zscaler.zia",
-        "title": "Zscaler NSS logs"
-      }
-    ]
-  },
-  {
     "name": "zscaler_zpa",
     "title": "Zscaler Private Access",
     "version": "0.1.2",
@@ -9068,52 +9114,6 @@
         "type": "logs",
         "dataset": "zscaler_zpa.user_status",
         "title": "User Status Logs"
-      }
-    ]
-  },
-  {
-    "name": "pfsense",
-    "title": "pfSense Logs",
-    "version": "0.3.1",
-    "release": "experimental",
-    "description": "Collect and parse logs from pfSense devices with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/pfsense/pfsense-0.3.1.zip",
-    "path": "/package/pfsense/0.3.1",
-    "icons": [
-      {
-        "src": "/img/pfsense.svg",
-        "path": "/package/pfsense/0.3.1/img/pfsense.svg",
-        "title": "pfsense",
-        "size": "512x143",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "pfsense",
-        "title": "pfSense logs",
-        "description": "Collect logs from pfSense systems"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.15.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "network",
-      "security"
-    ],
-    "signature_path": "/epr/pfsense/pfsense-0.3.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "pfsense.log",
-        "title": "pfSense log logs"
       }
     ]
   }

--- a/testdata/generated/storage-indexer/search.json
+++ b/testdata/generated/storage-indexer/search.json
@@ -54,6 +54,538 @@
     ]
   },
   {
+    "name": "activemq",
+    "title": "ActiveMQ",
+    "version": "0.3.0",
+    "release": "beta",
+    "description": "Collect logs and metrics from ActiveMQ instances with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/activemq/activemq-0.3.0.zip",
+    "path": "/package/activemq/0.3.0",
+    "icons": [
+      {
+        "src": "/img/activemq.svg",
+        "path": "/package/activemq/0.3.0/img/activemq.svg",
+        "title": "activemq",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "activemq",
+        "title": "ActiveMQ logs and metrics",
+        "description": "Collect logs and metrics from ActiveMQ instances"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "web"
+    ],
+    "signature_path": "/epr/activemq/activemq-0.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "activemq.audit",
+        "title": "ActiveMQ audit logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "activemq.broker",
+        "title": "ActiveMQ broker metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "activemq.log",
+        "title": "ActiveMQ log logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "activemq.queue",
+        "title": "ActiveMQ queue metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "activemq.topic",
+        "title": "ActiveMQ topic metrics"
+      }
+    ]
+  },
+  {
+    "name": "akamai",
+    "title": "Akamai",
+    "version": "2.28.0",
+    "release": "ga",
+    "description": "Collect logs from Akamai with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/akamai/akamai-2.28.0.zip",
+    "path": "/package/akamai/2.28.0",
+    "icons": [
+      {
+        "src": "/img/akamai_logo.svg",
+        "path": "/package/akamai/2.28.0/img/akamai_logo.svg",
+        "title": "Akamai",
+        "size": "409×167",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "akamai",
+        "title": "Akamai logs",
+        "description": "Collect SIEM logs from Akamai"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.13.0 || ^9.0.0"
+      }
+    },
+    "owner": {
+      "type": "community",
+      "github": "elastic/security-service-integrations"
+    },
+    "categories": [
+      "security",
+      "cdn_security"
+    ],
+    "signature_path": "/epr/akamai/akamai-2.28.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "akamai.siem",
+        "title": "Akamai SIEM Logs"
+      }
+    ]
+  },
+  {
+    "name": "apache",
+    "title": "Apache HTTP Server",
+    "version": "1.3.5",
+    "release": "ga",
+    "description": "Collect logs and metrics from Apache servers with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/apache/apache-1.3.5.zip",
+    "path": "/package/apache/1.3.5",
+    "icons": [
+      {
+        "src": "/img/logo_apache.svg",
+        "path": "/package/apache/1.3.5/img/logo_apache.svg",
+        "title": "Apache Logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "apache",
+        "title": "Apache logs and metrics",
+        "description": "Collect logs and metrics from Apache instances"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "web"
+    ],
+    "signature_path": "/epr/apache/apache-1.3.5.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "apache.access",
+        "title": "Apache access logs",
+        "deprecated": {
+          "since": "1.3.5",
+          "description": "This data stream is deprecated"
+        }
+      },
+      {
+        "type": "logs",
+        "dataset": "apache.error",
+        "title": "Apache error logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apache.status",
+        "title": "Apache status metrics"
+      }
+    ],
+    "deprecated": {
+      "since": "1.3.0",
+      "description": "This package is deprecated"
+    }
+  },
+  {
+    "name": "apm",
+    "title": "Elastic APM",
+    "version": "8.2.0",
+    "release": "ga",
+    "description": "Ingest APM data",
+    "type": "integration",
+    "download": "/epr/apm/apm-8.2.0.zip",
+    "path": "/package/apm/8.2.0",
+    "icons": [
+      {
+        "src": "/img/logo_apm.svg",
+        "path": "/package/apm/8.2.0/img/logo_apm.svg",
+        "title": "APM Logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "apmserver",
+        "title": "Elastic APM Integration",
+        "description": "Elastic APM Integration"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.2.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/apm-server"
+    },
+    "categories": [
+      "elastic_stack",
+      "monitoring"
+    ],
+    "signature_path": "/epr/apm/apm-8.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "apm.app",
+        "title": "APM application logs"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.app",
+        "title": "APM application metrics"
+      },
+      {
+        "type": "logs",
+        "dataset": "apm.error",
+        "title": "APM errors"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.internal",
+        "title": "APM internal metrics"
+      },
+      {
+        "type": "metrics",
+        "dataset": "apm.profiling",
+        "title": "APM profiles"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm.rum",
+        "title": "APM RUM traces"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm.sampled",
+        "title": "APM tail-sampled traces"
+      },
+      {
+        "type": "traces",
+        "dataset": "apm",
+        "title": "APM traces"
+      }
+    ]
+  },
+  {
+    "name": "atlassian_bitbucket",
+    "title": "Atlassian Bitbucket",
+    "version": "1.2.1",
+    "release": "ga",
+    "description": "Collect logs from Atlassian Bitbucket with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.2.1.zip",
+    "path": "/package/atlassian_bitbucket/1.2.1",
+    "icons": [
+      {
+        "src": "/img/bitbucket-logo.svg",
+        "path": "/package/atlassian_bitbucket/1.2.1/img/bitbucket-logo.svg",
+        "title": "Bitbucket Logo",
+        "size": "625x564",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "audit",
+        "title": "Audit Logs",
+        "description": "Collect audit logs from Atlassian Bitbucket with Elastic Agent."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security",
+      "web"
+    ],
+    "signature_path": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_bitbucket.audit",
+        "title": "Bitbucket Audit Logs"
+      }
+    ]
+  },
+  {
+    "name": "atlassian_confluence",
+    "title": "Atlassian Confluence",
+    "version": "1.3.0",
+    "release": "ga",
+    "description": "Collect logs from Atlassian Confluence with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/atlassian_confluence/atlassian_confluence-1.3.0.zip",
+    "path": "/package/atlassian_confluence/1.3.0",
+    "icons": [
+      {
+        "src": "/img/confluence-logo.svg",
+        "path": "/package/atlassian_confluence/1.3.0/img/confluence-logo.svg",
+        "title": "Confluence Logo",
+        "size": "400x400",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "audit",
+        "title": "Audit Logs",
+        "description": "Collect audit logs from Atlassian Confluence with Elastic Agent."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security",
+      "web"
+    ],
+    "signature_path": "/epr/atlassian_confluence/atlassian_confluence-1.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_confluence.audit",
+        "title": "Confluence Audit Logs"
+      }
+    ]
+  },
+  {
+    "name": "atlassian_jira",
+    "title": "Atlassian Jira",
+    "version": "1.3.0",
+    "release": "ga",
+    "description": "Collect logs from Atlassian Jira with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/atlassian_jira/atlassian_jira-1.3.0.zip",
+    "path": "/package/atlassian_jira/1.3.0",
+    "icons": [
+      {
+        "src": "/img/jira-software-logo.svg",
+        "path": "/package/atlassian_jira/1.3.0/img/jira-software-logo.svg",
+        "title": "Jira Software Logo",
+        "size": "590x625",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "audit",
+        "title": "Audit Logs",
+        "description": "Collect audit logs from Atlassian Jira with Elastic Agent."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security",
+      "web"
+    ],
+    "signature_path": "/epr/atlassian_jira/atlassian_jira-1.3.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "atlassian_jira.audit",
+        "title": "Jira Audit Logs"
+      }
+    ]
+  },
+  {
+    "name": "auditd",
+    "title": "Auditd Logs",
+    "version": "3.1.0",
+    "release": "ga",
+    "description": "Collect logs from Linux audit daemon with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/auditd/auditd-3.1.0.zip",
+    "path": "/package/auditd/3.1.0",
+    "icons": [
+      {
+        "src": "/img/linux.svg",
+        "path": "/package/auditd/3.1.0/img/linux.svg",
+        "title": "linux",
+        "size": "299x354",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "auditd",
+        "title": "Auditd logs",
+        "description": "Collect logs from Auditd instances"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "os_system"
+    ],
+    "signature_path": "/epr/auditd/auditd-3.1.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "auditd.log",
+        "title": "Auditd logs"
+      }
+    ]
+  },
+  {
+    "name": "auditd_manager",
+    "title": "Auditd Manager",
+    "version": "1.0.0",
+    "release": "ga",
+    "description": "The Auditd Manager Integration receives audit events from the Linux Audit Framework that is a part of the Linux kernel.",
+    "type": "integration",
+    "download": "/epr/auditd_manager/auditd_manager-1.0.0.zip",
+    "path": "/package/auditd_manager/1.0.0",
+    "icons": [
+      {
+        "src": "/img/linux.svg",
+        "path": "/package/auditd_manager/1.0.0/img/linux.svg",
+        "title": "linux",
+        "size": "299x354",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "auditd",
+        "title": "Auditd",
+        "description": "Collect auditd events"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.2.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "os_system",
+      "security"
+    ],
+    "signature_path": "/epr/auditd_manager/auditd_manager-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "auditd_manager.auditd",
+        "title": "Auditd Manager"
+      }
+    ]
+  },
+  {
+    "name": "auth0",
+    "title": "Auth0 Log Streams Integration",
+    "version": "1.0.0",
+    "release": "ga",
+    "description": "Collect logs from Auth0 with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/auth0/auth0-1.0.0.zip",
+    "path": "/package/auth0/1.0.0",
+    "icons": [
+      {
+        "src": "/img/auth0-logo.svg",
+        "path": "/package/auth0/1.0.0/img/auth0-logo.svg",
+        "title": "Auth0 logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "auth0_events",
+        "title": "Auth0 log stream events via Webhooks",
+        "description": "Collect Auth0 log streams events via Webhooks."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "cloud",
+      "network",
+      "security"
+    ],
+    "signature_path": "/epr/auth0/auth0-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "auth0.logs",
+        "title": "Auth0 logs via Webhooks"
+      }
+    ]
+  },
+  {
     "name": "aws",
     "title": "AWS",
     "version": "1.16.4",
@@ -649,6 +1181,51 @@
     ]
   },
   {
+    "name": "aws_logs",
+    "title": "Custom AWS Logs",
+    "version": "0.2.1",
+    "release": "beta",
+    "description": "Collect raw logs from AWS S3 or CloudWatch with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/aws_logs/aws_logs-0.2.1.zip",
+    "path": "/package/aws_logs/0.2.1",
+    "icons": [
+      {
+        "src": "/img/icon.svg",
+        "path": "/package/aws_logs/0.2.1/img/icon.svg",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "aws_logs",
+        "title": "Custom AWS Logs",
+        "description": "Collect raw logs from AWS S3 or CloudWatch with Elastic Agent."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/obs-cloud-monitoring"
+    },
+    "categories": [
+      "custom",
+      "cloud",
+      "aws"
+    ],
+    "signature_path": "/epr/aws_logs/aws_logs-0.2.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "aws_logs.generic",
+        "title": "Custom logs from AWS"
+      }
+    ]
+  },
+  {
     "name": "awsfargate",
     "title": "AWS Fargate",
     "version": "0.1.1",
@@ -692,790 +1269,6 @@
         "type": "metrics",
         "dataset": "awsfargate.task_stats",
         "title": "AWS Fargate task_stats metrics"
-      }
-    ]
-  },
-  {
-    "name": "ti_abusech",
-    "title": "AbuseCH",
-    "version": "1.2.3",
-    "release": "ga",
-    "description": "Collect threat intelligence from AbuseCH API with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/ti_abusech/ti_abusech-1.2.3.zip",
-    "path": "/package/ti_abusech/1.2.3",
-    "icons": [
-      {
-        "src": "/img/abusech2.svg",
-        "path": "/package/ti_abusech/1.2.3/img/abusech2.svg",
-        "title": "AbuseCH",
-        "size": "512x512",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "ti_abusech",
-        "title": "AbuseCH API",
-        "description": "Collect threat intelligence from the AbuseCH API"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/ti_abusech/ti_abusech-1.2.3.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ti_abusech.malware",
-        "title": "AbuseCH Malware logs"
-      },
-      {
-        "type": "logs",
-        "dataset": "ti_abusech.malwarebazaar",
-        "title": "AbuseCH MalwareBazaar logs"
-      },
-      {
-        "type": "logs",
-        "dataset": "ti_abusech.url",
-        "title": "AbuseCH URL logs"
-      }
-    ]
-  },
-  {
-    "name": "activemq",
-    "title": "ActiveMQ",
-    "version": "0.3.0",
-    "release": "beta",
-    "description": "Collect logs and metrics from ActiveMQ instances with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/activemq/activemq-0.3.0.zip",
-    "path": "/package/activemq/0.3.0",
-    "icons": [
-      {
-        "src": "/img/activemq.svg",
-        "path": "/package/activemq/0.3.0/img/activemq.svg",
-        "title": "activemq",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "activemq",
-        "title": "ActiveMQ logs and metrics",
-        "description": "Collect logs and metrics from ActiveMQ instances"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "web"
-    ],
-    "signature_path": "/epr/activemq/activemq-0.3.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "activemq.audit",
-        "title": "ActiveMQ audit logs"
-      },
-      {
-        "type": "metrics",
-        "dataset": "activemq.broker",
-        "title": "ActiveMQ broker metrics"
-      },
-      {
-        "type": "logs",
-        "dataset": "activemq.log",
-        "title": "ActiveMQ log logs"
-      },
-      {
-        "type": "metrics",
-        "dataset": "activemq.queue",
-        "title": "ActiveMQ queue metrics"
-      },
-      {
-        "type": "metrics",
-        "dataset": "activemq.topic",
-        "title": "ActiveMQ topic metrics"
-      }
-    ]
-  },
-  {
-    "name": "akamai",
-    "title": "Akamai",
-    "version": "2.28.0",
-    "release": "ga",
-    "description": "Collect logs from Akamai with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/akamai/akamai-2.28.0.zip",
-    "path": "/package/akamai/2.28.0",
-    "icons": [
-      {
-        "src": "/img/akamai_logo.svg",
-        "path": "/package/akamai/2.28.0/img/akamai_logo.svg",
-        "title": "Akamai",
-        "size": "409×167",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "akamai",
-        "title": "Akamai logs",
-        "description": "Collect SIEM logs from Akamai"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.13.0 || ^9.0.0"
-      }
-    },
-    "owner": {
-      "type": "community",
-      "github": "elastic/security-service-integrations"
-    },
-    "categories": [
-      "security",
-      "cdn_security"
-    ],
-    "signature_path": "/epr/akamai/akamai-2.28.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "akamai.siem",
-        "title": "Akamai SIEM Logs"
-      }
-    ]
-  },
-  {
-    "name": "ti_otx",
-    "title": "AlienVault OTX",
-    "version": "1.2.2",
-    "release": "ga",
-    "description": "Collect threat intelligence from AlienVault OTX with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/ti_otx/ti_otx-1.2.2.zip",
-    "path": "/package/ti_otx/1.2.2",
-    "icons": [
-      {
-        "src": "/img/otx.svg",
-        "path": "/package/ti_otx/1.2.2/img/otx.svg",
-        "title": "Alienvault OTX",
-        "size": "216x216",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "ti_otx",
-        "title": "Alienvault OTX",
-        "description": "Collect threat intelligence from the Alienvault OTX"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/ti_otx/ti_otx-1.2.2.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ti_otx.threat",
-        "title": "Alienvault OTX logs"
-      }
-    ]
-  },
-  {
-    "name": "ti_anomali",
-    "title": "Anomali",
-    "version": "1.2.3",
-    "release": "ga",
-    "description": "Collect threat intelligence from Anomali APIs with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/ti_anomali/ti_anomali-1.2.3.zip",
-    "path": "/package/ti_anomali/1.2.3",
-    "icons": [
-      {
-        "src": "/img/anomali.svg",
-        "path": "/package/ti_anomali/1.2.3/img/anomali.svg",
-        "title": "Anomali",
-        "size": "216x216",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "ti_anomali",
-        "title": "Anomali",
-        "description": "Collect threat intelligence from the Anomali Limo API and Anomali Threatstream."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/ti_anomali/ti_anomali-1.2.3.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ti_anomali.limo",
-        "title": "Anomali Limo"
-      },
-      {
-        "type": "logs",
-        "dataset": "ti_anomali.threatstream",
-        "title": "Anomali Threatstream"
-      }
-    ]
-  },
-  {
-    "name": "apache",
-    "title": "Apache HTTP Server",
-    "version": "1.3.5",
-    "release": "ga",
-    "description": "Collect logs and metrics from Apache servers with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/apache/apache-1.3.5.zip",
-    "path": "/package/apache/1.3.5",
-    "icons": [
-      {
-        "src": "/img/logo_apache.svg",
-        "path": "/package/apache/1.3.5/img/logo_apache.svg",
-        "title": "Apache Logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "apache",
-        "title": "Apache logs and metrics",
-        "description": "Collect logs and metrics from Apache instances"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "web"
-    ],
-    "signature_path": "/epr/apache/apache-1.3.5.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "apache.access",
-        "title": "Apache access logs",
-        "deprecated": {
-          "since": "1.3.5",
-          "description": "This data stream is deprecated"
-        }
-      },
-      {
-        "type": "logs",
-        "dataset": "apache.error",
-        "title": "Apache error logs"
-      },
-      {
-        "type": "metrics",
-        "dataset": "apache.status",
-        "title": "Apache status metrics"
-      }
-    ],
-    "deprecated": {
-      "since": "1.3.0",
-      "description": "This package is deprecated"
-    }
-  },
-  {
-    "name": "tomcat",
-    "title": "Apache Tomcat",
-    "version": "1.3.1",
-    "release": "ga",
-    "description": "Collect and parse logs from Apache Tomcat servers with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/tomcat/tomcat-1.3.1.zip",
-    "path": "/package/tomcat/1.3.1",
-    "icons": [
-      {
-        "src": "/img/logo.svg",
-        "path": "/package/tomcat/1.3.1/img/logo.svg",
-        "title": "Apache Tomcat logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "log",
-        "title": "Apache Tomcat",
-        "description": "Collect Apache Tomcat logs from syslog or a file."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.1 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "web",
-      "security"
-    ],
-    "signature_path": "/epr/tomcat/tomcat-1.3.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "tomcat.log",
-        "title": "Apache Tomcat logs"
-      }
-    ]
-  },
-  {
-    "name": "atlassian_bitbucket",
-    "title": "Atlassian Bitbucket",
-    "version": "1.2.1",
-    "release": "ga",
-    "description": "Collect logs from Atlassian Bitbucket with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.2.1.zip",
-    "path": "/package/atlassian_bitbucket/1.2.1",
-    "icons": [
-      {
-        "src": "/img/bitbucket-logo.svg",
-        "path": "/package/atlassian_bitbucket/1.2.1/img/bitbucket-logo.svg",
-        "title": "Bitbucket Logo",
-        "size": "625x564",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "audit",
-        "title": "Audit Logs",
-        "description": "Collect audit logs from Atlassian Bitbucket with Elastic Agent."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security",
-      "web"
-    ],
-    "signature_path": "/epr/atlassian_bitbucket/atlassian_bitbucket-1.2.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "atlassian_bitbucket.audit",
-        "title": "Bitbucket Audit Logs"
-      }
-    ]
-  },
-  {
-    "name": "atlassian_confluence",
-    "title": "Atlassian Confluence",
-    "version": "1.3.0",
-    "release": "ga",
-    "description": "Collect logs from Atlassian Confluence with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/atlassian_confluence/atlassian_confluence-1.3.0.zip",
-    "path": "/package/atlassian_confluence/1.3.0",
-    "icons": [
-      {
-        "src": "/img/confluence-logo.svg",
-        "path": "/package/atlassian_confluence/1.3.0/img/confluence-logo.svg",
-        "title": "Confluence Logo",
-        "size": "400x400",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "audit",
-        "title": "Audit Logs",
-        "description": "Collect audit logs from Atlassian Confluence with Elastic Agent."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security",
-      "web"
-    ],
-    "signature_path": "/epr/atlassian_confluence/atlassian_confluence-1.3.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "atlassian_confluence.audit",
-        "title": "Confluence Audit Logs"
-      }
-    ]
-  },
-  {
-    "name": "atlassian_jira",
-    "title": "Atlassian Jira",
-    "version": "1.3.0",
-    "release": "ga",
-    "description": "Collect logs from Atlassian Jira with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/atlassian_jira/atlassian_jira-1.3.0.zip",
-    "path": "/package/atlassian_jira/1.3.0",
-    "icons": [
-      {
-        "src": "/img/jira-software-logo.svg",
-        "path": "/package/atlassian_jira/1.3.0/img/jira-software-logo.svg",
-        "title": "Jira Software Logo",
-        "size": "590x625",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "audit",
-        "title": "Audit Logs",
-        "description": "Collect audit logs from Atlassian Jira with Elastic Agent."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security",
-      "web"
-    ],
-    "signature_path": "/epr/atlassian_jira/atlassian_jira-1.3.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "atlassian_jira.audit",
-        "title": "Jira Audit Logs"
-      }
-    ]
-  },
-  {
-    "name": "auditd",
-    "title": "Auditd Logs",
-    "version": "3.1.0",
-    "release": "ga",
-    "description": "Collect logs from Linux audit daemon with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/auditd/auditd-3.1.0.zip",
-    "path": "/package/auditd/3.1.0",
-    "icons": [
-      {
-        "src": "/img/linux.svg",
-        "path": "/package/auditd/3.1.0/img/linux.svg",
-        "title": "linux",
-        "size": "299x354",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "auditd",
-        "title": "Auditd logs",
-        "description": "Collect logs from Auditd instances"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "os_system"
-    ],
-    "signature_path": "/epr/auditd/auditd-3.1.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "auditd.log",
-        "title": "Auditd logs"
-      }
-    ]
-  },
-  {
-    "name": "auditd_manager",
-    "title": "Auditd Manager",
-    "version": "1.0.0",
-    "release": "ga",
-    "description": "The Auditd Manager Integration receives audit events from the Linux Audit Framework that is a part of the Linux kernel.",
-    "type": "integration",
-    "download": "/epr/auditd_manager/auditd_manager-1.0.0.zip",
-    "path": "/package/auditd_manager/1.0.0",
-    "icons": [
-      {
-        "src": "/img/linux.svg",
-        "path": "/package/auditd_manager/1.0.0/img/linux.svg",
-        "title": "linux",
-        "size": "299x354",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "auditd",
-        "title": "Auditd",
-        "description": "Collect auditd events"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.2.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "os_system",
-      "security"
-    ],
-    "signature_path": "/epr/auditd_manager/auditd_manager-1.0.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "auditd_manager.auditd",
-        "title": "Auditd Manager"
-      }
-    ]
-  },
-  {
-    "name": "auth0",
-    "title": "Auth0 Log Streams Integration",
-    "version": "1.0.0",
-    "release": "ga",
-    "description": "Collect logs from Auth0 with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/auth0/auth0-1.0.0.zip",
-    "path": "/package/auth0/1.0.0",
-    "icons": [
-      {
-        "src": "/img/auth0-logo.svg",
-        "path": "/package/auth0/1.0.0/img/auth0-logo.svg",
-        "title": "Auth0 logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "auth0_events",
-        "title": "Auth0 log stream events via Webhooks",
-        "description": "Collect Auth0 log streams events via Webhooks."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "cloud",
-      "network",
-      "security"
-    ],
-    "signature_path": "/epr/auth0/auth0-1.0.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "auth0.logs",
-        "title": "Auth0 logs via Webhooks"
-      }
-    ]
-  },
-  {
-    "name": "azure_application_insights",
-    "title": "Azure Application Insights Metrics Overview",
-    "version": "1.0.1",
-    "release": "ga",
-    "description": "Collect application insights metrics from Azure Monitor with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/azure_application_insights/azure_application_insights-1.0.1.zip",
-    "path": "/package/azure_application_insights/1.0.1",
-    "icons": [
-      {
-        "src": "/img/app_insights.png",
-        "path": "/package/azure_application_insights/1.0.1/img/app_insights.png",
-        "title": "logo docker",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "app_insights",
-        "title": "Azure Application Insights Metrics",
-        "description": "Collect application insights metrics from Azure Monitor with Elastic Agent.",
-        "icons": [
-          {
-            "src": "/img//app_insights.png",
-            "path": "/package/azure_application_insights/1.0.1/img/app_insights.png",
-            "title": "logo azure",
-            "size": "32x32",
-            "type": "image/svg+xml"
-          }
-        ],
-        "data_streams": [
-          "app_insights"
-        ]
-      },
-      {
-        "name": "app_state",
-        "title": "Azure Application State Insights Metrics",
-        "description": "Collect application state related metrics from Azure Monitor with Elastic Agent.",
-        "icons": [
-          {
-            "src": "/img/application_insights_blue.png",
-            "path": "/package/azure_application_insights/1.0.1/img/application_insights_blue.png",
-            "title": "logo azure",
-            "size": "32x32",
-            "type": "image/svg+xml"
-          }
-        ],
-        "data_streams": [
-          "app_state"
-        ]
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "azure",
-      "web"
-    ],
-    "signature_path": "/epr/azure_application_insights/azure_application_insights-1.0.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "metrics",
-        "dataset": "azure.app_insights",
-        "title": "Azure Application Insights"
-      },
-      {
-        "type": "metrics",
-        "dataset": "azure.app_state",
-        "title": "Azure Application State"
-      }
-    ]
-  },
-  {
-    "name": "azure_billing",
-    "title": "Azure Billing Metrics",
-    "version": "1.0.1",
-    "release": "ga",
-    "description": "Collect billing metrics with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/azure_billing/azure_billing-1.0.1.zip",
-    "path": "/package/azure_billing/1.0.1",
-    "icons": [
-      {
-        "src": "/img/billing.png",
-        "path": "/package/azure_billing/1.0.1/img/billing.png",
-        "title": "logo docker",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "billing",
-        "title": "Azure Billing Metrics",
-        "description": "Collect billing information with Elastic Agent.",
-        "icons": [
-          {
-            "src": "/img//billing.png",
-            "path": "/package/azure_billing/1.0.1/img/billing.png",
-            "title": "logo azure",
-            "size": "32x32",
-            "type": "image/svg+xml"
-          }
-        ],
-        "data_streams": [
-          "billing"
-        ]
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.15.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "azure"
-    ],
-    "signature_path": "/epr/azure_billing/azure_billing-1.0.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "metrics",
-        "dataset": "azure.billing",
-        "title": "Azure Billing Metrics"
       }
     ]
   },
@@ -1630,6 +1423,143 @@
         "type": "logs",
         "dataset": "azure.springcloudlogs",
         "title": "Azure Spring Cloud Logs"
+      }
+    ]
+  },
+  {
+    "name": "azure_application_insights",
+    "title": "Azure Application Insights Metrics Overview",
+    "version": "1.0.1",
+    "release": "ga",
+    "description": "Collect application insights metrics from Azure Monitor with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/azure_application_insights/azure_application_insights-1.0.1.zip",
+    "path": "/package/azure_application_insights/1.0.1",
+    "icons": [
+      {
+        "src": "/img/app_insights.png",
+        "path": "/package/azure_application_insights/1.0.1/img/app_insights.png",
+        "title": "logo docker",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "app_insights",
+        "title": "Azure Application Insights Metrics",
+        "description": "Collect application insights metrics from Azure Monitor with Elastic Agent.",
+        "icons": [
+          {
+            "src": "/img//app_insights.png",
+            "path": "/package/azure_application_insights/1.0.1/img/app_insights.png",
+            "title": "logo azure",
+            "size": "32x32",
+            "type": "image/svg+xml"
+          }
+        ],
+        "data_streams": [
+          "app_insights"
+        ]
+      },
+      {
+        "name": "app_state",
+        "title": "Azure Application State Insights Metrics",
+        "description": "Collect application state related metrics from Azure Monitor with Elastic Agent.",
+        "icons": [
+          {
+            "src": "/img/application_insights_blue.png",
+            "path": "/package/azure_application_insights/1.0.1/img/application_insights_blue.png",
+            "title": "logo azure",
+            "size": "32x32",
+            "type": "image/svg+xml"
+          }
+        ],
+        "data_streams": [
+          "app_state"
+        ]
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "azure",
+      "web"
+    ],
+    "signature_path": "/epr/azure_application_insights/azure_application_insights-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "azure.app_insights",
+        "title": "Azure Application Insights"
+      },
+      {
+        "type": "metrics",
+        "dataset": "azure.app_state",
+        "title": "Azure Application State"
+      }
+    ]
+  },
+  {
+    "name": "azure_billing",
+    "title": "Azure Billing Metrics",
+    "version": "1.0.1",
+    "release": "ga",
+    "description": "Collect billing metrics with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/azure_billing/azure_billing-1.0.1.zip",
+    "path": "/package/azure_billing/1.0.1",
+    "icons": [
+      {
+        "src": "/img/billing.png",
+        "path": "/package/azure_billing/1.0.1/img/billing.png",
+        "title": "logo docker",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "billing",
+        "title": "Azure Billing Metrics",
+        "description": "Collect billing information with Elastic Agent.",
+        "icons": [
+          {
+            "src": "/img//billing.png",
+            "path": "/package/azure_billing/1.0.1/img/billing.png",
+            "title": "logo azure",
+            "size": "32x32",
+            "type": "image/svg+xml"
+          }
+        ],
+        "data_streams": [
+          "billing"
+        ]
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.15.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "azure"
+    ],
+    "signature_path": "/epr/azure_billing/azure_billing-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "metrics",
+        "dataset": "azure.billing",
+        "title": "Azure Billing Metrics"
       }
     ]
   },
@@ -1846,39 +1776,112 @@
     ]
   },
   {
-    "name": "cef",
-    "title": "CEF Logs",
-    "version": "2.0.0",
+    "name": "carbon_black_cloud",
+    "title": "VMware Carbon Black Cloud",
+    "version": "1.0.2",
     "release": "ga",
-    "description": "Collect logs from CEF Logs with Elastic Agent.",
+    "description": "Collect logs from VMWare Carbon Black Cloud with Elastic Agent.",
     "type": "integration",
-    "download": "/epr/cef/cef-2.0.0.zip",
-    "path": "/package/cef/2.0.0",
+    "download": "/epr/carbon_black_cloud/carbon_black_cloud-1.0.2.zip",
+    "path": "/package/carbon_black_cloud/1.0.2",
+    "icons": [
+      {
+        "src": "/img/carbon_black_cloud-logo.svg",
+        "path": "/package/carbon_black_cloud/1.0.2/img/carbon_black_cloud-logo.svg",
+        "title": "Carbon Black Cloud logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
     "policy_templates": [
       {
-        "name": "cef",
-        "title": "CEF logs",
-        "description": "Collect logs from CEF instances"
+        "name": "carbon_black_cloud",
+        "title": "Carbon Black Cloud",
+        "description": "Collect Logs from Carbon Black Cloud"
       }
     ],
     "conditions": {
       "kibana": {
-        "version": "^8.0.0"
+        "version": "^7.17.0 || ^8.0.0"
       }
     },
     "owner": {
       "github": "elastic/security-external-integrations"
     },
     "categories": [
-      "network",
       "security"
     ],
-    "signature_path": "/epr/cef/cef-2.0.0.zip.sig",
+    "signature_path": "/epr/carbon_black_cloud/carbon_black_cloud-1.0.2.zip.sig",
     "data_streams": [
       {
         "type": "logs",
-        "dataset": "cef.log",
-        "title": "CEF log logs"
+        "dataset": "carbon_black_cloud.alert",
+        "title": "Alert"
+      },
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.asset_vulnerability_summary",
+        "title": "Asset Vulnerability Summary"
+      },
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.audit",
+        "title": "Audit"
+      },
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.endpoint_event",
+        "title": "Endpoint Event"
+      },
+      {
+        "type": "logs",
+        "dataset": "carbon_black_cloud.watchlist_hit",
+        "title": "Watchlist Hit"
+      }
+    ]
+  },
+  {
+    "name": "carbonblack_edr",
+    "title": "VMware Carbon Black EDR",
+    "version": "1.2.0",
+    "release": "ga",
+    "description": "Collect logs from VMware Carbon Black EDR with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/carbonblack_edr/carbonblack_edr-1.2.0.zip",
+    "path": "/package/carbonblack_edr/1.2.0",
+    "icons": [
+      {
+        "src": "/img/carbon-black-logo.svg",
+        "path": "/package/carbonblack_edr/1.2.0/img/carbon-black-logo.svg",
+        "title": "VMWare Carbon Black",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "log",
+        "title": "Carbon Black EDR logs",
+        "description": "Collect logs from Carbon Black EDR"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/carbonblack_edr/carbonblack_edr-1.2.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "carbonblack_edr.log",
+        "title": "Carbon Black EDR logs"
       }
     ]
   },
@@ -1930,6 +1933,43 @@
         "type": "metrics",
         "dataset": "cassandra.metrics",
         "title": "metrics"
+      }
+    ]
+  },
+  {
+    "name": "cef",
+    "title": "CEF Logs",
+    "version": "2.0.0",
+    "release": "ga",
+    "description": "Collect logs from CEF Logs with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/cef/cef-2.0.0.zip",
+    "path": "/package/cef/2.0.0",
+    "policy_templates": [
+      {
+        "name": "cef",
+        "title": "CEF logs",
+        "description": "Collect logs from CEF instances"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "network",
+      "security"
+    ],
+    "signature_path": "/epr/cef/cef-2.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "cef.log",
+        "title": "CEF log logs"
       }
     ]
   },
@@ -2524,344 +2564,6 @@
     ]
   },
   {
-    "name": "aws_logs",
-    "title": "Custom AWS Logs",
-    "version": "0.2.1",
-    "release": "beta",
-    "description": "Collect raw logs from AWS S3 or CloudWatch with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/aws_logs/aws_logs-0.2.1.zip",
-    "path": "/package/aws_logs/0.2.1",
-    "icons": [
-      {
-        "src": "/img/icon.svg",
-        "path": "/package/aws_logs/0.2.1/img/icon.svg",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "aws_logs",
-        "title": "Custom AWS Logs",
-        "description": "Collect raw logs from AWS S3 or CloudWatch with Elastic Agent."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/obs-cloud-monitoring"
-    },
-    "categories": [
-      "custom",
-      "cloud",
-      "aws"
-    ],
-    "signature_path": "/epr/aws_logs/aws_logs-0.2.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "aws_logs.generic",
-        "title": "Custom logs from AWS"
-      }
-    ]
-  },
-  {
-    "name": "gcp_pubsub",
-    "title": "Custom Google Pub/Sub Logs",
-    "version": "1.0.0",
-    "release": "ga",
-    "description": "Collect Logs from Google Pub/Sub topics",
-    "type": "integration",
-    "download": "/epr/gcp_pubsub/gcp_pubsub-1.0.0.zip",
-    "path": "/package/gcp_pubsub/1.0.0",
-    "icons": [
-      {
-        "src": "/img/logo_gcp.svg",
-        "path": "/package/gcp_pubsub/1.0.0/img/logo_gcp.svg",
-        "title": "logo gcp",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "gcp",
-        "title": "Custom Google Pub/Sub Logs",
-        "description": "Collect Logs from Google Pub/Sub topics"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "google_cloud",
-      "cloud",
-      "custom"
-    ],
-    "signature_path": "/epr/gcp_pubsub/gcp_pubsub-1.0.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "gcp_pubsub.generic",
-        "title": "Custom Google Pub/Sub Logs"
-      }
-    ]
-  },
-  {
-    "name": "http_endpoint",
-    "title": "Custom HTTP Endpoint Logs",
-    "version": "1.0.1",
-    "release": "ga",
-    "description": "Collect JSON data from listening HTTP port with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/http_endpoint/http_endpoint-1.0.1.zip",
-    "path": "/package/http_endpoint/1.0.1",
-    "icons": [
-      {
-        "src": "/img/icon.svg",
-        "path": "/package/http_endpoint/1.0.1/img/icon.svg",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "http_endpoint",
-        "title": "Custom HTTP Endpoint Logs",
-        "description": "Collect JSON data from listening HTTP port with Elastic Agent."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "signature_path": "/epr/http_endpoint/http_endpoint-1.0.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "http_endpoint.generic",
-        "title": "Custom HTTP Endpoint Logs"
-      }
-    ]
-  },
-  {
-    "name": "httpjson",
-    "title": "Custom HTTPJSON Input",
-    "version": "1.1.1",
-    "release": "ga",
-    "description": "Collect custom data from REST API's with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/httpjson/httpjson-1.1.1.zip",
-    "path": "/package/httpjson/1.1.1",
-    "policy_templates": [
-      {
-        "name": "generic",
-        "title": "Custom HTTPJSON Input",
-        "description": "Collect custom data from REST API's"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "signature_path": "/epr/httpjson/httpjson-1.1.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "httpjson.generic",
-        "title": "Custom HTTPJSON Input"
-      }
-    ]
-  },
-  {
-    "name": "log",
-    "title": "Custom Logs",
-    "version": "1.0.0",
-    "release": "ga",
-    "description": "Collect custom logs with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/log/log-1.0.0.zip",
-    "path": "/package/log/1.0.0",
-    "icons": [
-      {
-        "src": "/img/icon.svg",
-        "path": "/package/log/1.0.0/img/icon.svg",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "logs",
-        "title": "Custom logs",
-        "description": "Collect your custom log files."
-      }
-    ],
-    "owner": {
-      "github": "elastic/integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "signature_path": "/epr/log/log-1.0.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "log.log",
-        "title": "Log Dataset"
-      }
-    ]
-  },
-  {
-    "name": "tcp",
-    "title": "Custom TCP Logs",
-    "version": "1.0.0",
-    "release": "ga",
-    "description": "Collect raw TCP data from listening TCP port with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/tcp/tcp-1.0.0.zip",
-    "path": "/package/tcp/1.0.0",
-    "icons": [
-      {
-        "src": "/img/icon.svg",
-        "path": "/package/tcp/1.0.0/img/icon.svg",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "tcp",
-        "title": "Custom TCP Logs",
-        "description": "Collect raw TCP data from listening TCP port with Elastic Agent."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "signature_path": "/epr/tcp/tcp-1.0.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "tcp.generic",
-        "title": "Custom TCP Logs"
-      }
-    ]
-  },
-  {
-    "name": "udp",
-    "title": "Custom UDP Logs",
-    "version": "1.0.1",
-    "release": "ga",
-    "description": "Collect raw UDP data from listening UDP port with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/udp/udp-1.0.1.zip",
-    "path": "/package/udp/1.0.1",
-    "icons": [
-      {
-        "src": "/img/icon.svg",
-        "path": "/package/udp/1.0.1/img/icon.svg",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "udp",
-        "title": "Custom UDP Logs",
-        "description": "Collect raw UDP data from listening UDP port with Elastic Agent."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "signature_path": "/epr/udp/udp-1.0.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "udp.generic",
-        "title": "Custom UDP Logs"
-      }
-    ]
-  },
-  {
-    "name": "winlog",
-    "title": "Custom Windows Event Logs",
-    "version": "1.4.0",
-    "release": "ga",
-    "description": "Collect and parse logs from any Windows event log channel with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/winlog/winlog-1.4.0.zip",
-    "path": "/package/winlog/1.4.0",
-    "icons": [
-      {
-        "src": "/img/logo_windows.svg",
-        "path": "/package/winlog/1.4.0/img/logo_windows.svg",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "winlogs",
-        "title": "Custom Windows event logs",
-        "description": "Collect your custom Windows event logs."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "custom"
-    ],
-    "signature_path": "/epr/winlog/winlog-1.4.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "winlog.winlog",
-        "title": "Custom Windows Event Log Dataset"
-      }
-    ]
-  },
-  {
     "name": "cyberarkpas",
     "title": "CyberArk Privileged Access Security Logs",
     "version": "2.4.2",
@@ -2907,49 +2609,40 @@
     ]
   },
   {
-    "name": "ti_cybersixgill",
-    "title": "Cybersixgill",
-    "version": "1.3.2",
-    "release": "ga",
-    "description": "This Elastic integration collects threat intelligence from Cybersixgill",
-    "type": "integration",
-    "download": "/epr/ti_cybersixgill/ti_cybersixgill-1.3.2.zip",
-    "path": "/package/ti_cybersixgill/1.3.2",
+    "name": "discovery_empty",
+    "title": "Discovery Empty",
+    "version": "0.1.0",
+    "release": "beta",
+    "source": {
+      "license": "Apache-2.0"
+    },
+    "description": "This package is a dummy example for packages with the content type and discovery field empty. These packages contain resources that are useful with data ingested by other integrations. They are not used to configure data sources.\n",
+    "type": "content",
+    "download": "/epr/discovery_empty/discovery_empty-0.1.0.zip",
+    "path": "/package/discovery_empty/0.1.0",
     "icons": [
       {
-        "src": "/img/cybersixgill.svg",
-        "path": "/package/ti_cybersixgill/1.3.2/img/cybersixgill.svg",
-        "title": "Cybersixgill",
-        "size": "32x32",
+        "src": "/img/system.svg",
+        "path": "/package/discovery_empty/0.1.0/img/system.svg",
+        "title": "system",
+        "size": "1000x1000",
         "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "cybersixgill",
-        "title": "Cybersixgill Threat Intel",
-        "description": "Collect Threat Intel from Cybersixgill"
       }
     ],
     "conditions": {
       "kibana": {
-        "version": "^8.0.0"
+        "version": "^8.16.0"
+      },
+      "elastic": {
+        "subscription": "basic"
       }
     },
     "owner": {
-      "github": "elastic/security-external-integrations"
+      "type": "elastic",
+      "github": "elastic/ecosystem"
     },
     "categories": [
-      "security",
-      "productivity"
-    ],
-    "signature_path": "/epr/ti_cybersixgill/ti_cybersixgill-1.3.2.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ti_cybersixgill.threat",
-        "title": "Cybersixgill Darkfeed Logs"
-      }
+      "support"
     ]
   },
   {
@@ -3003,43 +2696,6 @@
         }
       ]
     }
-  },
-  {
-    "name": "discovery_empty",
-    "title": "Discovery Empty",
-    "version": "0.1.0",
-    "release": "beta",
-    "source": {
-      "license": "Apache-2.0"
-    },
-    "description": "This package is a dummy example for packages with the content type and discovery field empty. These packages contain resources that are useful with data ingested by other integrations. They are not used to configure data sources.\n",
-    "type": "content",
-    "download": "/epr/discovery_empty/discovery_empty-0.1.0.zip",
-    "path": "/package/discovery_empty/0.1.0",
-    "icons": [
-      {
-        "src": "/img/system.svg",
-        "path": "/package/discovery_empty/0.1.0/img/system.svg",
-        "title": "system",
-        "size": "1000x1000",
-        "type": "image/svg+xml"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.16.0"
-      },
-      "elastic": {
-        "subscription": "basic"
-      }
-    },
-    "owner": {
-      "type": "elastic",
-      "github": "elastic/ecosystem"
-    },
-    "categories": [
-      "support"
-    ]
   },
   {
     "name": "docker",
@@ -3124,87 +2780,6 @@
         "type": "metrics",
         "dataset": "docker.network",
         "title": "Docker network metrics"
-      }
-    ]
-  },
-  {
-    "name": "apm",
-    "title": "Elastic APM",
-    "version": "8.2.0",
-    "release": "ga",
-    "description": "Ingest APM data",
-    "type": "integration",
-    "download": "/epr/apm/apm-8.2.0.zip",
-    "path": "/package/apm/8.2.0",
-    "icons": [
-      {
-        "src": "/img/logo_apm.svg",
-        "path": "/package/apm/8.2.0/img/logo_apm.svg",
-        "title": "APM Logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "apmserver",
-        "title": "Elastic APM Integration",
-        "description": "Elastic APM Integration"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.2.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/apm-server"
-    },
-    "categories": [
-      "elastic_stack",
-      "monitoring"
-    ],
-    "signature_path": "/epr/apm/apm-8.2.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "apm.app",
-        "title": "APM application logs"
-      },
-      {
-        "type": "metrics",
-        "dataset": "apm.app",
-        "title": "APM application metrics"
-      },
-      {
-        "type": "logs",
-        "dataset": "apm.error",
-        "title": "APM errors"
-      },
-      {
-        "type": "metrics",
-        "dataset": "apm.internal",
-        "title": "APM internal metrics"
-      },
-      {
-        "type": "metrics",
-        "dataset": "apm.profiling",
-        "title": "APM profiles"
-      },
-      {
-        "type": "traces",
-        "dataset": "apm.rum",
-        "title": "APM RUM traces"
-      },
-      {
-        "type": "traces",
-        "dataset": "apm.sampled",
-        "title": "APM tail-sampled traces"
-      },
-      {
-        "type": "traces",
-        "dataset": "apm",
-        "title": "APM traces"
       }
     ]
   },
@@ -3338,77 +2913,6 @@
         "type": "metrics",
         "dataset": "elastic_agent.packetbeat",
         "title": "Elastic Agent"
-      }
-    ]
-  },
-  {
-    "name": "synthetics",
-    "title": "Elastic Synthetics",
-    "version": "0.9.2",
-    "release": "beta",
-    "description": "Monitor the availability of your services with Elastic Synthetics.",
-    "type": "integration",
-    "download": "/epr/synthetics/synthetics-0.9.2.zip",
-    "path": "/package/synthetics/0.9.2",
-    "icons": [
-      {
-        "src": "/img/uptime-logo-color-64px.svg",
-        "path": "/package/synthetics/0.9.2/img/uptime-logo-color-64px.svg",
-        "size": "16x16",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "synthetics",
-        "title": "Elastic Synthetics",
-        "description": "Perform synthetic health checks on network endpoints."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.1.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/uptime"
-    },
-    "categories": [
-      "elastic_stack",
-      "monitoring",
-      "web"
-    ],
-    "signature_path": "/epr/synthetics/synthetics-0.9.2.zip.sig",
-    "data_streams": [
-      {
-        "type": "synthetics",
-        "dataset": "browser",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "browser.network",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "browser.screenshot",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "http",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "icmp",
-        "title": "synthetic monitor check"
-      },
-      {
-        "type": "synthetics",
-        "dataset": "tcp",
-        "title": "synthetic monitor check"
       }
     ]
   },
@@ -3710,51 +3214,6 @@
     ]
   },
   {
-    "name": "github",
-    "title": "GitHub",
-    "version": "1.0.0",
-    "release": "ga",
-    "description": "Collect events from GitHub with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/github/github-1.0.0.zip",
-    "path": "/package/github/1.0.0",
-    "icons": [
-      {
-        "src": "/img/github.svg",
-        "path": "/package/github/1.0.0/img/github.svg",
-        "title": "GitHub",
-        "size": "1024x1024",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "github",
-        "title": "GitHub logs",
-        "description": "Collect logs from GitHub"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/github/github-1.0.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "github.audit",
-        "title": "GitHub Audit Logs"
-      }
-    ]
-  },
-  {
     "name": "gcp",
     "title": "Google Cloud Platform",
     "version": "1.9.0",
@@ -3818,47 +3277,94 @@
     ]
   },
   {
-    "name": "santa",
-    "title": "Google Santa Logs",
-    "version": "2.0.1",
+    "name": "gcp_pubsub",
+    "title": "Custom Google Pub/Sub Logs",
+    "version": "1.0.0",
     "release": "ga",
-    "description": "Collect and parse logs from Google Santa instances with Elastic Agent.",
+    "description": "Collect Logs from Google Pub/Sub topics",
     "type": "integration",
-    "download": "/epr/santa/santa-2.0.1.zip",
-    "path": "/package/santa/2.0.1",
+    "download": "/epr/gcp_pubsub/gcp_pubsub-1.0.0.zip",
+    "path": "/package/gcp_pubsub/1.0.0",
     "icons": [
       {
-        "src": "/img/icon.svg",
-        "path": "/package/santa/2.0.1/img/icon.svg",
-        "title": "Google Santa",
+        "src": "/img/logo_gcp.svg",
+        "path": "/package/gcp_pubsub/1.0.0/img/logo_gcp.svg",
+        "title": "logo gcp",
+        "size": "32x32",
         "type": "image/svg+xml"
       }
     ],
     "policy_templates": [
       {
-        "name": "santa",
-        "title": "Google Santa logs",
-        "description": "Collect logs from Google Santa instances"
+        "name": "gcp",
+        "title": "Custom Google Pub/Sub Logs",
+        "description": "Collect Logs from Google Pub/Sub topics"
       }
     ],
     "conditions": {
       "kibana": {
-        "version": "^7.17.0 || ^8.0.0"
+        "version": "^7.16.0 || ^8.0.0"
       }
     },
     "owner": {
       "github": "elastic/security-external-integrations"
     },
     "categories": [
-      "security",
-      "os_system"
+      "google_cloud",
+      "cloud",
+      "custom"
     ],
-    "signature_path": "/epr/santa/santa-2.0.1.zip.sig",
+    "signature_path": "/epr/gcp_pubsub/gcp_pubsub-1.0.0.zip.sig",
     "data_streams": [
       {
         "type": "logs",
-        "dataset": "santa.log",
-        "title": "Google Santa log logs"
+        "dataset": "gcp_pubsub.generic",
+        "title": "Custom Google Pub/Sub Logs"
+      }
+    ]
+  },
+  {
+    "name": "github",
+    "title": "GitHub",
+    "version": "1.0.0",
+    "release": "ga",
+    "description": "Collect events from GitHub with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/github/github-1.0.0.zip",
+    "path": "/package/github/1.0.0",
+    "icons": [
+      {
+        "src": "/img/github.svg",
+        "path": "/package/github/1.0.0/img/github.svg",
+        "title": "GitHub",
+        "size": "1024x1024",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "github",
+        "title": "GitHub logs",
+        "description": "Collect logs from GitHub"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/github/github-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "github.audit",
+        "title": "GitHub Audit Logs"
       }
     ]
   },
@@ -4034,6 +3540,85 @@
         "type": "logs",
         "dataset": "hid_bravura_monitor.winlog",
         "title": "Hitachi ID Security Fabric logs"
+      }
+    ]
+  },
+  {
+    "name": "http_endpoint",
+    "title": "Custom HTTP Endpoint Logs",
+    "version": "1.0.1",
+    "release": "ga",
+    "description": "Collect JSON data from listening HTTP port with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/http_endpoint/http_endpoint-1.0.1.zip",
+    "path": "/package/http_endpoint/1.0.1",
+    "icons": [
+      {
+        "src": "/img/icon.svg",
+        "path": "/package/http_endpoint/1.0.1/img/icon.svg",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "http_endpoint",
+        "title": "Custom HTTP Endpoint Logs",
+        "description": "Collect JSON data from listening HTTP port with Elastic Agent."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "signature_path": "/epr/http_endpoint/http_endpoint-1.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "http_endpoint.generic",
+        "title": "Custom HTTP Endpoint Logs"
+      }
+    ]
+  },
+  {
+    "name": "httpjson",
+    "title": "Custom HTTPJSON Input",
+    "version": "1.1.1",
+    "release": "ga",
+    "description": "Collect custom data from REST API's with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/httpjson/httpjson-1.1.1.zip",
+    "path": "/package/httpjson/1.1.1",
+    "policy_templates": [
+      {
+        "name": "generic",
+        "title": "Custom HTTPJSON Input",
+        "description": "Collect custom data from REST API's"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "signature_path": "/epr/httpjson/httpjson-1.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "httpjson.generic",
+        "title": "Custom HTTPJSON Input"
       }
     ]
   },
@@ -4874,6 +4459,44 @@
     ]
   },
   {
+    "name": "log",
+    "title": "Custom Logs",
+    "version": "1.0.0",
+    "release": "ga",
+    "description": "Collect custom logs with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/log/log-1.0.0.zip",
+    "path": "/package/log/1.0.0",
+    "icons": [
+      {
+        "src": "/img/icon.svg",
+        "path": "/package/log/1.0.0/img/icon.svg",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "logs",
+        "title": "Custom logs",
+        "description": "Collect your custom log files."
+      }
+    ],
+    "owner": {
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "signature_path": "/epr/log/log-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "log.log",
+        "title": "Log Dataset"
+      }
+    ]
+  },
+  {
     "name": "logstash",
     "title": "Logstash",
     "version": "1.0.0",
@@ -4981,51 +4604,6 @@
     ]
   },
   {
-    "name": "ti_misp",
-    "title": "MISP",
-    "version": "1.2.2",
-    "release": "ga",
-    "description": "This Elastic integration collects events from MISP",
-    "type": "integration",
-    "download": "/epr/ti_misp/ti_misp-1.2.2.zip",
-    "path": "/package/ti_misp/1.2.2",
-    "icons": [
-      {
-        "src": "/img/misp.svg",
-        "path": "/package/ti_misp/1.2.2/img/misp.svg",
-        "title": "MISP",
-        "size": "216x216",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "ti_misp",
-        "title": "MISP",
-        "description": "Collect threat intelligence from the MISP API."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/ti_misp/ti_misp-1.2.2.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ti_misp.threat",
-        "title": "MISP"
-      }
-    ]
-  },
-  {
     "name": "mattermost",
     "title": "Mattermost",
     "version": "1.1.1",
@@ -5124,51 +4702,6 @@
     ]
   },
   {
-    "name": "microsoft_dhcp",
-    "title": "Microsoft DHCP",
-    "version": "1.3.1",
-    "release": "ga",
-    "description": "Collect logs from Microsoft DHCP with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/microsoft_dhcp/microsoft_dhcp-1.3.1.zip",
-    "path": "/package/microsoft_dhcp/1.3.1",
-    "icons": [
-      {
-        "src": "/img/logo.svg",
-        "path": "/package/microsoft_dhcp/1.3.1/img/logo.svg",
-        "title": "Microsoft logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "microsoft_dhcp",
-        "title": "Microsoft DHCP",
-        "description": "Collect Microsoft DHCP logs."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "network"
-    ],
-    "signature_path": "/epr/microsoft_dhcp/microsoft_dhcp-1.3.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "microsoft_dhcp.log",
-        "title": "Microsoft DHCP Logs"
-      }
-    ]
-  },
-  {
     "name": "microsoft_defender_endpoint",
     "title": "Microsoft Defender for Endpoint",
     "version": "2.1.0",
@@ -5212,6 +4745,51 @@
         "type": "logs",
         "dataset": "microsoft_defender_endpoint.log",
         "title": "Microsoft Defender for Endpoint logs"
+      }
+    ]
+  },
+  {
+    "name": "microsoft_dhcp",
+    "title": "Microsoft DHCP",
+    "version": "1.3.1",
+    "release": "ga",
+    "description": "Collect logs from Microsoft DHCP with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/microsoft_dhcp/microsoft_dhcp-1.3.1.zip",
+    "path": "/package/microsoft_dhcp/1.3.1",
+    "icons": [
+      {
+        "src": "/img/logo.svg",
+        "path": "/package/microsoft_dhcp/1.3.1/img/logo.svg",
+        "title": "Microsoft logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "microsoft_dhcp",
+        "title": "Microsoft DHCP",
+        "description": "Collect Microsoft DHCP logs."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "network"
+    ],
+    "signature_path": "/epr/microsoft_dhcp/microsoft_dhcp-1.3.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "microsoft_dhcp.log",
+        "title": "Microsoft DHCP Logs"
       }
     ]
   },
@@ -6052,51 +5630,6 @@
     ]
   },
   {
-    "name": "panw_cortex_xdr",
-    "title": "Palo Alto Cortex XDR Logs",
-    "version": "1.1.1",
-    "release": "ga",
-    "description": "Collect and parse logs from Palo Alto Cortex XDR API with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/panw_cortex_xdr/panw_cortex_xdr-1.1.1.zip",
-    "path": "/package/panw_cortex_xdr/1.1.1",
-    "icons": [
-      {
-        "src": "/img/icon-cortex.svg",
-        "path": "/package/panw_cortex_xdr/1.1.1/img/icon-cortex.svg",
-        "title": "Palo Alto",
-        "size": "216x216",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "alerts",
-        "title": "Palo Alto Cortex XDR API",
-        "description": "Collect logs from Palo Alto Cortex XDR API"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.15.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/panw_cortex_xdr/panw_cortex_xdr-1.1.1.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "panw_cortex_xdr.alerts",
-        "title": "Palo Alto Cortex XDR API"
-      }
-    ]
-  },
-  {
     "name": "panw",
     "title": "Palo Alto Networks Logs",
     "version": "1.5.3",
@@ -6138,6 +5671,51 @@
         "type": "logs",
         "dataset": "panw.panos",
         "title": "Palo Alto Networks PAN-OS firewall logs"
+      }
+    ]
+  },
+  {
+    "name": "panw_cortex_xdr",
+    "title": "Palo Alto Cortex XDR Logs",
+    "version": "1.1.1",
+    "release": "ga",
+    "description": "Collect and parse logs from Palo Alto Cortex XDR API with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/panw_cortex_xdr/panw_cortex_xdr-1.1.1.zip",
+    "path": "/package/panw_cortex_xdr/1.1.1",
+    "icons": [
+      {
+        "src": "/img/icon-cortex.svg",
+        "path": "/package/panw_cortex_xdr/1.1.1/img/icon-cortex.svg",
+        "title": "Palo Alto",
+        "size": "216x216",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "alerts",
+        "title": "Palo Alto Cortex XDR API",
+        "description": "Collect logs from Palo Alto Cortex XDR API"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.15.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/panw_cortex_xdr/panw_cortex_xdr-1.1.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "panw_cortex_xdr.alerts",
+        "title": "Palo Alto Cortex XDR API"
       }
     ]
   },
@@ -6205,42 +5783,6 @@
         "title": "PostgreSQL statement metrics"
       }
     ]
-  },
-  {
-    "name": "security_detection_engine",
-    "title": "Prebuilt Security Detection Rules",
-    "version": "1.0.2",
-    "release": "ga",
-    "description": "Prebuilt detection rules for Elastic Security",
-    "type": "integration",
-    "download": "/epr/security_detection_engine/security_detection_engine-1.0.2.zip",
-    "path": "/package/security_detection_engine/1.0.2",
-    "icons": [
-      {
-        "src": "/img/security-logo-color-64px.svg",
-        "path": "/package/security_detection_engine/1.0.2/img/security-logo-color-64px.svg",
-        "size": "16x16",
-        "type": "image/svg+xml"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      },
-      "elastic": {
-        "subscription": "basic",
-        "capabilities": [
-          "security"
-        ]
-      }
-    },
-    "owner": {
-      "github": "elastic/protections"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/security_detection_engine/security_detection_engine-1.0.2.zip.sig"
   },
   {
     "name": "qnap_nas",
@@ -6353,51 +5895,6 @@
     ]
   },
   {
-    "name": "ti_recordedfuture",
-    "title": "Recorded Future",
-    "version": "0.1.2",
-    "release": "beta",
-    "description": "Collect threat intelligence from Recorded Future with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/ti_recordedfuture/ti_recordedfuture-0.1.2.zip",
-    "path": "/package/ti_recordedfuture/0.1.2",
-    "icons": [
-      {
-        "src": "/img/logo.svg",
-        "path": "/package/ti_recordedfuture/0.1.2/img/logo.svg",
-        "title": "Recorded Future",
-        "size": "216x216",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "ti_recordedfuture",
-        "title": "Recorded Future",
-        "description": "Collect threat intelligence from Recorded Future."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/ti_recordedfuture/ti_recordedfuture-0.1.2.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "ti_recordedfuture.threat",
-        "title": "Recorded Future"
-      }
-    ]
-  },
-  {
     "name": "redis",
     "title": "Redis",
     "version": "1.2.0",
@@ -6460,6 +5957,187 @@
         "type": "logs",
         "dataset": "redis.slowlog",
         "title": "Redis slow logs"
+      }
+    ]
+  },
+  {
+    "name": "santa",
+    "title": "Google Santa Logs",
+    "version": "2.0.1",
+    "release": "ga",
+    "description": "Collect and parse logs from Google Santa instances with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/santa/santa-2.0.1.zip",
+    "path": "/package/santa/2.0.1",
+    "icons": [
+      {
+        "src": "/img/icon.svg",
+        "path": "/package/santa/2.0.1/img/icon.svg",
+        "title": "Google Santa",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "santa",
+        "title": "Google Santa logs",
+        "description": "Collect logs from Google Santa instances"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.17.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security",
+      "os_system"
+    ],
+    "signature_path": "/epr/santa/santa-2.0.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "santa.log",
+        "title": "Google Santa log logs"
+      }
+    ]
+  },
+  {
+    "name": "security_detection_engine",
+    "title": "Prebuilt Security Detection Rules",
+    "version": "1.0.2",
+    "release": "ga",
+    "description": "Prebuilt detection rules for Elastic Security",
+    "type": "integration",
+    "download": "/epr/security_detection_engine/security_detection_engine-1.0.2.zip",
+    "path": "/package/security_detection_engine/1.0.2",
+    "icons": [
+      {
+        "src": "/img/security-logo-color-64px.svg",
+        "path": "/package/security_detection_engine/1.0.2/img/security-logo-color-64px.svg",
+        "size": "16x16",
+        "type": "image/svg+xml"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      },
+      "elastic": {
+        "subscription": "basic",
+        "capabilities": [
+          "security"
+        ]
+      }
+    },
+    "owner": {
+      "github": "elastic/protections"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/security_detection_engine/security_detection_engine-1.0.2.zip.sig"
+  },
+  {
+    "name": "snyk",
+    "title": "Snyk",
+    "version": "1.1.2",
+    "release": "ga",
+    "description": "Collect logs from Snyk API with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/snyk/snyk-1.1.2.zip",
+    "path": "/package/snyk/1.1.2",
+    "icons": [
+      {
+        "src": "/img/snyk-logo.svg",
+        "path": "/package/snyk/1.1.2/img/snyk-logo.svg",
+        "title": "Snyk logo",
+        "size": "382x625",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "snyk",
+        "title": "Snyk Events",
+        "description": "Collect data from Snyk API"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/snyk/snyk-1.1.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "snyk.audit",
+        "title": "Collect Snyk Audit Logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "snyk.vulnerabilities",
+        "title": "Collect Snyk Vulnerability Data"
+      }
+    ]
+  },
+  {
+    "name": "sophos",
+    "title": "Sophos Logs",
+    "version": "1.2.2",
+    "release": "ga",
+    "description": "Collect and parse logs from Sophos Products with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/sophos/sophos-1.2.2.zip",
+    "path": "/package/sophos/1.2.2",
+    "icons": [
+      {
+        "src": "/img/logo.svg",
+        "path": "/package/sophos/1.2.2/img/logo.svg",
+        "title": "Sophos logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "sophos",
+        "title": "Sophos logs",
+        "description": "Collect Sophos logs from syslog or a file."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.1 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/sophos/sophos-1.2.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "sophos.utm",
+        "title": "Sophos UTM logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "sophos.xg",
+        "title": "Sophos XG logs"
       }
     ]
   },
@@ -6574,106 +6252,6 @@
     ]
   },
   {
-    "name": "snyk",
-    "title": "Snyk",
-    "version": "1.1.2",
-    "release": "ga",
-    "description": "Collect logs from Snyk API with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/snyk/snyk-1.1.2.zip",
-    "path": "/package/snyk/1.1.2",
-    "icons": [
-      {
-        "src": "/img/snyk-logo.svg",
-        "path": "/package/snyk/1.1.2/img/snyk-logo.svg",
-        "title": "Snyk logo",
-        "size": "382x625",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "snyk",
-        "title": "Snyk Events",
-        "description": "Collect data from Snyk API"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.16.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/snyk/snyk-1.1.2.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "snyk.audit",
-        "title": "Collect Snyk Audit Logs"
-      },
-      {
-        "type": "logs",
-        "dataset": "snyk.vulnerabilities",
-        "title": "Collect Snyk Vulnerability Data"
-      }
-    ]
-  },
-  {
-    "name": "sophos",
-    "title": "Sophos Logs",
-    "version": "1.2.2",
-    "release": "ga",
-    "description": "Collect and parse logs from Sophos Products with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/sophos/sophos-1.2.2.zip",
-    "path": "/package/sophos/1.2.2",
-    "icons": [
-      {
-        "src": "/img/logo.svg",
-        "path": "/package/sophos/1.2.2/img/logo.svg",
-        "title": "Sophos logo",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "sophos",
-        "title": "Sophos logs",
-        "description": "Collect Sophos logs from syslog or a file."
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.1 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/sophos/sophos-1.2.2.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "sophos.utm",
-        "title": "Sophos UTM logs"
-      },
-      {
-        "type": "logs",
-        "dataset": "sophos.xg",
-        "title": "Sophos XG logs"
-      }
-    ]
-  },
-  {
     "name": "suricata",
     "title": "Suricata Events",
     "version": "1.6.1",
@@ -6761,6 +6339,77 @@
         "type": "logs",
         "dataset": "symantec_endpoint.log",
         "title": "Symantec Endpoint Protection (SEP) Logs"
+      }
+    ]
+  },
+  {
+    "name": "synthetics",
+    "title": "Elastic Synthetics",
+    "version": "0.9.2",
+    "release": "beta",
+    "description": "Monitor the availability of your services with Elastic Synthetics.",
+    "type": "integration",
+    "download": "/epr/synthetics/synthetics-0.9.2.zip",
+    "path": "/package/synthetics/0.9.2",
+    "icons": [
+      {
+        "src": "/img/uptime-logo-color-64px.svg",
+        "path": "/package/synthetics/0.9.2/img/uptime-logo-color-64px.svg",
+        "size": "16x16",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "synthetics",
+        "title": "Elastic Synthetics",
+        "description": "Perform synthetic health checks on network endpoints."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.1.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/uptime"
+    },
+    "categories": [
+      "elastic_stack",
+      "monitoring",
+      "web"
+    ],
+    "signature_path": "/epr/synthetics/synthetics-0.9.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "synthetics",
+        "dataset": "browser",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "browser.network",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "browser.screenshot",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "http",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "icmp",
+        "title": "synthetic monitor check"
+      },
+      {
+        "type": "synthetics",
+        "dataset": "tcp",
+        "title": "synthetic monitor check"
       }
     ]
   },
@@ -6891,6 +6540,49 @@
     ]
   },
   {
+    "name": "tcp",
+    "title": "Custom TCP Logs",
+    "version": "1.0.0",
+    "release": "ga",
+    "description": "Collect raw TCP data from listening TCP port with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/tcp/tcp-1.0.0.zip",
+    "path": "/package/tcp/1.0.0",
+    "icons": [
+      {
+        "src": "/img/icon.svg",
+        "path": "/package/tcp/1.0.0/img/icon.svg",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "tcp",
+        "title": "Custom TCP Logs",
+        "description": "Collect raw TCP data from listening TCP port with Elastic Agent."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "signature_path": "/epr/tcp/tcp-1.0.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "tcp.generic",
+        "title": "Custom TCP Logs"
+      }
+    ]
+  },
+  {
     "name": "tenable_sc",
     "title": "Tenable.sc",
     "version": "1.1.1",
@@ -6946,6 +6638,292 @@
     ]
   },
   {
+    "name": "ti_abusech",
+    "title": "AbuseCH",
+    "version": "1.2.3",
+    "release": "ga",
+    "description": "Collect threat intelligence from AbuseCH API with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/ti_abusech/ti_abusech-1.2.3.zip",
+    "path": "/package/ti_abusech/1.2.3",
+    "icons": [
+      {
+        "src": "/img/abusech2.svg",
+        "path": "/package/ti_abusech/1.2.3/img/abusech2.svg",
+        "title": "AbuseCH",
+        "size": "512x512",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "ti_abusech",
+        "title": "AbuseCH API",
+        "description": "Collect threat intelligence from the AbuseCH API"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/ti_abusech/ti_abusech-1.2.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_abusech.malware",
+        "title": "AbuseCH Malware logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "ti_abusech.malwarebazaar",
+        "title": "AbuseCH MalwareBazaar logs"
+      },
+      {
+        "type": "logs",
+        "dataset": "ti_abusech.url",
+        "title": "AbuseCH URL logs"
+      }
+    ]
+  },
+  {
+    "name": "ti_anomali",
+    "title": "Anomali",
+    "version": "1.2.3",
+    "release": "ga",
+    "description": "Collect threat intelligence from Anomali APIs with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/ti_anomali/ti_anomali-1.2.3.zip",
+    "path": "/package/ti_anomali/1.2.3",
+    "icons": [
+      {
+        "src": "/img/anomali.svg",
+        "path": "/package/ti_anomali/1.2.3/img/anomali.svg",
+        "title": "Anomali",
+        "size": "216x216",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "ti_anomali",
+        "title": "Anomali",
+        "description": "Collect threat intelligence from the Anomali Limo API and Anomali Threatstream."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/ti_anomali/ti_anomali-1.2.3.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_anomali.limo",
+        "title": "Anomali Limo"
+      },
+      {
+        "type": "logs",
+        "dataset": "ti_anomali.threatstream",
+        "title": "Anomali Threatstream"
+      }
+    ]
+  },
+  {
+    "name": "ti_cybersixgill",
+    "title": "Cybersixgill",
+    "version": "1.3.2",
+    "release": "ga",
+    "description": "This Elastic integration collects threat intelligence from Cybersixgill",
+    "type": "integration",
+    "download": "/epr/ti_cybersixgill/ti_cybersixgill-1.3.2.zip",
+    "path": "/package/ti_cybersixgill/1.3.2",
+    "icons": [
+      {
+        "src": "/img/cybersixgill.svg",
+        "path": "/package/ti_cybersixgill/1.3.2/img/cybersixgill.svg",
+        "title": "Cybersixgill",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "cybersixgill",
+        "title": "Cybersixgill Threat Intel",
+        "description": "Collect Threat Intel from Cybersixgill"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security",
+      "productivity"
+    ],
+    "signature_path": "/epr/ti_cybersixgill/ti_cybersixgill-1.3.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_cybersixgill.threat",
+        "title": "Cybersixgill Darkfeed Logs"
+      }
+    ]
+  },
+  {
+    "name": "ti_misp",
+    "title": "MISP",
+    "version": "1.2.2",
+    "release": "ga",
+    "description": "This Elastic integration collects events from MISP",
+    "type": "integration",
+    "download": "/epr/ti_misp/ti_misp-1.2.2.zip",
+    "path": "/package/ti_misp/1.2.2",
+    "icons": [
+      {
+        "src": "/img/misp.svg",
+        "path": "/package/ti_misp/1.2.2/img/misp.svg",
+        "title": "MISP",
+        "size": "216x216",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "ti_misp",
+        "title": "MISP",
+        "description": "Collect threat intelligence from the MISP API."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/ti_misp/ti_misp-1.2.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_misp.threat",
+        "title": "MISP"
+      }
+    ]
+  },
+  {
+    "name": "ti_otx",
+    "title": "AlienVault OTX",
+    "version": "1.2.2",
+    "release": "ga",
+    "description": "Collect threat intelligence from AlienVault OTX with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/ti_otx/ti_otx-1.2.2.zip",
+    "path": "/package/ti_otx/1.2.2",
+    "icons": [
+      {
+        "src": "/img/otx.svg",
+        "path": "/package/ti_otx/1.2.2/img/otx.svg",
+        "title": "Alienvault OTX",
+        "size": "216x216",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "ti_otx",
+        "title": "Alienvault OTX",
+        "description": "Collect threat intelligence from the Alienvault OTX"
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/ti_otx/ti_otx-1.2.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_otx.threat",
+        "title": "Alienvault OTX logs"
+      }
+    ]
+  },
+  {
+    "name": "ti_recordedfuture",
+    "title": "Recorded Future",
+    "version": "0.1.2",
+    "release": "beta",
+    "description": "Collect threat intelligence from Recorded Future with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/ti_recordedfuture/ti_recordedfuture-0.1.2.zip",
+    "path": "/package/ti_recordedfuture/0.1.2",
+    "icons": [
+      {
+        "src": "/img/logo.svg",
+        "path": "/package/ti_recordedfuture/0.1.2/img/logo.svg",
+        "title": "Recorded Future",
+        "size": "216x216",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "ti_recordedfuture",
+        "title": "Recorded Future",
+        "description": "Collect threat intelligence from Recorded Future."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "security"
+    ],
+    "signature_path": "/epr/ti_recordedfuture/ti_recordedfuture-0.1.2.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "ti_recordedfuture.threat",
+        "title": "Recorded Future"
+      }
+    ]
+  },
+  {
     "name": "ti_threatq",
     "title": "ThreatQuotient",
     "version": "1.2.2",
@@ -6987,6 +6965,52 @@
         "type": "logs",
         "dataset": "ti_threatq.threat",
         "title": "ThreatQ"
+      }
+    ]
+  },
+  {
+    "name": "tomcat",
+    "title": "Apache Tomcat",
+    "version": "1.3.1",
+    "release": "ga",
+    "description": "Collect and parse logs from Apache Tomcat servers with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/tomcat/tomcat-1.3.1.zip",
+    "path": "/package/tomcat/1.3.1",
+    "icons": [
+      {
+        "src": "/img/logo.svg",
+        "path": "/package/tomcat/1.3.1/img/logo.svg",
+        "title": "Apache Tomcat logo",
+        "size": "32x32",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "log",
+        "title": "Apache Tomcat",
+        "description": "Collect Apache Tomcat logs from syslog or a file."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.14.1 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "web",
+      "security"
+    ],
+    "signature_path": "/epr/tomcat/tomcat-1.3.1.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "tomcat.log",
+        "title": "Apache Tomcat logs"
       }
     ]
   },
@@ -7042,112 +7066,45 @@
     ]
   },
   {
-    "name": "carbon_black_cloud",
-    "title": "VMware Carbon Black Cloud",
-    "version": "1.0.2",
+    "name": "udp",
+    "title": "Custom UDP Logs",
+    "version": "1.0.1",
     "release": "ga",
-    "description": "Collect logs from VMWare Carbon Black Cloud with Elastic Agent.",
+    "description": "Collect raw UDP data from listening UDP port with Elastic Agent.",
     "type": "integration",
-    "download": "/epr/carbon_black_cloud/carbon_black_cloud-1.0.2.zip",
-    "path": "/package/carbon_black_cloud/1.0.2",
+    "download": "/epr/udp/udp-1.0.1.zip",
+    "path": "/package/udp/1.0.1",
     "icons": [
       {
-        "src": "/img/carbon_black_cloud-logo.svg",
-        "path": "/package/carbon_black_cloud/1.0.2/img/carbon_black_cloud-logo.svg",
-        "title": "Carbon Black Cloud logo",
-        "size": "32x32",
+        "src": "/img/icon.svg",
+        "path": "/package/udp/1.0.1/img/icon.svg",
         "type": "image/svg+xml"
       }
     ],
     "policy_templates": [
       {
-        "name": "carbon_black_cloud",
-        "title": "Carbon Black Cloud",
-        "description": "Collect Logs from Carbon Black Cloud"
+        "name": "udp",
+        "title": "Custom UDP Logs",
+        "description": "Collect raw UDP data from listening UDP port with Elastic Agent."
       }
     ],
     "conditions": {
       "kibana": {
-        "version": "^7.17.0 || ^8.0.0"
+        "version": "^7.16.0 || ^8.0.0"
       }
     },
     "owner": {
       "github": "elastic/security-external-integrations"
     },
     "categories": [
-      "security"
+      "custom"
     ],
-    "signature_path": "/epr/carbon_black_cloud/carbon_black_cloud-1.0.2.zip.sig",
+    "signature_path": "/epr/udp/udp-1.0.1.zip.sig",
     "data_streams": [
       {
         "type": "logs",
-        "dataset": "carbon_black_cloud.alert",
-        "title": "Alert"
-      },
-      {
-        "type": "logs",
-        "dataset": "carbon_black_cloud.asset_vulnerability_summary",
-        "title": "Asset Vulnerability Summary"
-      },
-      {
-        "type": "logs",
-        "dataset": "carbon_black_cloud.audit",
-        "title": "Audit"
-      },
-      {
-        "type": "logs",
-        "dataset": "carbon_black_cloud.endpoint_event",
-        "title": "Endpoint Event"
-      },
-      {
-        "type": "logs",
-        "dataset": "carbon_black_cloud.watchlist_hit",
-        "title": "Watchlist Hit"
-      }
-    ]
-  },
-  {
-    "name": "carbonblack_edr",
-    "title": "VMware Carbon Black EDR",
-    "version": "1.2.0",
-    "release": "ga",
-    "description": "Collect logs from VMware Carbon Black EDR with Elastic Agent.",
-    "type": "integration",
-    "download": "/epr/carbonblack_edr/carbonblack_edr-1.2.0.zip",
-    "path": "/package/carbonblack_edr/1.2.0",
-    "icons": [
-      {
-        "src": "/img/carbon-black-logo.svg",
-        "path": "/package/carbonblack_edr/1.2.0/img/carbon-black-logo.svg",
-        "title": "VMWare Carbon Black",
-        "size": "32x32",
-        "type": "image/svg+xml"
-      }
-    ],
-    "policy_templates": [
-      {
-        "name": "log",
-        "title": "Carbon Black EDR logs",
-        "description": "Collect logs from Carbon Black EDR"
-      }
-    ],
-    "conditions": {
-      "kibana": {
-        "version": "^7.14.0 || ^8.0.0"
-      }
-    },
-    "owner": {
-      "github": "elastic/security-external-integrations"
-    },
-    "categories": [
-      "security"
-    ],
-    "signature_path": "/epr/carbonblack_edr/carbonblack_edr-1.2.0.zip.sig",
-    "data_streams": [
-      {
-        "type": "logs",
-        "dataset": "carbonblack_edr.log",
-        "title": "Carbon Black EDR logs"
+        "dataset": "udp.generic",
+        "title": "Custom UDP Logs"
       }
     ]
   },
@@ -7280,6 +7237,49 @@
         "type": "logs",
         "dataset": "windows.sysmon_operational",
         "title": "Windows Sysmon/Operational events"
+      }
+    ]
+  },
+  {
+    "name": "winlog",
+    "title": "Custom Windows Event Logs",
+    "version": "1.4.0",
+    "release": "ga",
+    "description": "Collect and parse logs from any Windows event log channel with Elastic Agent.",
+    "type": "integration",
+    "download": "/epr/winlog/winlog-1.4.0.zip",
+    "path": "/package/winlog/1.4.0",
+    "icons": [
+      {
+        "src": "/img/logo_windows.svg",
+        "path": "/package/winlog/1.4.0/img/logo_windows.svg",
+        "type": "image/svg+xml"
+      }
+    ],
+    "policy_templates": [
+      {
+        "name": "winlogs",
+        "title": "Custom Windows event logs",
+        "description": "Collect your custom Windows event logs."
+      }
+    ],
+    "conditions": {
+      "kibana": {
+        "version": "^7.16.0 || ^8.0.0"
+      }
+    },
+    "owner": {
+      "github": "elastic/security-external-integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "signature_path": "/epr/winlog/winlog-1.4.0.zip.sig",
+    "data_streams": [
+      {
+        "type": "logs",
+        "dataset": "winlog.winlog",
+        "title": "Custom Windows Event Log Dataset"
       }
     ]
   },


### PR DESCRIPTION
Resolve https://github.com/elastic/package-registry/issues/1601 

## Description

  - Sort packages by Name instead of Title for a more stable and deterministic sort order
  - Test fixtures and generated golden files updated to reflect the new ordering

##  Test plan

  - Unit tests updated in packages/packages_test.go — sort by name alphabetically, by semver within the same name, and combined name+version ordering
  - Golden file testdata/generated/search-all-proxy.json regenerated to match new sort order
  - Existing test suite passes