### PR TITLE
Add missing test case for zip file indexer and disabling required signatures

### DIFF
--- a/flags_test.go
+++ b/flags_test.go
@@ -6,7 +6,6 @@ package main
 
 import (
 	"flag"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -15,7 +14,7 @@ import (
 
 func TestFlagsFromEnv(t *testing.T) {
 	expected := "my value"
-	os.Setenv("EPR_TEST_DUMMY", expected)
+	t.Setenv("EPR_TEST_DUMMY", expected)
 
 	var dummyFlag string
 	flagSet := flag.NewFlagSet("", flag.PanicOnError)
@@ -28,7 +27,7 @@ func TestFlagsFromEnv(t *testing.T) {
 
 func TestFlagsPrecedence(t *testing.T) {
 	expected := "flag value"
-	os.Setenv("EPR_TEST_PRECEDENCE_DUMMY", "other value")
+	t.Setenv("EPR_TEST_PRECEDENCE_DUMMY", "other value")
 
 	var dummyFlag string
 	flagSet := flag.NewFlagSet("", flag.PanicOnError)

--- a/packages/packages_test.go
+++ b/packages/packages_test.go
@@ -1100,6 +1100,24 @@ func TestRequireSignatures(t *testing.T) {
 		require.NoError(t, err)
 		assert.Len(t, pkgs, 1)
 	})
+
+	t.Run("ZipFileSystemIndexer succeeds when RequireSignatures=false and no sig file", func(t *testing.T) {
+		ValidationDisabled = true
+		tmpDir := t.TempDir()
+		createMockZipPackage(t, tmpDir, "mypkg")
+
+		indexer := NewZipFileSystemIndexer(FSIndexerOptions{
+			Logger:            logger,
+			RequireSignatures: false,
+		}, tmpDir)
+
+		err := indexer.Init(context.Background())
+		require.NoError(t, err)
+
+		pkgs, err := indexer.Get(context.Background(), nil)
+		require.NoError(t, err)
+		assert.Len(t, pkgs, 1)
+	})
 }
 
 func createMockSignatureFile(t *testing.T, basePath string) {


### PR DESCRIPTION
This is already tested with other indexers, check it too in the zip file indexer that is more commonly used in production environments.

Update tests that check environment variables to use `t.Setenv()`, that is safer than `os.Setenv` for tests.