### PR TITLE
Add post-dependabot workflow to keep cmd/distribution go.mod in sync

### DIFF
--- a/.github/workflows/post-dependabot.yml
+++ b/.github/workflows/post-dependabot.yml
@@ -2,6 +2,7 @@
 # in cmd/distribution (a separate Go module) may fall out of sync. This workflow
 # runs go mod tidy in cmd/distribution on every dependabot go_modules push and
 # commits any resulting changes back to the branch.
+
 name: post-dependabot
 
 on:

--- a/.github/workflows/post-dependabot.yml
+++ b/.github/workflows/post-dependabot.yml
@@ -1,0 +1,54 @@
+# When dependabot bumps a dependency in the root module, indirect dependencies
+# in cmd/distribution (a separate Go module) may fall out of sync. This workflow
+# runs go mod tidy in cmd/distribution on every dependabot go_modules push and
+# commits any resulting changes back to the branch.
+
+name: post-dependabot
+
+on:
+  push:
+    branches:
+      - "dependabot/go_modules/**"
+      - "!dependabot/go_modules/cmd/distribution/**"
+
+jobs:
+  update-cmd-distribution:
+    permissions:
+      contents: write
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: .go-version
+
+      - name: set up git user
+        uses: elastic/oblt-actions/git/setup@v1
+        with:
+          username: 'dependabot[bot]'
+          email: 'dependabot[bot]@users.noreply.github.com'
+
+      - name: Run go mod tidy in cmd/distribution
+        run: cd cmd/distribution && go mod tidy
+
+      - name: Check for modified go.mod or go.sum
+        id: dist-check
+        run: |
+          if git diff --quiet HEAD -- cmd/distribution/go.mod cmd/distribution/go.sum; then
+            echo "modified=false" >> $GITHUB_OUTPUT
+          else
+            echo "modified=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Commit updated cmd/distribution go.mod and go.sum
+        if: steps.dist-check.outputs.modified == 'true'
+        run: |
+          git add cmd/distribution/go.mod cmd/distribution/go.sum
+          git commit -m "Update go.mod in cmd/distribution"
+
+      - name: Push changes
+        if: steps.dist-check.outputs.modified == 'true'
+        run: git push

--- a/.github/workflows/post-dependabot.yml
+++ b/.github/workflows/post-dependabot.yml
@@ -2,7 +2,6 @@
 # in cmd/distribution (a separate Go module) may fall out of sync. This workflow
 # runs go mod tidy in cmd/distribution on every dependabot go_modules push and
 # commits any resulting changes back to the branch.
-
 name: post-dependabot
 
 on:


### PR DESCRIPTION
## Summary

`cmd/distribution` is a separate Go module (with its own `go.mod`) nested inside this repository. When dependabot bumps a dependency in the root module, it does not automatically update the indirect dependencies in `cmd/distribution` — only the direct dependency in that submodule gets a separate dependabot PR. This leaves transitive deps (e.g. `golang.org/x/crypto`, `golang.org/x/sys`) silently out of sync until someone runs `go mod tidy` manually.

This PR adds a GitHub Actions workflow (`.github/workflows/post-dependabot.yml`) that fires on every push to a `dependabot/go_modules/**` branch (excluding `dependabot/go_modules/cmd/distribution/**`, which dependabot already handles correctly), runs `go mod tidy` inside `cmd/distribution`, and commits any changes back to the branch automatically.

The workflow is based on a similar pattern used in [`elastic/elastic-agent`](https://github.com/elastic/elastic-agent/blob/d7eec0f46b8f0841b19a2bcb67e40277ba100232/.github/workflows/post-dependabot.yml).

## PRs that would have benefited from this workflow

The following merged dependabot PRs all required a manual follow-up commit to `cmd/distribution/go.mod` or `go.sum`:

| PR | Dependency bumped (root module) | Manual fix |
|----|---------------------------------|------------|
| [#1621](https://github.com/elastic/package-registry/pull/1621) | `golang.org/x/tools` 0.42.0 → 0.43.0 | Updated `x/tools`, `x/crypto`, `x/mod`, `x/sys`, `x/telemetry` in `cmd/distribution` |
| [#1667](https://github.com/elastic/package-registry/pull/1667) | `golang.org/x/tools` 0.43.0 → 0.44.0 | Updated `x/crypto` 0.49.0 → 0.50.0 in `cmd/distribution` |
| [#1706](https://github.com/elastic/package-registry/pull/1706) | `golang.org/x/tools` 0.44.0 → 0.45.0 | Updated `x/crypto` 0.50.0 → 0.51.0 in `cmd/distribution` |

With this workflow in place, those manual commits would have been created automatically on the dependabot branch.

## Changes

- `.github/workflows/post-dependabot.yml`: new workflow that runs `go mod tidy` in `cmd/distribution` on dependabot go_modules pushes and commits any diff back to the branch.

---

> This PR was generated with the assistance of [Claude](https://claude.ai) (claude-sonnet-4-6).