### PR TITLE
[CI] Enable set_commit_status for main pipeline

### DIFF
--- a/.buildkite/pull-requests.json
+++ b/.buildkite/pull-requests.json
@@ -6,6 +6,7 @@
             "allow_org_users": true,
             "allowed_repo_permissions": ["admin", "write"],
             "allowed_list": ["dependabot[bot]", "mergify[bot]"],
+            "set_commit_status": true,
             "build_on_commit": true,
             "build_on_comment": true,
             "trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:build|test)\\W+(?:this|it))|^/test$",


### PR DESCRIPTION
This setting is required to set the commit status as success if the Pull Request just modifies files defined in `skip_ci_on_only_changed`.

Relates https://github.com/elastic/package-registry/pull/1717