### PR TITLE
Fix DOCKER_TAG on package-registry distribution copy to dockerhub

### DIFF
--- a/.buildkite/release-package-registry-distribution.yml
+++ b/.buildkite/release-package-registry-distribution.yml
@@ -55,8 +55,8 @@ steps:
     command: |
         set -euo pipefail
 
-        DOCKER_TAG="$$(buildkite-agent meta-data get DOCKER_TAG)"
-        if [[ -z "${DOCKER_TAG}" ]]; then
+        DOCKER_TAG="$$(buildkite-agent meta-data get DOCKER_TAG --default="")"
+        if [[ -z "$${DOCKER_TAG:-""}" ]]; then
             echo "ERROR: DOCKER_TAG meta-data is empty or not set"
             exit 1
         fi

--- a/.buildkite/release-package-registry-distribution.yml
+++ b/.buildkite/release-package-registry-distribution.yml
@@ -56,6 +56,10 @@ steps:
         set -euo pipefail
 
         DOCKER_TAG="$$(buildkite-agent meta-data get DOCKER_TAG)"
+        if [[ -z "${DOCKER_TAG}" ]]; then
+            echo "ERROR: DOCKER_TAG meta-data is empty or not set"
+            exit 1
+        fi
 
         buildkite-agent pipeline upload << PIPELINE
         steps:

--- a/.buildkite/release-package-registry-distribution.yml
+++ b/.buildkite/release-package-registry-distribution.yml
@@ -55,6 +55,7 @@ steps:
     command: |
         set -euo pipefail
 
+        DOCKER_TAG="$$(buildkite-agent meta-data get DOCKER_TAG)"
 
         buildkite-agent pipeline upload << PIPELINE
         steps:

--- a/.buildkite/release-package-registry-distribution.yml
+++ b/.buildkite/release-package-registry-distribution.yml
@@ -55,9 +55,8 @@ steps:
     command: |
         set -euo pipefail
 
-        DOCKER_TAG="$(buildkite-agent meta-data get DOCKER_TAG)"
 
-        cat <<YAML | buildkite-agent pipeline upload
+        buildkite-agent pipeline upload << PIPELINE
         steps:
           - trigger: unified-release-copy-elastic-images-to-dockerhub
             label: ":docker: Copy release images to Docker Hub"
@@ -66,7 +65,7 @@ steps:
             build:
               env:
                 IMAGES_NAMES: "package-registry/distribution"
-                IMAGES_TAG: "${DOCKER_TAG}"
+                IMAGES_TAG: "$${DOCKER_TAG}"
           - trigger: unified-release-copy-elastic-images-to-dockerhub
             label: ":docker: Copy release UBI images to Docker Hub"
             key: copy-prod-ubi
@@ -74,7 +73,7 @@ steps:
             build:
               env:
                 IMAGES_NAMES: "package-registry/distribution"
-                IMAGES_TAG: "${DOCKER_TAG}-ubi"
+                IMAGES_TAG: "$${DOCKER_TAG}-ubi"
           - trigger: unified-release-copy-elastic-images-to-dockerhub
             label: ":docker: Copy release lite images to Docker Hub"
             key: copy-lite
@@ -82,7 +81,7 @@ steps:
             build:
               env:
                 IMAGES_NAMES: "package-registry/distribution"
-                IMAGES_TAG: "lite-${DOCKER_TAG}"
+                IMAGES_TAG: "lite-$${DOCKER_TAG}"
           - trigger: unified-release-copy-elastic-images-to-dockerhub
             label: ":docker: Copy release lite UBI images to Docker Hub"
             key: copy-lite-ubi
@@ -90,8 +89,8 @@ steps:
             build:
               env:
                 IMAGES_NAMES: "package-registry/distribution"
-                IMAGES_TAG: "lite-${DOCKER_TAG}-ubi"
-        YAML
+                IMAGES_TAG: "lite-$${DOCKER_TAG}-ubi"
+        PIPELINE
     depends_on:
       - step: "release-distribution"
         allow_failure: false

--- a/.buildkite/scripts/publish-distribution.sh
+++ b/.buildkite/scripts/publish-distribution.sh
@@ -4,7 +4,12 @@ source .buildkite/scripts/tooling.sh
 
 set -euo pipefail
 
-DOCKER_TAG=$(buildkite-agent meta-data get DOCKER_TAG)
+DOCKER_TAG=$(buildkite-agent meta-data get DOCKER_TAG --default="")
+if [[ -z "${DOCKER_TAG:-""}" ]]; then
+    echo "ERROR: DOCKER_TAG meta-data is empty or not set"
+    exit 1
+fi
+
 echo "version for tagging: ${DOCKER_TAG}"
 
 DOCKER_IMG_SOURCE="${DOCKER_IMAGE}:${TAG_NAME}"

--- a/.buildkite/scripts/validate-tag.sh
+++ b/.buildkite/scripts/validate-tag.sh
@@ -19,10 +19,10 @@ transformTagAndValidate() {
 }
 
 set +e
-DOCKER_TAG=$(buildkite-agent meta-data get DOCKER_TAG)
+DOCKER_TAG=$(buildkite-agent meta-data get DOCKER_TAG --default="")
 set -e
-if [ -z "${DOCKER_TAG:-}" ]; then
-    echo "erorr: DOCKER_TAG is not set up, Please setup, DOCKER_TAG"
+if [ -z "${DOCKER_TAG:-""}" ]; then
+    echo "ERROR: DOCKER_TAG meta-data is empty or not set"
     exit 1
 fi
 


### PR DESCRIPTION
Fix package-registry distribution step to use DOCKER_TAG effectivly