### PR TITLE
[CI] Allow github-actions[bot] users

### DIFF
--- a/.buildkite/pull-requests.json
+++ b/.buildkite/pull-requests.json
@@ -5,7 +5,7 @@
             "pipeline_slug": "package-registry",
             "allow_org_users": true,
             "allowed_repo_permissions": ["admin", "write"],
-            "allowed_list": ["dependabot[bot]", "mergify[bot]"],
+            "allowed_list": ["dependabot[bot]", "mergify[bot]", "github-actions[bot]"],
             "set_commit_status": true,
             "build_on_commit": true,
             "build_on_comment": true,


### PR DESCRIPTION
Allow triggering Buildkite builds from `github-actions[bot]` user.

Follows #1717

Related PR: #1724