### PR TITLE
Add agentless release field support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Add support for the `deployment_modes.agentless.release` field so it is exposed in package and search responses. [#1801](https://github.com/elastic/package-registry/pull/1801)
+
 ### Deprecated
 
 ### Known Issues

--- a/packages/package.go
+++ b/packages/package.go
@@ -236,8 +236,9 @@ type DeploymentModes struct {
 }
 
 type DeploymentMode struct {
-	Enabled   bool  `config:"enabled" json:"enabled" yaml:"enabled" validate:"required"`
-	IsDefault *bool `config:"is_default" json:"is_default,omitempty" yaml:"is_default,omitempty"`
+	Enabled   bool   `config:"enabled" json:"enabled" yaml:"enabled" validate:"required"`
+	IsDefault *bool  `config:"is_default" json:"is_default,omitempty" yaml:"is_default,omitempty"`
+	Release   string `config:"release,omitempty" json:"release,omitempty" yaml:"release,omitempty"`
 }
 
 type Deprecated struct {
@@ -368,6 +369,10 @@ func newPackage(basePath string, fsBuilder FileSystemBuilder) (*Package, error) 
 		// Fill ingestion method for input packages.
 		if p.Type == "input" && p.PolicyTemplates[i].Input != "" {
 			p.PolicyTemplates[i].IngestionMethod = IngestionMethods.Get(p.PolicyTemplates[i].Input)
+		}
+
+		if err := validateDeploymentModeRelease(p.PolicyTemplates[i].DeploymentModes); err != nil {
+			return nil, fmt.Errorf("policy template %q: %w", p.PolicyTemplates[i].Name, err)
 		}
 	}
 
@@ -623,6 +628,16 @@ func (p *Package) IsNewerOrEqual(pp *Package) bool {
 
 func (p *Package) IsPrerelease() bool {
 	return isPrerelease(p.versionSemVer)
+}
+
+func validateDeploymentModeRelease(modes *DeploymentModes) error {
+	if modes == nil || modes.Agentless == nil || modes.Agentless.Release == "" {
+		return nil
+	}
+	if !IsValidAgentlessRelease(modes.Agentless.Release) {
+		return fmt.Errorf("invalid agentless release: %q", modes.Agentless.Release)
+	}
+	return nil
 }
 
 func (p *Package) isTechPreview() bool {

--- a/packages/package.go
+++ b/packages/package.go
@@ -638,7 +638,7 @@ func validateDeploymentModeRelease(modes *DeploymentModes) error {
 	if modes == nil || modes.Agentless == nil || modes.Agentless.Release == "" {
 		return nil
 	}
-	if !IsValidAgentlessRelease(modes.Agentless.Release) {
+	if !isValidAgentlessRelease(modes.Agentless.Release) {
 		return fmt.Errorf("invalid agentless release: %q", modes.Agentless.Release)
 	}
 	return nil

--- a/packages/package.go
+++ b/packages/package.go
@@ -231,11 +231,15 @@ type Download struct {
 }
 
 type DeploymentModes struct {
-	Default   *DeploymentMode `config:"default,omitempty" json:"default,omitempty" yaml:"default,omitempty"`
-	Agentless *DeploymentMode `config:"agentless,omitempty" json:"agentless,omitempty" yaml:"agentless,omitempty"`
+	Default   *DefaultDeploymentMode   `config:"default,omitempty" json:"default,omitempty" yaml:"default,omitempty"`
+	Agentless *AgentlessDeploymentMode `config:"agentless,omitempty" json:"agentless,omitempty" yaml:"agentless,omitempty"`
 }
 
-type DeploymentMode struct {
+type DefaultDeploymentMode struct {
+	Enabled bool `config:"enabled" json:"enabled" yaml:"enabled" validate:"required"`
+}
+
+type AgentlessDeploymentMode struct {
 	Enabled   bool   `config:"enabled" json:"enabled" yaml:"enabled" validate:"required"`
 	IsDefault *bool  `config:"is_default" json:"is_default,omitempty" yaml:"is_default,omitempty"`
 	Release   string `config:"release,omitempty" json:"release,omitempty" yaml:"release,omitempty"`

--- a/packages/releases.go
+++ b/packages/releases.go
@@ -26,8 +26,20 @@ var ReleaseTypes = map[string]interface{}{
 	ReleaseGa:           nil,
 }
 
+// AgentlessReleaseTypes contains valid release values for deployment_modes.agentless.release.
+// Unlike the package-level release, "experimental" is not valid here.
+var AgentlessReleaseTypes = map[string]interface{}{
+	ReleaseBeta: nil,
+	ReleaseGa:   nil,
+}
+
 func IsValidRelease(release string) bool {
 	_, exists := ReleaseTypes[release]
+	return exists
+}
+
+func IsValidAgentlessRelease(release string) bool {
+	_, exists := AgentlessReleaseTypes[release]
 	return exists
 }
 

--- a/packages/releases.go
+++ b/packages/releases.go
@@ -26,9 +26,9 @@ var ReleaseTypes = map[string]interface{}{
 	ReleaseGa:           nil,
 }
 
-// AgentlessReleaseTypes contains valid release values for deployment_modes.agentless.release.
+// agentlessReleaseTypes contains valid release values for deployment_modes.agentless.release.
 // Unlike the package-level release, "experimental" is not valid here.
-var AgentlessReleaseTypes = map[string]interface{}{
+var agentlessReleaseTypes = map[string]interface{}{
 	ReleaseBeta: nil,
 	ReleaseGa:   nil,
 }
@@ -38,8 +38,8 @@ func IsValidRelease(release string) bool {
 	return exists
 }
 
-func IsValidAgentlessRelease(release string) bool {
-	_, exists := AgentlessReleaseTypes[release]
+func isValidAgentlessRelease(release string) bool {
+	_, exists := agentlessReleaseTypes[release]
 	return exists
 }
 

--- a/packages/testdata/marshaler/packages.json
+++ b/packages/testdata/marshaler/packages.json
@@ -655,7 +655,8 @@
       },
       "agentless": {
        "enabled": true,
-       "is_default": true
+       "is_default": true,
+       "release": "beta"
       }
      }
     },

--- a/testdata/generated/package/deployment_modes/0.0.1/index.json
+++ b/testdata/generated/package/deployment_modes/0.0.1/index.json
@@ -98,7 +98,8 @@
         },
         "agentless": {
           "enabled": true,
-          "is_default": true
+          "is_default": true,
+          "release": "beta"
         }
       }
     },

--- a/testdata/generated/search-all-proxy.json
+++ b/testdata/generated/search-all-proxy.json
@@ -234,7 +234,8 @@
           },
           "agentless": {
             "enabled": true,
-            "is_default": true
+            "is_default": true,
+            "release": "beta"
           }
         }
       },

--- a/testdata/generated/search-all.json
+++ b/testdata/generated/search-all.json
@@ -234,7 +234,8 @@
           },
           "agentless": {
             "enabled": true,
-            "is_default": true
+            "is_default": true,
+            "release": "beta"
           }
         }
       },

--- a/testdata/generated/search-category-custom.json
+++ b/testdata/generated/search-category-custom.json
@@ -148,7 +148,8 @@
           },
           "agentless": {
             "enabled": true,
-            "is_default": true
+            "is_default": true,
+            "release": "beta"
           }
         }
       },

--- a/testdata/generated/search-just-latest-proxy.json
+++ b/testdata/generated/search-just-latest-proxy.json
@@ -234,7 +234,8 @@
           },
           "agentless": {
             "enabled": true,
-            "is_default": true
+            "is_default": true,
+            "release": "beta"
           }
         }
       },

--- a/testdata/generated/search-package-experimental.json
+++ b/testdata/generated/search-package-experimental.json
@@ -234,7 +234,8 @@
           },
           "agentless": {
             "enabled": true,
-            "is_default": true
+            "is_default": true,
+            "release": "beta"
           }
         }
       },

--- a/testdata/generated/search-package-internal.json
+++ b/testdata/generated/search-package-internal.json
@@ -234,7 +234,8 @@
           },
           "agentless": {
             "enabled": true,
-            "is_default": true
+            "is_default": true,
+            "release": "beta"
           }
         }
       },

--- a/testdata/generated/search-package-prerelease.json
+++ b/testdata/generated/search-package-prerelease.json
@@ -234,7 +234,8 @@
           },
           "agentless": {
             "enabled": true,
-            "is_default": true
+            "is_default": true,
+            "release": "beta"
           }
         }
       },

--- a/testdata/generated/search-prerelease-capabilities-none.json
+++ b/testdata/generated/search-prerelease-capabilities-none.json
@@ -234,7 +234,8 @@
           },
           "agentless": {
             "enabled": true,
-            "is_default": true
+            "is_default": true,
+            "release": "beta"
           }
         }
       },

--- a/testdata/generated/search-prerelease-capabilities-observability-security.json
+++ b/testdata/generated/search-prerelease-capabilities-observability-security.json
@@ -234,7 +234,8 @@
           },
           "agentless": {
             "enabled": true,
-            "is_default": true
+            "is_default": true,
+            "release": "beta"
           }
         }
       },

--- a/testdata/generated/search.json
+++ b/testdata/generated/search.json
@@ -234,7 +234,8 @@
           },
           "agentless": {
             "enabled": true,
-            "is_default": true
+            "is_default": true,
+            "release": "beta"
           }
         }
       },

--- a/testdata/package/deployment_modes/0.0.1/manifest.yml
+++ b/testdata/package/deployment_modes/0.0.1/manifest.yml
@@ -53,6 +53,7 @@ policy_templates:
       agentless:
         enabled: true
         is_default: true
+        release: beta
         organization: elastic
         division: observability
         team: integration


### PR DESCRIPTION
In support of: https://github.com/elastic/package-spec/issues/1098

* Adds support of agentless deployment mode `release` field so its exposed in search responses