### PR TITLE
Publish distribution image to DockerHub as package-registry-distribution

### DIFF
--- a/.buildkite/release-package-registry-distribution.yml
+++ b/.buildkite/release-package-registry-distribution.yml
@@ -56,7 +56,7 @@ steps:
     command: |
         set -euo pipefail
 
-        DRY_RUN="$$(buildkite-agent meta-data get DRY_RUN --default="${DRY_RUN:-"false"}")"
+        DRY_RUN="$$(buildkite-agent meta-data get DRY_RUN --default="$${DRY_RUN:-"false"}")"
         if [[ "$${DRY_RUN:-"false"}" == "true" ]]; then
             echo "Skip triggering steps to release images to Docker Hub"
             exit 0

--- a/.buildkite/release-package-registry-distribution.yml
+++ b/.buildkite/release-package-registry-distribution.yml
@@ -50,11 +50,17 @@ steps:
       - elastic/vault-docker-login#v0.6.0:
           secret_path: 'kv/ci-shared/platform-ingest/elastic_docker_registry'
 
-  - label: ":docker: Copy release images to Docker Hub"
-    key: copy-release-images-to-dockerhub
+  - label: ":docker: Trigger copy release images to Docker Hub"
+    key: trigger-copy-release-images-to-dockerhub
     if: "build.source == 'ui' || build.env('BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG') == 'fleet-server'"
     command: |
         set -euo pipefail
+
+        DRY_RUN="$$(buildkite-agent meta-data get DRY_RUN --default="${DRY_RUN:-"false"}")"
+        if [[ "$${DRY_RUN:-"false"}" == "true" ]]; then
+            echo "Skip triggering steps to release images to Docker Hub"
+            exit 0
+        fi
 
         DOCKER_TAG="$$(buildkite-agent meta-data get DOCKER_TAG --default="")"
         if [[ -z "$${DOCKER_TAG:-""}" ]]; then

--- a/.buildkite/release-package-registry-distribution.yml
+++ b/.buildkite/release-package-registry-distribution.yml
@@ -37,6 +37,7 @@ steps:
     env:
       TAG_NAME: "{{matrix.tag_name}}"
       DOCKER_IMAGE: "docker.elastic.co/package-registry/distribution"
+      DOCKER_IMAGE_RENAMED: "docker.elastic.co/package-registry/package-registry-distribution"
       DRY_RUN: false
     command:
       - ".buildkite/scripts/publish-distribution.sh"
@@ -69,7 +70,7 @@ steps:
             async: false
             build:
               env:
-                IMAGES_NAMES: "package-registry/distribution"
+                IMAGES_NAMES: "package-registry/package-registry-distribution"
                 IMAGES_TAG: "$${DOCKER_TAG}"
           - trigger: unified-release-copy-elastic-images-to-dockerhub
             label: ":docker: Copy release UBI images to Docker Hub"
@@ -77,7 +78,7 @@ steps:
             async: false
             build:
               env:
-                IMAGES_NAMES: "package-registry/distribution"
+                IMAGES_NAMES: "package-registry/package-registry-distribution"
                 IMAGES_TAG: "$${DOCKER_TAG}-ubi"
           - trigger: unified-release-copy-elastic-images-to-dockerhub
             label: ":docker: Copy release lite images to Docker Hub"
@@ -85,7 +86,7 @@ steps:
             async: false
             build:
               env:
-                IMAGES_NAMES: "package-registry/distribution"
+                IMAGES_NAMES: "package-registry/package-registry-distribution"
                 IMAGES_TAG: "lite-$${DOCKER_TAG}"
           - trigger: unified-release-copy-elastic-images-to-dockerhub
             label: ":docker: Copy release lite UBI images to Docker Hub"
@@ -93,7 +94,7 @@ steps:
             async: false
             build:
               env:
-                IMAGES_NAMES: "package-registry/distribution"
+                IMAGES_NAMES: "package-registry/package-registry-distribution"
                 IMAGES_TAG: "lite-$${DOCKER_TAG}-ubi"
         PIPELINE
     depends_on:

--- a/.buildkite/scripts/publish-distribution.sh
+++ b/.buildkite/scripts/publish-distribution.sh
@@ -14,21 +14,32 @@ echo "version for tagging: ${DOCKER_TAG}"
 
 DOCKER_IMG_SOURCE="${DOCKER_IMAGE}:${TAG_NAME}"
 
-if [[ "${TAG_NAME}" == "production" ]]; then
-    DOCKER_IMG_TARGET="${DOCKER_IMAGE}:${DOCKER_TAG}"
-else
-    DOCKER_IMG_TARGET="${DOCKER_IMAGE}:${TAG_NAME}-${DOCKER_TAG}"
+# DOCKER_IMAGE_RENAMED is optional: when set, the retagged image is also
+# published under this second name (same digest), e.g. to introduce a new
+# image name in docker.elastic.co without breaking existing consumers of
+# DOCKER_IMAGE.
+DOCKER_IMAGE_TARGETS=("${DOCKER_IMAGE}")
+if [[ -n "${DOCKER_IMAGE_RENAMED:-""}" ]]; then
+    DOCKER_IMAGE_TARGETS+=("${DOCKER_IMAGE_RENAMED}")
 fi
 
 echo "Docker retag"
 docker buildx create --use
 
-# do not push if DRY_RUN is true
-if [[ ${DRY_RUN:-true} == "true" ]]; then
-    docker buildx imagetools create --dry-run -t "${DOCKER_IMG_TARGET}" "${DOCKER_IMG_SOURCE}"
-    docker buildx imagetools create --dry-run -t "${DOCKER_IMG_TARGET}-ubi" "${DOCKER_IMG_SOURCE}-ubi"
-else
-    retry 3 docker buildx imagetools create -t "${DOCKER_IMG_TARGET}" "${DOCKER_IMG_SOURCE}"
-    retry 3 docker buildx imagetools create -t "${DOCKER_IMG_TARGET}-ubi" "${DOCKER_IMG_SOURCE}-ubi"
-    echo "Docker image pushed: ${DOCKER_IMG_TARGET}"
-fi
+for image in "${DOCKER_IMAGE_TARGETS[@]}"; do
+    if [[ "${TAG_NAME}" == "production" ]]; then
+        DOCKER_IMG_TARGET="${image}:${DOCKER_TAG}"
+    else
+        DOCKER_IMG_TARGET="${image}:${TAG_NAME}-${DOCKER_TAG}"
+    fi
+
+    # do not push if DRY_RUN is true
+    if [[ ${DRY_RUN:-true} == "true" ]]; then
+        docker buildx imagetools create --dry-run -t "${DOCKER_IMG_TARGET}" "${DOCKER_IMG_SOURCE}"
+        docker buildx imagetools create --dry-run -t "${DOCKER_IMG_TARGET}-ubi" "${DOCKER_IMG_SOURCE}-ubi"
+    else
+        retry 3 docker buildx imagetools create -t "${DOCKER_IMG_TARGET}" "${DOCKER_IMG_SOURCE}"
+        retry 3 docker buildx imagetools create -t "${DOCKER_IMG_TARGET}-ubi" "${DOCKER_IMG_SOURCE}-ubi"
+        echo "Docker image pushed: ${DOCKER_IMG_TARGET}"
+    fi
+done


### PR DESCRIPTION
## Summary
- Retag the internal `docker.elastic.co/package-registry/distribution` image as `package-registry/package-registry-distribution` (same digest) so it can be published under a non-misleading name.
- Update the DockerHub copy step to publish as `elastic/package-registry-distribution` instead of `elastic/distribution`.

## Related issue
Related to elastic/platform-engineering-productivity#2953, which tracks deleting the old `elastic/distribution` image from DockerHub once this is live.

Follow-up of #1692, which added the DockerHub copy step and introduced the `elastic/distribution` name.