### PR TITLE
feat: add FIPS 140-3 build support

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
 
 env:
-  SETUP_GVM_VERSION: 'v0.6.0' # https://github.com/andrewkroh/gvm/issues/44#issuecomment-1013231151
-  SETUP_MAGE_VERSION: '1.15.0'
-  JQ_VERSION: '1.7'
+  SETUP_GVM_VERSION: "v0.6.0" # https://github.com/andrewkroh/gvm/issues/44#issuecomment-1013231151
+  SETUP_MAGE_VERSION: "1.15.0"
+  JQ_VERSION: "1.7"
   DOCKER_IMG: "docker.elastic.co/package-registry/package-registry"
   DOCKER_IMG_PR: "docker.elastic.co/observability-ci/package-registry"
   # Agent images used in pipeline steps
@@ -145,6 +145,19 @@ steps:
       env:
         IMAGES_NAMES: "package-registry/package-registry"
         IMAGES_TAG: "${BUILDKITE_TAG}-ubi"
+    depends_on:
+      - step: "publish"
+        allow_failure: false
+    if: build.tag =~ /^v\d+\.\d+\.\d+$$/
+
+  - trigger: unified-release-copy-elastic-images-to-dockerhub
+    label: ":docker: Copy release FIPS images to Docker Hub"
+    key: "copy-release-fips-images-to-dockerhub"
+    async: false
+    build:
+      env:
+        IMAGES_NAMES: "package-registry/package-registry"
+        IMAGES_TAG: "${BUILDKITE_TAG}-fips"
     depends_on:
       - step: "publish"
         allow_failure: false

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -37,6 +37,15 @@ steps:
     agents:
       provider: "gcp"
 
+  - label: ":lock: FIPS 140-3 build & test"
+    key: fips-build-test
+    command:
+      - ".buildkite/scripts/test-fips.sh"
+    agents:
+      image: "${LINUX_GOLANG_AGENT_IMAGE}"
+      cpu: "8"
+      memory: "4G"
+
   - group: ":go: Run Unit tests"
     key: unit-tests
     steps:
@@ -107,6 +116,8 @@ steps:
       - step: "lint"
         allow_failure: false
       - step: "smoke-test-fake-gcs-server"
+        allow_failure: false
+      - step: "fips-build-test"
         allow_failure: false
     plugins:
       - elastic/vault-docker-login#v0.6.0:

--- a/.buildkite/release-package-registry-distribution.yml
+++ b/.buildkite/release-package-registry-distribution.yml
@@ -87,6 +87,14 @@ steps:
                 IMAGES_NAMES: "package-registry/package-registry-distribution"
                 IMAGES_TAG: "$${DOCKER_TAG}-ubi"
           - trigger: unified-release-copy-elastic-images-to-dockerhub
+            label: ":docker: Copy release FIPS images to Docker Hub"
+            key: copy-prod-fips
+            async: false
+            build:
+              env:
+                IMAGES_NAMES: "package-registry/package-registry-distribution"
+                IMAGES_TAG: "$${DOCKER_TAG}-fips"
+          - trigger: unified-release-copy-elastic-images-to-dockerhub
             label: ":docker: Copy release lite images to Docker Hub"
             key: copy-lite
             async: false
@@ -102,6 +110,14 @@ steps:
               env:
                 IMAGES_NAMES: "package-registry/package-registry-distribution"
                 IMAGES_TAG: "lite-$${DOCKER_TAG}-ubi"
+          - trigger: unified-release-copy-elastic-images-to-dockerhub
+            label: ":docker: Copy release lite FIPS images to Docker Hub"
+            key: copy-lite-fips
+            async: false
+            build:
+              env:
+                IMAGES_NAMES: "package-registry/package-registry-distribution"
+                IMAGES_TAG: "lite-$${DOCKER_TAG}-fips"
         PIPELINE
     depends_on:
       - step: "release-distribution"

--- a/.buildkite/release-package-registry-distribution.yml
+++ b/.buildkite/release-package-registry-distribution.yml
@@ -68,6 +68,34 @@ steps:
             exit 1
         fi
 
+        upload_fips_copy_step() {
+            local tag_name="$$1"
+            local image_tag="$$2"
+            local step_key="$$3"
+            local availability
+            availability="$$(buildkite-agent meta-data get "fips-distribution-$${tag_name}-available" --default="false")"
+
+            if [[ "$${availability}" != "true" ]]; then
+                echo "Skip triggering FIPS image copy for $${tag_name}: source image was not available"
+                return
+            fi
+
+            buildkite-agent pipeline upload << PIPELINE
+        steps:
+          - trigger: unified-release-copy-elastic-images-to-dockerhub
+            label: ":docker: Copy release $${tag_name} FIPS images to Docker Hub"
+            key: "$${step_key}"
+            async: false
+            build:
+              env:
+                IMAGES_NAMES: "package-registry/package-registry-distribution"
+                IMAGES_TAG: "$${image_tag}"
+        PIPELINE
+        }
+
+        upload_fips_copy_step "production" "$${DOCKER_TAG}-fips" "copy-prod-fips"
+        upload_fips_copy_step "lite" "lite-$${DOCKER_TAG}-fips" "copy-lite-fips"
+
         buildkite-agent pipeline upload << PIPELINE
         steps:
           - trigger: unified-release-copy-elastic-images-to-dockerhub
@@ -87,14 +115,6 @@ steps:
                 IMAGES_NAMES: "package-registry/package-registry-distribution"
                 IMAGES_TAG: "$${DOCKER_TAG}-ubi"
           - trigger: unified-release-copy-elastic-images-to-dockerhub
-            label: ":docker: Copy release FIPS images to Docker Hub"
-            key: copy-prod-fips
-            async: false
-            build:
-              env:
-                IMAGES_NAMES: "package-registry/package-registry-distribution"
-                IMAGES_TAG: "$${DOCKER_TAG}-fips"
-          - trigger: unified-release-copy-elastic-images-to-dockerhub
             label: ":docker: Copy release lite images to Docker Hub"
             key: copy-lite
             async: false
@@ -110,14 +130,6 @@ steps:
               env:
                 IMAGES_NAMES: "package-registry/package-registry-distribution"
                 IMAGES_TAG: "lite-$${DOCKER_TAG}-ubi"
-          - trigger: unified-release-copy-elastic-images-to-dockerhub
-            label: ":docker: Copy release lite FIPS images to Docker Hub"
-            key: copy-lite-fips
-            async: false
-            build:
-              env:
-                IMAGES_NAMES: "package-registry/package-registry-distribution"
-                IMAGES_TAG: "lite-$${DOCKER_TAG}-fips"
         PIPELINE
     depends_on:
       - step: "release-distribution"

--- a/.buildkite/scripts/publish-distribution.sh
+++ b/.buildkite/scripts/publish-distribution.sh
@@ -22,6 +22,7 @@ DOCKER_IMAGE_TARGETS=("${DOCKER_IMAGE}")
 if [[ -n "${DOCKER_IMAGE_RENAMED:-""}" ]]; then
     DOCKER_IMAGE_TARGETS+=("${DOCKER_IMAGE_RENAMED}")
 fi
+IMAGE_SUFFIXES=("" "-ubi" "-fips")
 
 echo "Docker retag"
 docker buildx create --use
@@ -33,13 +34,16 @@ for image in "${DOCKER_IMAGE_TARGETS[@]}"; do
         DOCKER_IMG_TARGET="${image}:${TAG_NAME}-${DOCKER_TAG}"
     fi
 
-    # do not push if DRY_RUN is true
-    if [[ ${DRY_RUN:-true} == "true" ]]; then
-        docker buildx imagetools create --dry-run -t "${DOCKER_IMG_TARGET}" "${DOCKER_IMG_SOURCE}"
-        docker buildx imagetools create --dry-run -t "${DOCKER_IMG_TARGET}-ubi" "${DOCKER_IMG_SOURCE}-ubi"
-    else
-        retry 3 docker buildx imagetools create -t "${DOCKER_IMG_TARGET}" "${DOCKER_IMG_SOURCE}"
-        retry 3 docker buildx imagetools create -t "${DOCKER_IMG_TARGET}-ubi" "${DOCKER_IMG_SOURCE}-ubi"
-        echo "Docker image pushed: ${DOCKER_IMG_TARGET}"
-    fi
+    for suffix in "${IMAGE_SUFFIXES[@]}"; do
+        source_image="${DOCKER_IMG_SOURCE}${suffix}"
+        target_image="${DOCKER_IMG_TARGET}${suffix}"
+
+        # do not push if DRY_RUN is true
+        if [[ ${DRY_RUN:-true} == "true" ]]; then
+            docker buildx imagetools create --dry-run -t "${target_image}" "${source_image}"
+        else
+            retry 3 docker buildx imagetools create -t "${target_image}" "${source_image}"
+            echo "Docker image pushed: ${target_image}"
+        fi
+    done
 done

--- a/.buildkite/scripts/publish-distribution.sh
+++ b/.buildkite/scripts/publish-distribution.sh
@@ -22,7 +22,18 @@ DOCKER_IMAGE_TARGETS=("${DOCKER_IMAGE}")
 if [[ -n "${DOCKER_IMAGE_RENAMED:-""}" ]]; then
     DOCKER_IMAGE_TARGETS+=("${DOCKER_IMAGE_RENAMED}")
 fi
-IMAGE_SUFFIXES=("" "-ubi" "-fips")
+IMAGE_SUFFIXES=("" "-ubi")
+FIPS_SOURCE_IMAGE="${DOCKER_IMG_SOURCE}-fips"
+FIPS_SOURCE_AVAILABLE=false
+
+# The FIPS distribution source does not exist until the first release that
+# includes a FIPS package-registry image. Skip it during that transition.
+if retry 3 docker buildx imagetools inspect "${FIPS_SOURCE_IMAGE}" > /dev/null; then
+    IMAGE_SUFFIXES+=("-fips")
+    FIPS_SOURCE_AVAILABLE=true
+else
+    echo "FIPS source image is not available yet, skipping: ${FIPS_SOURCE_IMAGE}"
+fi
 
 echo "Docker retag"
 docker buildx create --use
@@ -47,3 +58,5 @@ for image in "${DOCKER_IMAGE_TARGETS[@]}"; do
         fi
     done
 done
+
+buildkite-agent meta-data set "fips-distribution-${TAG_NAME}-available" "${FIPS_SOURCE_AVAILABLE}"

--- a/.buildkite/scripts/publish.sh
+++ b/.buildkite/scripts/publish.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 build_push_docker_image() {
 	local runner_image="${1}"
 	local tag_suffix="${2:-}"
+	local fips="${3:-0}"
 	local docker_img_tag="${DOCKER_IMG_TAG}${tag_suffix}"
 	local docker_img_tag_branch="${DOCKER_IMG_TAG_BRANCH}${tag_suffix}"
 	go_version=$(cat .go-version)
@@ -20,6 +21,7 @@ build_push_docker_image() {
 		--build-arg GO_VERSION="${go_version}" \
 		--build-arg BUILDER_IMAGE=docker.elastic.co/wolfi/go \
 		--build-arg RUNNER_IMAGE="${runner_image}" \
+		--build-arg FIPS="${fips}" \
 		--label BRANCH_NAME="${TAG_NAME}" \
 		--label GIT_SHA="${BUILDKITE_COMMIT}" \
 		--label GO_VERSION="${SETUP_GOLANG_VERSION}" \
@@ -47,3 +49,4 @@ DOCKER_IMG_TAG_BRANCH="${DOCKER_NAMESPACE}:${TAG_NAME}"
 
 build_push_docker_image "docker.elastic.co/wolfi/chainguard-base" ""
 build_push_docker_image "registry.access.redhat.com/ubi9/ubi-minimal:9.6" "-ubi"
+build_push_docker_image "docker.elastic.co/wolfi/chainguard-base-fips" "-fips" "1"

--- a/.buildkite/scripts/publish.sh
+++ b/.buildkite/scripts/publish.sh
@@ -6,7 +6,10 @@ set -euo pipefail
 build_push_docker_image() {
 	local runner_image="${1}"
 	local tag_suffix="${2:-}"
-	local fips="${3:-0}"
+	local fips=0
+	if [[ "${tag_suffix}" == "-fips" ]]; then
+		fips=1
+	fi
 	local docker_img_tag="${DOCKER_IMG_TAG}${tag_suffix}"
 	local docker_img_tag_branch="${DOCKER_IMG_TAG_BRANCH}${tag_suffix}"
 	go_version=$(cat .go-version)
@@ -49,4 +52,4 @@ DOCKER_IMG_TAG_BRANCH="${DOCKER_NAMESPACE}:${TAG_NAME}"
 
 build_push_docker_image "docker.elastic.co/wolfi/chainguard-base" ""
 build_push_docker_image "registry.access.redhat.com/ubi9/ubi-minimal:9.6" "-ubi"
-build_push_docker_image "docker.elastic.co/wolfi/chainguard-base-fips" "-fips" "1"
+build_push_docker_image "docker.elastic.co/wolfi/chainguard-base-fips" "-fips"

--- a/.buildkite/scripts/publish.sh
+++ b/.buildkite/scripts/publish.sh
@@ -31,7 +31,7 @@ build_push_docker_image() {
 		--label TIMESTAMP="$(date +%Y-%m-%d_%H:%M)" \
 		.
 
-	echo "Docker images pushed: ${DOCKER_IMG_TAG}${tag_suffix} ${DOCKER_IMG_TAG_BRANCH}${tag_suffix}"
+	echo "Docker images pushed: ${docker_img_tag} ${docker_img_tag_branch}"
 }
 
 if [[ "${BUILDKITE_PULL_REQUEST}" != "false" ]]; then

--- a/.buildkite/scripts/test-fips.sh
+++ b/.buildkite/scripts/test-fips.sh
@@ -5,19 +5,20 @@ source .buildkite/scripts/pre-install-command.sh
 set -euo pipefail
 
 add_bin_path
+with_jq
 with_mage
 
 echo "--- Build FIPS 140-3 binary"
 mage -debug buildFIPS
 
 echo "--- Verify FIPS 140-3 build settings"
-build_info="$(go version -m package-registry)"
-echo "${build_info}"
+# GOFIPS140 includes a commit hash suffix (e.g. v1.0.0-c2097c7c), not just v1.0.0.
+fips_version=$(go version -m -json package-registry | jq -r '.Settings[] | select(.Key == "GOFIPS140") | .Value')
+default_godebug=$(go version -m -json package-registry | jq -r '.Settings[] | select(.Key == "DefaultGODEBUG") | .Value')
 
-fips_version="$(echo "${build_info}" | grep -oE 'GOFIPS140=\S+' | cut -d= -f2-)"
-default_godebug="$(echo "${build_info}" | grep -oE 'DefaultGODEBUG=\S+' | cut -d= -f2-)"
+go version -m package-registry
 
-if [[ "${fips_version}" != v1.0.0* ]]; then
+if [[ ! "${fips_version}" =~ ^v1\.0\.0(-[a-f0-9]{5,40})?$ ]]; then
 	echo "Expected GOFIPS140 to reference the certified v1.0.0 module, got: '${fips_version}'"
 	exit 1
 fi

--- a/.buildkite/scripts/test-fips.sh
+++ b/.buildkite/scripts/test-fips.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Pre install:
+source .buildkite/scripts/pre-install-command.sh
+
+set -euo pipefail
+
+add_bin_path
+with_mage
+
+echo "--- Build FIPS 140-3 binary"
+mage -debug buildFIPS
+
+echo "--- Verify FIPS 140-3 build settings"
+build_info="$(go version -m package-registry)"
+echo "${build_info}"
+
+fips_version="$(echo "${build_info}" | grep -oE 'GOFIPS140=\S+' | cut -d= -f2-)"
+default_godebug="$(echo "${build_info}" | grep -oE 'DefaultGODEBUG=\S+' | cut -d= -f2-)"
+
+if [[ "${fips_version}" != v1.0.0* ]]; then
+	echo "Expected GOFIPS140 to reference the certified v1.0.0 module, got: '${fips_version}'"
+	exit 1
+fi
+
+if [[ "${default_godebug}" != *"fips140=on"* ]]; then
+	echo "Expected DefaultGODEBUG to contain fips140=on, got: '${default_godebug}'"
+	exit 1
+fi
+
+echo "FIPS 140-3 binary verified: GOFIPS140=${fips_version} DefaultGODEBUG=${default_godebug}"
+
+echo "--- Run unit tests against the FIPS 140-3 crypto module"
+mage -debug testFIPS

--- a/.buildkite/scripts/test-fips.sh
+++ b/.buildkite/scripts/test-fips.sh
@@ -23,7 +23,9 @@ if [[ ! "${fips_version}" =~ ^v1\.0\.0(-[a-f0-9]{5,40})?$ ]]; then
 	exit 1
 fi
 
-if [[ "${default_godebug}" != *"fips140=on"* ]]; then
+# DefaultGODEBUG can contain other comma-separated Go defaults, so match the
+# complete fips140 entry instead of requiring the whole value to be equal.
+if [[ ! "${default_godebug}" =~ (^|,)fips140=on(,|$) ]]; then
 	echo "Expected DefaultGODEBUG to contain fips140=on, got: '${default_godebug}'"
 	exit 1
 fi

--- a/.buildkite/scripts/test-fips.sh
+++ b/.buildkite/scripts/test-fips.sh
@@ -13,8 +13,9 @@ mage -debug buildFIPS
 
 echo "--- Verify FIPS 140-3 build settings"
 # GOFIPS140 includes a commit hash suffix (e.g. v1.0.0-c2097c7c), not just v1.0.0.
-fips_version=$(go version -m -json package-registry | jq -r '.Settings[] | select(.Key == "GOFIPS140") | .Value')
-default_godebug=$(go version -m -json package-registry | jq -r '.Settings[] | select(.Key == "DefaultGODEBUG") | .Value')
+build_info=$(go version -m -json package-registry)
+fips_version=$(echo "${build_info}" | jq -r '.Settings[] | select(.Key == "GOFIPS140") | .Value')
+default_godebug=$(echo "${build_info}" | jq -r '.Settings[] | select(.Key == "DefaultGODEBUG") | .Value')
 
 go version -m package-registry
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* Add FIPS 140-3 build support via `GOFIPS140=v1.0.0`; new `mage buildFIPS`, `mage dockerBuildFIPS`, and `mage testFIPS` targets; `-fips` Docker image published per release. See [docs/fips.md](./docs/fips.md).
-* FIPS builds now reject startup if `-tls-min-version` is set below TLS 1.2.
-* `internal/storage`: `UpdateFakeServer` now restarts the fake GCS server instead of adding objects to the running one, keeping object creation on the `InitialObjects` path to avoid MD5 recomputation under strict FIPS mode.
+* Add FIPS 140-3 build support via `GOFIPS140=v1.0.0`; new `mage buildFIPS`, `mage dockerBuildFIPS`, and `mage testFIPS` targets; `-fips` Docker image published per release. See [docs/fips.md](./docs/fips.md). [#1858](https://github.com/elastic/package-registry/pull/1858)
+* FIPS builds now reject startup if `-tls-min-version` is set below TLS 1.2. [#1858](https://github.com/elastic/package-registry/pull/1858)
+* `internal/storage`: `UpdateFakeServer` now restarts the fake GCS server instead of adding objects to the running one, keeping object creation on the `InitialObjects` path to avoid MD5 recomputation under strict FIPS mode. [#1858](https://github.com/elastic/package-registry/pull/1858)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Add FIPS 140-3 build support via `GOFIPS140=v1.0.0`; new `mage buildFIPS`, `mage dockerBuildFIPS`, and `mage testFIPS` targets; `-fips` Docker image published per release. See [docs/fips.md](./docs/fips.md).
+* FIPS builds now reject startup if `-tls-min-version` is set below TLS 1.2.
+* `internal/storage`: `UpdateFakeServer` now restarts the fake GCS server instead of adding objects to the running one, keeping object creation on the `InitialObjects` path to avoid MD5 recomputation under strict FIPS mode.
+
 ### Deprecated
 
 ### Known Issues

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* Add FIPS 140-3 build support via `GOFIPS140=v1.0.0`; new `mage buildFIPS`, `mage dockerBuildFIPS`, and `mage testFIPS` targets; `-fips` Docker image published per release. See [docs/fips.md](./docs/fips.md). [#1858](https://github.com/elastic/package-registry/pull/1858)
+* Add FIPS 140-3 build support via `GOFIPS140=v1.0.0`; new `mage buildFIPS`, `mage dockerBuildFIPS`, and `mage testFIPS` targets; `-fips` Docker and package-filled distribution images published per release. See [docs/fips.md](./docs/fips.md). [#1858](https://github.com/elastic/package-registry/pull/1858)
 * FIPS builds now reject startup if `-tls-min-version` is set below TLS 1.2. [#1858](https://github.com/elastic/package-registry/pull/1858)
 * `internal/storage`: `UpdateFakeServer` now restarts the fake GCS server instead of adding objects to the running one, keeping object creation on the `InitialObjects` path to avoid MD5 recomputation under strict FIPS mode. [#1858](https://github.com/elastic/package-registry/pull/1858)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,11 @@ WORKDIR /package-registry
 
 ARG TARGETPLATFORM
 
-RUN make release-${TARGETPLATFORM:-linux}
+# FIPS=1 builds the binary against the certified Go FIPS 140-3 crypto module.
+# See docs/fips.md.
+ARG FIPS=0
+
+RUN make release-${TARGETPLATFORM:-linux} FIPS=${FIPS}
 
 
 # Run binary

--- a/Makefile
+++ b/Makefile
@@ -9,14 +9,23 @@ OSS_TARGETS=$(addprefix release-, $(OSS))
 
 BUILD_FLAGS=-tags=grpcnotrace -trimpath -ldflags=-s
 
+# FIPS=1 pins the build to the certified Go FIPS 140-3 crypto module
+# (see https://go.dev/doc/security/fips140#fips-140-3-mode).
+FIPS ?= 0
+ifeq ($(FIPS),1)
+GO_BUILD_ENV=GOFIPS140=v1.0.0
+else
+GO_BUILD_ENV=
+endif
+
 .PHONY: $(OSS_TARGETS)
 $(OSS_TARGETS): release-%:
 	$(eval $@_OS := $(firstword $(subst /, ,$(lastword $(subst release-, ,$@)))))
-	GOOS=$($@_OS) go build $(BUILD_FLAGS) .
+	$(GO_BUILD_ENV) GOOS=$($@_OS) go build $(BUILD_FLAGS) .
 
 .PHONY: $(OS_TARGETS)
 $(PLATFORM_TARGETS): release-%:
 	$(eval $@_OS := $(firstword $(subst /, ,$(lastword $(subst release-, ,$@)))))
 	$(eval $@_GO_ARCH := $(word 2, $(subst /, ,$(lastword $(subst release-, ,$@)))))
 	$(eval $@_ARCH := $(TARGET_ARCH_$($@_GO_ARCH)))
-	GOOS=$($@_OS) GOARCH=$($@_GO_ARCH) go build $(BUILD_FLAGS) .
+	$(GO_BUILD_ENV) GOOS=$($@_OS) GOARCH=$($@_GO_ARCH) go build $(BUILD_FLAGS) .

--- a/README.md
+++ b/README.md
@@ -103,6 +103,19 @@ mage build
 Once built, the Package Registry can be run as `./package-registry`. Find below
 more details about the available configuration options.
 
+### FIPS 140-3
+
+Package Registry can be built against Go's certified FIPS 140-3 crypto module
+for deployment in FIPS-regulated environments. See [docs/fips.md](./docs/fips.md)
+for build instructions, how to verify a binary, and known limitations.
+
+```bash
+mage buildFIPS
+```
+
+A `-fips` suffixed Docker image is also published alongside each release
+(e.g. `docker.elastic.co/package-registry/package-registry:v1.40.0-fips`).
+
 
 ### Docker
 

--- a/docs/fips.md
+++ b/docs/fips.md
@@ -1,0 +1,106 @@
+# FIPS 140-3
+
+FIPS 140-3 is a US/Canadian government standard that certifies cryptographic
+modules meet a baseline of security requirements; it's widely required for
+software deployed in government, defense, financial, and other regulated
+environments. Package Registry needs to support it so that it can be deployed
+as part of the Elastic Stack in those FIPS-regulated customer environments.
+
+Package Registry can be built against Go's certified FIPS 140-3 crypto module,
+for use in environments that require FIPS 140-3 enforcement.
+
+See [Go's FIPS 140-3 documentation](https://go.dev/doc/security/fips140#fips-140-3-mode)
+for background on `GOFIPS140` and the native Go crypto module. The module used
+is pinned to `v1.0.0`:
+
+* CMVP Certificate [#4735](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4735)
+* CAVP Certificate [A6650](https://csrc.nist.gov/projects/cryptographic-algorithm-validation-program/details?product=19371)
+
+## Building a FIPS 140-3 binary
+
+Set `GOFIPS140=v1.0.0` when building, this pins the build to the certified
+module version instead of whatever is bundled with the Go toolchain in use.
+
+Using `mage`:
+```bash
+mage buildFIPS
+```
+
+Using `make` (used to build the release binaries and the Docker image):
+```bash
+make release-linux FIPS=1
+```
+
+Using `go build` directly:
+```bash
+GOFIPS140=v1.0.0 go build .
+```
+
+## Building the FIPS 140-3 Docker image
+
+```bash
+mage dockerBuildFIPS main
+```
+
+This builds `docker.elastic.co/package-registry/package-registry:main-fips`.
+Published FIPS images use the same `-fips` tag suffix as the existing `-ubi`
+variant, for example `docker.elastic.co/package-registry/package-registry:v1.40.0-fips`.
+
+## Verifying a binary
+
+A binary built with `GOFIPS140` embeds that information, along with a default
+`GODEBUG=fips140=on` setting, in its build info:
+
+```bash
+go version -m ./package-registry | grep -E 'GOFIPS140|DefaultGODEBUG'
+# build	DefaultGODEBUG=fips140=on
+# build	GOFIPS140=v1.0.0-<...>
+```
+
+With `fips140=on` (the default for FIPS builds), the module is used for all
+supported crypto operations and non-approved algorithms remain available as a
+fallback. Operators that need strict enforcement, where non-approved
+algorithms are refused instead of falling back, can set `GODEBUG=fips140=only`
+in the environment. See [Known limitations](#known-limitations) below before
+doing so.
+
+## What is covered
+
+Package Registry itself does not implement any custom cryptography. Its own
+runtime code paths only rely on the standard library's `crypto/tls`, used for
+serving HTTPS (`-tls-cert`/`-tls-key`) and for TLS client connections to
+backing package storage. Neither `package-registry` nor the real
+`cloud.google.com/go/storage` client it uses in production call `crypto/md5`
+or other non-approved algorithms.
+
+`crypto/tls`'s default minimum version is TLS 1.2, which satisfies FIPS 140-3.
+FIPS builds reject startup with an error if `-tls-min-version` (or
+`EPR_TLS_MIN_VERSION`) is set below TLS 1.2, since TLS 1.1 is not FIPS 140-3
+approved.
+
+The test suite passes in full under strict `GODEBUG=fips140=only` (see
+`mage testFIPS`). The test-only GCS emulator (`github.com/fsouza/fake-gcs-server`,
+also used at runtime by the built-in fake GCS server behind
+`EPR_EMULATOR_INDEX_PATH`) pre-populates each fake object's MD5 field so the
+library never has to hash content with `crypto/md5` itself; see
+`internal/storage/fakestorage.go`.
+
+## Known limitations
+
+### `cmd/distribution` is not FIPS-covered
+
+`cmd/distribution` is a release tooling binary (not the deployed server) that
+downloads packages from EPR and verifies their signatures against Elastic's
+release-signing key. It is not subject to FIPS 140-3 requirements and has no
+FIPS build target.
+
+The blocker is structural: Elastic's release-signing key is an OpenPGP v4 key,
+and RFC 4880 §12.2 mandates SHA-1 for all v4 key fingerprints. The
+`github.com/ProtonMail/go-crypto` library computes this SHA-1 unconditionally
+at parse time whenever it reads any v4 key. Under `GODEBUG=fips140=only` that
+call panics immediately, before any package verification takes place.
+
+Resolving this requires Elastic to re-issue the release-signing key as an
+OpenPGP v6 key (which uses SHA-256 fingerprints). That is an org-level change
+outside the scope of this repository. Note that the SHA-1 is only used for the
+key's identifier; actual package integrity verification uses SHA-256.

--- a/docs/fips.md
+++ b/docs/fips.md
@@ -46,6 +46,20 @@ This builds `docker.elastic.co/package-registry/package-registry:main-fips`.
 Published FIPS images use the same `-fips` tag suffix as the existing `-ubi`
 variant, for example `docker.elastic.co/package-registry/package-registry:v1.40.0-fips`.
 
+Package-filled distribution images are also published with the `-fips` suffix.
+For an Elastic Stack release such as `8.19.0`, the production and lite variants
+are available as:
+
+```text
+docker.elastic.co/package-registry/distribution:8.19.0-fips
+docker.elastic.co/package-registry/distribution:lite-8.19.0-fips
+```
+
+These images use the FIPS-enabled Package Registry server and contain the same
+package sets as their corresponding non-FIPS distribution images. The
+`cmd/distribution` limitation described below applies to the build-time package
+collection tool, not to the deployed server in these images.
+
 ## Verifying a binary
 
 A binary built with `GOFIPS140` embeds that information, along with a default

--- a/docs/fips.md
+++ b/docs/fips.md
@@ -47,12 +47,12 @@ Published FIPS images use the same `-fips` tag suffix as the existing `-ubi`
 variant, for example `docker.elastic.co/package-registry/package-registry:v1.40.0-fips`.
 
 Package-filled distribution images are also published with the `-fips` suffix.
-For an Elastic Stack release such as `8.19.0`, the production and lite variants
+For an Elastic Stack release such as `9.6.0`, the production and lite variants
 are available as:
 
 ```text
-docker.elastic.co/package-registry/distribution:8.19.0-fips
-docker.elastic.co/package-registry/distribution:lite-8.19.0-fips
+docker.elastic.co/package-registry/distribution:9.6.0-fips
+docker.elastic.co/package-registry/distribution:lite-9.6.0-fips
 ```
 
 These images use the FIPS-enabled Package Registry server and contain the same

--- a/flags.go
+++ b/flags.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"os"
 	"runtime/debug"
+	"slices"
 	"strings"
 )
 
@@ -78,12 +79,9 @@ var isFIPSBinary = func() bool {
 	if !ok {
 		return false
 	}
-	for _, s := range bi.Settings {
-		if s.Key == "GOFIPS140" && s.Value != "" {
-			return true
-		}
-	}
-	return false
+	return slices.ContainsFunc(bi.Settings, func(s debug.BuildSetting) bool {
+		return s.Key == "GOFIPS140" && s.Value != ""
+	})
 }
 
 const flagEnvPrefix = "EPR_"

--- a/flags.go
+++ b/flags.go
@@ -73,8 +73,7 @@ func flagsFromEnv(flagSet *flag.FlagSet) error {
 }
 
 // isFIPSBinary reports whether the running binary was built with GOFIPS140.
-// Exposed as a variable so tests can stub the build-info check.
-var isFIPSBinary = func() bool {
+func isFIPSBinary() bool {
 	bi, ok := debug.ReadBuildInfo()
 	if !ok {
 		return false

--- a/flags.go
+++ b/flags.go
@@ -10,6 +10,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"runtime/debug"
 	"strings"
 )
 
@@ -68,6 +69,21 @@ func flagsFromEnv(flagSet *flag.FlagSet) error {
 		}
 	})
 	return flagErrors
+}
+
+// isFIPSBinary reports whether the running binary was built with GOFIPS140.
+// Exposed as a variable so tests can stub the build-info check.
+var isFIPSBinary = func() bool {
+	bi, ok := debug.ReadBuildInfo()
+	if !ok {
+		return false
+	}
+	for _, s := range bi.Settings {
+		if s.Key == "GOFIPS140" && s.Value != "" {
+			return true
+		}
+	}
+	return false
 }
 
 const flagEnvPrefix = "EPR_"

--- a/flags_test.go
+++ b/flags_test.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"crypto/tls"
 	"flag"
 	"testing"
 
@@ -52,4 +53,45 @@ func TestFlagEnvName(t *testing.T) {
 	for _, c := range cases {
 		assert.Equal(t, c.expected, flagEnvName(c.flagName))
 	}
+}
+
+func TestValidateFlagsFIPSTLSMinVersion(t *testing.T) {
+	// Save and restore globals modified by validateFlags.
+	origIsFIPS := isFIPSBinary
+	origTLSMin := tlsMinVersionValue
+	origCert := tlsCertFile
+	origKey := tlsKeyFile
+	t.Cleanup(func() {
+		isFIPSBinary = origIsFIPS
+		tlsMinVersionValue = origTLSMin
+		tlsCertFile = origCert
+		tlsKeyFile = origKey
+	})
+
+	// Provide dummy cert/key paths so the existing cert-presence check passes.
+	tlsCertFile = "cert.pem"
+	tlsKeyFile = "key.pem"
+
+	t.Run("FIPS binary with TLS 1.1 is rejected", func(t *testing.T) {
+		isFIPSBinary = func() bool { return true }
+		tlsMinVersionValue = tlsVersionValue(tls.VersionTLS11)
+		err := validateFlags()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "FIPS 140-3")
+		assert.Contains(t, err.Error(), "1.1")
+	})
+
+	t.Run("FIPS binary with TLS 1.2 is allowed", func(t *testing.T) {
+		isFIPSBinary = func() bool { return true }
+		tlsMinVersionValue = tlsVersionValue(tls.VersionTLS12)
+		err := validateFlags()
+		require.NoError(t, err)
+	})
+
+	t.Run("non-FIPS binary with TLS 1.1 is allowed", func(t *testing.T) {
+		isFIPSBinary = func() bool { return false }
+		tlsMinVersionValue = tlsVersionValue(tls.VersionTLS11)
+		err := validateFlags()
+		require.NoError(t, err)
+	})
 }

--- a/flags_test.go
+++ b/flags_test.go
@@ -55,43 +55,38 @@ func TestFlagEnvName(t *testing.T) {
 	}
 }
 
-func TestValidateFlagsFIPSTLSMinVersion(t *testing.T) {
-	// Save and restore globals modified by validateFlags.
-	origIsFIPS := isFIPSBinary
-	origTLSMin := tlsMinVersionValue
-	origCert := tlsCertFile
-	origKey := tlsKeyFile
-	t.Cleanup(func() {
-		isFIPSBinary = origIsFIPS
-		tlsMinVersionValue = origTLSMin
-		tlsCertFile = origCert
-		tlsKeyFile = origKey
-	})
+func TestValidateTLSFlagsFIPSTLSMinVersion(t *testing.T) {
+	tests := []struct {
+		name       string
+		fips       bool
+		minVersion tlsVersionValue
+		wantError  string
+	}{
+		{
+			name:       "FIPS binary with TLS 1.1 is rejected",
+			fips:       true,
+			minVersion: tlsVersionValue(tls.VersionTLS11),
+			wantError:  "FIPS 140-3 build: -tls-min-version 1.1 is not permitted; minimum allowed version is 1.2",
+		},
+		{
+			name:       "FIPS binary with TLS 1.2 is allowed",
+			fips:       true,
+			minVersion: tlsVersionValue(tls.VersionTLS12),
+		},
+		{
+			name:       "non-FIPS binary with TLS 1.1 is allowed",
+			minVersion: tlsVersionValue(tls.VersionTLS11),
+		},
+	}
 
-	// Provide dummy cert/key paths so the existing cert-presence check passes.
-	tlsCertFile = "cert.pem"
-	tlsKeyFile = "key.pem"
-
-	t.Run("FIPS binary with TLS 1.1 is rejected", func(t *testing.T) {
-		isFIPSBinary = func() bool { return true }
-		tlsMinVersionValue = tlsVersionValue(tls.VersionTLS11)
-		err := validateFlags()
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "FIPS 140-3")
-		assert.Contains(t, err.Error(), "1.1")
-	})
-
-	t.Run("FIPS binary with TLS 1.2 is allowed", func(t *testing.T) {
-		isFIPSBinary = func() bool { return true }
-		tlsMinVersionValue = tlsVersionValue(tls.VersionTLS12)
-		err := validateFlags()
-		require.NoError(t, err)
-	})
-
-	t.Run("non-FIPS binary with TLS 1.1 is allowed", func(t *testing.T) {
-		isFIPSBinary = func() bool { return false }
-		tlsMinVersionValue = tlsVersionValue(tls.VersionTLS11)
-		err := validateFlags()
-		require.NoError(t, err)
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateTLSFlags("cert.pem", "key.pem", tt.minVersion, tt.fips)
+			if tt.wantError != "" {
+				assert.EqualError(t, err, tt.wantError)
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
 }

--- a/flags_test.go
+++ b/flags_test.go
@@ -90,3 +90,33 @@ func TestValidateTLSFlagsFIPSTLSMinVersion(t *testing.T) {
 		})
 	}
 }
+
+func TestEffectiveTLSMinVersion(t *testing.T) {
+	tests := []struct {
+		name       string
+		fips       bool
+		minVersion tlsVersionValue
+		expected   uint16
+	}{
+		{
+			name:       "explicit version is preserved",
+			fips:       true,
+			minVersion: tlsVersionValue(tls.VersionTLS13),
+			expected:   tls.VersionTLS13,
+		},
+		{
+			name:     "FIPS binary defaults to TLS 1.2",
+			fips:     true,
+			expected: tls.VersionTLS12,
+		},
+		{
+			name: "non-FIPS binary uses Go default",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, effectiveTLSMinVersion(tt.minVersion, tt.fips))
+		})
+	}
+}

--- a/internal/storage/fakestorage.go
+++ b/internal/storage/fakestorage.go
@@ -90,8 +90,8 @@ func ClientNoAuth(server *fakestorage.Server) *storage.Client {
 
 // UpdateFakeServer simulates an index update by stopping the given fake
 // server and returning a new one that contains the previous server's objects
-// plus the new revision's objects. Callers must point any client bound to
-// the old server at the returned one.
+// plus the new revision's objects, together with a storage client configured
+// to use the new server.
 //
 // It doesn't add the new revision's objects to the running server via
 // Server.CreateObject because fake-gcs-server's internal toBackendObjects
@@ -104,7 +104,7 @@ func ClientNoAuth(server *fakestorage.Server) *storage.Client {
 //
 // New revision objects are appended after the existing ones so they win any
 // name conflicts (e.g. the cursor object is overwritten with the new revision).
-func UpdateFakeServer(tb testing.TB, server *fakestorage.Server, revision, indexPath string) *fakestorage.Server {
+func UpdateFakeServer(tb testing.TB, server *fakestorage.Server, revision, indexPath string) (*fakestorage.Server, *storage.Client) {
 	indexContent, err := os.ReadFile(indexPath)
 	require.NoError(tb, err, "index file must be populated")
 
@@ -129,7 +129,8 @@ func UpdateFakeServer(tb testing.TB, server *fakestorage.Server, revision, index
 	allObjects = append(allObjects, newObjects...)
 
 	server.Stop()
-	return fakestorage.NewServer(allObjects)
+	newServer := fakestorage.NewServer(allObjects)
+	return newServer, ClientNoAuth(newServer)
 }
 
 type searchIndexAll struct {

--- a/internal/storage/fakestorage.go
+++ b/internal/storage/fakestorage.go
@@ -6,6 +6,7 @@ package storage
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -20,6 +21,19 @@ import (
 )
 
 const FakePackageStorageBucketInternal = "fake-package-storage-internal"
+
+// fakeObjectMD5Hash is a placeholder MD5 digest (16 zero bytes, base64-encoded)
+// used to pre-populate ObjectAttrs.Md5Hash on the fake objects we hand to
+// fake-gcs-server.
+//
+// fake-gcs-server's backends only compute a real MD5 hash of the object
+// content when Md5Hash is empty (see addObject in
+// github.com/fsouza/fake-gcs-server/internal/backend), and that computation
+// panics under strict FIPS 140-3 enforcement (GODEBUG=fips140=only) since MD5
+// isn't an approved algorithm. The value itself is never inspected: the real
+// cloud.google.com/go/storage client explicitly ignores the MD5 hash on
+// reads, and package-registry never reads ObjectAttrs.Md5Hash/Etag.
+var fakeObjectMD5Hash = base64.StdEncoding.EncodeToString(make([]byte, 16))
 
 func RunFakeServerOnHostPort(indexPath, host string, port uint16) (*fakestorage.Server, error) {
 	indexContent, err := os.ReadFile(indexPath)
@@ -74,7 +88,20 @@ func ClientNoAuth(server *fakestorage.Server) *storage.Client {
 	return client
 }
 
-func UpdateFakeServer(tb testing.TB, server *fakestorage.Server, revision, indexPath string) {
+// UpdateFakeServer simulates an index update by stopping the given fake
+// server and returning a new one seeded with the objects for the given
+// revision. Callers must point any client bound to the old server at the
+// returned one.
+//
+// It deliberately doesn't add the new revision's objects to the running
+// server via Server.CreateObject: fake-gcs-server always recomputes real
+// crc32c/MD5 checksums server-side for objects added that way (and via the
+// HTTP upload path), mirroring how real GCS never trusts client-supplied
+// checksums on write, which panics under strict FIPS 140-3 enforcement
+// (GODEBUG=fips140=only). InitialObjects bypass that recomputation (see
+// PrepareFakeServer), so restarting the server keeps object creation on
+// that path instead.
+func UpdateFakeServer(tb testing.TB, server *fakestorage.Server, revision, indexPath string) *fakestorage.Server {
 	indexContent, err := os.ReadFile(indexPath)
 	require.NoError(tb, err, "index file must be populated")
 
@@ -82,9 +109,8 @@ func UpdateFakeServer(tb testing.TB, server *fakestorage.Server, revision, index
 	require.NoError(tb, err, "failed to prepare server objects")
 	tb.Logf("Prepared %d packages with total %d server objects.", numPackages, len(serverObjects))
 
-	for _, so := range serverObjects {
-		server.CreateObject(so)
-	}
+	server.Stop()
+	return fakestorage.NewServer(serverObjects)
 }
 
 type searchIndexAll struct {
@@ -105,13 +131,13 @@ func PrepareServerObjects(revision string, indexContent []byte) ([]fakestorage.O
 	// Add cursor and index file
 	serverObjects = append(serverObjects, fakestorage.Object{
 		ObjectAttrs: fakestorage.ObjectAttrs{
-			BucketName: FakePackageStorageBucketInternal, Name: cursorStoragePath,
+			BucketName: FakePackageStorageBucketInternal, Name: cursorStoragePath, Md5Hash: fakeObjectMD5Hash,
 		},
 		Content: []byte(`{"current":"` + revision + `"}`),
 	})
 	serverObjects = append(serverObjects, fakestorage.Object{
 		ObjectAttrs: fakestorage.ObjectAttrs{
-			BucketName: FakePackageStorageBucketInternal, Name: joinObjectPaths(v2MetadataStoragePath, revision, searchIndexAllFile),
+			BucketName: FakePackageStorageBucketInternal, Name: joinObjectPaths(v2MetadataStoragePath, revision, searchIndexAllFile), Md5Hash: fakeObjectMD5Hash,
 		},
 		Content: indexContent,
 	})

--- a/internal/storage/fakestorage.go
+++ b/internal/storage/fakestorage.go
@@ -89,28 +89,47 @@ func ClientNoAuth(server *fakestorage.Server) *storage.Client {
 }
 
 // UpdateFakeServer simulates an index update by stopping the given fake
-// server and returning a new one seeded with the objects for the given
-// revision. Callers must point any client bound to the old server at the
-// returned one.
+// server and returning a new one that contains the previous server's objects
+// plus the new revision's objects. Callers must point any client bound to
+// the old server at the returned one.
 //
-// It deliberately doesn't add the new revision's objects to the running
-// server via Server.CreateObject: fake-gcs-server always recomputes real
-// crc32c/MD5 checksums server-side for objects added that way (and via the
-// HTTP upload path), mirroring how real GCS never trusts client-supplied
-// checksums on write, which panics under strict FIPS 140-3 enforcement
-// (GODEBUG=fips140=only). InitialObjects bypass that recomputation (see
-// PrepareFakeServer), so restarting the server keeps object creation on
+// It doesn't add the new revision's objects to the running server via
+// Server.CreateObject because fake-gcs-server's internal toBackendObjects
+// converter (used on that path) strips Md5Hash before handing off to the
+// backend, which then recomputes it from scratch — a path that panics under
+// strict FIPS 140-3 enforcement (GODEBUG=fips140=only) since MD5 isn't an
+// approved algorithm. InitialObjects bypass that recomputation (see
+// PrepareFakeServer), so restarting the server keeps all object creation on
 // that path instead.
+//
+// New revision objects are appended after the existing ones so they win any
+// name conflicts (e.g. the cursor object is overwritten with the new revision).
 func UpdateFakeServer(tb testing.TB, server *fakestorage.Server, revision, indexPath string) *fakestorage.Server {
 	indexContent, err := os.ReadFile(indexPath)
 	require.NoError(tb, err, "index file must be populated")
 
-	serverObjects, numPackages, err := PrepareServerObjects(revision, indexContent)
+	newObjects, numPackages, err := PrepareServerObjects(revision, indexContent)
 	require.NoError(tb, err, "failed to prepare server objects")
-	tb.Logf("Prepared %d packages with total %d server objects.", numPackages, len(serverObjects))
+	tb.Logf("Prepared %d packages with total %d server objects.", numPackages, len(newObjects))
+
+	// Collect all existing objects from the running server so the new server
+	// is additive: previous revision files remain accessible alongside the
+	// new ones. GetObject round-trips through fromBackendObjects which
+	// preserves the stored Md5Hash, keeping subsequent InitialObjects
+	// insertion FIPS-safe (non-empty Md5Hash skips recomputation).
+	listResp, err := server.ListObjectsWithOptionsPaginated(FakePackageStorageBucketInternal, fakestorage.ListOptions{})
+	require.NoError(tb, err, "failed to list existing server objects")
+	existingAttrs := listResp.Objects
+	allObjects := make([]fakestorage.Object, 0, len(existingAttrs)+len(newObjects))
+	for _, attrs := range existingAttrs {
+		obj, err := server.GetObject(FakePackageStorageBucketInternal, attrs.Name)
+		require.NoError(tb, err, "failed to retrieve existing server object %q", attrs.Name)
+		allObjects = append(allObjects, obj)
+	}
+	allObjects = append(allObjects, newObjects...)
 
 	server.Stop()
-	return fakestorage.NewServer(serverObjects)
+	return fakestorage.NewServer(allObjects)
 }
 
 type searchIndexAll struct {

--- a/internal/storage/fakestorage.go
+++ b/internal/storage/fakestorage.go
@@ -117,9 +117,17 @@ func UpdateFakeServer(tb testing.TB, server *fakestorage.Server, revision, index
 	// new ones. GetObject round-trips through fromBackendObjects which
 	// preserves the stored Md5Hash, keeping subsequent InitialObjects
 	// insertion FIPS-safe (non-empty Md5Hash skips recomputation).
-	listResp, err := server.ListObjectsWithOptionsPaginated(FakePackageStorageBucketInternal, fakestorage.ListOptions{})
-	require.NoError(tb, err, "failed to list existing server objects")
-	existingAttrs := listResp.Objects
+	var existingAttrs []fakestorage.ObjectAttrs
+	var pageToken string
+	for {
+		listResp, err := server.ListObjectsWithOptionsPaginated(FakePackageStorageBucketInternal, fakestorage.ListOptions{PageToken: pageToken})
+		require.NoError(tb, err, "failed to list existing server objects")
+		existingAttrs = append(existingAttrs, listResp.Objects...)
+		if listResp.NextPageToken == "" {
+			break
+		}
+		pageToken = listResp.NextPageToken
+	}
 	allObjects := make([]fakestorage.Object, 0, len(existingAttrs)+len(newObjects))
 	for _, attrs := range existingAttrs {
 		obj, err := server.GetObject(FakePackageStorageBucketInternal, attrs.Name)

--- a/internal/storage/sqlindexer_test.go
+++ b/internal/storage/sqlindexer_test.go
@@ -110,8 +110,7 @@ func BenchmarkSQLIndexerUpdateIndex(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		b.StopTimer()
 		revision := fmt.Sprintf("%d", i+2)
-		fs = UpdateFakeServer(b, fs, revision, "../../storage/testdata/search-index-all-full.json")
-		indexer.storageClient = ClientNoAuth(fs)
+		fs, indexer.storageClient = UpdateFakeServer(b, fs, revision, "../../storage/testdata/search-index-all-full.json")
 		b.StartTimer()
 		start = time.Now()
 		err = indexer.updateIndex(b.Context())
@@ -499,8 +498,7 @@ func TestSQLGet_IndexUpdated(t *testing.T) {
 	require.Equal(t, "0.2.0", foundPackages[0].Version)
 
 	// when: index update is performed
-	fs = UpdateFakeServer(t, fs, "2", "../../storage/testdata/search-index-all-full.json")
-	indexer.storageClient = ClientNoAuth(fs)
+	fs, indexer.storageClient = UpdateFakeServer(t, fs, "2", "../../storage/testdata/search-index-all-full.json")
 	err = indexer.updateIndex(t.Context())
 	require.NoError(t, err, "index should be updated successfully")
 
@@ -519,8 +517,7 @@ func TestSQLGet_IndexUpdated(t *testing.T) {
 	require.Equal(t, "1.4.0", foundPackages[0].Version)
 
 	// when: index update is performed removing packages
-	fs = UpdateFakeServer(t, fs, "3", "../../storage/testdata/search-index-all-small.json")
-	indexer.storageClient = ClientNoAuth(fs)
+	fs, indexer.storageClient = UpdateFakeServer(t, fs, "3", "../../storage/testdata/search-index-all-small.json")
 	err = indexer.updateIndex(t.Context())
 	require.NoError(t, err, "index should be updated successfully")
 
@@ -540,8 +537,7 @@ func TestSQLGet_IndexUpdated(t *testing.T) {
 	require.Equal(t, "1Password Events Reporting", *foundPackages[0].Title)
 
 	// when: index update is performed updating some field of an existing package
-	fs = UpdateFakeServer(t, fs, "4", "../../storage/testdata/search-index-all-small-updated-fields.json")
-	indexer.storageClient = ClientNoAuth(fs)
+	fs, indexer.storageClient = UpdateFakeServer(t, fs, "4", "../../storage/testdata/search-index-all-small-updated-fields.json")
 	err = indexer.updateIndex(t.Context())
 	require.NoError(t, err, "index should be updated successfully")
 

--- a/internal/storage/sqlindexer_test.go
+++ b/internal/storage/sqlindexer_test.go
@@ -94,7 +94,7 @@ func BenchmarkSQLIndexerUpdateIndex(b *testing.B) {
 	require.NoError(b, err)
 
 	fs := PrepareFakeServer(b, "../../storage/testdata/search-index-all-full.json")
-	defer fs.Stop()
+	defer func() { fs.Stop() }()
 
 	logger := util.NewTestLoggerLevel(zapcore.FatalLevel)
 
@@ -110,7 +110,8 @@ func BenchmarkSQLIndexerUpdateIndex(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		b.StopTimer()
 		revision := fmt.Sprintf("%d", i+2)
-		UpdateFakeServer(b, fs, revision, "../../storage/testdata/search-index-all-full.json")
+		fs = UpdateFakeServer(b, fs, revision, "../../storage/testdata/search-index-all-full.json")
+		indexer.storageClient = ClientNoAuth(fs)
 		b.StartTimer()
 		start = time.Now()
 		err = indexer.updateIndex(b.Context())
@@ -472,7 +473,7 @@ func TestSQLGet_IndexUpdated(t *testing.T) {
 	require.NoError(t, err)
 
 	fs := PrepareFakeServer(t, "../../storage/testdata/search-index-all-small.json")
-	t.Cleanup(fs.Stop)
+	t.Cleanup(func() { fs.Stop() })
 
 	storageClient := ClientNoAuth(fs)
 
@@ -498,7 +499,8 @@ func TestSQLGet_IndexUpdated(t *testing.T) {
 	require.Equal(t, "0.2.0", foundPackages[0].Version)
 
 	// when: index update is performed
-	UpdateFakeServer(t, fs, "2", "../../storage/testdata/search-index-all-full.json")
+	fs = UpdateFakeServer(t, fs, "2", "../../storage/testdata/search-index-all-full.json")
+	indexer.storageClient = ClientNoAuth(fs)
 	err = indexer.updateIndex(t.Context())
 	require.NoError(t, err, "index should be updated successfully")
 
@@ -517,7 +519,8 @@ func TestSQLGet_IndexUpdated(t *testing.T) {
 	require.Equal(t, "1.4.0", foundPackages[0].Version)
 
 	// when: index update is performed removing packages
-	UpdateFakeServer(t, fs, "3", "../../storage/testdata/search-index-all-small.json")
+	fs = UpdateFakeServer(t, fs, "3", "../../storage/testdata/search-index-all-small.json")
+	indexer.storageClient = ClientNoAuth(fs)
 	err = indexer.updateIndex(t.Context())
 	require.NoError(t, err, "index should be updated successfully")
 
@@ -537,7 +540,8 @@ func TestSQLGet_IndexUpdated(t *testing.T) {
 	require.Equal(t, "1Password Events Reporting", *foundPackages[0].Title)
 
 	// when: index update is performed updating some field of an existing package
-	UpdateFakeServer(t, fs, "4", "../../storage/testdata/search-index-all-small-updated-fields.json")
+	fs = UpdateFakeServer(t, fs, "4", "../../storage/testdata/search-index-all-small-updated-fields.json")
+	indexer.storageClient = ClientNoAuth(fs)
 	err = indexer.updateIndex(t.Context())
 	require.NoError(t, err, "index should be updated successfully")
 

--- a/magefile.go
+++ b/magefile.go
@@ -32,6 +32,10 @@ const (
 	StaticcheckImportPath = "honnef.co/go/tools/cmd/staticcheck"
 
 	buildDir = "./build"
+
+	// GOFIPS140Version pins the certified Go FIPS 140-3 crypto module used by
+	// FIPS builds. See https://go.dev/doc/security/fips140#fips-140-3-mode and docs/fips.md.
+	GOFIPS140Version = "v1.0.0"
 )
 
 type module struct {
@@ -42,8 +46,8 @@ type module struct {
 // modules is the list of Go modules in this repository.
 // Add new modules here to automatically include them in test, lint, and other targets.
 var modules = []module{
-	{"package-registry", "."},
-	{"cmd/distribution", "cmd/distribution"},
+	{name: "package-registry", path: "."},
+	{name: "cmd/distribution", path: "cmd/distribution"},
 }
 
 func runInAllModules(fn func(mod module) error) error {
@@ -76,6 +80,13 @@ func Build() error {
 	return sh.Run("go", "build", ".")
 }
 
+// BuildFIPS builds package-registry against the certified Go FIPS 140-3
+// crypto module. See docs/fips.md.
+func BuildFIPS() error {
+	fmt.Println(">> Building package-registry (FIPS 140-3)")
+	return sh.RunWith(map[string]string{"GOFIPS140": GOFIPS140Version}, "go", "build", ".")
+}
+
 // BuildDistribution builds the distribution binary in cmd/distribution.
 func BuildDistribution() error {
 	return runInAllModules(func(mod module) error {
@@ -90,6 +101,16 @@ func BuildDistribution() error {
 // DockerBuild builds the Docker image for the package registry. It must be specified
 // the docker tag to be used as an argument (e.g. main, latest).
 func DockerBuild(tag string) error {
+	return dockerBuild(tag, false)
+}
+
+// DockerBuildFIPS builds the Docker image for the package registry against the
+// certified Go FIPS 140-3 crypto module. See docs/fips.md.
+func DockerBuildFIPS(tag string) error {
+	return dockerBuild(tag, true)
+}
+
+func dockerBuild(tag string, fips bool) error {
 	contents, err := os.ReadFile(".go-version")
 	if err != nil {
 		return fmt.Errorf("failed to read .go-version: %w", err)
@@ -100,9 +121,15 @@ func DockerBuild(tag string) error {
 	}
 	dockerImage := fmt.Sprintf("docker.elastic.co/package-registry/package-registry:%s", tag)
 
+	args := []string{"build", "--rm", "--build-arg", fmt.Sprintf("GO_VERSION=%s", goVersion)}
+	if fips {
+		dockerImage += "-fips"
+		args = append(args, "--build-arg", "FIPS=1")
+	}
+	args = append(args, "-t", dockerImage, ".")
+
 	fmt.Println(">> Building Docker image:", dockerImage)
-	err = sh.Run("docker", "build", "--rm", "--build-arg", fmt.Sprintf("GO_VERSION=%s", goVersion), "-t", dockerImage, ".")
-	if err != nil {
+	if err := sh.Run("docker", args...); err != nil {
 		return fmt.Errorf("failed to build docker image: %w", err)
 	}
 	return nil
@@ -130,6 +157,14 @@ func Test() error {
 		fmt.Fprintf(os.Stderr, ">> test - running tests for %s\n", mod.name)
 		return sh.RunV("go", "test", "./...", "-v")
 	})
+}
+
+// TestFIPS runs the package-registry test suite compiled against the certified
+// Go FIPS 140-3 crypto module (GOFIPS140) under strict GODEBUG=fips140=only.
+// See docs/fips.md.
+func TestFIPS() error {
+	fmt.Fprintf(os.Stderr, ">> test - running FIPS 140-3 tests for package-registry (GODEBUG=fips140=only)\n")
+	return sh.RunWithV(map[string]string{"GOFIPS140": GOFIPS140Version, "GODEBUG": "fips140=only"}, "go", "test", "./...", "-v")
 }
 
 func WriteTestGoldenFiles() error {

--- a/main.go
+++ b/main.go
@@ -747,13 +747,8 @@ func getRouter(logger *zap.Logger, options serverOptions) (*mux.Router, error) {
 }
 
 func validateFlags() error {
-	if tlsMinVersionValue > 0 {
-		if tlsCertFile == "" || tlsKeyFile == "" {
-			return fmt.Errorf("-tls-min-version set but missing TLS cert and key files (-tls-cert and -tls-key)")
-		}
-		if isFIPSBinary() && uint16(tlsMinVersionValue) < tls.VersionTLS12 {
-			return fmt.Errorf("FIPS 140-3 build: -tls-min-version %s is not permitted; minimum allowed version is 1.2", tlsMinVersionValue)
-		}
+	if err := validateTLSFlags(tlsCertFile, tlsKeyFile, tlsMinVersionValue, isFIPSBinary()); err != nil {
+		return err
 	}
 
 	if featureStorageIndexer && featureSQLStorageIndexer {
@@ -782,5 +777,18 @@ func validateFlags() error {
 		}
 	}
 
+	return nil
+}
+
+func validateTLSFlags(certFile, keyFile string, minVersion tlsVersionValue, fips bool) error {
+	if minVersion == 0 {
+		return nil
+	}
+	if certFile == "" || keyFile == "" {
+		return fmt.Errorf("-tls-min-version set but missing TLS cert and key files (-tls-cert and -tls-key)")
+	}
+	if fips && uint16(minVersion) < tls.VersionTLS12 {
+		return fmt.Errorf("FIPS 140-3 build: -tls-min-version %s is not permitted; minimum allowed version is 1.2", minVersion)
+	}
 	return nil
 }

--- a/main.go
+++ b/main.go
@@ -751,6 +751,9 @@ func validateFlags() error {
 		if tlsCertFile == "" || tlsKeyFile == "" {
 			return fmt.Errorf("-tls-min-version set but missing TLS cert and key files (-tls-cert and -tls-key)")
 		}
+		if isFIPSBinary() && uint16(tlsMinVersionValue) < tls.VersionTLS12 {
+			return fmt.Errorf("FIPS 140-3 build: -tls-min-version %s is not permitted; minimum allowed version is 1.2", tlsMinVersionValue)
+		}
 	}
 
 	if featureStorageIndexer && featureSQLStorageIndexer {

--- a/main.go
+++ b/main.go
@@ -512,9 +512,8 @@ func initServer(logger *zap.Logger, options serverOptions) *http.Server {
 	apmgorilla.Instrument(router, apmgorilla.WithTracer(options.apmTracer))
 	router.Use(util.LoggingMiddleware(logger))
 
-	var tlsConfig tls.Config
-	if tlsMinVersionValue > 0 {
-		tlsConfig.MinVersion = uint16(tlsMinVersionValue)
+	tlsConfig := tls.Config{
+		MinVersion: effectiveTLSMinVersion(tlsMinVersionValue, isFIPSBinary()),
 	}
 
 	return &http.Server{Addr: address, Handler: router, TLSConfig: &tlsConfig}
@@ -791,4 +790,16 @@ func validateTLSFlags(certFile, keyFile string, minVersion tlsVersionValue, fips
 		return fmt.Errorf("FIPS 140-3 build: -tls-min-version %s is not permitted; minimum allowed version is 1.2", minVersion)
 	}
 	return nil
+}
+
+func effectiveTLSMinVersion(minVersion tlsVersionValue, fips bool) uint16 {
+	if minVersion > 0 {
+		return uint16(minVersion)
+	}
+	// Make the FIPS requirement explicit instead of relying on Go's default,
+	// while preserving that default for non-FIPS binaries.
+	if fips {
+		return tls.VersionTLS12
+	}
+	return 0
 }

--- a/storage/indexer_test.go
+++ b/storage/indexer_test.go
@@ -57,7 +57,7 @@ func BenchmarkInit(b *testing.B) {
 func BenchmarkIndexerUpdateIndex(b *testing.B) {
 	// given
 	fs := internalStorage.PrepareFakeServer(b, "testdata/search-index-all-full.json")
-	defer fs.Stop()
+	defer func() { fs.Stop() }()
 
 	logger := util.NewTestLoggerLevel(zapcore.FatalLevel)
 	indexer := NewIndexer(logger, internalStorage.ClientNoAuth(fs), FakeIndexerOptions)
@@ -70,7 +70,8 @@ func BenchmarkIndexerUpdateIndex(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		b.StopTimer()
 		revision := fmt.Sprintf("%d", i+2)
-		internalStorage.UpdateFakeServer(b, fs, revision, "testdata/search-index-all-full.json")
+		fs = internalStorage.UpdateFakeServer(b, fs, revision, "testdata/search-index-all-full.json")
+		indexer.storageClient = internalStorage.ClientNoAuth(fs)
 		b.StartTimer()
 		err = indexer.updateIndex(b.Context())
 		require.NoError(b, err, "index should be updated successfully")
@@ -318,7 +319,7 @@ func TestGet_IndexUpdated(t *testing.T) {
 
 	// given
 	fs := internalStorage.PrepareFakeServer(t, "testdata/search-index-all-small.json")
-	t.Cleanup(fs.Stop)
+	t.Cleanup(func() { fs.Stop() })
 
 	indexer := NewIndexer(util.NewTestLogger(), internalStorage.ClientNoAuth(fs), FakeIndexerOptions)
 	t.Cleanup(func() { indexer.Close(context.Background()) })
@@ -343,7 +344,8 @@ func TestGet_IndexUpdated(t *testing.T) {
 
 	// when: index update is performed adding new packages
 	const secondRevision = "2"
-	internalStorage.UpdateFakeServer(t, fs, secondRevision, "testdata/search-index-all-full.json")
+	fs = internalStorage.UpdateFakeServer(t, fs, secondRevision, "testdata/search-index-all-full.json")
+	indexer.storageClient = internalStorage.ClientNoAuth(fs)
 	err = indexer.updateIndex(t.Context())
 	require.NoError(t, err, "index should be updated successfully")
 
@@ -363,7 +365,8 @@ func TestGet_IndexUpdated(t *testing.T) {
 
 	// when: index update is performed removing packages
 	const thirdRevision = "3"
-	internalStorage.UpdateFakeServer(t, fs, thirdRevision, "testdata/search-index-all-small.json")
+	fs = internalStorage.UpdateFakeServer(t, fs, thirdRevision, "testdata/search-index-all-small.json")
+	indexer.storageClient = internalStorage.ClientNoAuth(fs)
 	err = indexer.updateIndex(t.Context())
 	require.NoError(t, err, "index should be updated successfully")
 
@@ -382,7 +385,8 @@ func TestGet_IndexUpdated(t *testing.T) {
 	require.Equal(t, "0.2.0", foundPackages[0].Version)
 
 	// when: index update is performed updating some field of an existing pacakage
-	internalStorage.UpdateFakeServer(t, fs, "4", "testdata/search-index-all-small-updated-fields.json")
+	fs = internalStorage.UpdateFakeServer(t, fs, "4", "testdata/search-index-all-small-updated-fields.json")
+	indexer.storageClient = internalStorage.ClientNoAuth(fs)
 	err = indexer.updateIndex(t.Context())
 	require.NoError(t, err, "index should be updated successfully")
 

--- a/storage/indexer_test.go
+++ b/storage/indexer_test.go
@@ -70,8 +70,7 @@ func BenchmarkIndexerUpdateIndex(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		b.StopTimer()
 		revision := fmt.Sprintf("%d", i+2)
-		fs = internalStorage.UpdateFakeServer(b, fs, revision, "testdata/search-index-all-full.json")
-		indexer.storageClient = internalStorage.ClientNoAuth(fs)
+		fs, indexer.storageClient = internalStorage.UpdateFakeServer(b, fs, revision, "testdata/search-index-all-full.json")
 		b.StartTimer()
 		err = indexer.updateIndex(b.Context())
 		require.NoError(b, err, "index should be updated successfully")
@@ -344,8 +343,7 @@ func TestGet_IndexUpdated(t *testing.T) {
 
 	// when: index update is performed adding new packages
 	const secondRevision = "2"
-	fs = internalStorage.UpdateFakeServer(t, fs, secondRevision, "testdata/search-index-all-full.json")
-	indexer.storageClient = internalStorage.ClientNoAuth(fs)
+	fs, indexer.storageClient = internalStorage.UpdateFakeServer(t, fs, secondRevision, "testdata/search-index-all-full.json")
 	err = indexer.updateIndex(t.Context())
 	require.NoError(t, err, "index should be updated successfully")
 
@@ -365,8 +363,7 @@ func TestGet_IndexUpdated(t *testing.T) {
 
 	// when: index update is performed removing packages
 	const thirdRevision = "3"
-	fs = internalStorage.UpdateFakeServer(t, fs, thirdRevision, "testdata/search-index-all-small.json")
-	indexer.storageClient = internalStorage.ClientNoAuth(fs)
+	fs, indexer.storageClient = internalStorage.UpdateFakeServer(t, fs, thirdRevision, "testdata/search-index-all-small.json")
 	err = indexer.updateIndex(t.Context())
 	require.NoError(t, err, "index should be updated successfully")
 
@@ -385,8 +382,7 @@ func TestGet_IndexUpdated(t *testing.T) {
 	require.Equal(t, "0.2.0", foundPackages[0].Version)
 
 	// when: index update is performed updating some field of an existing pacakage
-	fs = internalStorage.UpdateFakeServer(t, fs, "4", "testdata/search-index-all-small-updated-fields.json")
-	indexer.storageClient = internalStorage.ClientNoAuth(fs)
+	fs, indexer.storageClient = internalStorage.UpdateFakeServer(t, fs, "4", "testdata/search-index-all-small-updated-fields.json")
 	err = indexer.updateIndex(t.Context())
 	require.NoError(t, err, "index should be updated successfully")
 


### PR DESCRIPTION
## Why

Elastic Package Registry must be deployable in FIPS 140-3 regulated environments
(government, defense, financial). Following the Go ecosystem team's direction
(elastic/beats#51345), this uses Go's native certified FIPS module (`GOFIPS140=v1.0.0`,
CMVP cert #4735) rather than microsoft-go/OpenSSL — no CGO, no special toolchain
image, the entire certified module lives in the binary. Go 1.26.4 (already in use)
supports `GOFIPS140` natively; no toolchain upgrade was needed.

Closes elastic/ingest-dev#7234

---

## What was done

### Build

- **`Makefile`**: `FIPS ?= 0`; when `FIPS=1`, prefixes `go build` with `GOFIPS140=v1.0.0`.
- **`Dockerfile`**: `ARG FIPS=0` passed through to `make release-... FIPS=${FIPS}`. Same builder image, no CGO.
- **`magefile.go`**: Three new targets — `BuildFIPS`, `DockerBuildFIPS`, `TestFIPS`.
  `TestFIPS` runs `go test ./...` against the `package-registry` module only,
  with `GOFIPS140=v1.0.0` and strict `GODEBUG=fips140=only`.

### FIPS compliance fixes

Under `GODEBUG=fips140=only`, three test packages panicked on `crypto/md5` — traced to
`github.com/fsouza/fake-gcs-server` hashing object content with MD5 when
`ObjectAttrs.Md5Hash` is empty (both on startup and on `Server.CreateObject`).

Fixed in **`internal/storage/fakestorage.go`**:
- `fakeObjectMD5Hash`: placeholder pre-populated on every fake object so the
  library never computes MD5 itself. Harmless — the real GCS client never reads it.
- `UpdateFakeServer`: rewrote to stop and restart the server with fresh
  `InitialObjects` instead of calling `Server.CreateObject`, keeping object
  creation off the MD5-recomputing path.
- Updated 8 call sites in `storage/indexer_test.go` and
  `internal/storage/sqlindexer_test.go`.

`go test ./...` now passes clean under strict `GODEBUG=fips140=only` across every
package in the `package-registry` module.

Note: `internal/storage/fakestorage.go` compiles into the shipped binary (not
test-only). The `EPR_EMULATOR_INDEX_PATH` production path uses the same
`PrepareServerObjects` code — verified to run without panic under `fips140=only`.

### TLS guardrail

`-tls-min-version=1.1` would violate FIPS 140-3. FIPS builds now reject startup
with a clear error if this flag is set below TLS 1.2. Non-FIPS builds are
unaffected. Implemented via `isFIPSBinary()` (reads `debug.ReadBuildInfo()` for
the `GOFIPS140` build setting) and three unit tests in `flags_test.go`.

### CI

- **`.buildkite/pipeline.yml`**: New `fips-build-test` step (`allow_failure: false`,
  required gate on `publish`).
- **`.buildkite/scripts/test-fips.sh`** (new): builds FIPS binary, asserts
  `GOFIPS140=v1.0.0*` and `DefaultGODEBUG=fips140=on` in buildinfo, runs `mage testFIPS`.
- **`.buildkite/scripts/publish.sh`**: pushes `-fips` tagged image using
  `docker.elastic.co/wolfi/chainguard-base-fips` as the runtime base.

### Documentation

- **`docs/fips.md`** (new): build/verify instructions, what is covered, known limitations.
- **`README.md`**: FIPS 140-3 section linking to `docs/fips.md`.
- **`CHANGELOG.md`**: entry under `[unreleased] / Added`.

---

## Known limitations

### `cmd/distribution` is not FIPS-covered

`cmd/distribution` verifies packages against Elastic's release-signing key via
`github.com/ProtonMail/go-crypto/openpgp`. That key is an OpenPGP v4 key; RFC 4880
§12.2 mandates SHA-1 for all v4 fingerprints, computed unconditionally at parse
time. Under `fips140=only` this panics before any verification takes place.

Fixing it requires Elastic to re-issue the signing key as a v6 key (SHA-256
fingerprint) — an org-level change outside this repo. Note: SHA-1 is only used
for the key identifier; actual package integrity verification uses SHA-256.
Documented in `docs/fips.md`.

---

## How to verify

```bash
mage buildFIPS
go version -m package-registry | grep -E 'GOFIPS140|DefaultGODEBUG'
# build  DefaultGODEBUG=fips140=on
# build  GOFIPS140=v1.0.0-...

mage testFIPS
```