### PR TITLE
packages: expose iac_blueprints and provider_permissions in manifest structs

### DIFF
--- a/packages/datastream.go
+++ b/packages/datastream.go
@@ -78,14 +78,14 @@ type DataStream struct {
 }
 
 type Input struct {
-	Type            string      `config:"type,omitempty" json:"type,omitempty" yaml:"type,omitempty"`
-	Package         string      `config:"package,omitempty" json:"package,omitempty" yaml:"package,omitempty"`
-	Vars            []Variable  `config:"vars" json:"vars,omitempty" yaml:"vars,omitempty"`
-	Title           string      `config:"title" json:"title,omitempty" yaml:"title,omitempty"`
-	Description     string      `config:"description" json:"description,omitempty" yaml:"description,omitempty"`
-	Streams         []Stream    `config:"streams" json:"streams,omitempty" yaml:"streams,omitempty"`
-	TemplatePath    string      `config:"template_path" json:"template_path,omitempty" yaml:"template_path,omitempty"`
-	InputGroup      string      `config:"input_group" json:"input_group,omitempty" yaml:"input_group,omitempty"`
+	Type                string               `config:"type,omitempty" json:"type,omitempty" yaml:"type,omitempty"`
+	Package             string               `config:"package,omitempty" json:"package,omitempty" yaml:"package,omitempty"`
+	Vars                []Variable           `config:"vars" json:"vars,omitempty" yaml:"vars,omitempty"`
+	Title               string               `config:"title" json:"title,omitempty" yaml:"title,omitempty"`
+	Description         string               `config:"description" json:"description,omitempty" yaml:"description,omitempty"`
+	Streams             []Stream             `config:"streams" json:"streams,omitempty" yaml:"streams,omitempty"`
+	TemplatePath        string               `config:"template_path" json:"template_path,omitempty" yaml:"template_path,omitempty"`
+	InputGroup          string               `config:"input_group" json:"input_group,omitempty" yaml:"input_group,omitempty"`
 	DeploymentModes     []string             `config:"deployment_modes,omitempty" json:"deployment_modes,omitempty" yaml:"deployment_modes,omitempty"`
 	Deprecated          *Deprecated          `config:"deprecated,omitempty" json:"deprecated,omitempty" yaml:"deprecated,omitempty"`
 	IaCBlueprints       []IaCBlueprint       `config:"iac_blueprints,omitempty" json:"iac_blueprints,omitempty" yaml:"iac_blueprints,omitempty"`

--- a/packages/datastream.go
+++ b/packages/datastream.go
@@ -72,7 +72,9 @@ type DataStream struct {
 	// Reference to the package containing this data stream
 	packageRef *Package
 
-	Deprecated *Deprecated `config:"deprecated,omitempty" json:"deprecated,omitempty" yaml:"deprecated,omitempty"`
+	Deprecated          *Deprecated          `config:"deprecated,omitempty" json:"deprecated,omitempty" yaml:"deprecated,omitempty"`
+	IaCBlueprints       []IaCBlueprint       `config:"iac_blueprints,omitempty" json:"iac_blueprints,omitempty" yaml:"iac_blueprints,omitempty"`
+	ProviderPermissions []ProviderPermission `config:"provider_permissions,omitempty" json:"provider_permissions,omitempty" yaml:"provider_permissions,omitempty"`
 }
 
 type Input struct {
@@ -84,8 +86,10 @@ type Input struct {
 	Streams         []Stream    `config:"streams" json:"streams,omitempty" yaml:"streams,omitempty"`
 	TemplatePath    string      `config:"template_path" json:"template_path,omitempty" yaml:"template_path,omitempty"`
 	InputGroup      string      `config:"input_group" json:"input_group,omitempty" yaml:"input_group,omitempty"`
-	DeploymentModes []string    `config:"deployment_modes,omitempty" json:"deployment_modes,omitempty" yaml:"deployment_modes,omitempty"`
-	Deprecated      *Deprecated `config:"deprecated,omitempty" json:"deprecated,omitempty" yaml:"deprecated,omitempty"`
+	DeploymentModes     []string             `config:"deployment_modes,omitempty" json:"deployment_modes,omitempty" yaml:"deployment_modes,omitempty"`
+	Deprecated          *Deprecated          `config:"deprecated,omitempty" json:"deprecated,omitempty" yaml:"deprecated,omitempty"`
+	IaCBlueprints       []IaCBlueprint       `config:"iac_blueprints,omitempty" json:"iac_blueprints,omitempty" yaml:"iac_blueprints,omitempty"`
+	ProviderPermissions []ProviderPermission `config:"provider_permissions,omitempty" json:"provider_permissions,omitempty" yaml:"provider_permissions,omitempty"`
 }
 
 type Stream struct {

--- a/packages/package.go
+++ b/packages/package.go
@@ -40,10 +40,10 @@ type Package struct {
 	BasePackage   `config:",inline" json:",inline" yaml:",inline"`
 	FormatVersion string `config:"format_version" json:"format_version" yaml:"format_version"`
 
-	Readme          *string               `config:"readme,omitempty" json:"readme,omitempty" yaml:"readme,omitempty"`
-	License         string                `config:"license,omitempty" json:"license,omitempty" yaml:"license,omitempty"`
-	Screenshots     []Image               `config:"screenshots,omitempty" json:"screenshots,omitempty" yaml:"screenshots,omitempty"`
-	Assets          []string              `config:"assets,omitempty" json:"assets,omitempty" yaml:"assets,omitempty"`
+	Readme              *string               `config:"readme,omitempty" json:"readme,omitempty" yaml:"readme,omitempty"`
+	License             string                `config:"license,omitempty" json:"license,omitempty" yaml:"license,omitempty"`
+	Screenshots         []Image               `config:"screenshots,omitempty" json:"screenshots,omitempty" yaml:"screenshots,omitempty"`
+	Assets              []string              `config:"assets,omitempty" json:"assets,omitempty" yaml:"assets,omitempty"`
 	PolicyTemplates     []PolicyTemplate      `config:"policy_templates,omitempty" json:"policy_templates,omitempty" yaml:"policy_templates,omitempty"`
 	DataStreams         []*DataStream         `config:"data_streams,omitempty" json:"data_streams,omitempty" yaml:"data_streams,omitempty"`
 	Vars                []Variable            `config:"vars" json:"vars,omitempty" yaml:"vars,omitempty"`
@@ -133,7 +133,7 @@ type PolicyTemplate struct {
 	TemplatePath    string      `config:"template_path,omitempty" json:"template_path,omitempty" yaml:"template_path,omitempty"`
 	Deprecated      *Deprecated `config:"deprecated,omitempty" json:"deprecated,omitempty" yaml:"deprecated,omitempty"`
 
-	IaCBlueprints      []IaCBlueprint      `config:"iac_blueprints,omitempty" json:"iac_blueprints,omitempty" yaml:"iac_blueprints,omitempty"`
+	IaCBlueprints       []IaCBlueprint       `config:"iac_blueprints,omitempty" json:"iac_blueprints,omitempty" yaml:"iac_blueprints,omitempty"`
 	ProviderPermissions []ProviderPermission `config:"provider_permissions,omitempty" json:"provider_permissions,omitempty" yaml:"provider_permissions,omitempty"`
 }
 

--- a/packages/package.go
+++ b/packages/package.go
@@ -44,11 +44,13 @@ type Package struct {
 	License         string                `config:"license,omitempty" json:"license,omitempty" yaml:"license,omitempty"`
 	Screenshots     []Image               `config:"screenshots,omitempty" json:"screenshots,omitempty" yaml:"screenshots,omitempty"`
 	Assets          []string              `config:"assets,omitempty" json:"assets,omitempty" yaml:"assets,omitempty"`
-	PolicyTemplates []PolicyTemplate      `config:"policy_templates,omitempty" json:"policy_templates,omitempty" yaml:"policy_templates,omitempty"`
-	DataStreams     []*DataStream         `config:"data_streams,omitempty" json:"data_streams,omitempty" yaml:"data_streams,omitempty"`
-	Vars            []Variable            `config:"vars" json:"vars,omitempty" yaml:"vars,omitempty"`
-	Elasticsearch   *PackageElasticsearch `config:"elasticsearch,omitempty" json:"elasticsearch,omitempty" yaml:"elasticsearch,omitempty"`
-	Agent           *PackageAgent         `config:"agent,omitempty" json:"agent,omitempty" yaml:"agent,omitempty"`
+	PolicyTemplates     []PolicyTemplate      `config:"policy_templates,omitempty" json:"policy_templates,omitempty" yaml:"policy_templates,omitempty"`
+	DataStreams         []*DataStream         `config:"data_streams,omitempty" json:"data_streams,omitempty" yaml:"data_streams,omitempty"`
+	Vars                []Variable            `config:"vars" json:"vars,omitempty" yaml:"vars,omitempty"`
+	Elasticsearch       *PackageElasticsearch `config:"elasticsearch,omitempty" json:"elasticsearch,omitempty" yaml:"elasticsearch,omitempty"`
+	Agent               *PackageAgent         `config:"agent,omitempty" json:"agent,omitempty" yaml:"agent,omitempty"`
+	IaCBlueprints       []IaCBlueprint        `config:"iac_blueprints,omitempty" json:"iac_blueprints,omitempty" yaml:"iac_blueprints,omitempty"`
+	ProviderPermissions []ProviderPermission  `config:"provider_permissions,omitempty" json:"provider_permissions,omitempty" yaml:"provider_permissions,omitempty"`
 	// Local path to the package dir
 	BasePath string `json:"-" yaml:"-"`
 
@@ -130,6 +132,40 @@ type PolicyTemplate struct {
 	IngestionMethod string      `config:"ingestion_method,omitempty" json:"ingestion_method,omitempty" yaml:"ingestion_method,omitempty"`
 	TemplatePath    string      `config:"template_path,omitempty" json:"template_path,omitempty" yaml:"template_path,omitempty"`
 	Deprecated      *Deprecated `config:"deprecated,omitempty" json:"deprecated,omitempty" yaml:"deprecated,omitempty"`
+
+	IaCBlueprints      []IaCBlueprint      `config:"iac_blueprints,omitempty" json:"iac_blueprints,omitempty" yaml:"iac_blueprints,omitempty"`
+	ProviderPermissions []ProviderPermission `config:"provider_permissions,omitempty" json:"provider_permissions,omitempty" yaml:"provider_permissions,omitempty"`
+}
+
+// IaCBlueprint is a contribution to a shared IaC canonical blueprint.
+type IaCBlueprint struct {
+	ID      string `config:"id" json:"id" yaml:"id" validate:"required"`
+	Format  string `config:"format" json:"format" yaml:"format" validate:"required"`
+	Patches string `config:"patches" json:"patches" yaml:"patches" validate:"required"`
+	Title   string `config:"title,omitempty" json:"title,omitempty" yaml:"title,omitempty"`
+}
+
+// ProviderPermission declares permissions and roles required from a named provider.
+type ProviderPermission struct {
+	Provider    string            `config:"provider" json:"provider" yaml:"provider" validate:"required"`
+	Description string            `config:"description,omitempty" json:"description,omitempty" yaml:"description,omitempty"`
+	Roles       []ProviderRole    `config:"roles,omitempty" json:"roles,omitempty" yaml:"roles,omitempty"`
+	Permissions []PermissionEntry `config:"permissions,omitempty" json:"permissions,omitempty" yaml:"permissions,omitempty"`
+}
+
+// ProviderRole is a pre-defined role or managed policy to attach.
+type ProviderRole struct {
+	Name        string `config:"name" json:"name" yaml:"name" validate:"required"`
+	ID          string `config:"id,omitempty" json:"id,omitempty" yaml:"id,omitempty"`
+	Description string `config:"description,omitempty" json:"description,omitempty" yaml:"description,omitempty"`
+}
+
+// PermissionEntry is an individual permission grant required by an integration unit.
+type PermissionEntry struct {
+	Name        string                 `config:"name" json:"name" yaml:"name" validate:"required"`
+	Description string                 `config:"description,omitempty" json:"description,omitempty" yaml:"description,omitempty"`
+	Resources   []string               `config:"resources,omitempty" json:"resources,omitempty" yaml:"resources,omitempty"`
+	Conditions  map[string]interface{} `config:"conditions,omitempty" json:"conditions,omitempty" yaml:"conditions,omitempty"`
 }
 
 // Source contains metadata about the source of the package and its distribution.


### PR DESCRIPTION
`iac_blueprints` and `provider_permissions`are being added to the package-spec
(https://github.com/elastic/package-spec/pull/1209, https://github.com/elastic/package-spec/pull/1180). Adding to the registry's Go manifest structs to include
them, so the fields would appear in the JSON API responses.

This adds the necessary Go types (`IaCBlueprint`, `ProviderPermission`,
`ProviderRole`, `PermissionEntry`) and wires them into all four levels where the
spec allows the fields:

- `Package` (package-level)
- `PolicyTemplate` (policy-template-level)
- `Input` (input-level, datastream.go)
- `DataStream` (data-stream-level, datastream.go)

All fields are omitempty so there is no impact on existing packages that don't
declare them.