### PR TITLE
feat: add group field to BasePackage for client-side tile grouping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add FIPS 140-3 build support via `GOFIPS140=v1.0.0`; new `mage buildFIPS`, `mage dockerBuildFIPS`, and `mage testFIPS` targets; `-fips` Docker and package-filled distribution images published per release. See [docs/fips.md](./docs/fips.md). [#1858](https://github.com/elastic/package-registry/pull/1858)
 * FIPS builds now reject startup if `-tls-min-version` is set below TLS 1.2. [#1858](https://github.com/elastic/package-registry/pull/1858)
 * `internal/storage`: `UpdateFakeServer` now restarts the fake GCS server instead of adding objects to the running one, keeping object creation on the `InitialObjects` path to avoid MD5 recomputation under strict FIPS mode. [#1858](https://github.com/elastic/package-registry/pull/1858)
-* Add optional `group` field to `BasePackage`; packages whose manifest sets `group` now include it in `/search` and `/package/{name}/{version}` responses. Packages without `group` omit the field (`omitempty`), preserving backwards compatibility. [1896](https://github.com/elastic/package-registry/pull/1896)
+* Add optional `group` field to `BasePackage`; packages whose manifest sets `group` now include it in `/search` and `/package/{name}/{version}` responses. Packages without `group` omit the field (`omitempty`), preserving backwards compatibility. [#1896](https://github.com/elastic/package-registry/pull/1896)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add FIPS 140-3 build support via `GOFIPS140=v1.0.0`; new `mage buildFIPS`, `mage dockerBuildFIPS`, and `mage testFIPS` targets; `-fips` Docker and package-filled distribution images published per release. See [docs/fips.md](./docs/fips.md). [#1858](https://github.com/elastic/package-registry/pull/1858)
 * FIPS builds now reject startup if `-tls-min-version` is set below TLS 1.2. [#1858](https://github.com/elastic/package-registry/pull/1858)
 * `internal/storage`: `UpdateFakeServer` now restarts the fake GCS server instead of adding objects to the running one, keeping object creation on the `InitialObjects` path to avoid MD5 recomputation under strict FIPS mode. [#1858](https://github.com/elastic/package-registry/pull/1858)
-* Add optional `group` field to `BasePackage`; packages whose manifest sets `group` now include it in `/search` and `/package/{name}/{version}` responses. Packages without `group` omit the field (`omitempty`), preserving backwards compatibility.
+* Add optional `group` field to `BasePackage`; packages whose manifest sets `group` now include it in `/search` and `/package/{name}/{version}` responses. Packages without `group` omit the field (`omitempty`), preserving backwards compatibility. [1896](https://github.com/elastic/package-registry/pull/1896)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add FIPS 140-3 build support via `GOFIPS140=v1.0.0`; new `mage buildFIPS`, `mage dockerBuildFIPS`, and `mage testFIPS` targets; `-fips` Docker and package-filled distribution images published per release. See [docs/fips.md](./docs/fips.md). [#1858](https://github.com/elastic/package-registry/pull/1858)
 * FIPS builds now reject startup if `-tls-min-version` is set below TLS 1.2. [#1858](https://github.com/elastic/package-registry/pull/1858)
 * `internal/storage`: `UpdateFakeServer` now restarts the fake GCS server instead of adding objects to the running one, keeping object creation on the `InitialObjects` path to avoid MD5 recomputation under strict FIPS mode. [#1858](https://github.com/elastic/package-registry/pull/1858)
+* Add optional `group` field to `BasePackage`; packages whose manifest sets `group` now include it in `/search` and `/package/{name}/{version}` responses. Packages without `group` omit the field (`omitempty`), preserving backwards compatibility.
 
 ### Deprecated
 

--- a/packages/package.go
+++ b/packages/package.go
@@ -96,6 +96,7 @@ type BasePackage struct {
 	BaseDataStreams         []*BaseDataStream    `config:"data_streams,omitempty" json:"data_streams,omitempty" yaml:"data_streams,omitempty"`
 	Deprecated              *Deprecated          `config:"deprecated,omitempty" json:"deprecated,omitempty" yaml:"deprecated,omitempty"`
 	Requires                *PackageRequirements `config:"requires,omitempty" json:"requires,omitempty" yaml:"requires,omitempty"`
+	Group                   string               `config:"group,omitempty" json:"group,omitempty" yaml:"group,omitempty"`
 }
 
 // BasePolicyTemplate is used for the package policy templates in the /search endpoint

--- a/packages/testdata/marshaler/packages.json
+++ b/packages/testdata/marshaler/packages.json
@@ -2954,6 +2954,36 @@
    ]
   },
   {
+   "name": "nginx_grouped",
+   "title": "Nginx Grouped",
+   "version": "0.1.0",
+   "release": "beta",
+   "description": "Test package for the group field on BasePackage.",
+   "type": "integration",
+   "download": "/epr/nginx_grouped/nginx_grouped-0.1.0.zip",
+   "path": "/package/nginx_grouped/0.1.0",
+   "conditions": {
+    "kibana": {
+     "version": "\u003e=8.0.0"
+    }
+   },
+   "owner": {
+    "type": "elastic",
+    "github": "elastic/integrations"
+   },
+   "categories": [
+    "custom"
+   ],
+   "group": "nginx",
+   "format_version": "2.10.0",
+   "readme": "/package/nginx_grouped/0.1.0/docs/README.md",
+   "license": "basic",
+   "assets": [
+    "/package/nginx_grouped/0.1.0/manifest.yml",
+    "/package/nginx_grouped/0.1.0/docs/README.md"
+   ]
+  },
+  {
    "name": "no_stream_configs",
    "title": "No Stream configs",
    "version": "1.0.0",

--- a/testdata/generated/categories-agent-910.json
+++ b/testdata/generated/categories-agent-910.json
@@ -27,7 +27,7 @@
   {
     "id": "custom",
     "title": "Custom",
-    "count": 24
+    "count": 25
   },
   {
     "id": "datastore",

--- a/testdata/generated/categories-agent-950.json
+++ b/testdata/generated/categories-agent-950.json
@@ -27,7 +27,7 @@
   {
     "id": "custom",
     "title": "Custom",
-    "count": 25
+    "count": 26
   },
   {
     "id": "datastore",

--- a/testdata/generated/categories-experimental.json
+++ b/testdata/generated/categories-experimental.json
@@ -27,7 +27,7 @@
   {
     "id": "custom",
     "title": "Custom",
-    "count": 25
+    "count": 26
   },
   {
     "id": "datastore",

--- a/testdata/generated/categories-include-policy-templates.json
+++ b/testdata/generated/categories-include-policy-templates.json
@@ -32,7 +32,7 @@
   {
     "id": "custom",
     "title": "Custom",
-    "count": 29
+    "count": 30
   },
   {
     "id": "datastore",

--- a/testdata/generated/categories-prerelease-capabilities-none.json
+++ b/testdata/generated/categories-prerelease-capabilities-none.json
@@ -27,7 +27,7 @@
   {
     "id": "custom",
     "title": "Custom",
-    "count": 24
+    "count": 25
   },
   {
     "id": "datastore",

--- a/testdata/generated/categories-prerelease-capabilities-observability-security.json
+++ b/testdata/generated/categories-prerelease-capabilities-observability-security.json
@@ -27,7 +27,7 @@
   {
     "id": "custom",
     "title": "Custom",
-    "count": 24
+    "count": 25
   },
   {
     "id": "datastore",

--- a/testdata/generated/categories-prerelease.json
+++ b/testdata/generated/categories-prerelease.json
@@ -27,7 +27,7 @@
   {
     "id": "custom",
     "title": "Custom",
-    "count": 25
+    "count": 26
   },
   {
     "id": "datastore",

--- a/testdata/generated/categories-spec-max-2.10.0.json
+++ b/testdata/generated/categories-spec-max-2.10.0.json
@@ -27,7 +27,7 @@
   {
     "id": "custom",
     "title": "Custom",
-    "count": 18
+    "count": 19
   },
   {
     "id": "datastore",

--- a/testdata/generated/categories-spec-min-1.1.0-max-2.10.0.json
+++ b/testdata/generated/categories-spec-min-1.1.0-max-2.10.0.json
@@ -12,6 +12,6 @@
   {
     "id": "custom",
     "title": "Custom",
-    "count": 1
+    "count": 2
   }
 ]

--- a/testdata/generated/categories.json
+++ b/testdata/generated/categories.json
@@ -27,7 +27,7 @@
   {
     "id": "custom",
     "title": "Custom",
-    "count": 25
+    "count": 26
   },
   {
     "id": "datastore",

--- a/testdata/generated/package/nginx_grouped/0.1.0/index.json
+++ b/testdata/generated/package/nginx_grouped/0.1.0/index.json
@@ -1,0 +1,30 @@
+{
+  "name": "nginx_grouped",
+  "title": "Nginx Grouped",
+  "version": "0.1.0",
+  "release": "beta",
+  "description": "Test package for the group field on BasePackage.",
+  "type": "integration",
+  "download": "/epr/nginx_grouped/nginx_grouped-0.1.0.zip",
+  "path": "/package/nginx_grouped/0.1.0",
+  "conditions": {
+    "kibana": {
+      "version": ">=8.0.0"
+    }
+  },
+  "owner": {
+    "type": "elastic",
+    "github": "elastic/integrations"
+  },
+  "categories": [
+    "custom"
+  ],
+  "group": "nginx",
+  "format_version": "2.10.0",
+  "readme": "/package/nginx_grouped/0.1.0/docs/README.md",
+  "license": "basic",
+  "assets": [
+    "/package/nginx_grouped/0.1.0/manifest.yml",
+    "/package/nginx_grouped/0.1.0/docs/README.md"
+  ]
+}

--- a/testdata/generated/search-all-proxy.json
+++ b/testdata/generated/search-all-proxy.json
@@ -1222,6 +1222,29 @@
     "signature_path": "/epr/nginx/nginx-1.15.0.zip.sig"
   },
   {
+    "name": "nginx_grouped",
+    "title": "Nginx Grouped",
+    "version": "0.1.0",
+    "release": "beta",
+    "description": "Test package for the group field on BasePackage.",
+    "type": "integration",
+    "download": "/epr/nginx_grouped/nginx_grouped-0.1.0.zip",
+    "path": "/package/nginx_grouped/0.1.0",
+    "conditions": {
+      "kibana": {
+        "version": ">=8.0.0"
+      }
+    },
+    "owner": {
+      "type": "elastic",
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "group": "nginx"
+  },
+  {
     "name": "no_stream_configs",
     "title": "No Stream configs",
     "version": "1.0.0",

--- a/testdata/generated/search-all.json
+++ b/testdata/generated/search-all.json
@@ -1183,6 +1183,29 @@
     }
   },
   {
+    "name": "nginx_grouped",
+    "title": "Nginx Grouped",
+    "version": "0.1.0",
+    "release": "beta",
+    "description": "Test package for the group field on BasePackage.",
+    "type": "integration",
+    "download": "/epr/nginx_grouped/nginx_grouped-0.1.0.zip",
+    "path": "/package/nginx_grouped/0.1.0",
+    "conditions": {
+      "kibana": {
+        "version": ">=8.0.0"
+      }
+    },
+    "owner": {
+      "type": "elastic",
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "group": "nginx"
+  },
+  {
     "name": "no_stream_configs",
     "title": "No Stream configs",
     "version": "1.0.0",

--- a/testdata/generated/search-category-custom.json
+++ b/testdata/generated/search-category-custom.json
@@ -653,6 +653,29 @@
     }
   },
   {
+    "name": "nginx_grouped",
+    "title": "Nginx Grouped",
+    "version": "0.1.0",
+    "release": "beta",
+    "description": "Test package for the group field on BasePackage.",
+    "type": "integration",
+    "download": "/epr/nginx_grouped/nginx_grouped-0.1.0.zip",
+    "path": "/package/nginx_grouped/0.1.0",
+    "conditions": {
+      "kibana": {
+        "version": ">=8.0.0"
+      }
+    },
+    "owner": {
+      "type": "elastic",
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "group": "nginx"
+  },
+  {
     "name": "no_stream_configs",
     "title": "No Stream configs",
     "version": "1.0.0",

--- a/testdata/generated/search-just-latest-proxy.json
+++ b/testdata/generated/search-just-latest-proxy.json
@@ -999,6 +999,29 @@
     "signature_path": "/epr/nginx/nginx-1.15.0.zip.sig"
   },
   {
+    "name": "nginx_grouped",
+    "title": "Nginx Grouped",
+    "version": "0.1.0",
+    "release": "beta",
+    "description": "Test package for the group field on BasePackage.",
+    "type": "integration",
+    "download": "/epr/nginx_grouped/nginx_grouped-0.1.0.zip",
+    "path": "/package/nginx_grouped/0.1.0",
+    "conditions": {
+      "kibana": {
+        "version": ">=8.0.0"
+      }
+    },
+    "owner": {
+      "type": "elastic",
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "group": "nginx"
+  },
+  {
     "name": "no_stream_configs",
     "title": "No Stream configs",
     "version": "1.0.0",

--- a/testdata/generated/search-kibana800.json
+++ b/testdata/generated/search-kibana800.json
@@ -457,6 +457,29 @@
     }
   },
   {
+    "name": "nginx_grouped",
+    "title": "Nginx Grouped",
+    "version": "0.1.0",
+    "release": "beta",
+    "description": "Test package for the group field on BasePackage.",
+    "type": "integration",
+    "download": "/epr/nginx_grouped/nginx_grouped-0.1.0.zip",
+    "path": "/package/nginx_grouped/0.1.0",
+    "conditions": {
+      "kibana": {
+        "version": ">=8.0.0"
+      }
+    },
+    "owner": {
+      "type": "elastic",
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "group": "nginx"
+  },
+  {
     "name": "no_stream_configs",
     "title": "No Stream configs",
     "version": "1.0.0",

--- a/testdata/generated/search-package-experimental.json
+++ b/testdata/generated/search-package-experimental.json
@@ -960,6 +960,29 @@
     }
   },
   {
+    "name": "nginx_grouped",
+    "title": "Nginx Grouped",
+    "version": "0.1.0",
+    "release": "beta",
+    "description": "Test package for the group field on BasePackage.",
+    "type": "integration",
+    "download": "/epr/nginx_grouped/nginx_grouped-0.1.0.zip",
+    "path": "/package/nginx_grouped/0.1.0",
+    "conditions": {
+      "kibana": {
+        "version": ">=8.0.0"
+      }
+    },
+    "owner": {
+      "type": "elastic",
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "group": "nginx"
+  },
+  {
     "name": "no_stream_configs",
     "title": "No Stream configs",
     "version": "1.0.0",

--- a/testdata/generated/search-package-internal.json
+++ b/testdata/generated/search-package-internal.json
@@ -960,6 +960,29 @@
     }
   },
   {
+    "name": "nginx_grouped",
+    "title": "Nginx Grouped",
+    "version": "0.1.0",
+    "release": "beta",
+    "description": "Test package for the group field on BasePackage.",
+    "type": "integration",
+    "download": "/epr/nginx_grouped/nginx_grouped-0.1.0.zip",
+    "path": "/package/nginx_grouped/0.1.0",
+    "conditions": {
+      "kibana": {
+        "version": ">=8.0.0"
+      }
+    },
+    "owner": {
+      "type": "elastic",
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "group": "nginx"
+  },
+  {
     "name": "no_stream_configs",
     "title": "No Stream configs",
     "version": "1.0.0",

--- a/testdata/generated/search-package-prerelease.json
+++ b/testdata/generated/search-package-prerelease.json
@@ -968,6 +968,29 @@
     }
   },
   {
+    "name": "nginx_grouped",
+    "title": "Nginx Grouped",
+    "version": "0.1.0",
+    "release": "beta",
+    "description": "Test package for the group field on BasePackage.",
+    "type": "integration",
+    "download": "/epr/nginx_grouped/nginx_grouped-0.1.0.zip",
+    "path": "/package/nginx_grouped/0.1.0",
+    "conditions": {
+      "kibana": {
+        "version": ">=8.0.0"
+      }
+    },
+    "owner": {
+      "type": "elastic",
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "group": "nginx"
+  },
+  {
     "name": "no_stream_configs",
     "title": "No Stream configs",
     "version": "1.0.0",

--- a/testdata/generated/search-prerelease-capabilities-none.json
+++ b/testdata/generated/search-prerelease-capabilities-none.json
@@ -935,6 +935,29 @@
     }
   },
   {
+    "name": "nginx_grouped",
+    "title": "Nginx Grouped",
+    "version": "0.1.0",
+    "release": "beta",
+    "description": "Test package for the group field on BasePackage.",
+    "type": "integration",
+    "download": "/epr/nginx_grouped/nginx_grouped-0.1.0.zip",
+    "path": "/package/nginx_grouped/0.1.0",
+    "conditions": {
+      "kibana": {
+        "version": ">=8.0.0"
+      }
+    },
+    "owner": {
+      "type": "elastic",
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "group": "nginx"
+  },
+  {
     "name": "no_stream_configs",
     "title": "No Stream configs",
     "version": "1.0.0",

--- a/testdata/generated/search-prerelease-capabilities-observability-security.json
+++ b/testdata/generated/search-prerelease-capabilities-observability-security.json
@@ -943,6 +943,29 @@
     }
   },
   {
+    "name": "nginx_grouped",
+    "title": "Nginx Grouped",
+    "version": "0.1.0",
+    "release": "beta",
+    "description": "Test package for the group field on BasePackage.",
+    "type": "integration",
+    "download": "/epr/nginx_grouped/nginx_grouped-0.1.0.zip",
+    "path": "/package/nginx_grouped/0.1.0",
+    "conditions": {
+      "kibana": {
+        "version": ">=8.0.0"
+      }
+    },
+    "owner": {
+      "type": "elastic",
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "group": "nginx"
+  },
+  {
     "name": "no_stream_configs",
     "title": "No Stream configs",
     "version": "1.0.0",

--- a/testdata/generated/search-spec-max-2.10.0.json
+++ b/testdata/generated/search-spec-max-2.10.0.json
@@ -601,6 +601,29 @@
     }
   },
   {
+    "name": "nginx_grouped",
+    "title": "Nginx Grouped",
+    "version": "0.1.0",
+    "release": "beta",
+    "description": "Test package for the group field on BasePackage.",
+    "type": "integration",
+    "download": "/epr/nginx_grouped/nginx_grouped-0.1.0.zip",
+    "path": "/package/nginx_grouped/0.1.0",
+    "conditions": {
+      "kibana": {
+        "version": ">=8.0.0"
+      }
+    },
+    "owner": {
+      "type": "elastic",
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "group": "nginx"
+  },
+  {
     "name": "no_stream_configs",
     "title": "No Stream configs",
     "version": "1.0.0",

--- a/testdata/generated/search-spec-min-1.1.0-max-2.10.0.json
+++ b/testdata/generated/search-spec-min-1.1.0-max-2.10.0.json
@@ -65,5 +65,28 @@
     "categories": [
       "custom"
     ]
+  },
+  {
+    "name": "nginx_grouped",
+    "title": "Nginx Grouped",
+    "version": "0.1.0",
+    "release": "beta",
+    "description": "Test package for the group field on BasePackage.",
+    "type": "integration",
+    "download": "/epr/nginx_grouped/nginx_grouped-0.1.0.zip",
+    "path": "/package/nginx_grouped/0.1.0",
+    "conditions": {
+      "kibana": {
+        "version": ">=8.0.0"
+      }
+    },
+    "owner": {
+      "type": "elastic",
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "group": "nginx"
   }
 ]

--- a/testdata/generated/search.json
+++ b/testdata/generated/search.json
@@ -960,6 +960,29 @@
     }
   },
   {
+    "name": "nginx_grouped",
+    "title": "Nginx Grouped",
+    "version": "0.1.0",
+    "release": "beta",
+    "description": "Test package for the group field on BasePackage.",
+    "type": "integration",
+    "download": "/epr/nginx_grouped/nginx_grouped-0.1.0.zip",
+    "path": "/package/nginx_grouped/0.1.0",
+    "conditions": {
+      "kibana": {
+        "version": ">=8.0.0"
+      }
+    },
+    "owner": {
+      "type": "elastic",
+      "github": "elastic/integrations"
+    },
+    "categories": [
+      "custom"
+    ],
+    "group": "nginx"
+  },
+  {
     "name": "no_stream_configs",
     "title": "No Stream configs",
     "version": "1.0.0",

--- a/testdata/package/nginx_grouped/0.1.0/docs/README.md
+++ b/testdata/package/nginx_grouped/0.1.0/docs/README.md
@@ -1,0 +1,3 @@
+# Nginx Grouped
+
+Test package for the `group` manifest field.

--- a/testdata/package/nginx_grouped/0.1.0/manifest.yml
+++ b/testdata/package/nginx_grouped/0.1.0/manifest.yml
@@ -1,0 +1,16 @@
+format_version: 2.10.0
+name: nginx_grouped
+title: Nginx Grouped
+description: Test package for the group field on BasePackage.
+version: 0.1.0
+type: integration
+release: beta
+categories:
+  - custom
+group: nginx
+conditions:
+  kibana:
+    version: ">=8.0.0"
+owner:
+  github: elastic/integrations
+  type: elastic


### PR DESCRIPTION
## What

Add optional `group` string to `BasePackage` so packages whose manifest sets `group` expose it on `/search` and `/package/{name}/{version}` responses. Kibana can then group tiles client-side without any new server-side filtering.

## Why

Partially addresses elastic/ingest-dev#8082 (https://github.com/elastic/ingest-dev/issues/8082#issuecomment-5114570023). No new endpoint, no `?group=` filter — EPR just surfaces the field and Kibana owns the grouping logic.

## Changes

| File | Change |
|---|---|
| `packages/package.go` | Add `Group string` to `BasePackage` with `config/json/yaml:"group,omitempty"` |
| `testdata/package/nginx_grouped/0.1.0/` | Fixture package with `group: nginx` in manifest |
| `testdata/generated/**` | Regenerated golden files (search + package index endpoints) |
| `packages/testdata/marshaler/packages.json` | Regenerated marshaler snapshot |
| `CHANGELOG.md` | Entry under `[unreleased] → Added` |

## How it flows

- **Manifest → struct**: ucfg unpacks `group` from `manifest.yml` into `BasePackage.Group` automatically — no custom parsing.
- **`/search`**: serializes `p.BasePackage` directly; `omitempty` drops the key when unset.
- **`/package/{name}/{version}`**: `Package` embeds `BasePackage` inline; same serialization path.
- **SQL storage indexer**: write path is `json.Marshal(pkg.BasePackage)` → `BaseData` BLOB; read path is `json.Unmarshal(BaseData, pkg)`. Full marshal/unmarshal — no field enumeration, no schema migration needed. `group` is not a server-side filter column.
- **GCS/storage indexer**: reads pre-serialized JSON blobs; no field enumeration, no changes needed.

## Re-index note

Existing packages in SQL/GCS stores will not surface `group` until re-ingested. Low impact today since no published packages currently carry `group` in their manifests — any package that ships it for the first time will be a new version going through a fresh ingest.

## Testing

- `TestAllPackageIndex` covers `/package/nginx_grouped/0.1.0/` — asserts `"group": "nginx"` present.
- `TestEndpoints` golden files for `/search` and `/search?category=custom` — assert presence for `nginx_grouped`, absence for all other packages.
- `TestMarshalJSON` / `TestUnmarshalJSON` — marshaler snapshot updated.
- All tests pass (`go test ./...`).

## Out of scope (per spec)

- No `?group=` query parameter
- No grouping/ranking logic in EPR
- No new endpoints or artifact types