### PR TITLE
feat: add incremental index updates for storage indexer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Add incremental index updates for the storage indexer via `--feature-incremental-updates` / `EPR_FEATURE_INCREMENTAL_UPDATES`. When enabled, poll cycles after the initial full sync apply `search-index-delta.json` files instead of re-downloading the full index, significantly reducing per-cycle memory and CPU usage. [#1923](https://github.com/elastic/package-registry/pull/1923)
+* Improve performance of `Filter.Apply` and `legacyApply` for large package lists by replacing the latest-version dedup pass with a map-based lookup. [#1923](https://github.com/elastic/package-registry/pull/1923)
+
 ### Deprecated
 
 ### Known Issues

--- a/internal/storage/cursor.go
+++ b/internal/storage/cursor.go
@@ -51,3 +51,16 @@ func loadCursor(ctx context.Context, logger *zap.Logger, storageClient *storage.
 	logger.Debug("loaded cursor file", zap.String("cursor", c.String()))
 	return &c, nil
 }
+
+// LoadLatestCursorValue reads cursor.json and returns the Current timestamp value.
+func LoadLatestCursorValue(ctx context.Context, logger *zap.Logger, storageClient *storage.Client, storageBucketInternal string) (string, error) {
+	bucketName, rootStoragePath, err := extractBucketNameFromURL(storageBucketInternal)
+	if err != nil {
+		return "", fmt.Errorf("can't extract bucket name from URL: %w", err)
+	}
+	c, err := loadCursor(ctx, logger, storageClient, bucketName, rootStoragePath)
+	if err != nil {
+		return "", err
+	}
+	return c.Current, nil
+}

--- a/internal/storage/cursors.go
+++ b/internal/storage/cursors.go
@@ -1,0 +1,59 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package storage
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"cloud.google.com/go/storage"
+	"google.golang.org/api/iterator"
+)
+
+// listCursorsBetween returns all timestamp folder names in v2/metadata/ that are
+// strictly greater than since and less than or equal to until, in ascending order.
+func listCursorsBetween(ctx context.Context, storageClient *storage.Client, bucketName, rootStoragePath, since, until string) ([]string, error) {
+	prefix := joinObjectPaths(rootStoragePath, v2MetadataStoragePath) + "/"
+
+	query := &storage.Query{
+		Prefix:    prefix,
+		Delimiter: "/",
+	}
+
+	it := storageClient.Bucket(bucketName).Objects(ctx, query)
+
+	var timestamps []string
+	for {
+		attrs, err := it.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("error listing cursor folders: %w", err)
+		}
+		if attrs.Prefix == "" {
+			continue
+		}
+		token := strings.TrimSuffix(strings.TrimPrefix(attrs.Prefix, prefix), "/")
+		if token > since && token <= until {
+			timestamps = append(timestamps, token)
+		}
+	}
+
+	sort.Strings(timestamps)
+	return timestamps, nil
+}
+
+// ListCursorsBetween returns all timestamp folder names in v2/metadata/ strictly
+// greater than since and less than or equal to until, in ascending order.
+func ListCursorsBetween(ctx context.Context, storageClient *storage.Client, storageBucketInternal, since, until string) ([]string, error) {
+	bucketName, rootStoragePath, err := extractBucketNameFromURL(storageBucketInternal)
+	if err != nil {
+		return nil, fmt.Errorf("can't extract bucket name from URL: %w", err)
+	}
+	return listCursorsBetween(ctx, storageClient, bucketName, rootStoragePath, since, until)
+}

--- a/internal/storage/cursors.go
+++ b/internal/storage/cursors.go
@@ -16,6 +16,9 @@ import (
 
 // listCursorsBetween returns all timestamp folder names in v2/metadata/ that are
 // strictly greater than since and less than or equal to until, in ascending order.
+// Cursor values must be lexicographically comparable in chronological order (e.g.
+// zero-padded or fixed-length strings such as Unix epoch seconds). Simple unpadded
+// integer strings break ordering once they reach a second digit ("9" > "10").
 func listCursorsBetween(ctx context.Context, storageClient *storage.Client, bucketName, rootStoragePath, since, until string) ([]string, error) {
 	prefix := joinObjectPaths(rootStoragePath, v2MetadataStoragePath) + "/"
 

--- a/internal/storage/cursors_test.go
+++ b/internal/storage/cursors_test.go
@@ -62,17 +62,6 @@ func TestListCursorsBetween_MultipleIntermediates(t *testing.T) {
 	assert.Equal(t, []string{"2", "3", "4"}, timestamps)
 }
 
-func TestListCursorsBetween_ExcludesSince(t *testing.T) {
-	server := newCursorsServer(t, "1", "2", "3")
-	client := ClientNoAuth(server)
-
-	timestamps, err := listCursorsBetween(t.Context(), client, FakePackageStorageBucketInternal, "", "1", "3")
-	require.NoError(t, err)
-	assert.NotContains(t, timestamps, "1")
-	assert.Contains(t, timestamps, "2")
-	assert.Contains(t, timestamps, "3")
-}
-
 // TestListCursorsBetween_FixedLengthSort verifies that multi-character cursor values
 // sort correctly. listCursorsBetween uses lexicographic ordering, which requires
 // cursor values to be fixed-length strings (e.g. zero-padded integers or Unix

--- a/internal/storage/cursors_test.go
+++ b/internal/storage/cursors_test.go
@@ -81,3 +81,16 @@ func TestListCursorsBetween_IncludesUntil(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, timestamps, "3")
 }
+
+// TestListCursorsBetween_FixedLengthSort verifies that multi-character cursor values
+// sort correctly. listCursorsBetween uses lexicographic ordering, which requires
+// cursor values to be fixed-length strings (e.g. zero-padded integers or Unix
+// epoch timestamps). This test uses zero-padded values to document that assumption.
+func TestListCursorsBetween_FixedLengthSort(t *testing.T) {
+	server := newCursorsServer(t, "09", "10", "11", "12")
+	client := ClientNoAuth(server)
+
+	timestamps, err := listCursorsBetween(t.Context(), client, FakePackageStorageBucketInternal, "", "09", "12")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"10", "11", "12"}, timestamps)
+}

--- a/internal/storage/cursors_test.go
+++ b/internal/storage/cursors_test.go
@@ -1,0 +1,83 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package storage
+
+import (
+	"testing"
+
+	"github.com/fsouza/fake-gcs-server/fakestorage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func revisionObject(revision string) fakestorage.Object {
+	return fakestorage.Object{
+		ObjectAttrs: fakestorage.ObjectAttrs{
+			BucketName: FakePackageStorageBucketInternal,
+			Name:       joinObjectPaths(v2MetadataStoragePath, revision, searchIndexDeltaFile),
+			Md5Hash:    fakeObjectMD5Hash,
+		},
+		Content: []byte(`{}`),
+	}
+}
+
+func newCursorsServer(t *testing.T, revisions ...string) *fakestorage.Server {
+	t.Helper()
+	objects := make([]fakestorage.Object, 0, len(revisions))
+	for _, r := range revisions {
+		objects = append(objects, revisionObject(r))
+	}
+	server := fakestorage.NewServer(objects)
+	t.Cleanup(server.Stop)
+	return server
+}
+
+func TestListCursorsBetween_EmptyRange(t *testing.T) {
+	server := newCursorsServer(t, "2", "3")
+	client := ClientNoAuth(server)
+
+	timestamps, err := listCursorsBetween(t.Context(), client, FakePackageStorageBucketInternal, "", "3", "3")
+	require.NoError(t, err)
+	assert.Empty(t, timestamps)
+}
+
+func TestListCursorsBetween_SingleIntermediate(t *testing.T) {
+	server := newCursorsServer(t, "1", "2", "3")
+	client := ClientNoAuth(server)
+
+	timestamps, err := listCursorsBetween(t.Context(), client, FakePackageStorageBucketInternal, "", "1", "2")
+	require.NoError(t, err)
+	require.Len(t, timestamps, 1)
+	assert.Equal(t, "2", timestamps[0])
+}
+
+func TestListCursorsBetween_MultipleIntermediates(t *testing.T) {
+	server := newCursorsServer(t, "1", "2", "3", "4", "5")
+	client := ClientNoAuth(server)
+
+	timestamps, err := listCursorsBetween(t.Context(), client, FakePackageStorageBucketInternal, "", "1", "4")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"2", "3", "4"}, timestamps)
+}
+
+func TestListCursorsBetween_ExcludesSince(t *testing.T) {
+	server := newCursorsServer(t, "1", "2", "3")
+	client := ClientNoAuth(server)
+
+	timestamps, err := listCursorsBetween(t.Context(), client, FakePackageStorageBucketInternal, "", "1", "3")
+	require.NoError(t, err)
+	assert.NotContains(t, timestamps, "1")
+	assert.Contains(t, timestamps, "2")
+	assert.Contains(t, timestamps, "3")
+}
+
+func TestListCursorsBetween_IncludesUntil(t *testing.T) {
+	server := newCursorsServer(t, "1", "2", "3")
+	client := ClientNoAuth(server)
+
+	timestamps, err := listCursorsBetween(t.Context(), client, FakePackageStorageBucketInternal, "", "1", "3")
+	require.NoError(t, err)
+	assert.Contains(t, timestamps, "3")
+}

--- a/internal/storage/cursors_test.go
+++ b/internal/storage/cursors_test.go
@@ -73,15 +73,6 @@ func TestListCursorsBetween_ExcludesSince(t *testing.T) {
 	assert.Contains(t, timestamps, "3")
 }
 
-func TestListCursorsBetween_IncludesUntil(t *testing.T) {
-	server := newCursorsServer(t, "1", "2", "3")
-	client := ClientNoAuth(server)
-
-	timestamps, err := listCursorsBetween(t.Context(), client, FakePackageStorageBucketInternal, "", "1", "3")
-	require.NoError(t, err)
-	assert.Contains(t, timestamps, "3")
-}
-
 // TestListCursorsBetween_FixedLengthSort verifies that multi-character cursor values
 // sort correctly. listCursorsBetween uses lexicographic ordering, which requires
 // cursor values to be fixed-length strings (e.g. zero-padded integers or Unix

--- a/internal/storage/delta.go
+++ b/internal/storage/delta.go
@@ -1,0 +1,68 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package storage
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"cloud.google.com/go/storage"
+	"go.elastic.co/apm/v2"
+	"go.uber.org/zap"
+
+	"github.com/elastic/package-registry/packages"
+)
+
+// packageIndexEntry mirrors the package_manifest wrapper used by package-storage-infra
+// when writing added/updated entries to the delta file.
+type packageIndexEntry struct {
+	PackageManifest packages.Package `json:"package_manifest"`
+}
+
+// SearchIndexDelta holds the changes between two consecutive index revisions.
+// Field names match the JSON produced by package-storage-infra:
+//   - added/updated entries are wrapped in {"package_manifest": {...}}
+//   - removed entries use the key "removed" (not "deleted")
+type SearchIndexDelta struct {
+	Added   []packageIndexEntry `json:"added"`
+	Updated []packageIndexEntry `json:"updated"`
+	Removed []RemovedPackageRef `json:"removed"`
+}
+
+// RemovedPackageRef identifies a package to remove by name and version.
+type RemovedPackageRef struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+func loadSearchIndexDelta(ctx context.Context, logger *zap.Logger, storageClient *storage.Client, bucketName, rootStoragePath string, aCursor cursor) (*SearchIndexDelta, error) {
+	span, ctx := apm.StartSpan(ctx, "LoadSearchIndexDelta", "app")
+	defer span.End()
+
+	logger.Debug("load search-index-delta", zap.String("delta.file", searchIndexDeltaFile))
+
+	rootedPath := buildIndexStoragePath(rootStoragePath, aCursor, searchIndexDeltaFile)
+	objectReader, err := storageClient.Bucket(bucketName).Object(rootedPath).NewReader(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("can't read the delta file (path: %s): %w", rootedPath, err)
+	}
+	defer objectReader.Close()
+
+	var delta SearchIndexDelta
+	if err := json.NewDecoder(objectReader).Decode(&delta); err != nil {
+		return nil, fmt.Errorf("can't decode the delta file: %w", err)
+	}
+	return &delta, nil
+}
+
+// LoadSearchIndexDelta reads and parses the delta file for the given cursor value.
+func LoadSearchIndexDelta(ctx context.Context, logger *zap.Logger, storageClient *storage.Client, storageBucketInternal, cursorValue string) (*SearchIndexDelta, error) {
+	bucketName, rootStoragePath, err := extractBucketNameFromURL(storageBucketInternal)
+	if err != nil {
+		return nil, fmt.Errorf("can't extract bucket name from URL: %w", err)
+	}
+	return loadSearchIndexDelta(ctx, logger, storageClient, bucketName, rootStoragePath, cursor{Current: cursorValue})
+}

--- a/internal/storage/delta.go
+++ b/internal/storage/delta.go
@@ -29,11 +29,11 @@ type packageIndexEntry struct {
 type SearchIndexDelta struct {
 	Added   []packageIndexEntry `json:"added"`
 	Updated []packageIndexEntry `json:"updated"`
-	Removed []RemovedPackageRef `json:"removed"`
+	Removed []removedPackageRef `json:"removed"`
 }
 
-// RemovedPackageRef identifies a package to remove by name and version.
-type RemovedPackageRef struct {
+// removedPackageRef identifies a package to remove by name and version.
+type removedPackageRef struct {
 	Name    string `json:"name"`
 	Version string `json:"version"`
 }

--- a/internal/storage/delta_test.go
+++ b/internal/storage/delta_test.go
@@ -1,0 +1,98 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package storage
+
+import (
+	"testing"
+
+	"cloud.google.com/go/storage"
+	"github.com/fsouza/fake-gcs-server/fakestorage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func newDeltaServer(t *testing.T, deltaJSON string) (*fakestorage.Server, *storage.Client) {
+	t.Helper()
+	server := fakestorage.NewServer([]fakestorage.Object{
+		{
+			ObjectAttrs: fakestorage.ObjectAttrs{
+				BucketName: FakePackageStorageBucketInternal,
+				Name:       joinObjectPaths(v2MetadataStoragePath, "1", searchIndexDeltaFile),
+				Md5Hash:    fakeObjectMD5Hash,
+			},
+			Content: []byte(deltaJSON),
+		},
+	})
+	t.Cleanup(server.Stop)
+	return server, ClientNoAuth(server)
+}
+
+func TestLoadSearchIndexDelta_ParsesAdded(t *testing.T) {
+	server, client := newDeltaServer(t, `{"added":[{"package_manifest":{"name":"mypkg","version":"1.0.0","type":"integration"}}],"updated":[],"removed":[]}`)
+
+	delta, err := loadSearchIndexDelta(t.Context(), zap.NewNop(), client, FakePackageStorageBucketInternal, "", cursor{Current: "1"})
+	require.NoError(t, err)
+	require.Len(t, delta.Added, 1)
+	assert.Equal(t, "mypkg", delta.Added[0].PackageManifest.Name)
+	assert.Equal(t, "1.0.0", delta.Added[0].PackageManifest.Version)
+	assert.Empty(t, delta.Updated)
+	assert.Empty(t, delta.Removed)
+	_ = server
+}
+
+func TestLoadSearchIndexDelta_ParsesUpdated(t *testing.T) {
+	server, client := newDeltaServer(t, `{"added":[],"updated":[{"package_manifest":{"name":"mypkg","version":"2.0.0","type":"integration"}}],"removed":[]}`)
+
+	delta, err := loadSearchIndexDelta(t.Context(), zap.NewNop(), client, FakePackageStorageBucketInternal, "", cursor{Current: "1"})
+	require.NoError(t, err)
+	assert.Empty(t, delta.Added)
+	require.Len(t, delta.Updated, 1)
+	assert.Equal(t, "mypkg", delta.Updated[0].PackageManifest.Name)
+	assert.Equal(t, "2.0.0", delta.Updated[0].PackageManifest.Version)
+	assert.Empty(t, delta.Removed)
+	_ = server
+}
+
+func TestLoadSearchIndexDelta_ParsesRemoved(t *testing.T) {
+	server, client := newDeltaServer(t, `{"added":[],"updated":[],"removed":[{"name":"oldpkg","version":"1.0.0"}]}`)
+
+	delta, err := loadSearchIndexDelta(t.Context(), zap.NewNop(), client, FakePackageStorageBucketInternal, "", cursor{Current: "1"})
+	require.NoError(t, err)
+	assert.Empty(t, delta.Added)
+	assert.Empty(t, delta.Updated)
+	require.Len(t, delta.Removed, 1)
+	assert.Equal(t, "oldpkg", delta.Removed[0].Name)
+	assert.Equal(t, "1.0.0", delta.Removed[0].Version)
+	_ = server
+}
+
+func TestLoadSearchIndexDelta_AllFields(t *testing.T) {
+	server, client := newDeltaServer(t, `{
+		"added":[{"package_manifest":{"name":"newpkg","version":"1.0.0","type":"integration"}}],
+		"updated":[{"package_manifest":{"name":"existpkg","version":"2.1.0","type":"integration"}}],
+		"removed":[{"name":"oldpkg","version":"1.0.0"}]
+	}`)
+
+	delta, err := loadSearchIndexDelta(t.Context(), zap.NewNop(), client, FakePackageStorageBucketInternal, "", cursor{Current: "1"})
+	require.NoError(t, err)
+	require.Len(t, delta.Added, 1)
+	require.Len(t, delta.Updated, 1)
+	require.Len(t, delta.Removed, 1)
+	assert.Equal(t, "newpkg", delta.Added[0].PackageManifest.Name)
+	assert.Equal(t, "existpkg", delta.Updated[0].PackageManifest.Name)
+	assert.Equal(t, "oldpkg", delta.Removed[0].Name)
+	_ = server
+}
+
+func TestLoadSearchIndexDelta_MissingFile_ReturnsError(t *testing.T) {
+	server := fakestorage.NewServer([]fakestorage.Object{})
+	t.Cleanup(server.Stop)
+	client := ClientNoAuth(server)
+
+	_, err := loadSearchIndexDelta(t.Context(), zap.NewNop(), client, FakePackageStorageBucketInternal, "", cursor{Current: "1"})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, storage.ErrObjectNotExist)
+}

--- a/internal/storage/fakestorage.go
+++ b/internal/storage/fakestorage.go
@@ -172,9 +172,9 @@ func PrepareServerObjects(revision string, indexContent []byte) ([]fakestorage.O
 	return serverObjects, len(index.Packages), nil
 }
 
-// PrepareDeltaServerObjects creates GCS objects for a delta file revision:
+// prepareDeltaServerObjects creates GCS objects for a delta file revision:
 // a cursor.json pointing to revision and a search-index-delta.json at that revision's path.
-func PrepareDeltaServerObjects(revision string, deltaContent []byte) []fakestorage.Object {
+func prepareDeltaServerObjects(revision string, deltaContent []byte) []fakestorage.Object {
 	return []fakestorage.Object{
 		{
 			ObjectAttrs: fakestorage.ObjectAttrs{
@@ -195,7 +195,7 @@ func PrepareDeltaServerObjects(revision string, deltaContent []byte) []fakestora
 // server and returning a new one with the previous objects plus the new revision's
 // delta file (no search-index-all.json for the new revision).
 func UpdateFakeServerWithDelta(tb testing.TB, server *fakestorage.Server, revision string, deltaContent []byte) (*fakestorage.Server, *storage.Client) {
-	newObjects := PrepareDeltaServerObjects(revision, deltaContent)
+	newObjects := prepareDeltaServerObjects(revision, deltaContent)
 
 	var existingAttrs []fakestorage.ObjectAttrs
 	var pageToken string

--- a/internal/storage/fakestorage.go
+++ b/internal/storage/fakestorage.go
@@ -171,3 +171,52 @@ func PrepareServerObjects(revision string, indexContent []byte) ([]fakestorage.O
 	})
 	return serverObjects, len(index.Packages), nil
 }
+
+// PrepareDeltaServerObjects creates GCS objects for a delta file revision:
+// a cursor.json pointing to revision and a search-index-delta.json at that revision's path.
+func PrepareDeltaServerObjects(revision string, deltaContent []byte) []fakestorage.Object {
+	return []fakestorage.Object{
+		{
+			ObjectAttrs: fakestorage.ObjectAttrs{
+				BucketName: FakePackageStorageBucketInternal, Name: cursorStoragePath, Md5Hash: fakeObjectMD5Hash,
+			},
+			Content: []byte(`{"current":"` + revision + `"}`),
+		},
+		{
+			ObjectAttrs: fakestorage.ObjectAttrs{
+				BucketName: FakePackageStorageBucketInternal, Name: joinObjectPaths(v2MetadataStoragePath, revision, searchIndexDeltaFile), Md5Hash: fakeObjectMD5Hash,
+			},
+			Content: deltaContent,
+		},
+	}
+}
+
+// UpdateFakeServerWithDelta simulates a delta update by stopping the given fake
+// server and returning a new one with the previous objects plus the new revision's
+// delta file (no search-index-all.json for the new revision).
+func UpdateFakeServerWithDelta(tb testing.TB, server *fakestorage.Server, revision string, deltaContent []byte) (*fakestorage.Server, *storage.Client) {
+	newObjects := PrepareDeltaServerObjects(revision, deltaContent)
+
+	var existingAttrs []fakestorage.ObjectAttrs
+	var pageToken string
+	for {
+		listResp, err := server.ListObjectsWithOptionsPaginated(FakePackageStorageBucketInternal, fakestorage.ListOptions{PageToken: pageToken})
+		require.NoError(tb, err, "failed to list existing server objects")
+		existingAttrs = append(existingAttrs, listResp.Objects...)
+		if listResp.NextPageToken == "" {
+			break
+		}
+		pageToken = listResp.NextPageToken
+	}
+	allObjects := make([]fakestorage.Object, 0, len(existingAttrs)+len(newObjects))
+	for _, attrs := range existingAttrs {
+		obj, err := server.GetObject(FakePackageStorageBucketInternal, attrs.Name)
+		require.NoError(tb, err, "failed to retrieve existing server object %q", attrs.Name)
+		allObjects = append(allObjects, obj)
+	}
+	allObjects = append(allObjects, newObjects...)
+
+	server.Stop()
+	newServer := fakestorage.NewServer(allObjects)
+	return newServer, ClientNoAuth(newServer)
+}

--- a/internal/storage/index.go
+++ b/internal/storage/index.go
@@ -91,30 +91,6 @@ func buildIndexStoragePath(rootStoragePath string, aCursor cursor, indexFile str
 	return joinObjectPaths(rootStoragePath, v2MetadataStoragePath, aCursor.Current, indexFile)
 }
 
-func LoadPackagesAndCursorFromIndex(ctx context.Context, logger *zap.Logger, storageClient *storage.Client, storageBucketInternal, currentCursor string) (*packages.Packages, string, error) {
-	bucketName, rootStoragePath, err := extractBucketNameFromURL(storageBucketInternal)
-	if err != nil {
-		return nil, "", fmt.Errorf("can't extract bucket name from URL (url: %s): %w", storageBucketInternal, err)
-	}
-
-	storageCursor, err := loadCursor(ctx, logger, storageClient, bucketName, rootStoragePath)
-	if err != nil {
-		return nil, "", fmt.Errorf("can't load latest cursor: %w", err)
-	}
-
-	if storageCursor.Current == currentCursor {
-		logger.Info("cursor is up-to-date", zap.String("cursor.current", currentCursor))
-		return nil, currentCursor, nil
-	}
-	logger.Info("cursor will be updated", zap.String("cursor.current", currentCursor), zap.String("cursor.next", storageCursor.Current))
-
-	anIndex, err := loadSearchIndexAll(ctx, logger, storageClient, bucketName, rootStoragePath, *storageCursor)
-	if err != nil {
-		return nil, "", fmt.Errorf("can't load the search-index-all index content: %w", err)
-	}
-	return anIndex, storageCursor.Current, nil
-}
-
 func loadSearchIndexAllBatches(ctx context.Context, logger *zap.Logger, storageClient *storage.Client, bucketName, rootStoragePath string, aCursor cursor, batchSize int, process func(context.Context, packages.Packages, string) error) error {
 	span, ctx := apm.StartSpan(ctx, "LoadSearchIndexAll", "app")
 	span.Context.SetLabel("load.method", "batches")

--- a/internal/storage/index.go
+++ b/internal/storage/index.go
@@ -223,3 +223,12 @@ func LoadPackagesAndCursorFromIndexBatches(ctx context.Context, logger *zap.Logg
 	}
 	return storageCursor.Current, nil
 }
+
+// LoadSearchIndexAllForCursor reads search-index-all.json for a specific cursor value.
+func LoadSearchIndexAllForCursor(ctx context.Context, logger *zap.Logger, storageClient *storage.Client, storageBucketInternal, cursorValue string) (*packages.Packages, error) {
+	bucketName, rootStoragePath, err := extractBucketNameFromURL(storageBucketInternal)
+	if err != nil {
+		return nil, fmt.Errorf("can't extract bucket name from URL: %w", err)
+	}
+	return loadSearchIndexAll(ctx, logger, storageClient, bucketName, rootStoragePath, cursor{Current: cursorValue})
+}

--- a/internal/storage/paths.go
+++ b/internal/storage/paths.go
@@ -15,6 +15,7 @@ const (
 	v2MetadataStoragePath = "v2/metadata"
 	cursorStoragePath     = v2MetadataStoragePath + "/cursor.json"
 	searchIndexAllFile    = "search-index-all.json"
+	searchIndexDeltaFile  = "search-index-delta.json"
 
 	// Public bucket
 	artifactsStoragePath         = "artifacts"

--- a/main.go
+++ b/main.go
@@ -400,6 +400,9 @@ func initIndexer(ctx context.Context, logger *zap.Logger, options serverOptions)
 		}
 		combined = append(combined, indexer)
 	case featureStorageIndexer:
+		if featureIncrementalUpdates {
+			logger.Warn("Technical preview: Incremental updates feature is enabled.")
+		}
 		indexer, err := initStorageIndexer(ctx, logger, options)
 		if err != nil {
 			logger.Fatal("failed to initialize storage indexer", zap.Error(err))
@@ -756,6 +759,10 @@ func validateFlags() error {
 
 	if featureStorageIndexer && featureSQLStorageIndexer {
 		return fmt.Errorf("both -feature-storage-indexer and -feature-sql-storage-indexer flags are enabled but are mutually exclusive")
+	}
+
+	if featureIncrementalUpdates && featureSQLStorageIndexer {
+		return fmt.Errorf("feature-incremental-updates is not supported with feature-sql-storage-indexer; disable one of them")
 	}
 
 	if featureEnableSearchCache && !featureSQLStorageIndexer {

--- a/main.go
+++ b/main.go
@@ -131,7 +131,7 @@ func init() {
 	// The following storage related flags are technical preview and might be removed in the future or renamed
 	flag.BoolVar(&featureSQLStorageIndexer, "feature-sql-storage-indexer", false, "Enable SQL storage indexer to include packages from Package Storage v2 (technical preview).")
 	flag.BoolVar(&featureIncrementalUpdates, "feature-incremental-updates", false,
-		"Enable incremental index updates using delta files (technical preview).")
+		"Enable incremental index updates using delta files (technical preview). Not supported with the SQL storage indexer.")
 	flag.BoolVar(&featureEnableSearchCache, "feature-enable-search-cache", false, "Enable cache for search requests. Just supported with the SQL storage indexer. (technical preview).")
 	flag.BoolVar(&featureEnableCategoriesCache, "feature-enable-categories-cache", false, "Enable cache for categories requests. Just supported with the SQL storage indexer. (technical preview).")
 

--- a/main.go
+++ b/main.go
@@ -76,6 +76,7 @@ var (
 	featureEnableCategoriesCache bool
 
 	featureStorageIndexer        bool
+	featureIncrementalUpdates    bool
 	storageIndexerBucketInternal string
 	storageEndpoint              string
 	storageIndexerWatchInterval  time.Duration
@@ -129,6 +130,8 @@ func init() {
 	flag.DurationVar(&storageIndexerWatchInterval, "storage-indexer-watch-interval", 1*time.Minute, "Address of the package-registry service.")
 	// The following storage related flags are technical preview and might be removed in the future or renamed
 	flag.BoolVar(&featureSQLStorageIndexer, "feature-sql-storage-indexer", false, "Enable SQL storage indexer to include packages from Package Storage v2 (technical preview).")
+	flag.BoolVar(&featureIncrementalUpdates, "feature-incremental-updates", false,
+		"Enable incremental index updates using delta files (technical preview).")
 	flag.BoolVar(&featureEnableSearchCache, "feature-enable-search-cache", false, "Enable cache for search requests. Just supported with the SQL storage indexer. (technical preview).")
 	flag.BoolVar(&featureEnableCategoriesCache, "feature-enable-categories-cache", false, "Enable cache for categories requests. Just supported with the SQL storage indexer. (technical preview).")
 
@@ -432,6 +435,7 @@ func initStorageIndexer(ctx context.Context, logger *zap.Logger, options serverO
 		PackageStorageBucketInternal: storageIndexerBucketInternal,
 		PackageStorageEndpoint:       storageEndpoint,
 		WatchInterval:                storageIndexerWatchInterval,
+		IncrementalUpdates:           featureIncrementalUpdates,
 	}), nil
 }
 

--- a/packages/deprecated.go
+++ b/packages/deprecated.go
@@ -45,10 +45,14 @@ func UpdateLatestDeprecatedPackagesMapByName(input Packages, deprecatedPackages 
 
 // PropagateLatestDeprecatedInfoToPackageList adds deprecation information to all packages in the package list
 // based on the latest deprecated info available in the deprecated packages map.
+// Each affected package is shallow-copied before setting Deprecated so that callers holding a prior
+// Get() result are not subject to a data race on the shared *Package pointer.
 func PropagateLatestDeprecatedInfoToPackageList(packageList Packages, deprecatedPackages DeprecatedPackages) {
-	for _, pkg := range packageList {
+	for i, pkg := range packageList {
 		if deprecatedInfo, found := deprecatedPackages.Deprecated(pkg.Name); found {
-			pkg.Deprecated = deprecatedInfo
+			pkgCopy := *pkg
+			pkgCopy.Deprecated = deprecatedInfo
+			packageList[i] = &pkgCopy
 		}
 	}
 }

--- a/packages/deprecated_test.go
+++ b/packages/deprecated_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestUpdateLatestDeprecatedPackagesMapByName(t *testing.T) {
@@ -259,4 +260,26 @@ func TestPropagateLatestDeprecatedInfoToPackageList(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPropagateLatestDeprecatedInfoToPackageList_DoesNotMutateOriginalPointer(t *testing.T) {
+	// Callers that hold a *Package pointer obtained before PropagateLatestDeprecatedInfoToPackageList
+	// runs (e.g. via a prior Get()) must not observe a write to their pointer's Deprecated field.
+	// The function must allocate a new *Package for each affected entry instead of mutating in-place.
+	original := &Package{BasePackage: BasePackage{Name: "test-package"}}
+	list := Packages{original}
+
+	deprecatedPackages := DeprecatedPackages{
+		"test-package": deprecatedMeta{
+			deprecated: &Deprecated{Since: "2.0.0"},
+			version:    semver.MustParse("2.0.0"),
+		},
+	}
+
+	PropagateLatestDeprecatedInfoToPackageList(list, deprecatedPackages)
+
+	assert.Nil(t, original.Deprecated, "original *Package must not be mutated")
+	assert.NotSame(t, original, list[0], "list must hold a new *Package allocation, not the original pointer")
+	require.NotNil(t, list[0].Deprecated)
+	assert.Equal(t, "2.0.0", list[0].Deprecated.Since)
 }

--- a/packages/packages.go
+++ b/packages/packages.go
@@ -632,7 +632,11 @@ func (f *Filter) Apply(ctx context.Context, packages Packages) (Packages, error)
 	}
 
 	// Checks that only the most recent version of an integration is added to the list
-	var packagesList Packages
+	packagesList := make(Packages, 0, len(packages))
+	var latestIdx map[string]int
+	if !f.AllVersions {
+		latestIdx = make(map[string]int, len(packages))
+	}
 	for _, p := range packages {
 		// Skip experimental packages if flag is not specified.
 		if p.Release == ReleaseExperimental && !f.Prerelease {
@@ -689,29 +693,17 @@ func (f *Filter) Apply(ctx context.Context, packages Packages) (Packages, error)
 			}
 		}
 
-		addPackage := true
 		if !f.AllVersions {
-			// Check if the version exists and if it should be added or not.
-			for i, current := range packagesList {
-				if current.Name != p.Name {
-					continue
+			if idx, found := latestIdx[p.Name]; found {
+				// Slot already exists: replace only if p is newer.
+				if !packagesList[idx].IsNewerOrEqual(p) {
+					packagesList[idx] = p
 				}
-
-				addPackage = false
-
-				// If the package in the list is newer or equal, do nothing.
-				if current.IsNewerOrEqual(p) {
-					continue
-				}
-
-				// Otherwise replace it.
-				packagesList[i] = p
+				continue
 			}
+			latestIdx[p.Name] = len(packagesList)
 		}
-
-		if addPackage {
-			packagesList = append(packagesList, p)
-		}
+		packagesList = append(packagesList, p)
 	}
 
 	// Filter by category after selecting the newer packages.
@@ -727,7 +719,11 @@ func (f *Filter) legacyApply(ctx context.Context, packages Packages) Packages {
 	}
 
 	// Checks that only the most recent version of an integration is added to the list
-	var packagesList Packages
+	packagesList := make(Packages, 0, len(packages))
+	var latestIdx map[string]int
+	if !f.AllVersions {
+		latestIdx = make(map[string]int, len(packages))
+	}
 	for _, p := range packages {
 		// Skip experimental packages if flag is not specified.
 		if p.Release == ReleaseExperimental && !f.Experimental {
@@ -752,34 +748,24 @@ func (f *Filter) legacyApply(ctx context.Context, packages Packages) Packages {
 			continue
 		}
 
-		addPackage := true
 		if !f.AllVersions {
-			// Check if the version exists and if it should be added or not.
-			for i, current := range packagesList {
-				if current.Name != p.Name {
-					continue
-				}
-
-				addPackage = false
-
+			if idx, found := latestIdx[p.Name]; found {
+				current := packagesList[idx]
 				// If the package in the list is newer or equal, do nothing, unless it is a prerelease.
 				if current.IsPrerelease() == p.IsPrerelease() && current.IsNewerOrEqual(p) {
 					continue
 				}
-
 				// If the package in the list is not a prerelease, and current is, do nothing.
 				if !current.IsPrerelease() && p.IsPrerelease() {
 					continue
 				}
-
 				// Otherwise replace it.
-				packagesList[i] = p
+				packagesList[idx] = p
+				continue
 			}
+			latestIdx[p.Name] = len(packagesList)
 		}
-
-		if addPackage {
-			packagesList = append(packagesList, p)
-		}
+		packagesList = append(packagesList, p)
 	}
 
 	if f.AllVersions {
@@ -812,7 +798,7 @@ func filterCategories(packages Packages, category string) Packages {
 	if category == "" {
 		return packages
 	}
-	var result Packages
+	result := make(Packages, 0, len(packages))
 	for _, p := range packages {
 		if !p.HasCategory(category) && !p.HasPolicyTemplateWithCategory(category) {
 			continue

--- a/packages/packages_test.go
+++ b/packages/packages_test.go
@@ -23,6 +23,82 @@ import (
 	"github.com/elastic/package-registry/internal/util"
 )
 
+// BenchmarkFilterApply measures Filter.Apply ("latest version per name" path).
+// The inner O(N²) scan is replaced by an O(1) map lookup, so runtime should
+// scale linearly with the number of packages instead of quadratically.
+func BenchmarkFilterApply(b *testing.B) {
+	for _, tc := range []struct {
+		names    int // distinct package names
+		versions int // versions per name
+	}{
+		{100, 5},
+		{500, 5},
+		{1000, 5},
+		{2000, 5},
+	} {
+		pkgs := syntheticPackages(tc.names, tc.versions)
+		f := Filter{AllVersions: false}
+
+		b.Run(fmt.Sprintf("names=%d/versions=%d", tc.names, tc.versions), func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				_, _ = f.Apply(b.Context(), pkgs)
+			}
+		})
+	}
+}
+
+// BenchmarkFilterApplyAllVersions is the AllVersions=true path (no dedup map).
+func BenchmarkFilterApplyAllVersions(b *testing.B) {
+	pkgs := syntheticPackages(500, 5)
+	f := Filter{AllVersions: true}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		_, _ = f.Apply(b.Context(), pkgs)
+	}
+}
+
+// BenchmarkLegacyApply measures the experimental=true path (legacyApply).
+func BenchmarkLegacyApply(b *testing.B) {
+	for _, tc := range []struct {
+		names    int
+		versions int
+	}{
+		{100, 5},
+		{500, 5},
+		{1000, 5},
+	} {
+		pkgs := syntheticPackages(tc.names, tc.versions)
+		f := Filter{Experimental: true, AllVersions: false}
+
+		b.Run(fmt.Sprintf("names=%d/versions=%d", tc.names, tc.versions), func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				_ = f.legacyApply(b.Context(), pkgs)
+			}
+		})
+	}
+}
+
+// syntheticPackages builds a slice of names*versions Package pointers with
+// distinct names and ascending semver versions, simulating a realistic index.
+func syntheticPackages(names, versions int) Packages {
+	pkgs := make(Packages, 0, names*versions)
+	for i := 0; i < names; i++ {
+		for v := 0; v < versions; v++ {
+			pkgs = append(pkgs, filterTestPackage{
+				Name:    fmt.Sprintf("pkg-%04d", i),
+				Version: fmt.Sprintf("1.%d.0", v),
+				Type:    "integration",
+			}.Build())
+		}
+	}
+	return pkgs
+}
+
 func BenchmarkInit(b *testing.B) {
 	// given
 	packagesBasePaths := []string{"../testdata/second_package_path", "../testdata/package"}

--- a/storage/indexer.go
+++ b/storage/indexer.go
@@ -214,6 +214,7 @@ func (i *Indexer) incrementalSync(ctx context.Context, latestCursorValue string)
 	type revision struct {
 		timestamp string
 		delta     *internalStorage.SearchIndexDelta
+		prepared  *preparedDelta
 		fullIndex *packages.Packages
 	}
 
@@ -244,10 +245,14 @@ func (i *Indexer) incrementalSync(ctx context.Context, latestCursorValue string)
 		return nil
 	}
 
-	// Pre-transform full-index revisions before acquiring the lock; i.resolver is read-only after init.
+	// Pre-process all revisions before acquiring the lock; i.resolver is read-only after init.
 	for j := range revisions {
 		if revisions[j].fullIndex != nil {
 			i.transformSearchIndexAllToPackages(revisions[j].fullIndex)
+		} else if revisions[j].delta != nil {
+			pd := i.prepareDelta(revisions[j].delta)
+			revisions[j].prepared = &pd
+			revisions[j].delta = nil
 		}
 	}
 
@@ -257,8 +262,8 @@ func (i *Indexer) incrementalSync(ctx context.Context, latestCursorValue string)
 	for _, r := range revisions {
 		if r.fullIndex != nil {
 			i.packageList = *r.fullIndex
-		} else if r.delta != nil {
-			i.applyDelta(r.delta)
+		} else if r.prepared != nil {
+			i.applyDelta(*r.prepared)
 		}
 		i.cursor = r.timestamp
 	}
@@ -272,13 +277,15 @@ func (i *Indexer) incrementalSync(ctx context.Context, latestCursorValue string)
 	return nil
 }
 
-// applyDelta modifies the in-memory packageList by applying a delta.
-// Must be called with i.m held for writing.
-//
-// The implementation avoids the previous 3× peak (full slice → full map → new slice)
-// by building small maps only for the delta entries and doing a single-pass
-// filter+update over the existing slice, reusing its backing array.
-func (i *Indexer) applyDelta(delta *internalStorage.SearchIndexDelta) {
+type preparedDelta struct {
+	removeKeys map[string]struct{}
+	updateMap  map[string]*packages.Package
+	added      packages.Packages
+}
+
+// prepareDelta builds lookup structures from a raw delta. Safe to call without holding i.m
+// because it only reads delta.* and i.resolver, both of which are read-only after init.
+func (i *Indexer) prepareDelta(delta *internalStorage.SearchIndexDelta) preparedDelta {
 	removeKeys := make(map[string]struct{}, len(delta.Removed))
 	for _, ref := range delta.Removed {
 		removeKeys[ref.Name+"-"+ref.Version] = struct{}{}
@@ -292,27 +299,34 @@ func (i *Indexer) applyDelta(delta *internalStorage.SearchIndexDelta) {
 		updateMap[p.Name+"-"+p.Version] = &p
 	}
 
-	out := make(packages.Packages, 0, len(i.packageList))
-	for _, p := range i.packageList {
-		key := p.Name + "-" + p.Version
-		if _, removed := removeKeys[key]; removed {
-			continue
-		}
-		if newer, ok := updateMap[key]; ok {
-			out = append(out, newer)
-			delete(updateMap, key)
-		} else {
-			out = append(out, p)
-		}
-	}
-
+	added := make(packages.Packages, 0, len(delta.Added))
 	for _, entry := range delta.Added {
 		p := entry.PackageManifest
 		p.BasePath = fmt.Sprintf("%s-%s.zip", p.Name, p.Version)
 		p.SetRemoteResolver(i.resolver)
-		out = append(out, &p)
+		added = append(added, &p)
 	}
 
+	return preparedDelta{removeKeys: removeKeys, updateMap: updateMap, added: added}
+}
+
+// applyDelta applies a pre-processed delta to i.packageList.
+// Must be called with i.m held for writing.
+func (i *Indexer) applyDelta(pd preparedDelta) {
+	out := make(packages.Packages, 0, max(0, len(i.packageList)-len(pd.removeKeys))+len(pd.added))
+	for _, p := range i.packageList {
+		key := p.Name + "-" + p.Version
+		if _, removed := pd.removeKeys[key]; removed {
+			continue
+		}
+		if newer, ok := pd.updateMap[key]; ok {
+			out = append(out, newer)
+			delete(pd.updateMap, key)
+		} else {
+			out = append(out, p)
+		}
+	}
+	out = append(out, pd.added...)
 	i.packageList = out
 }
 

--- a/storage/indexer.go
+++ b/storage/indexer.go
@@ -212,7 +212,7 @@ func (i *Indexer) incrementalSync(ctx context.Context, latestCursorValue string)
 	}
 
 	type revision struct {
-		cursor string
+		cursor    string
 		delta     *internalStorage.SearchIndexDelta
 		prepared  *preparedDelta
 		fullIndex *packages.Packages

--- a/storage/indexer.go
+++ b/storage/indexer.go
@@ -205,34 +205,34 @@ func (i *Indexer) fullSync(ctx context.Context, latestCursorValue string) error 
 }
 
 func (i *Indexer) incrementalSync(ctx context.Context, latestCursorValue string) error {
-	timestamps, err := internalStorage.ListCursorsBetween(ctx, i.storageClient, i.options.PackageStorageBucketInternal, i.cursor, latestCursorValue)
+	cursors, err := internalStorage.ListCursorsBetween(ctx, i.storageClient, i.options.PackageStorageBucketInternal, i.cursor, latestCursorValue)
 	if err != nil {
 		metrics.StorageIndexerUpdateIndexErrorsTotal.Inc()
 		return fmt.Errorf("can't list cursors between %s and %s: %w", i.cursor, latestCursorValue, err)
 	}
 
 	type revision struct {
-		timestamp string
+		cursor string
 		delta     *internalStorage.SearchIndexDelta
 		prepared  *preparedDelta
 		fullIndex *packages.Packages
 	}
 
-	revisions := make([]revision, 0, len(timestamps))
-	for _, ts := range timestamps {
-		delta, err := internalStorage.LoadSearchIndexDelta(ctx, i.logger, i.storageClient, i.options.PackageStorageBucketInternal, ts)
+	revisions := make([]revision, 0, len(cursors))
+	for _, cursor := range cursors {
+		delta, err := internalStorage.LoadSearchIndexDelta(ctx, i.logger, i.storageClient, i.options.PackageStorageBucketInternal, cursor)
 		if err != nil {
-			i.logger.Warn("failed to load delta, falling back to full sync for timestamp", zap.String("cursor", ts), zap.Error(err))
-			anIndex, err := internalStorage.LoadSearchIndexAllForCursor(ctx, i.logger, i.storageClient, i.options.PackageStorageBucketInternal, ts)
+			i.logger.Warn("failed to load delta, falling back to full sync for timestamp", zap.String("cursor", cursor), zap.Error(err))
+			anIndex, err := internalStorage.LoadSearchIndexAllForCursor(ctx, i.logger, i.storageClient, i.options.PackageStorageBucketInternal, cursor)
 			if err != nil {
 				metrics.StorageIndexerUpdateIndexErrorsTotal.Inc()
-				return fmt.Errorf("can't load search-index-all for cursor %s: %w", ts, err)
+				return fmt.Errorf("can't load search-index-all for cursor %s: %w", cursor, err)
 			}
 			// Full sync supersedes all prior deltas — reset to avoid holding multiple full copies in memory.
 			revisions = revisions[:0]
-			revisions = append(revisions, revision{timestamp: ts, fullIndex: anIndex})
+			revisions = append(revisions, revision{cursor: cursor, fullIndex: anIndex})
 		} else {
-			revisions = append(revisions, revision{timestamp: ts, delta: delta})
+			revisions = append(revisions, revision{cursor: cursor, delta: delta})
 		}
 	}
 
@@ -259,9 +259,9 @@ func (i *Indexer) incrementalSync(ctx context.Context, latestCursorValue string)
 			i.packageList = *r.fullIndex
 		} else if r.prepared != nil {
 			i.applyDelta(*r.prepared)
-			i.logger.Debug("applied delta", zap.String("timestamp", r.timestamp), zap.String("index.packages.size", fmt.Sprintf("%d", i.packageList.Len())))
+			i.logger.Debug("applied delta", zap.String("cursor", r.cursor), zap.String("index.packages.size", fmt.Sprintf("%d", i.packageList.Len())))
 		}
-		i.cursor = r.timestamp
+		i.cursor = r.cursor
 	}
 
 	metrics.StorageIndexerUpdateIndexSuccessTotal.Inc()

--- a/storage/indexer.go
+++ b/storage/indexer.go
@@ -231,6 +231,8 @@ func (i *Indexer) incrementalSync(ctx context.Context, latestCursorValue string)
 				if anIndex == nil {
 					i.logger.Info("Delta fallback: full sync returned no packages for revision.", zap.String("cursor", ts))
 				}
+				// Full sync supersedes all prior deltas — reset to avoid holding multiple full copies in memory.
+				revisions = revisions[:0]
 				revisions = append(revisions, revision{timestamp: ts, fullIndex: anIndex})
 			} else {
 				metrics.StorageIndexerUpdateIndexErrorsTotal.Inc()
@@ -239,6 +241,10 @@ func (i *Indexer) incrementalSync(ctx context.Context, latestCursorValue string)
 		} else {
 			revisions = append(revisions, revision{timestamp: ts, delta: delta})
 		}
+	}
+
+	if len(revisions) == 0 {
+		return nil
 	}
 
 	i.m.Lock()

--- a/storage/indexer.go
+++ b/storage/indexer.go
@@ -259,6 +259,7 @@ func (i *Indexer) incrementalSync(ctx context.Context, latestCursorValue string)
 			i.packageList = *r.fullIndex
 		} else if r.prepared != nil {
 			i.applyDelta(*r.prepared)
+			i.logger.Debug("applied delta", zap.String("timestamp", r.timestamp), zap.String("index.packages.size", fmt.Sprintf("%d", i.packageList.Len())))
 		}
 		i.cursor = r.timestamp
 	}
@@ -313,19 +314,24 @@ func (i *Indexer) applyDelta(pd preparedDelta) {
 	for _, p := range i.packageList {
 		key := p.Name + "-" + p.Version
 		if _, removed := pd.removeKeys[key]; removed {
+			i.logger.Debug("removed package", zap.String("package", key))
 			continue
 		}
 		if newer, ok := pd.updateMap[key]; ok {
 			out = append(out, newer)
 			delete(pd.updateMap, key)
+			i.logger.Debug("updated package", zap.String("package", key))
 		} else {
 			out = append(out, p)
+			i.logger.Debug("kept package", zap.String("package", key))
 		}
 		seen[key] = struct{}{}
 	}
 	for _, p := range pd.added {
-		if _, exists := seen[p.Name+"-"+p.Version]; !exists {
+		key := p.Name + "-" + p.Version
+		if _, exists := seen[key]; !exists {
 			out = append(out, p)
+			i.logger.Debug("added package", zap.String("package", key))
 		}
 	}
 	i.packageList = out

--- a/storage/indexer.go
+++ b/storage/indexer.go
@@ -247,12 +247,18 @@ func (i *Indexer) incrementalSync(ctx context.Context, latestCursorValue string)
 		return nil
 	}
 
+	// Pre-transform full-index revisions before acquiring the lock; i.resolver is read-only after init.
+	for j := range revisions {
+		if revisions[j].fullIndex != nil {
+			i.transformSearchIndexAllToPackages(revisions[j].fullIndex)
+		}
+	}
+
 	i.m.Lock()
 	defer i.m.Unlock()
 
 	for _, r := range revisions {
 		if r.fullIndex != nil {
-			i.transformSearchIndexAllToPackages(r.fullIndex)
 			i.packageList = *r.fullIndex
 		} else if r.delta != nil {
 			i.applyDelta(r.delta)

--- a/storage/indexer.go
+++ b/storage/indexer.go
@@ -48,6 +48,7 @@ type IndexerOptions struct {
 	PackageStorageBucketInternal string
 	PackageStorageEndpoint       string
 	WatchInterval                time.Duration
+	IncrementalUpdates           bool
 }
 
 func NewIndexer(logger *zap.Logger, storageClient *storage.Client, options IndexerOptions) *Indexer {
@@ -161,13 +162,26 @@ func (i *Indexer) updateIndex(ctx context.Context) error {
 		metrics.StorageIndexerUpdateIndexDurationSeconds.Observe(time.Since(start).Seconds())
 	}()
 
-	anIndex, currentCursor, err := internalStorage.LoadPackagesAndCursorFromIndex(ctx, i.logger, i.storageClient, i.options.PackageStorageBucketInternal, i.cursor)
+	latestCursorValue, err := internalStorage.LoadLatestCursorValue(ctx, i.logger, i.storageClient, i.options.PackageStorageBucketInternal)
+	if err != nil {
+		metrics.StorageIndexerUpdateIndexErrorsTotal.Inc()
+		return fmt.Errorf("can't load latest cursor: %w", err)
+	}
+	if i.cursor == latestCursorValue {
+		return nil
+	}
+
+	if i.cursor == "" || !i.options.IncrementalUpdates {
+		return i.fullSync(ctx, latestCursorValue)
+	}
+	return i.incrementalSync(ctx, latestCursorValue)
+}
+
+func (i *Indexer) fullSync(ctx context.Context, latestCursorValue string) error {
+	anIndex, err := internalStorage.LoadSearchIndexAllForCursor(ctx, i.logger, i.storageClient, i.options.PackageStorageBucketInternal, latestCursorValue)
 	if err != nil {
 		metrics.StorageIndexerUpdateIndexErrorsTotal.Inc()
 		return fmt.Errorf("can't load the search-index-all index content: %w", err)
-	}
-	if i.cursor == currentCursor {
-		return nil
 	}
 	if anIndex == nil {
 		i.logger.Info("Downloaded new search-index-all index. No packages found.")
@@ -179,16 +193,104 @@ func (i *Indexer) updateIndex(ctx context.Context) error {
 
 	i.m.Lock()
 	defer i.m.Unlock()
-	i.cursor = currentCursor
+	i.cursor = latestCursorValue
 	i.packageList = *anIndex
 	metrics.StorageIndexerUpdateIndexSuccessTotal.Inc()
 	metrics.NumberIndexedPackages.Set(float64(len(i.packageList)))
 
-	// set the deprecated notice information once the package list is updated
 	packages.UpdateLatestDeprecatedPackagesMapByName(i.packageList, i.deprecatedPackages)
 	packages.PropagateLatestDeprecatedInfoToPackageList(i.packageList, i.deprecatedPackages)
 
 	return nil
+}
+
+func (i *Indexer) incrementalSync(ctx context.Context, latestCursorValue string) error {
+	timestamps, err := internalStorage.ListCursorsBetween(ctx, i.storageClient, i.options.PackageStorageBucketInternal, i.cursor, latestCursorValue)
+	if err != nil {
+		metrics.StorageIndexerUpdateIndexErrorsTotal.Inc()
+		return fmt.Errorf("can't list cursors between %s and %s: %w", i.cursor, latestCursorValue, err)
+	}
+
+	type revision struct {
+		timestamp string
+		delta     *internalStorage.SearchIndexDelta
+		fullIndex *packages.Packages
+	}
+
+	revisions := make([]revision, 0, len(timestamps))
+	for _, ts := range timestamps {
+		delta, err := internalStorage.LoadSearchIndexDelta(ctx, i.logger, i.storageClient, i.options.PackageStorageBucketInternal, ts)
+		if err != nil {
+			if errors.Is(err, storage.ErrObjectNotExist) {
+				i.logger.Warn("delta file missing, falling back to full sync for timestamp", zap.String("cursor", ts))
+				anIndex, err := internalStorage.LoadSearchIndexAllForCursor(ctx, i.logger, i.storageClient, i.options.PackageStorageBucketInternal, ts)
+				if err != nil {
+					metrics.StorageIndexerUpdateIndexErrorsTotal.Inc()
+					return fmt.Errorf("can't load search-index-all for cursor %s: %w", ts, err)
+				}
+				revisions = append(revisions, revision{timestamp: ts, fullIndex: anIndex})
+			} else {
+				metrics.StorageIndexerUpdateIndexErrorsTotal.Inc()
+				return fmt.Errorf("can't load delta for cursor %s: %w", ts, err)
+			}
+		} else {
+			revisions = append(revisions, revision{timestamp: ts, delta: delta})
+		}
+	}
+
+	i.m.Lock()
+	defer i.m.Unlock()
+
+	for _, r := range revisions {
+		if r.fullIndex != nil {
+			i.transformSearchIndexAllToPackages(r.fullIndex)
+			i.packageList = *r.fullIndex
+		} else {
+			i.applyDelta(r.delta)
+		}
+		i.cursor = r.timestamp
+	}
+
+	metrics.StorageIndexerUpdateIndexSuccessTotal.Inc()
+	metrics.NumberIndexedPackages.Set(float64(len(i.packageList)))
+
+	packages.UpdateLatestDeprecatedPackagesMapByName(i.packageList, i.deprecatedPackages)
+	packages.PropagateLatestDeprecatedInfoToPackageList(i.packageList, i.deprecatedPackages)
+
+	return nil
+}
+
+// applyDelta modifies the in-memory packageList by applying a delta.
+// Must be called with i.m held for writing.
+func (i *Indexer) applyDelta(delta *internalStorage.SearchIndexDelta) {
+	pkgMap := make(map[string]*packages.Package, len(i.packageList))
+	for _, p := range i.packageList {
+		pkgMap[p.Name+"-"+p.Version] = p
+	}
+
+	for _, entry := range delta.Added {
+		p := entry.PackageManifest
+		p.BasePath = fmt.Sprintf("%s-%s.zip", p.Name, p.Version)
+		p.SetRemoteResolver(i.resolver)
+		pkgMap[p.Name+"-"+p.Version] = &p
+	}
+
+	for _, entry := range delta.Updated {
+		p := entry.PackageManifest
+		p.BasePath = fmt.Sprintf("%s-%s.zip", p.Name, p.Version)
+		p.SetRemoteResolver(i.resolver)
+		pkgMap[p.Name+"-"+p.Version] = &p
+	}
+
+	for _, ref := range delta.Removed {
+		delete(pkgMap, ref.Name+"-"+ref.Version)
+	}
+
+	newList := make(packages.Packages, 0, len(pkgMap))
+	for _, p := range pkgMap {
+		newList = append(newList, p)
+	}
+	i.packageList = newList
 }
 
 func (i *Indexer) Get(ctx context.Context, opts *packages.GetOptions) (packages.Packages, error) {

--- a/storage/indexer.go
+++ b/storage/indexer.go
@@ -228,9 +228,6 @@ func (i *Indexer) incrementalSync(ctx context.Context, latestCursorValue string)
 					metrics.StorageIndexerUpdateIndexErrorsTotal.Inc()
 					return fmt.Errorf("can't load search-index-all for cursor %s: %w", ts, err)
 				}
-				if anIndex == nil {
-					i.logger.Info("Delta fallback: full sync returned no packages for revision.", zap.String("cursor", ts))
-				}
 				// Full sync supersedes all prior deltas — reset to avoid holding multiple full copies in memory.
 				revisions = revisions[:0]
 				revisions = append(revisions, revision{timestamp: ts, fullIndex: anIndex})

--- a/storage/indexer.go
+++ b/storage/indexer.go
@@ -222,20 +222,15 @@ func (i *Indexer) incrementalSync(ctx context.Context, latestCursorValue string)
 	for _, ts := range timestamps {
 		delta, err := internalStorage.LoadSearchIndexDelta(ctx, i.logger, i.storageClient, i.options.PackageStorageBucketInternal, ts)
 		if err != nil {
-			if errors.Is(err, storage.ErrObjectNotExist) {
-				i.logger.Warn("delta file missing, falling back to full sync for timestamp", zap.String("cursor", ts))
-				anIndex, err := internalStorage.LoadSearchIndexAllForCursor(ctx, i.logger, i.storageClient, i.options.PackageStorageBucketInternal, ts)
-				if err != nil {
-					metrics.StorageIndexerUpdateIndexErrorsTotal.Inc()
-					return fmt.Errorf("can't load search-index-all for cursor %s: %w", ts, err)
-				}
-				// Full sync supersedes all prior deltas — reset to avoid holding multiple full copies in memory.
-				revisions = revisions[:0]
-				revisions = append(revisions, revision{timestamp: ts, fullIndex: anIndex})
-			} else {
+			i.logger.Warn("failed to load delta, falling back to full sync for timestamp", zap.String("cursor", ts), zap.Error(err))
+			anIndex, err := internalStorage.LoadSearchIndexAllForCursor(ctx, i.logger, i.storageClient, i.options.PackageStorageBucketInternal, ts)
+			if err != nil {
 				metrics.StorageIndexerUpdateIndexErrorsTotal.Inc()
-				return fmt.Errorf("can't load delta for cursor %s: %w", ts, err)
+				return fmt.Errorf("can't load search-index-all for cursor %s: %w", ts, err)
 			}
+			// Full sync supersedes all prior deltas — reset to avoid holding multiple full copies in memory.
+			revisions = revisions[:0]
+			revisions = append(revisions, revision{timestamp: ts, fullIndex: anIndex})
 		} else {
 			revisions = append(revisions, revision{timestamp: ts, delta: delta})
 		}

--- a/storage/indexer.go
+++ b/storage/indexer.go
@@ -313,6 +313,7 @@ func (i *Indexer) prepareDelta(delta *internalStorage.SearchIndexDelta) prepared
 // applyDelta applies a pre-processed delta to i.packageList.
 // Must be called with i.m held for writing.
 func (i *Indexer) applyDelta(pd preparedDelta) {
+	seen := make(map[string]struct{}, len(i.packageList))
 	out := make(packages.Packages, 0, max(0, len(i.packageList)-len(pd.removeKeys))+len(pd.added))
 	for _, p := range i.packageList {
 		key := p.Name + "-" + p.Version
@@ -325,8 +326,13 @@ func (i *Indexer) applyDelta(pd preparedDelta) {
 		} else {
 			out = append(out, p)
 		}
+		seen[key] = struct{}{}
 	}
-	out = append(out, pd.added...)
+	for _, p := range pd.added {
+		if _, exists := seen[p.Name+"-"+p.Version]; !exists {
+			out = append(out, p)
+		}
+	}
 	i.packageList = out
 }
 

--- a/storage/indexer.go
+++ b/storage/indexer.go
@@ -262,35 +262,46 @@ func (i *Indexer) incrementalSync(ctx context.Context, latestCursorValue string)
 
 // applyDelta modifies the in-memory packageList by applying a delta.
 // Must be called with i.m held for writing.
+//
+// The implementation avoids the previous 3× peak (full slice → full map → new slice)
+// by building small maps only for the delta entries and doing a single-pass
+// filter+update over the existing slice, reusing its backing array.
 func (i *Indexer) applyDelta(delta *internalStorage.SearchIndexDelta) {
-	pkgMap := make(map[string]*packages.Package, len(i.packageList))
+	removeKeys := make(map[string]struct{}, len(delta.Removed))
+	for _, ref := range delta.Removed {
+		removeKeys[ref.Name+"-"+ref.Version] = struct{}{}
+	}
+
+	updateMap := make(map[string]*packages.Package, len(delta.Updated))
+	for _, entry := range delta.Updated {
+		p := entry.PackageManifest
+		p.BasePath = fmt.Sprintf("%s-%s.zip", p.Name, p.Version)
+		p.SetRemoteResolver(i.resolver)
+		updateMap[p.Name+"-"+p.Version] = &p
+	}
+
+	out := i.packageList[:0]
 	for _, p := range i.packageList {
-		pkgMap[p.Name+"-"+p.Version] = p
+		key := p.Name + "-" + p.Version
+		if _, removed := removeKeys[key]; removed {
+			continue
+		}
+		if newer, ok := updateMap[key]; ok {
+			out = append(out, newer)
+			delete(updateMap, key)
+		} else {
+			out = append(out, p)
+		}
 	}
 
 	for _, entry := range delta.Added {
 		p := entry.PackageManifest
 		p.BasePath = fmt.Sprintf("%s-%s.zip", p.Name, p.Version)
 		p.SetRemoteResolver(i.resolver)
-		pkgMap[p.Name+"-"+p.Version] = &p
+		out = append(out, &p)
 	}
 
-	for _, entry := range delta.Updated {
-		p := entry.PackageManifest
-		p.BasePath = fmt.Sprintf("%s-%s.zip", p.Name, p.Version)
-		p.SetRemoteResolver(i.resolver)
-		pkgMap[p.Name+"-"+p.Version] = &p
-	}
-
-	for _, ref := range delta.Removed {
-		delete(pkgMap, ref.Name+"-"+ref.Version)
-	}
-
-	newList := make(packages.Packages, 0, len(pkgMap))
-	for _, p := range pkgMap {
-		newList = append(newList, p)
-	}
-	i.packageList = newList
+	i.packageList = out
 }
 
 func (i *Indexer) Get(ctx context.Context, opts *packages.GetOptions) (packages.Packages, error) {

--- a/storage/indexer.go
+++ b/storage/indexer.go
@@ -323,7 +323,6 @@ func (i *Indexer) applyDelta(pd preparedDelta) {
 			i.logger.Debug("updated package", zap.String("package", key))
 		} else {
 			out = append(out, p)
-			i.logger.Debug("kept package", zap.String("package", key))
 		}
 		seen[key] = struct{}{}
 	}

--- a/storage/indexer.go
+++ b/storage/indexer.go
@@ -228,6 +228,9 @@ func (i *Indexer) incrementalSync(ctx context.Context, latestCursorValue string)
 					metrics.StorageIndexerUpdateIndexErrorsTotal.Inc()
 					return fmt.Errorf("can't load search-index-all for cursor %s: %w", ts, err)
 				}
+				if anIndex == nil {
+					i.logger.Info("Delta fallback: full sync returned no packages for revision.", zap.String("cursor", ts))
+				}
 				revisions = append(revisions, revision{timestamp: ts, fullIndex: anIndex})
 			} else {
 				metrics.StorageIndexerUpdateIndexErrorsTotal.Inc()
@@ -245,7 +248,7 @@ func (i *Indexer) incrementalSync(ctx context.Context, latestCursorValue string)
 		if r.fullIndex != nil {
 			i.transformSearchIndexAllToPackages(r.fullIndex)
 			i.packageList = *r.fullIndex
-		} else {
+		} else if r.delta != nil {
 			i.applyDelta(r.delta)
 		}
 		i.cursor = r.timestamp
@@ -280,7 +283,7 @@ func (i *Indexer) applyDelta(delta *internalStorage.SearchIndexDelta) {
 		updateMap[p.Name+"-"+p.Version] = &p
 	}
 
-	out := i.packageList[:0]
+	out := make(packages.Packages, 0, len(i.packageList))
 	for _, p := range i.packageList {
 		key := p.Name + "-" + p.Version
 		if _, removed := removeKeys[key]; removed {

--- a/storage/indexer_test.go
+++ b/storage/indexer_test.go
@@ -763,4 +763,41 @@ func TestIncrementalUpdate(t *testing.T) {
 		require.NoError(t, err)
 		wg.Wait()
 	})
+
+	// Exercises the deprecated-propagation write path during concurrent Get calls.
+	// The seed contains a deprecated package so deprecatedPackages is populated after
+	// full sync. The delta adds a new version of the same package — applyDelta reuses
+	// the existing *Package pointer for the unchanged entry, then
+	// PropagateLatestDeprecatedInfoToPackageList writes through it. Run with -race to
+	// detect a regression back to in-place mutation of shared pointers.
+	t.Run("concurrent_get_and_apply_delta_with_deprecated", func(t *testing.T) {
+		t.Parallel()
+
+		fs := internalStorage.PrepareFakeServer(t, "testdata/search-index-all-small-deprecated.json")
+		t.Cleanup(fs.Stop)
+
+		indexer := NewIndexer(util.NewTestLogger(), internalStorage.ClientNoAuth(fs), incrementalOptions)
+		t.Cleanup(func() { indexer.Close(context.Background()) })
+
+		err := indexer.Init(t.Context())
+		require.NoError(t, err)
+
+		// Add 1password 0.3.0; the seeded 0.2.0 pointer is reused by applyDelta and
+		// then written to by PropagateLatestDeprecatedInfoToPackageList.
+		deltaContent := readDeltaFile(t, "testdata/search-index-delta-add.json")
+		_, indexer.storageClient = internalStorage.UpdateFakeServerWithDelta(t, fs, "2", deltaContent)
+
+		var wg sync.WaitGroup
+		for range 50 {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				_, _ = indexer.Get(t.Context(), &packages.GetOptions{})
+			}()
+		}
+
+		err = indexer.updateIndex(t.Context())
+		require.NoError(t, err)
+		wg.Wait()
+	})
 }

--- a/storage/indexer_test.go
+++ b/storage/indexer_test.go
@@ -842,3 +842,37 @@ func TestIncrementalUpdate(t *testing.T) {
 		wg.Wait()
 	})
 }
+
+func TestApplyDelta_AddDuplicateSkipped(t *testing.T) {
+	// If pd.added contains a package whose name+version is already in i.packageList,
+	// applyDelta must not produce a duplicate entry.
+	t.Parallel()
+
+	title := "Original"
+	existing := &packages.Package{BasePackage: packages.BasePackage{Name: "foo", Version: "1.0.0", Title: &title}}
+	other := &packages.Package{BasePackage: packages.BasePackage{Name: "bar", Version: "2.0.0"}}
+
+	indexer := &Indexer{
+		packageList: packages.Packages{existing, other},
+	}
+
+	dupTitle := "Duplicate"
+	dup := &packages.Package{BasePackage: packages.BasePackage{Name: "foo", Version: "1.0.0", Title: &dupTitle}}
+
+	indexer.applyDelta(preparedDelta{
+		removeKeys: map[string]struct{}{},
+		updateMap:  map[string]*packages.Package{},
+		added:      packages.Packages{dup},
+	})
+
+	require.Len(t, indexer.packageList, 2, "duplicate in added must not create a second entry")
+
+	byKey := make(map[string]*packages.Package)
+	for _, p := range indexer.packageList {
+		byKey[p.Name+"-"+p.Version] = p
+	}
+	require.Contains(t, byKey, "foo-1.0.0")
+	require.Contains(t, byKey, "bar-2.0.0")
+	// The original pointer wins; the duplicate is dropped.
+	assert.Equal(t, "Original", *byKey["foo-1.0.0"].Title, "original package must be kept, not the duplicate")
+}

--- a/storage/indexer_test.go
+++ b/storage/indexer_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sync"
 	"testing"
 
 	"github.com/Masterminds/semver/v3"
@@ -678,5 +679,36 @@ func TestIncrementalUpdate(t *testing.T) {
 		foundPackages, err := indexer.Get(t.Context(), &packages.GetOptions{})
 		require.NoError(t, err)
 		assert.Greater(t, len(foundPackages), 2, "fallback full sync should have loaded all packages")
+	})
+
+	// This test is intentionally racy without the fix in applyDelta that allocates a
+	// fresh backing array. Run with -race to detect regressions.
+	t.Run("concurrent_get_and_apply_delta", func(t *testing.T) {
+		t.Parallel()
+
+		fs := internalStorage.PrepareFakeServer(t, "testdata/search-index-all-small.json")
+		t.Cleanup(fs.Stop)
+
+		indexer := NewIndexer(util.NewTestLogger(), internalStorage.ClientNoAuth(fs), incrementalOptions)
+		t.Cleanup(func() { indexer.Close(context.Background()) })
+
+		err := indexer.Init(t.Context())
+		require.NoError(t, err)
+
+		deltaContent := readDeltaFile(t, "testdata/search-index-delta-add.json")
+		_, indexer.storageClient = internalStorage.UpdateFakeServerWithDelta(t, fs, "2", deltaContent)
+
+		var wg sync.WaitGroup
+		for range 50 {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				_, _ = indexer.Get(t.Context(), &packages.GetOptions{})
+			}()
+		}
+
+		err = indexer.updateIndex(t.Context())
+		require.NoError(t, err)
+		wg.Wait()
 	})
 }

--- a/storage/indexer_test.go
+++ b/storage/indexer_test.go
@@ -7,6 +7,7 @@ package storage
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/Masterminds/semver/v3"
@@ -74,6 +75,49 @@ func BenchmarkIndexerUpdateIndex(b *testing.B) {
 		b.StartTimer()
 		err = indexer.updateIndex(b.Context())
 		require.NoError(b, err, "index should be updated successfully")
+	}
+}
+
+// BenchmarkIndexerUpdateIndex_Incremental measures the cost of applying a small
+// delta (1 package added) against a large in-memory index (search-index-all-full.json,
+// ~1139 packages). Compare directly with BenchmarkIndexerUpdateIndex which does a
+// full reload of the same index every poll cycle.
+//
+// The delta server is set up once at revision "2" (lexicographically > "1", the
+// initial revision from PrepareFakeServer). Each iteration resets the indexer cursor
+// to "1" so updateIndex always sees a real "1"→"2" incremental transition, measuring
+// only the steady-state cost: GCS cursor list + delta read + applyDelta.
+func BenchmarkIndexerUpdateIndex_Incremental(b *testing.B) {
+	// given
+	fs := internalStorage.PrepareFakeServer(b, "testdata/search-index-all-full.json")
+	defer func() { fs.Stop() }()
+
+	deltaContent, err := os.ReadFile("testdata/search-index-delta-add.json")
+	require.NoError(b, err)
+
+	incrementalOptions := IndexerOptions{
+		PackageStorageBucketInternal: "gs://" + internalStorage.FakePackageStorageBucketInternal,
+		WatchInterval:                0,
+		IncrementalUpdates:           true,
+	}
+
+	logger := util.NewTestLoggerLevel(zapcore.FatalLevel)
+	indexer := NewIndexer(logger, internalStorage.ClientNoAuth(fs), incrementalOptions)
+	defer indexer.Close(b.Context())
+
+	err = indexer.Init(b.Context())
+	require.NoError(b, err)
+
+	// Set up the delta at revision "2" once — "2" > "1" lexicographically so
+	// ListCursorsBetween will find it on every iteration.
+	fs, indexer.storageClient = internalStorage.UpdateFakeServerWithDelta(b, fs, "2", deltaContent)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		// Reset cursor so updateIndex sees a live "1"→"2" incremental transition.
+		indexer.cursor = "1"
+		err = indexer.updateIndex(b.Context())
+		require.NoError(b, err, "incremental index update should succeed")
 	}
 }
 
@@ -402,4 +446,237 @@ func TestGet_IndexUpdated(t *testing.T) {
 	require.Equal(t, "1password", foundPackages[0].Name)
 	require.Equal(t, "0.2.0", foundPackages[0].Version)
 	require.Equal(t, "1Password Events Reporting UPDATED", *foundPackages[0].Title)
+}
+
+func TestIncrementalUpdate(t *testing.T) {
+	t.Parallel()
+
+	incrementalOptions := IndexerOptions{
+		PackageStorageBucketInternal: "gs://" + internalStorage.FakePackageStorageBucketInternal,
+		WatchInterval:                0,
+		IncrementalUpdates:           true,
+	}
+
+	readDeltaFile := func(t *testing.T, path string) []byte {
+		t.Helper()
+		content, err := os.ReadFile(path)
+		require.NoError(t, err, "delta test data file must be readable")
+		return content
+	}
+
+	t.Run("add_package", func(t *testing.T) {
+		t.Parallel()
+
+		fs := internalStorage.PrepareFakeServer(t, "testdata/search-index-all-small.json")
+		t.Cleanup(fs.Stop)
+
+		indexer := NewIndexer(util.NewTestLogger(), internalStorage.ClientNoAuth(fs), incrementalOptions)
+		t.Cleanup(func() { indexer.Close(context.Background()) })
+
+		err := indexer.Init(t.Context())
+		require.NoError(t, err)
+
+		deltaContent := readDeltaFile(t, "testdata/search-index-delta-add.json")
+		fs, indexer.storageClient = internalStorage.UpdateFakeServerWithDelta(t, fs, "2", deltaContent)
+
+		err = indexer.updateIndex(t.Context())
+		require.NoError(t, err)
+
+		foundPackages, err := indexer.Get(t.Context(), &packages.GetOptions{
+			Filter: &packages.Filter{AllVersions: true, Prerelease: true, PackageName: "1password"},
+		})
+		require.NoError(t, err)
+		require.Len(t, foundPackages, 3, "should have original 2 packages plus the new 0.3.0")
+
+		versions := make(map[string]bool)
+		for _, p := range foundPackages {
+			versions[p.Version] = true
+		}
+		assert.True(t, versions["0.3.0"], "new 0.3.0 package must be present")
+		assert.True(t, versions["0.1.1"], "original 0.1.1 package must be present")
+		assert.True(t, versions["0.2.0"], "original 0.2.0 package must be present")
+	})
+
+	t.Run("remove_package", func(t *testing.T) {
+		t.Parallel()
+
+		fs := internalStorage.PrepareFakeServer(t, "testdata/search-index-all-small.json")
+		t.Cleanup(fs.Stop)
+
+		indexer := NewIndexer(util.NewTestLogger(), internalStorage.ClientNoAuth(fs), incrementalOptions)
+		t.Cleanup(func() { indexer.Close(context.Background()) })
+
+		err := indexer.Init(t.Context())
+		require.NoError(t, err)
+
+		deltaContent := readDeltaFile(t, "testdata/search-index-delta-remove.json")
+		fs, indexer.storageClient = internalStorage.UpdateFakeServerWithDelta(t, fs, "2", deltaContent)
+
+		err = indexer.updateIndex(t.Context())
+		require.NoError(t, err)
+
+		foundPackages, err := indexer.Get(t.Context(), &packages.GetOptions{
+			Filter: &packages.Filter{AllVersions: true, Prerelease: true, PackageName: "1password"},
+		})
+		require.NoError(t, err)
+		require.Len(t, foundPackages, 1, "0.1.1 should have been removed")
+		assert.Equal(t, "0.2.0", foundPackages[0].Version)
+	})
+
+	t.Run("update_package_fields", func(t *testing.T) {
+		t.Parallel()
+
+		fs := internalStorage.PrepareFakeServer(t, "testdata/search-index-all-small.json")
+		t.Cleanup(fs.Stop)
+
+		indexer := NewIndexer(util.NewTestLogger(), internalStorage.ClientNoAuth(fs), incrementalOptions)
+		t.Cleanup(func() { indexer.Close(context.Background()) })
+
+		err := indexer.Init(t.Context())
+		require.NoError(t, err)
+
+		deltaContent := readDeltaFile(t, "testdata/search-index-delta-update.json")
+		fs, indexer.storageClient = internalStorage.UpdateFakeServerWithDelta(t, fs, "2", deltaContent)
+
+		err = indexer.updateIndex(t.Context())
+		require.NoError(t, err)
+
+		foundPackages, err := indexer.Get(t.Context(), &packages.GetOptions{
+			Filter: &packages.Filter{PackageName: "1password", PackageVersion: "0.2.0", Prerelease: true},
+		})
+		require.NoError(t, err)
+		require.Len(t, foundPackages, 1)
+		require.NotNil(t, foundPackages[0].Title)
+		assert.Equal(t, "1Password Events Reporting UPDATED DELTA", *foundPackages[0].Title)
+	})
+
+	t.Run("multiple_deltas_in_order", func(t *testing.T) {
+		t.Parallel()
+
+		fs := internalStorage.PrepareFakeServer(t, "testdata/search-index-all-small.json")
+		t.Cleanup(fs.Stop)
+
+		indexer := NewIndexer(util.NewTestLogger(), internalStorage.ClientNoAuth(fs), incrementalOptions)
+		t.Cleanup(func() { indexer.Close(context.Background()) })
+
+		err := indexer.Init(t.Context())
+		require.NoError(t, err)
+
+		// revision "2": add 0.3.0
+		fs, indexer.storageClient = internalStorage.UpdateFakeServerWithDelta(t, fs, "2", readDeltaFile(t, "testdata/search-index-delta-add.json"))
+		// revision "3": remove 0.1.1
+		fs, indexer.storageClient = internalStorage.UpdateFakeServerWithDelta(t, fs, "3", readDeltaFile(t, "testdata/search-index-delta-remove.json"))
+		// revision "4": update 0.2.0 title — cursor.json now points to "4"
+		fs, indexer.storageClient = internalStorage.UpdateFakeServerWithDelta(t, fs, "4", readDeltaFile(t, "testdata/search-index-delta-update.json"))
+
+		// single updateIndex call should apply all three deltas
+		err = indexer.updateIndex(t.Context())
+		require.NoError(t, err)
+
+		foundPackages, err := indexer.Get(t.Context(), &packages.GetOptions{
+			Filter: &packages.Filter{AllVersions: true, Prerelease: true, PackageName: "1password"},
+		})
+		require.NoError(t, err)
+		require.Len(t, foundPackages, 2, "0.1.1 removed, 0.2.0 and 0.3.0 remain")
+
+		versions := make(map[string]*packages.Package)
+		for _, p := range foundPackages {
+			pkg := p
+			versions[p.Version] = pkg
+		}
+		assert.Contains(t, versions, "0.2.0")
+		assert.Contains(t, versions, "0.3.0")
+		assert.NotContains(t, versions, "0.1.1")
+		if p, ok := versions["0.2.0"]; ok {
+			require.NotNil(t, p.Title)
+			assert.Equal(t, "1Password Events Reporting UPDATED DELTA", *p.Title)
+		}
+	})
+
+	t.Run("flag_off_uses_full_sync", func(t *testing.T) {
+		t.Parallel()
+
+		fs := internalStorage.PrepareFakeServer(t, "testdata/search-index-all-small.json")
+		t.Cleanup(fs.Stop)
+
+		indexer := NewIndexer(util.NewTestLogger(), internalStorage.ClientNoAuth(fs), FakeIndexerOptions)
+		t.Cleanup(func() { indexer.Close(context.Background()) })
+
+		err := indexer.Init(t.Context())
+		require.NoError(t, err)
+
+		fs, indexer.storageClient = internalStorage.UpdateFakeServer(t, fs, "2", "testdata/search-index-all-full.json")
+		err = indexer.updateIndex(t.Context())
+		require.NoError(t, err)
+
+		foundPackages, err := indexer.Get(t.Context(), &packages.GetOptions{})
+		require.NoError(t, err)
+		assert.Greater(t, len(foundPackages), 2, "full sync should have loaded all packages")
+	})
+
+	t.Run("same_cursor_skips", func(t *testing.T) {
+		t.Parallel()
+
+		fs := internalStorage.PrepareFakeServer(t, "testdata/search-index-all-small.json")
+		t.Cleanup(fs.Stop)
+
+		indexer := NewIndexer(util.NewTestLogger(), internalStorage.ClientNoAuth(fs), incrementalOptions)
+		t.Cleanup(func() { indexer.Close(context.Background()) })
+
+		err := indexer.Init(t.Context())
+		require.NoError(t, err)
+
+		// cursor still "1" — no change on server
+		err = indexer.updateIndex(t.Context())
+		require.NoError(t, err)
+
+		foundPackages, err := indexer.Get(t.Context(), &packages.GetOptions{
+			Filter: &packages.Filter{AllVersions: true, Prerelease: true, PackageName: "1password"},
+		})
+		require.NoError(t, err)
+		assert.Len(t, foundPackages, 2, "package list should be unchanged")
+	})
+
+	t.Run("startup_always_full_sync", func(t *testing.T) {
+		t.Parallel()
+
+		fs := internalStorage.PrepareFakeServer(t, "testdata/search-index-all-small.json")
+		t.Cleanup(fs.Stop)
+
+		indexer := NewIndexer(util.NewTestLogger(), internalStorage.ClientNoAuth(fs), incrementalOptions)
+		t.Cleanup(func() { indexer.Close(context.Background()) })
+
+		// cursor is "" on startup — must do full sync even with IncrementalUpdates: true
+		err := indexer.Init(t.Context())
+		require.NoError(t, err)
+
+		foundPackages, err := indexer.Get(t.Context(), &packages.GetOptions{
+			Filter: &packages.Filter{AllVersions: true, Prerelease: true, PackageName: "1password"},
+		})
+		require.NoError(t, err)
+		assert.Len(t, foundPackages, 2, "full sync on startup must load all packages")
+	})
+
+	t.Run("delta_missing_falls_back_to_full_sync", func(t *testing.T) {
+		t.Parallel()
+
+		fs := internalStorage.PrepareFakeServer(t, "testdata/search-index-all-small.json")
+		t.Cleanup(fs.Stop)
+
+		indexer := NewIndexer(util.NewTestLogger(), internalStorage.ClientNoAuth(fs), incrementalOptions)
+		t.Cleanup(func() { indexer.Close(context.Background()) })
+
+		err := indexer.Init(t.Context())
+		require.NoError(t, err)
+
+		// revision "2" has a full search-index-all.json but no delta file
+		fs, indexer.storageClient = internalStorage.UpdateFakeServer(t, fs, "2", "testdata/search-index-all-full.json")
+
+		err = indexer.updateIndex(t.Context())
+		require.NoError(t, err)
+
+		foundPackages, err := indexer.Get(t.Context(), &packages.GetOptions{})
+		require.NoError(t, err)
+		assert.Greater(t, len(foundPackages), 2, "fallback full sync should have loaded all packages")
+	})
 }

--- a/storage/indexer_test.go
+++ b/storage/indexer_test.go
@@ -482,6 +482,7 @@ func TestIncrementalUpdate(t *testing.T) {
 
 		err = indexer.updateIndex(t.Context())
 		require.NoError(t, err)
+		assert.Equal(t, "2", indexer.cursor, "cursor must advance to the applied revision")
 
 		foundPackages, err := indexer.Get(t.Context(), &packages.GetOptions{
 			Filter: &packages.Filter{AllVersions: true, Prerelease: true, PackageName: "1password"},
@@ -515,6 +516,7 @@ func TestIncrementalUpdate(t *testing.T) {
 
 		err = indexer.updateIndex(t.Context())
 		require.NoError(t, err)
+		assert.Equal(t, "2", indexer.cursor, "cursor must advance to the applied revision")
 
 		foundPackages, err := indexer.Get(t.Context(), &packages.GetOptions{
 			Filter: &packages.Filter{AllVersions: true, Prerelease: true, PackageName: "1password"},
@@ -541,6 +543,7 @@ func TestIncrementalUpdate(t *testing.T) {
 
 		err = indexer.updateIndex(t.Context())
 		require.NoError(t, err)
+		assert.Equal(t, "2", indexer.cursor, "cursor must advance to the applied revision")
 
 		foundPackages, err := indexer.Get(t.Context(), &packages.GetOptions{
 			Filter: &packages.Filter{PackageName: "1password", PackageVersion: "0.2.0", Prerelease: true},
@@ -549,6 +552,50 @@ func TestIncrementalUpdate(t *testing.T) {
 		require.Len(t, foundPackages, 1)
 		require.NotNil(t, foundPackages[0].Title)
 		assert.Equal(t, "1Password Events Reporting UPDATED DELTA", *foundPackages[0].Title)
+	})
+
+	t.Run("update_is_full_replacement", func(t *testing.T) {
+		// Verifies that an updated package is fully replaced, not merged with the original.
+		t.Parallel()
+
+		fs := internalStorage.PrepareFakeServer(t, "testdata/search-index-all-small.json")
+		t.Cleanup(fs.Stop)
+
+		indexer := NewIndexer(util.NewTestLogger(), internalStorage.ClientNoAuth(fs), incrementalOptions)
+		t.Cleanup(func() { indexer.Close(context.Background()) })
+
+		err := indexer.Init(t.Context())
+		require.NoError(t, err)
+
+		deltaContent := readDeltaFile(t, "testdata/search-index-delta-update.json")
+		_, indexer.storageClient = internalStorage.UpdateFakeServerWithDelta(t, fs, "2", deltaContent)
+
+		err = indexer.updateIndex(t.Context())
+		require.NoError(t, err)
+
+		allPackages, err := indexer.Get(t.Context(), &packages.GetOptions{
+			Filter: &packages.Filter{AllVersions: true, Prerelease: true, PackageName: "1password"},
+		})
+		require.NoError(t, err)
+		// Exact count: update must not duplicate — still exactly 2 versions.
+		require.Len(t, allPackages, 2, "update must replace, not duplicate the package entry")
+
+		byVersion := make(map[string]*packages.Package)
+		for _, p := range allPackages {
+			pkg := p
+			byVersion[p.Version] = pkg
+		}
+
+		require.Contains(t, byVersion, "0.2.0")
+		require.Contains(t, byVersion, "0.1.1")
+
+		updated := byVersion["0.2.0"]
+		require.NotNil(t, updated.Title)
+		assert.Equal(t, "1Password Events Reporting UPDATED DELTA", *updated.Title, "0.2.0 title must reflect the delta, not the original")
+
+		untouched := byVersion["0.1.1"]
+		require.NotNil(t, untouched.Title)
+		assert.Equal(t, "1Password Events Reporting", *untouched.Title, "0.1.1 must not be affected by the update delta")
 	})
 
 	t.Run("multiple_deltas_in_order", func(t *testing.T) {
@@ -573,6 +620,7 @@ func TestIncrementalUpdate(t *testing.T) {
 		// single updateIndex call should apply all three deltas
 		err = indexer.updateIndex(t.Context())
 		require.NoError(t, err)
+		assert.Equal(t, "4", indexer.cursor, "cursor must advance to the last applied revision")
 
 		foundPackages, err := indexer.Get(t.Context(), &packages.GetOptions{
 			Filter: &packages.Filter{AllVersions: true, Prerelease: true, PackageName: "1password"},

--- a/storage/indexer_test.go
+++ b/storage/indexer_test.go
@@ -477,7 +477,7 @@ func TestIncrementalUpdate(t *testing.T) {
 		require.NoError(t, err)
 
 		deltaContent := readDeltaFile(t, "testdata/search-index-delta-add.json")
-		fs, indexer.storageClient = internalStorage.UpdateFakeServerWithDelta(t, fs, "2", deltaContent)
+		_, indexer.storageClient = internalStorage.UpdateFakeServerWithDelta(t, fs, "2", deltaContent)
 
 		err = indexer.updateIndex(t.Context())
 		require.NoError(t, err)
@@ -510,7 +510,7 @@ func TestIncrementalUpdate(t *testing.T) {
 		require.NoError(t, err)
 
 		deltaContent := readDeltaFile(t, "testdata/search-index-delta-remove.json")
-		fs, indexer.storageClient = internalStorage.UpdateFakeServerWithDelta(t, fs, "2", deltaContent)
+		_, indexer.storageClient = internalStorage.UpdateFakeServerWithDelta(t, fs, "2", deltaContent)
 
 		err = indexer.updateIndex(t.Context())
 		require.NoError(t, err)
@@ -536,7 +536,7 @@ func TestIncrementalUpdate(t *testing.T) {
 		require.NoError(t, err)
 
 		deltaContent := readDeltaFile(t, "testdata/search-index-delta-update.json")
-		fs, indexer.storageClient = internalStorage.UpdateFakeServerWithDelta(t, fs, "2", deltaContent)
+		_, indexer.storageClient = internalStorage.UpdateFakeServerWithDelta(t, fs, "2", deltaContent)
 
 		err = indexer.updateIndex(t.Context())
 		require.NoError(t, err)
@@ -567,7 +567,7 @@ func TestIncrementalUpdate(t *testing.T) {
 		// revision "3": remove 0.1.1
 		fs, indexer.storageClient = internalStorage.UpdateFakeServerWithDelta(t, fs, "3", readDeltaFile(t, "testdata/search-index-delta-remove.json"))
 		// revision "4": update 0.2.0 title — cursor.json now points to "4"
-		fs, indexer.storageClient = internalStorage.UpdateFakeServerWithDelta(t, fs, "4", readDeltaFile(t, "testdata/search-index-delta-update.json"))
+		_, indexer.storageClient = internalStorage.UpdateFakeServerWithDelta(t, fs, "4", readDeltaFile(t, "testdata/search-index-delta-update.json"))
 
 		// single updateIndex call should apply all three deltas
 		err = indexer.updateIndex(t.Context())
@@ -605,7 +605,7 @@ func TestIncrementalUpdate(t *testing.T) {
 		err := indexer.Init(t.Context())
 		require.NoError(t, err)
 
-		fs, indexer.storageClient = internalStorage.UpdateFakeServer(t, fs, "2", "testdata/search-index-all-full.json")
+		_, indexer.storageClient = internalStorage.UpdateFakeServer(t, fs, "2", "testdata/search-index-all-full.json")
 		err = indexer.updateIndex(t.Context())
 		require.NoError(t, err)
 
@@ -670,7 +670,7 @@ func TestIncrementalUpdate(t *testing.T) {
 		require.NoError(t, err)
 
 		// revision "2" has a full search-index-all.json but no delta file
-		fs, indexer.storageClient = internalStorage.UpdateFakeServer(t, fs, "2", "testdata/search-index-all-full.json")
+		_, indexer.storageClient = internalStorage.UpdateFakeServer(t, fs, "2", "testdata/search-index-all-full.json")
 
 		err = indexer.updateIndex(t.Context())
 		require.NoError(t, err)

--- a/storage/indexer_test.go
+++ b/storage/indexer_test.go
@@ -906,6 +906,7 @@ func TestApplyDelta_AddDuplicateSkipped(t *testing.T) {
 	other := &packages.Package{BasePackage: packages.BasePackage{Name: "bar", Version: "2.0.0"}}
 
 	indexer := &Indexer{
+		logger:      util.NewTestLogger(),
 		packageList: packages.Packages{existing, other},
 	}
 

--- a/storage/indexer_test.go
+++ b/storage/indexer_test.go
@@ -658,9 +658,11 @@ func TestIncrementalUpdate(t *testing.T) {
 		err = indexer.updateIndex(t.Context())
 		require.NoError(t, err)
 
-		foundPackages, err := indexer.Get(t.Context(), &packages.GetOptions{})
+		foundPackages, err := indexer.Get(t.Context(), &packages.GetOptions{
+			Filter: &packages.Filter{AllVersions: true, Prerelease: true},
+		})
 		require.NoError(t, err)
-		assert.Greater(t, len(foundPackages), 2, "full sync should have loaded all packages")
+		assert.Len(t, foundPackages, 1139, "full sync should have loaded all packages")
 	})
 
 	t.Run("same_cursor_skips", func(t *testing.T) {
@@ -724,9 +726,11 @@ func TestIncrementalUpdate(t *testing.T) {
 		err = indexer.updateIndex(t.Context())
 		require.NoError(t, err)
 
-		foundPackages, err := indexer.Get(t.Context(), &packages.GetOptions{})
+		foundPackages, err := indexer.Get(t.Context(), &packages.GetOptions{
+			Filter: &packages.Filter{AllVersions: true, Prerelease: true},
+		})
 		require.NoError(t, err)
-		assert.Greater(t, len(foundPackages), 2, "fallback full sync should have loaded all packages")
+		assert.Len(t, foundPackages, 1139, "fallback full sync should have loaded all packages")
 	})
 
 	// This test is intentionally racy without the fix in applyDelta that allocates a

--- a/storage/indexer_test.go
+++ b/storage/indexer_test.go
@@ -598,6 +598,47 @@ func TestIncrementalUpdate(t *testing.T) {
 		assert.Equal(t, "1Password Events Reporting", *untouched.Title, "0.1.1 must not be affected by the update delta")
 	})
 
+	t.Run("update_removes_absent_fields", func(t *testing.T) {
+		// Verifies that a delta update is a full replacement: fields present in the
+		// original but absent from the delta entry must not survive in the result.
+		// Seed: 1password 0.2.0 has categories=["security"] and no group.
+		// Delta: replaces with a manifest that has group="observability" and no categories.
+		// Expected: group is set, categories is empty.
+		t.Parallel()
+
+		fs := internalStorage.PrepareFakeServer(t, "testdata/search-index-all-small.json")
+		t.Cleanup(fs.Stop)
+
+		indexer := NewIndexer(util.NewTestLogger(), internalStorage.ClientNoAuth(fs), incrementalOptions)
+		t.Cleanup(func() { indexer.Close(context.Background()) })
+
+		err := indexer.Init(t.Context())
+		require.NoError(t, err)
+
+		deltaContent := readDeltaFile(t, "testdata/search-index-delta-update-field-removal.json")
+		_, indexer.storageClient = internalStorage.UpdateFakeServerWithDelta(t, fs, "2", deltaContent)
+
+		err = indexer.updateIndex(t.Context())
+		require.NoError(t, err)
+
+		allPackages, err := indexer.Get(t.Context(), &packages.GetOptions{
+			Filter: &packages.Filter{AllVersions: true, Prerelease: true, PackageName: "1password"},
+		})
+		require.NoError(t, err)
+		require.Len(t, allPackages, 2)
+
+		byVersion := make(map[string]*packages.Package)
+		for _, p := range allPackages {
+			pkg := p
+			byVersion[p.Version] = pkg
+		}
+
+		updated := byVersion["0.2.0"]
+		require.NotNil(t, updated)
+		assert.Equal(t, "observability", updated.Group, "group from delta must be present")
+		assert.Empty(t, updated.Categories, "categories absent from delta must not survive in the result")
+	})
+
 	t.Run("multiple_deltas_in_order", func(t *testing.T) {
 		t.Parallel()
 

--- a/storage/indexer_test.go
+++ b/storage/indexer_test.go
@@ -749,6 +749,59 @@ func TestIncrementalUpdate(t *testing.T) {
 		assert.Len(t, foundPackages, 2, "full sync on startup must load all packages")
 	})
 
+	t.Run("delta_corrupt_falls_back_to_full_sync", func(t *testing.T) {
+		// A delta file that exists but contains invalid JSON (e.g. a write that was
+		// truncated mid-flight) must trigger the same full-sync fallback as a missing
+		// delta, leaving the indexer in a consistent state.
+		t.Parallel()
+
+		fs := internalStorage.PrepareFakeServer(t, "testdata/search-index-all-small.json")
+		t.Cleanup(fs.Stop)
+
+		indexer := NewIndexer(util.NewTestLogger(), internalStorage.ClientNoAuth(fs), incrementalOptions)
+		t.Cleanup(func() { indexer.Close(context.Background()) })
+
+		err := indexer.Init(t.Context())
+		require.NoError(t, err)
+
+		// Publish a valid search-index-all.json at revision "2" first, then overlay a
+		// corrupt delta for the same revision. The full index must survive as the fallback.
+		fs, indexer.storageClient = internalStorage.UpdateFakeServer(t, fs, "2", "testdata/search-index-all-full.json")
+		_, indexer.storageClient = internalStorage.UpdateFakeServerWithDelta(t, fs, "2", []byte(`{invalid json`))
+
+		err = indexer.updateIndex(t.Context())
+		require.NoError(t, err, "corrupt delta must fall back to full sync without error")
+		assert.Equal(t, "2", indexer.cursor, "cursor must advance even when delta was corrupt")
+
+		foundPackages, err := indexer.Get(t.Context(), &packages.GetOptions{
+			Filter: &packages.Filter{AllVersions: true, Prerelease: true},
+		})
+		require.NoError(t, err)
+		assert.Len(t, foundPackages, 1139, "fallback full sync must load all packages")
+	})
+
+	t.Run("delta_corrupt_no_full_index_returns_error", func(t *testing.T) {
+		// When a delta is corrupt AND no search-index-all.json exists for that revision,
+		// updateIndex must return an error and leave the cursor unchanged.
+		t.Parallel()
+
+		fs := internalStorage.PrepareFakeServer(t, "testdata/search-index-all-small.json")
+		t.Cleanup(fs.Stop)
+
+		indexer := NewIndexer(util.NewTestLogger(), internalStorage.ClientNoAuth(fs), incrementalOptions)
+		t.Cleanup(func() { indexer.Close(context.Background()) })
+
+		err := indexer.Init(t.Context())
+		require.NoError(t, err)
+
+		// Publish only a corrupt delta for revision "2" — no search-index-all.json.
+		_, indexer.storageClient = internalStorage.UpdateFakeServerWithDelta(t, fs, "2", []byte(`{invalid json`))
+
+		err = indexer.updateIndex(t.Context())
+		require.Error(t, err, "must return an error when both delta and full index are unavailable")
+		assert.Equal(t, "1", indexer.cursor, "cursor must not advance when update fails")
+	})
+
 	t.Run("delta_missing_falls_back_to_full_sync", func(t *testing.T) {
 		t.Parallel()
 

--- a/storage/testdata/search-index-all-small-deprecated.json
+++ b/storage/testdata/search-index-all-small-deprecated.json
@@ -1,0 +1,21 @@
+{
+    "packages": [
+        {
+            "package_manifest": {
+                "name": "1password",
+                "title": "1Password Events Reporting",
+                "version": "0.2.0",
+                "release": "beta",
+                "description": "Collect events from 1Password Events API with Elastic Agent.",
+                "type": "integration",
+                "download": "/epr/1password/1password-0.2.0.zip",
+                "path": "/package/1password/0.2.0",
+                "categories": ["security"],
+                "format_version": "1.0.0",
+                "readme": "/package/1password/0.2.0/docs/README.md",
+                "license": "basic",
+                "deprecated": {"since": "1.0.0"}
+            }
+        }
+    ]
+}

--- a/storage/testdata/search-index-delta-add.json
+++ b/storage/testdata/search-index-delta-add.json
@@ -1,0 +1,22 @@
+{
+    "added": [
+        {
+            "package_manifest": {
+                "name": "1password",
+                "title": "1Password Events Reporting",
+                "version": "0.3.0",
+                "release": "beta",
+                "description": "Collect events from 1Password Events API with Elastic Agent.",
+                "type": "integration",
+                "download": "/epr/1password/1password-0.3.0.zip",
+                "path": "/package/1password/0.3.0",
+                "categories": ["security"],
+                "format_version": "1.0.0",
+                "conditions": {"kibana": {"version": "^7.16.0 || ^8.0.0"}},
+                "owner": {"github": "elastic/security-external-integrations"}
+            }
+        }
+    ],
+    "updated": [],
+    "removed": []
+}

--- a/storage/testdata/search-index-delta-remove.json
+++ b/storage/testdata/search-index-delta-remove.json
@@ -1,0 +1,7 @@
+{
+    "added": [],
+    "updated": [],
+    "removed": [
+        {"name": "1password", "version": "0.1.1"}
+    ]
+}

--- a/storage/testdata/search-index-delta-update-field-removal.json
+++ b/storage/testdata/search-index-delta-update-field-removal.json
@@ -1,0 +1,20 @@
+{
+    "added": [],
+    "updated": [
+        {
+            "package_manifest": {
+                "name": "1password",
+                "title": "1Password Events Reporting",
+                "version": "0.2.0",
+                "release": "beta",
+                "description": "Collect events from 1Password Events API with Elastic Agent.",
+                "type": "integration",
+                "download": "/epr/1password/1password-0.2.0.zip",
+                "path": "/package/1password/0.2.0",
+                "format_version": "1.0.0",
+                "group": "observability"
+            }
+        }
+    ],
+    "removed": []
+}

--- a/storage/testdata/search-index-delta-update.json
+++ b/storage/testdata/search-index-delta-update.json
@@ -1,0 +1,300 @@
+{
+    "added": [],
+    "updated": [
+        {
+            "package_manifest": {
+                "name": "1password",
+                "title": "1Password Events Reporting UPDATED DELTA",
+                "version": "0.2.0",
+                "release": "beta",
+                "description": "Collect events from 1Password Events API with Elastic Agent.",
+                "type": "integration",
+                "download": "/epr/1password/1password-0.2.0.zip",
+                "path": "/package/1password/0.2.0",
+                "icons": [
+                    {
+                        "src": "/img/1password-logo-light-bg.svg",
+                        "path": "/package/1password/0.2.0/img/1password-logo-light-bg.svg",
+                        "title": "1Password",
+                        "size": "116x116",
+                        "type": "image/svg+xml"
+                    }
+                ],
+                "conditions": {
+                    "kibana": {
+                        "version": "^7.16.0 || ^8.0.0"
+                    }
+                },
+                "owner": {
+                    "github": "elastic/security-external-integrations"
+                },
+                "categories": [
+                    "security"
+                ],
+                "format_version": "1.0.0",
+                "readme": "/package/1password/0.2.0/docs/README.md",
+                "license": "basic",
+                "screenshots": [
+                    {
+                        "src": "/img/1password-signinattempts-screenshot.png",
+                        "path": "/package/1password/0.2.0/img/1password-signinattempts-screenshot.png",
+                        "title": "Sign-in attempts",
+                        "size": "1918x963",
+                        "type": "image/png"
+                    },
+                    {
+                        "src": "/img/1password-itemusages-screenshot.png",
+                        "path": "/package/1password/0.2.0/img/1password-itemusages-screenshot.png",
+                        "title": "Item usages",
+                        "size": "1916x965",
+                        "type": "image/png"
+                    }
+                ],
+                "assets": [
+                    "/package/1password/0.2.0/changelog.yml",
+                    "/package/1password/0.2.0/manifest.yml",
+                    "/package/1password/0.2.0/docs/README.md",
+                    "/package/1password/0.2.0/img/1password-itemusages-screenshot.png",
+                    "/package/1password/0.2.0/img/1password-logo-light-bg.svg",
+                    "/package/1password/0.2.0/img/1password-signinattempts-screenshot.png",
+                    "/package/1password/0.2.0/data_stream/item_usages/manifest.yml",
+                    "/package/1password/0.2.0/data_stream/item_usages/sample_event.json",
+                    "/package/1password/0.2.0/data_stream/signin_attempts/manifest.yml",
+                    "/package/1password/0.2.0/data_stream/signin_attempts/sample_event.json",
+                    "/package/1password/0.2.0/kibana/dashboard/1password-item-usages-full-dashboard.json",
+                    "/package/1password/0.2.0/kibana/dashboard/1password-signin-attempts-full-dashboard.json",
+                    "/package/1password/0.2.0/kibana/map/1password-item-usages-source-IPs-map.json",
+                    "/package/1password/0.2.0/kibana/map/1password-signin-attempts-source-IPs-map.json",
+                    "/package/1password/0.2.0/kibana/search/1password-all-events.json",
+                    "/package/1password/0.2.0/kibana/search/1password-item-usages.json",
+                    "/package/1password/0.2.0/kibana/search/1password-signin-attempts.json",
+                    "/package/1password/0.2.0/kibana/visualization/1password-item-usages-hot-items.json",
+                    "/package/1password/0.2.0/kibana/visualization/1password-item-usages-hot-users.json",
+                    "/package/1password/0.2.0/kibana/visualization/1password-item-usages-hot-vaults.json",
+                    "/package/1password/0.2.0/kibana/visualization/1password-item-usages-over-time.json",
+                    "/package/1password/0.2.0/kibana/visualization/1password-signin-attempts-categories-over-time.json",
+                    "/package/1password/0.2.0/kibana/visualization/1password-signin-attempts-count-over-time.json",
+                    "/package/1password/0.2.0/kibana/visualization/1password-signin-attempts-failed-gauge.json",
+                    "/package/1password/0.2.0/kibana/visualization/1password-signin-attempts-hot-users.json",
+                    "/package/1password/0.2.0/data_stream/item_usages/fields/base-fields.yml",
+                    "/package/1password/0.2.0/data_stream/item_usages/fields/ecs.yml",
+                    "/package/1password/0.2.0/data_stream/item_usages/fields/fields.yml",
+                    "/package/1password/0.2.0/data_stream/signin_attempts/fields/base-fields.yml",
+                    "/package/1password/0.2.0/data_stream/signin_attempts/fields/ecs.yml",
+                    "/package/1password/0.2.0/data_stream/signin_attempts/fields/fields.yml",
+                    "/package/1password/0.2.0/data_stream/item_usages/agent/stream/httpjson.yml.hbs",
+                    "/package/1password/0.2.0/data_stream/item_usages/elasticsearch/ingest_pipeline/default.yml",
+                    "/package/1password/0.2.0/data_stream/signin_attempts/agent/stream/httpjson.yml.hbs",
+                    "/package/1password/0.2.0/data_stream/signin_attempts/elasticsearch/ingest_pipeline/default.yml"
+                ],
+                "policy_templates": [
+                    {
+                        "name": "1password",
+                        "title": "1Password Events",
+                        "description": "Collect events from 1Password Events Reporting",
+                        "inputs": [
+                            {
+                                "type": "httpjson",
+                                "vars": [
+                                    {
+                                        "name": "url",
+                                        "type": "text",
+                                        "title": "URL of 1Password Events API Server",
+                                        "description": "options: https://events.1password.com, https://events.1password.ca, https://events.1password.eu, https://events.ent.1password.com. path is automatic\n",
+                                        "multi": false,
+                                        "required": true,
+                                        "show_user": true,
+                                        "default": "https://events.1password.com"
+                                    },
+                                    {
+                                        "name": "token",
+                                        "type": "password",
+                                        "title": "1Password Authorization Token",
+                                        "description": "Bearer Token, e.g. \"eyJhbGciO...\"\n",
+                                        "multi": false,
+                                        "required": true,
+                                        "show_user": true
+                                    },
+                                    {
+                                        "name": "http_client_timeout",
+                                        "type": "text",
+                                        "title": "HTTP Client Timeout",
+                                        "multi": false,
+                                        "required": false,
+                                        "show_user": true
+                                    },
+                                    {
+                                        "name": "proxy_url",
+                                        "type": "text",
+                                        "title": "Proxy URL",
+                                        "description": "URL to proxy connections in the form of http[s]://<user>:<password>@<server name/ip>:<port>",
+                                        "multi": false,
+                                        "required": false,
+                                        "show_user": false
+                                    },
+                                    {
+                                        "name": "ssl",
+                                        "type": "yaml",
+                                        "title": "SSL Configuration",
+                                        "description": "i.e. certificate_authorities, supported_protocols, verification_mode etc.",
+                                        "multi": false,
+                                        "required": false,
+                                        "show_user": false
+                                    }
+                                ],
+                                "title": "Collect events from 1Password Events API",
+                                "description": "Collect sign-in attempt and item usages from 1Password via the 1Password Events API"
+                            }
+                        ],
+                        "multiple": true
+                    }
+                ],
+                "data_streams": [
+                    {
+                        "type": "logs",
+                        "dataset": "1password.item_usages",
+                        "title": "Collect 1Password item usages events",
+                        "release": "beta",
+                        "ingest_pipeline": "default",
+                        "streams": [
+                            {
+                                "input": "httpjson",
+                                "vars": [
+                                    {
+                                        "name": "limit",
+                                        "type": "integer",
+                                        "title": "Limit",
+                                        "description": "Number of events to fetch on each request",
+                                        "multi": false,
+                                        "required": true,
+                                        "show_user": false,
+                                        "default": 1000
+                                    },
+                                    {
+                                        "name": "interval",
+                                        "type": "text",
+                                        "title": "Interval to query 1Password Events API",
+                                        "description": "Go Duration syntax (eg. 10s)",
+                                        "multi": false,
+                                        "required": true,
+                                        "show_user": false,
+                                        "default": "10s"
+                                    },
+                                    {
+                                        "name": "tags",
+                                        "type": "text",
+                                        "title": "Tags",
+                                        "multi": true,
+                                        "required": false,
+                                        "show_user": false,
+                                        "default": [
+                                            "forwarded",
+                                            "1password-item_usages"
+                                        ]
+                                    },
+                                    {
+                                        "name": "preserve_original_event",
+                                        "type": "bool",
+                                        "title": "Preserve original event",
+                                        "description": "Preserves a raw copy of the original event, added to the field `event.original`",
+                                        "multi": false,
+                                        "required": true,
+                                        "show_user": true,
+                                        "default": false
+                                    },
+                                    {
+                                        "name": "processors",
+                                        "type": "yaml",
+                                        "title": "Processors",
+                                        "description": "Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.",
+                                        "multi": false,
+                                        "required": false,
+                                        "show_user": false
+                                    }
+                                ],
+                                "template_path": "httpjson.yml.hbs",
+                                "title": "Collect 1Password item usages events",
+                                "description": "Collect item usages from 1Password via the 1Password Events API",
+                                "enabled": true
+                            }
+                        ],
+                        "package": "1password",
+                        "path": "item_usages"
+                    },
+                    {
+                        "type": "logs",
+                        "dataset": "1password.signin_attempts",
+                        "title": "1Password sign-in attempt events",
+                        "release": "beta",
+                        "ingest_pipeline": "default",
+                        "streams": [
+                            {
+                                "input": "httpjson",
+                                "vars": [
+                                    {
+                                        "name": "limit",
+                                        "type": "integer",
+                                        "title": "Limit",
+                                        "description": "Number of events to fetch on each request",
+                                        "multi": false,
+                                        "required": true,
+                                        "show_user": false,
+                                        "default": 1000
+                                    },
+                                    {
+                                        "name": "interval",
+                                        "type": "text",
+                                        "title": "Interval to query 1Password Events API",
+                                        "description": "Go Duration syntax (eg. 10s)",
+                                        "multi": false,
+                                        "required": true,
+                                        "show_user": false,
+                                        "default": "10s"
+                                    },
+                                    {
+                                        "name": "tags",
+                                        "type": "text",
+                                        "title": "Tags",
+                                        "multi": true,
+                                        "required": false,
+                                        "show_user": false,
+                                        "default": [
+                                            "forwarded",
+                                            "1password-signin_attempts"
+                                        ]
+                                    },
+                                    {
+                                        "name": "preserve_original_event",
+                                        "type": "bool",
+                                        "title": "Preserve original event",
+                                        "description": "Preserves a raw copy of the original event, added to the field `event.original`",
+                                        "multi": false,
+                                        "required": true,
+                                        "show_user": true,
+                                        "default": false
+                                    },
+                                    {
+                                        "name": "processors",
+                                        "type": "yaml",
+                                        "title": "Processors",
+                                        "description": "Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.",
+                                        "multi": false,
+                                        "required": false,
+                                        "show_user": false
+                                    }
+                                ],
+                                "template_path": "httpjson.yml.hbs",
+                                "title": "Collect 1Password sign-in attempt events",
+                                "description": "Collect sign-in attempts from 1Password via the 1Password Events API",
+                                "enabled": true
+                            }
+                        ],
+                        "package": "1password",
+                        "path": "signin_attempts"
+                    }
+                ]
+            }
+        }
+    ],
+    "removed": []
+}


### PR DESCRIPTION
Resolves https://github.com/elastic/package-registry/issues/1527

## Summary

Adds support for incremental package index updates in the in-memory `storage.Indexer`.
Instead of downloading and replacing the full `search-index-all.json` on every poll
cycle, the indexer can now apply a series of small `search-index-delta.json` files
that describe only what changed (packages added, updated, or removed).

The feature is off by default. Existing behaviour is fully preserved.

## What changed

### New flag

```
--feature-incremental-updates   (env: EPR_FEATURE_INCREMENTAL_UPDATES)
```

Default `false`. When `true`, the storage indexer uses the incremental path for every
poll cycle after the first full sync on startup. A warning is logged at startup when
the flag is enabled so it always appears in container logs.

### New GCS file: `v2/metadata/<revision>/search-index-delta.json`

```json
{
  "added":   [{ ...full package... }],
  "updated": [{ ...full package... }],
  "removed": [{ "name": "pkg", "version": "1.0.0" }]
}
```

`updated` entries must be the **complete** package representation, not a partial patch —
`applyDelta` does a full replacement by key, not a field merge.

### Poll flow

```
startup / cursor == ""     → full sync from search-index-all.json  (unchanged)
flag off                   → full sync from search-index-all.json  (unchanged)

flag on, cursor set:
  read cursor.json         → latest revision
  cursor unchanged         → skip (unchanged)
  list v2/metadata/ folders between current cursor and latest (ascending)
  for each revision:
    delta file present     → applyDelta (add / update / remove entries in memory)
    delta file missing     → warn + fall back to full sync for that revision
  update cursor
```

### `applyDelta` implementation

Rather than building a full `map[string]*Package` over all N in-memory packages
(the obvious approach, which causes a 3× transient memory peak), `applyDelta`:

1. Builds two small maps sized to the delta entries only (`removeKeys`, `updateMap`).
2. Does a single pass over the existing `packageList`, writing into a fresh backing
   array (allocated at the same capacity), filtering out removed packages and
   applying updates.
3. Appends added packages at the end of the new backing array.

Peak memory during a delta application is ~2× steady-state at peak (old array read,
new array being built), avoiding the full 3× (old slice + full map + new slice) of
the naïve approach.

### Out of scope

`SQLIndexer` is not changed — it uses a full DB-swap strategy and incremental updates
would require separate database-level operations. It continues to do full-swap loads
regardless of the flag.

## How this was tested

### Unit tests

```bash
go test ./internal/storage/... ./storage/... -run TestIncrementalUpdate -v
```

10 sub-tests covering: add, remove, update, update is full replacement (not a field
merge), multiple deltas in order, flag-off falls back to full sync, same cursor skips,
startup always full syncs, missing delta falls back to full sync for that revision,
concurrent get-and-apply-delta (race detector clean).

### Benchmarks — full sync vs incremental, against the full 1139-package index

```bash
go test ./storage/... -run='^$' -bench='^BenchmarkIndexerUpdateIndex' -benchmem -benchtime=5s
```

Results on Apple M4 Pro:

```
BenchmarkIndexerUpdateIndex-12                28   202 ms/op   101 MB/op   482 K allocs/op
BenchmarkIndexerUpdateIndex_Incremental-12  25926   574 µs/op   137 KB/op     815 allocs/op
```

**~351× faster and ~738× less memory per poll cycle.**

The 815 allocs/op in the incremental case are dominated by the fake-GCS HTTP
round-trip and JSON decode. `applyDelta` itself contributes only a handful of
allocs (two small maps + the delta entries), scaling with delta size rather
than index size.

### End-to-end with Docker (fake GCS server)

Started the fake GCS server via `dev/docker-compose-gcs.yml` and ran the registry
locally with:

```bash
STORAGE_EMULATOR_HOST=localhost:4443 \
EPR_FEATURE_STORAGE_INDEXER=true \
EPR_FEATURE_INCREMENTAL_UPDATES=true \
EPR_STORAGE_INDEXER_BUCKET_INTERNAL="gs://fake-package-storage-internal" \
EPR_STORAGE_INDEXER_WATCH_INTERVAL=10s \
EPR_CONFIG=config.docker.yml \
go run .
```

Delta files were pushed via the fake GCS JSON API and verified against the `/search`
endpoint within the watch interval — no restart required. All three delta operations
(add, remove, update) produced the correct response.

## Additional optimizations included

### O(N²) → O(N) in `Filter.Apply` and `legacyApply`

The "keep only the latest version per package name" dedup pass inside `Filter.Apply`
(and `legacyApply` for legacy clients) previously scanned the growing result slice with
an inner loop for every incoming package — O(N²) over the number of distinct package
names, hit on every API request.

Replaced with a `map[string]int` (name → index in result slice) so each lookup is O(1)
and the full pass is O(N). Also pre-sized the result slices in `Apply`, `legacyApply`,
and `filterCategories` to eliminate grow-reallocations.

Benchmarks (Apple M4 Pro, `-count=6`, `benchstat` p=0.002):

| Scale | Before | After | Change |
|---|---|---|---|
| 100 package names × 5 versions | 42 µs | 11 µs | −74% |
| 500 × 5 | 1,059 µs | 57 µs | −95% |
| 1,000 × 5 | 4,359 µs | 110 µs | −97% |
| 2,000 × 5 | 18,754 µs | 220 µs | −99% |

The widening gap confirms the quadratic behaviour of the old code: 10× more package
names cost ~100× more CPU. The new code scales linearly.

## Known limitations / open questions

- **`SQLIndexer`**: incremental updates are out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)