### PR TITLE
Rename ingest-fp team reference to Streams

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -11,7 +11,7 @@ metadata:
 
 spec:
   type: buildkite-pipeline
-  owner: group:Streams
+  owner: group:streams
   system: platform-ingest
   implementation:
     apiVersion: buildkite.elastic.dev/v1
@@ -39,7 +39,7 @@ spec:
       teams:
         ecosystem:
           access_level: MANAGE_BUILD_AND_READ
-        Streams:
+        streams:
           access_level: MANAGE_BUILD_AND_READ
         everyone:
           access_level: READ_ONLY
@@ -53,7 +53,7 @@ metadata:
 
 spec:
   type: tool
-  owner: group:Streams
+  owner: group:streams
   system: platform-ingest
   lifecycle: production
 
@@ -70,7 +70,7 @@ metadata:
 
 spec:
   type: buildkite-pipeline
-  owner: group:Streams
+  owner: group:streams
   system: platform-ingest
   implementation:
     apiVersion: buildkite.elastic.dev/v1
@@ -95,7 +95,7 @@ spec:
       teams:
         ecosystem:
           access_level: MANAGE_BUILD_AND_READ
-        Streams:
+        streams:
           access_level: MANAGE_BUILD_AND_READ
         everyone:
           access_level: READ_ONLY

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -11,7 +11,7 @@ metadata:
 
 spec:
   type: buildkite-pipeline
-  owner: group:ingest-fp
+  owner: group:Streams
   system: platform-ingest
   implementation:
     apiVersion: buildkite.elastic.dev/v1
@@ -39,7 +39,7 @@ spec:
       teams:
         ecosystem:
           access_level: MANAGE_BUILD_AND_READ
-        ingest-fp:
+        Streams:
           access_level: MANAGE_BUILD_AND_READ
         everyone:
           access_level: READ_ONLY
@@ -53,7 +53,7 @@ metadata:
 
 spec:
   type: tool
-  owner: group:ingest-fp
+  owner: group:Streams
   system: platform-ingest
   lifecycle: production
 
@@ -70,7 +70,7 @@ metadata:
 
 spec:
   type: buildkite-pipeline
-  owner: group:ingest-fp
+  owner: group:Streams
   system: platform-ingest
   implementation:
     apiVersion: buildkite.elastic.dev/v1
@@ -95,7 +95,7 @@ spec:
       teams:
         ecosystem:
           access_level: MANAGE_BUILD_AND_READ
-        ingest-fp:
+        Streams:
           access_level: MANAGE_BUILD_AND_READ
         everyone:
           access_level: READ_ONLY


### PR DESCRIPTION
Catches up catalog-info.yaml to the GitHub team's actual current name (ingest-fp was renamed to Streams).