### PR TITLE
chore: group golang.org/x/* dependabot updates into one PR per module

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,9 @@ updates:
       opentelemetry:
         patterns:
           - "go.opentelemetry.io/*"
+      golang-x:
+        patterns:
+          - "golang.org/x/*"
   - package-ecosystem: "gomod"
     directory: "/cmd/distribution"
     schedule:
@@ -26,3 +29,7 @@ updates:
     open-pull-requests-limit: 10
     allow:
       - dependency-type: "all" # Also indirect dependencies.
+    groups:
+      golang-x:
+        patterns:
+          - "golang.org/x/*"


### PR DESCRIPTION
When golang tools is updated, multiple prs are opened with changes already covered under the tools pr. this setting groups the deps into a single pr