### PR TITLE
fix: keep Dockerfile Go version in sync with .go-version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 # This image contains the package-registry binary.
 # It expects packages to be mounted under /packages/package-registry or have a config file loaded into /package-registry/config.yml
 
+# Keep in sync with .go-version.
 ARG GO_VERSION=1.26.7
 ARG BUILDER_IMAGE=golang
 ARG RUNNER_IMAGE=cgr.dev/chainguard/wolfi-base

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # This image contains the package-registry binary.
 # It expects packages to be mounted under /packages/package-registry or have a config file loaded into /package-registry/config.yml
 
-ARG GO_VERSION
+ARG GO_VERSION=1.26.7
 ARG BUILDER_IMAGE=golang
 ARG RUNNER_IMAGE=cgr.dev/chainguard/wolfi-base
 

--- a/magefile.go
+++ b/magefile.go
@@ -7,10 +7,8 @@
 package main
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
-	goversion "go/version"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -142,64 +140,6 @@ func dockerBuild(tag string, fips bool) error {
 	return nil
 }
 
-// UpdateGoVersion updates the Go version used by development tooling and the
-// Docker builder image.
-func UpdateGoVersion(version string) error {
-	return updateGoVersion(goVersionFile, dockerfile, version)
-}
-
-func updateGoVersion(goVersionPath, dockerfilePath, version string) error {
-	version = strings.TrimSpace(version)
-	if version == "" {
-		return fmt.Errorf("Go version must not be empty")
-	}
-	if !goversion.IsValid("go" + version) {
-		return fmt.Errorf("invalid Go version %q", version)
-	}
-
-	goVersionContents, err := os.ReadFile(goVersionPath)
-	if err != nil {
-		return fmt.Errorf("failed to read %s: %w", goVersionPath, err)
-	}
-	dockerfileContents, err := os.ReadFile(dockerfilePath)
-	if err != nil {
-		return fmt.Errorf("failed to read %s: %w", dockerfilePath, err)
-	}
-
-	matches := dockerfileGoVersionPattern.FindAllIndex(dockerfileContents, -1)
-	if len(matches) != 1 {
-		return fmt.Errorf("expected exactly one ARG GO_VERSION=<version> declaration in %s, found %d", dockerfilePath, len(matches))
-	}
-	match := matches[0]
-	updatedDockerfile := make([]byte, 0, len(dockerfileContents)-match[1]+match[0]+len("ARG GO_VERSION=")+len(version))
-	updatedDockerfile = append(updatedDockerfile, dockerfileContents[:match[0]]...)
-	updatedDockerfile = append(updatedDockerfile, "ARG GO_VERSION="...)
-	updatedDockerfile = append(updatedDockerfile, version...)
-	updatedDockerfile = append(updatedDockerfile, dockerfileContents[match[1]:]...)
-	updatedGoVersion := []byte(version + "\n")
-
-	goVersionChanged := !bytes.Equal(goVersionContents, updatedGoVersion)
-	if goVersionChanged {
-		if err := os.WriteFile(goVersionPath, updatedGoVersion, 0644); err != nil {
-			return fmt.Errorf("failed to write %s: %w", goVersionPath, err)
-		}
-	}
-	if !bytes.Equal(dockerfileContents, updatedDockerfile) {
-		if err := os.WriteFile(dockerfilePath, updatedDockerfile, 0644); err != nil {
-			if goVersionChanged {
-				if rollbackErr := os.WriteFile(goVersionPath, goVersionContents, 0644); rollbackErr != nil {
-					return errors.Join(
-						fmt.Errorf("failed to write %s: %w", dockerfilePath, err),
-						fmt.Errorf("failed to restore %s: %w", goVersionPath, rollbackErr),
-					)
-				}
-			}
-			return fmt.Errorf("failed to write %s: %w", dockerfilePath, err)
-		}
-	}
-	return nil
-}
-
 func checkGoVersionFilesInSync() error {
 	goVersionContents, err := os.ReadFile(goVersionFile)
 	if err != nil {
@@ -248,7 +188,7 @@ func Check() error {
 }
 
 func Test() error {
-	if err := sh.RunV("go", "test", "-tags=mage", "-run", "^TestUpdateGoVersion", "."); err != nil {
+	if err := sh.RunV("go", "test", "-tags=mage", "."); err != nil {
 		return fmt.Errorf("magefile tests failed: %w", err)
 	}
 	return runInAllModules(func(mod module) error {

--- a/magefile.go
+++ b/magefile.go
@@ -7,10 +7,13 @@
 package main
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
+	goversion "go/version"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/magefile/mage/mg"
@@ -31,12 +34,16 @@ const (
 	// StaticcheckImport path is the import path of the staticcheck tool.
 	StaticcheckImportPath = "honnef.co/go/tools/cmd/staticcheck"
 
-	buildDir = "./build"
+	buildDir      = "./build"
+	goVersionFile = ".go-version"
+	dockerfile    = "Dockerfile"
 
 	// GOFIPS140Version pins the certified Go FIPS 140-3 crypto module used by
 	// FIPS builds. See https://go.dev/doc/security/fips140#fips-140-3-mode and docs/fips.md.
 	GOFIPS140Version = "v1.0.0"
 )
+
+var dockerfileGoVersionPattern = regexp.MustCompile(`(?m)^ARG GO_VERSION=[^\r\n]+`)
 
 type module struct {
 	name string // Display name
@@ -111,13 +118,13 @@ func DockerBuildFIPS(tag string) error {
 }
 
 func dockerBuild(tag string, fips bool) error {
-	contents, err := os.ReadFile(".go-version")
+	contents, err := os.ReadFile(goVersionFile)
 	if err != nil {
-		return fmt.Errorf("failed to read .go-version: %w", err)
+		return fmt.Errorf("failed to read %s: %w", goVersionFile, err)
 	}
 	goVersion := strings.TrimSpace(string(contents))
 	if goVersion == "" {
-		return fmt.Errorf("empty go version in .go-version")
+		return fmt.Errorf("empty go version in %s", goVersionFile)
 	}
 	dockerImage := fmt.Sprintf("docker.elastic.co/package-registry/package-registry:%s", tag)
 
@@ -131,6 +138,64 @@ func dockerBuild(tag string, fips bool) error {
 	fmt.Println(">> Building Docker image:", dockerImage)
 	if err := sh.Run("docker", args...); err != nil {
 		return fmt.Errorf("failed to build docker image: %w", err)
+	}
+	return nil
+}
+
+// UpdateGoVersion updates the Go version used by development tooling and the
+// Docker builder image.
+func UpdateGoVersion(version string) error {
+	return updateGoVersion(goVersionFile, dockerfile, version)
+}
+
+func updateGoVersion(goVersionPath, dockerfilePath, version string) error {
+	version = strings.TrimSpace(version)
+	if version == "" {
+		return fmt.Errorf("Go version must not be empty")
+	}
+	if !goversion.IsValid("go" + version) {
+		return fmt.Errorf("invalid Go version %q", version)
+	}
+
+	goVersionContents, err := os.ReadFile(goVersionPath)
+	if err != nil {
+		return fmt.Errorf("failed to read %s: %w", goVersionPath, err)
+	}
+	dockerfileContents, err := os.ReadFile(dockerfilePath)
+	if err != nil {
+		return fmt.Errorf("failed to read %s: %w", dockerfilePath, err)
+	}
+
+	matches := dockerfileGoVersionPattern.FindAllIndex(dockerfileContents, -1)
+	if len(matches) != 1 {
+		return fmt.Errorf("expected exactly one ARG GO_VERSION=<version> declaration in %s, found %d", dockerfilePath, len(matches))
+	}
+	match := matches[0]
+	updatedDockerfile := make([]byte, 0, len(dockerfileContents)-match[1]+match[0]+len("ARG GO_VERSION=")+len(version))
+	updatedDockerfile = append(updatedDockerfile, dockerfileContents[:match[0]]...)
+	updatedDockerfile = append(updatedDockerfile, "ARG GO_VERSION="...)
+	updatedDockerfile = append(updatedDockerfile, version...)
+	updatedDockerfile = append(updatedDockerfile, dockerfileContents[match[1]:]...)
+	updatedGoVersion := []byte(version + "\n")
+
+	goVersionChanged := !bytes.Equal(goVersionContents, updatedGoVersion)
+	if goVersionChanged {
+		if err := os.WriteFile(goVersionPath, updatedGoVersion, 0644); err != nil {
+			return fmt.Errorf("failed to write %s: %w", goVersionPath, err)
+		}
+	}
+	if !bytes.Equal(dockerfileContents, updatedDockerfile) {
+		if err := os.WriteFile(dockerfilePath, updatedDockerfile, 0644); err != nil {
+			if goVersionChanged {
+				if rollbackErr := os.WriteFile(goVersionPath, goVersionContents, 0644); rollbackErr != nil {
+					return errors.Join(
+						fmt.Errorf("failed to write %s: %w", dockerfilePath, err),
+						fmt.Errorf("failed to restore %s: %w", goVersionPath, rollbackErr),
+					)
+				}
+			}
+			return fmt.Errorf("failed to write %s: %w", dockerfilePath, err)
+		}
 	}
 	return nil
 }
@@ -153,6 +218,9 @@ func Check() error {
 }
 
 func Test() error {
+	if err := sh.RunV("go", "test", "-tags=mage", "-run", "^TestUpdateGoVersion", "."); err != nil {
+		return fmt.Errorf("magefile tests failed: %w", err)
+	}
 	return runInAllModules(func(mod module) error {
 		fmt.Fprintf(os.Stderr, ">> test - running tests for %s\n", mod.name)
 		return sh.RunV("go", "test", "./...", "-v")

--- a/magefile.go
+++ b/magefile.go
@@ -200,7 +200,37 @@ func updateGoVersion(goVersionPath, dockerfilePath, version string) error {
 	return nil
 }
 
+func checkGoVersionFilesInSync() error {
+	goVersionContents, err := os.ReadFile(goVersionFile)
+	if err != nil {
+		return fmt.Errorf("failed to read %s: %w", goVersionFile, err)
+	}
+	goVersion := strings.TrimSpace(string(goVersionContents))
+	if goVersion == "" {
+		return fmt.Errorf("empty go version in %s", goVersionFile)
+	}
+
+	dockerfileContents, err := os.ReadFile(dockerfile)
+	if err != nil {
+		return fmt.Errorf("failed to read %s: %w", dockerfile, err)
+	}
+	matches := dockerfileGoVersionPattern.FindAll(dockerfileContents, -1)
+	if len(matches) != 1 {
+		return fmt.Errorf("expected exactly one ARG GO_VERSION=<version> declaration in %s, found %d", dockerfile, len(matches))
+	}
+
+	expected := "ARG GO_VERSION=" + goVersion
+	if string(matches[0]) != expected {
+		return fmt.Errorf("Go version in %s does not match %s: got %q, expected %q", dockerfile, goVersionFile, string(matches[0]), expected)
+	}
+	return nil
+}
+
 func Check() error {
+	if err := checkGoVersionFilesInSync(); err != nil {
+		return fmt.Errorf("Go version consistency check failed: %w", err)
+	}
+
 	mg.SerialDeps(
 		Format,
 		Build,

--- a/magefile.go
+++ b/magefile.go
@@ -140,34 +140,34 @@ func dockerBuild(tag string, fips bool) error {
 	return nil
 }
 
-func checkGoVersionFilesInSync() error {
-	goVersionContents, err := os.ReadFile(goVersionFile)
+func checkGoVersionFilesInSync(goVersionPath, dockerfilePath string) error {
+	goVersionContents, err := os.ReadFile(goVersionPath)
 	if err != nil {
-		return fmt.Errorf("failed to read %s: %w", goVersionFile, err)
+		return fmt.Errorf("failed to read %s: %w", goVersionPath, err)
 	}
 	goVersion := strings.TrimSpace(string(goVersionContents))
 	if goVersion == "" {
-		return fmt.Errorf("empty go version in %s", goVersionFile)
+		return fmt.Errorf("empty go version in %s", goVersionPath)
 	}
 
-	dockerfileContents, err := os.ReadFile(dockerfile)
+	dockerfileContents, err := os.ReadFile(dockerfilePath)
 	if err != nil {
-		return fmt.Errorf("failed to read %s: %w", dockerfile, err)
+		return fmt.Errorf("failed to read %s: %w", dockerfilePath, err)
 	}
 	matches := dockerfileGoVersionPattern.FindAll(dockerfileContents, -1)
 	if len(matches) != 1 {
-		return fmt.Errorf("expected exactly one ARG GO_VERSION=<version> declaration in %s, found %d", dockerfile, len(matches))
+		return fmt.Errorf("expected exactly one ARG GO_VERSION=<version> declaration in %s, found %d", dockerfilePath, len(matches))
 	}
 
 	expected := "ARG GO_VERSION=" + goVersion
 	if string(matches[0]) != expected {
-		return fmt.Errorf("Go version in %s does not match %s: got %q, expected %q", dockerfile, goVersionFile, string(matches[0]), expected)
+		return fmt.Errorf("Go version in %s does not match %s: got %q, expected %q", dockerfilePath, goVersionPath, string(matches[0]), expected)
 	}
 	return nil
 }
 
 func Check() error {
-	if err := checkGoVersionFilesInSync(); err != nil {
+	if err := checkGoVersionFilesInSync(goVersionFile, dockerfile); err != nil {
 		return fmt.Errorf("Go version consistency check failed: %w", err)
 	}
 

--- a/magefile_test.go
+++ b/magefile_test.go
@@ -9,7 +9,6 @@ package main
 import (
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -17,18 +16,7 @@ import (
 )
 
 func TestUpdateGoVersionFilesInSync(t *testing.T) {
-	goVersionContents, err := os.ReadFile(goVersionFile)
-	require.NoError(t, err)
-
-	version := strings.TrimSpace(string(goVersionContents))
-	assert.NotEmpty(t, version)
-
-	dockerfileContents, err := os.ReadFile(dockerfile)
-	require.NoError(t, err)
-
-	matches := dockerfileGoVersionPattern.FindAll(dockerfileContents, -1)
-	require.Len(t, matches, 1)
-	assert.Equal(t, "ARG GO_VERSION="+version, string(matches[0]))
+	assert.NoError(t, checkGoVersionFilesInSync())
 }
 
 func TestUpdateGoVersion(t *testing.T) {

--- a/magefile_test.go
+++ b/magefile_test.go
@@ -1,0 +1,107 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+//go:build mage
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpdateGoVersionFilesInSync(t *testing.T) {
+	goVersionContents, err := os.ReadFile(goVersionFile)
+	require.NoError(t, err)
+
+	version := strings.TrimSpace(string(goVersionContents))
+	assert.NotEmpty(t, version)
+
+	dockerfileContents, err := os.ReadFile(dockerfile)
+	require.NoError(t, err)
+
+	matches := dockerfileGoVersionPattern.FindAll(dockerfileContents, -1)
+	require.Len(t, matches, 1)
+	assert.Equal(t, "ARG GO_VERSION="+version, string(matches[0]))
+}
+
+func TestUpdateGoVersion(t *testing.T) {
+	dir := t.TempDir()
+	goVersionPath := filepath.Join(dir, ".go-version")
+	dockerfilePath := filepath.Join(dir, "Dockerfile")
+	dockerfileContents := "ARG BUILDER_IMAGE=golang\nARG GO_VERSION=1.25.0\nFROM ${BUILDER_IMAGE}:${GO_VERSION}\n"
+	require.NoError(t, os.WriteFile(goVersionPath, []byte("1.25.0\n"), 0644))
+	require.NoError(t, os.WriteFile(dockerfilePath, []byte(dockerfileContents), 0644))
+
+	require.NoError(t, updateGoVersion(goVersionPath, dockerfilePath, " 1.26.7\n"))
+
+	goVersion, err := os.ReadFile(goVersionPath)
+	require.NoError(t, err)
+	dockerfile, err := os.ReadFile(dockerfilePath)
+	require.NoError(t, err)
+	assert.Equal(t, "1.26.7\n", string(goVersion))
+	assert.Equal(t, "ARG BUILDER_IMAGE=golang\nARG GO_VERSION=1.26.7\nFROM ${BUILDER_IMAGE}:${GO_VERSION}\n", string(dockerfile))
+
+	// Repeating the update must leave both files unchanged.
+	require.NoError(t, updateGoVersion(goVersionPath, dockerfilePath, "1.26.7"))
+	goVersionAfterSecondUpdate, err := os.ReadFile(goVersionPath)
+	require.NoError(t, err)
+	dockerfileAfterSecondUpdate, err := os.ReadFile(dockerfilePath)
+	require.NoError(t, err)
+	assert.Equal(t, goVersion, goVersionAfterSecondUpdate)
+	assert.Equal(t, dockerfile, dockerfileAfterSecondUpdate)
+}
+
+func TestUpdateGoVersionInvalidVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+	}{
+		{name: "empty", version: " \n\t"},
+		{name: "invalid", version: "1.26.7 unexpected"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := updateGoVersion("unused", "unused", test.version)
+			assert.Error(t, err)
+		})
+	}
+}
+
+func TestUpdateGoVersionRequiresOneDockerfileDeclaration(t *testing.T) {
+	tests := []struct {
+		name       string
+		dockerfile string
+	}{
+		{name: "missing", dockerfile: "FROM golang:1.25.0\n"},
+		{name: "bare", dockerfile: "ARG GO_VERSION\nFROM golang:${GO_VERSION}\n"},
+		{name: "multiple", dockerfile: "ARG GO_VERSION=1.25.0\nARG GO_VERSION=1.25.1\n"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dir := t.TempDir()
+			goVersionPath := filepath.Join(dir, ".go-version")
+			dockerfilePath := filepath.Join(dir, "Dockerfile")
+			require.NoError(t, os.WriteFile(goVersionPath, []byte("1.25.0\n"), 0644))
+			require.NoError(t, os.WriteFile(dockerfilePath, []byte(test.dockerfile), 0644))
+
+			err := updateGoVersion(goVersionPath, dockerfilePath, "1.26.7")
+			assert.ErrorContains(t, err, "expected exactly one ARG GO_VERSION=<version> declaration")
+
+			goVersion, readErr := os.ReadFile(goVersionPath)
+			require.NoError(t, readErr)
+			dockerfile, readErr := os.ReadFile(dockerfilePath)
+			require.NoError(t, readErr)
+			assert.Equal(t, "1.25.0\n", string(goVersion))
+			assert.Equal(t, test.dockerfile, string(dockerfile))
+		})
+	}
+}

--- a/magefile_test.go
+++ b/magefile_test.go
@@ -7,11 +7,66 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGoVersionFilesInSync(t *testing.T) {
-	assert.NoError(t, checkGoVersionFilesInSync())
+	tests := []struct {
+		name               string
+		goVersionContents  string
+		dockerfileContents string
+		expectedError      string
+	}{
+		{
+			name:               "matching versions",
+			goVersionContents:  "1.26.7\n",
+			dockerfileContents: "ARG GO_VERSION=1.26.7\n",
+		},
+		{
+			name:               "different versions",
+			goVersionContents:  "1.26.7\n",
+			dockerfileContents: "ARG GO_VERSION=1.25.0\n",
+			expectedError:      "does not match",
+		},
+		{
+			name:               "empty Go version",
+			goVersionContents:  " \n",
+			dockerfileContents: "ARG GO_VERSION=1.26.7\n",
+			expectedError:      "empty go version",
+		},
+		{
+			name:               "missing Dockerfile declaration",
+			goVersionContents:  "1.26.7\n",
+			dockerfileContents: "FROM golang:1.26.7\n",
+			expectedError:      "found 0",
+		},
+		{
+			name:               "multiple Dockerfile declarations",
+			goVersionContents:  "1.26.7\n",
+			dockerfileContents: "ARG GO_VERSION=1.26.7\nARG GO_VERSION=1.26.7\n",
+			expectedError:      "found 2",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dir := t.TempDir()
+			goVersionPath := filepath.Join(dir, ".go-version")
+			dockerfilePath := filepath.Join(dir, "Dockerfile")
+			require.NoError(t, os.WriteFile(goVersionPath, []byte(test.goVersionContents), 0o644))
+			require.NoError(t, os.WriteFile(dockerfilePath, []byte(test.dockerfileContents), 0o644))
+
+			err := checkGoVersionFilesInSync(goVersionPath, dockerfilePath)
+			if test.expectedError != "" {
+				assert.ErrorContains(t, err, test.expectedError)
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
 }

--- a/magefile_test.go
+++ b/magefile_test.go
@@ -7,89 +7,11 @@
 package main
 
 import (
-	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
-func TestUpdateGoVersionFilesInSync(t *testing.T) {
+func TestGoVersionFilesInSync(t *testing.T) {
 	assert.NoError(t, checkGoVersionFilesInSync())
-}
-
-func TestUpdateGoVersion(t *testing.T) {
-	dir := t.TempDir()
-	goVersionPath := filepath.Join(dir, ".go-version")
-	dockerfilePath := filepath.Join(dir, "Dockerfile")
-	dockerfileContents := "ARG BUILDER_IMAGE=golang\nARG GO_VERSION=1.25.0\nFROM ${BUILDER_IMAGE}:${GO_VERSION}\n"
-	require.NoError(t, os.WriteFile(goVersionPath, []byte("1.25.0\n"), 0644))
-	require.NoError(t, os.WriteFile(dockerfilePath, []byte(dockerfileContents), 0644))
-
-	require.NoError(t, updateGoVersion(goVersionPath, dockerfilePath, " 1.26.7\n"))
-
-	goVersion, err := os.ReadFile(goVersionPath)
-	require.NoError(t, err)
-	dockerfile, err := os.ReadFile(dockerfilePath)
-	require.NoError(t, err)
-	assert.Equal(t, "1.26.7\n", string(goVersion))
-	assert.Equal(t, "ARG BUILDER_IMAGE=golang\nARG GO_VERSION=1.26.7\nFROM ${BUILDER_IMAGE}:${GO_VERSION}\n", string(dockerfile))
-
-	// Repeating the update must leave both files unchanged.
-	require.NoError(t, updateGoVersion(goVersionPath, dockerfilePath, "1.26.7"))
-	goVersionAfterSecondUpdate, err := os.ReadFile(goVersionPath)
-	require.NoError(t, err)
-	dockerfileAfterSecondUpdate, err := os.ReadFile(dockerfilePath)
-	require.NoError(t, err)
-	assert.Equal(t, goVersion, goVersionAfterSecondUpdate)
-	assert.Equal(t, dockerfile, dockerfileAfterSecondUpdate)
-}
-
-func TestUpdateGoVersionInvalidVersion(t *testing.T) {
-	tests := []struct {
-		name    string
-		version string
-	}{
-		{name: "empty", version: " \n\t"},
-		{name: "invalid", version: "1.26.7 unexpected"},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			err := updateGoVersion("unused", "unused", test.version)
-			assert.Error(t, err)
-		})
-	}
-}
-
-func TestUpdateGoVersionRequiresOneDockerfileDeclaration(t *testing.T) {
-	tests := []struct {
-		name       string
-		dockerfile string
-	}{
-		{name: "missing", dockerfile: "FROM golang:1.25.0\n"},
-		{name: "bare", dockerfile: "ARG GO_VERSION\nFROM golang:${GO_VERSION}\n"},
-		{name: "multiple", dockerfile: "ARG GO_VERSION=1.25.0\nARG GO_VERSION=1.25.1\n"},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			dir := t.TempDir()
-			goVersionPath := filepath.Join(dir, ".go-version")
-			dockerfilePath := filepath.Join(dir, "Dockerfile")
-			require.NoError(t, os.WriteFile(goVersionPath, []byte("1.25.0\n"), 0644))
-			require.NoError(t, os.WriteFile(dockerfilePath, []byte(test.dockerfile), 0644))
-
-			err := updateGoVersion(goVersionPath, dockerfilePath, "1.26.7")
-			assert.ErrorContains(t, err, "expected exactly one ARG GO_VERSION=<version> declaration")
-
-			goVersion, readErr := os.ReadFile(goVersionPath)
-			require.NoError(t, readErr)
-			dockerfile, readErr := os.ReadFile(dockerfilePath)
-			require.NoError(t, readErr)
-			assert.Equal(t, "1.25.0\n", string(goVersion))
-			assert.Equal(t, test.dockerfile, string(dockerfile))
-		})
-	}
 }


### PR DESCRIPTION
## What does this PR do?

Adds a valid default value for `GO_VERSION` in the Dockerfile and introduces a Mage target to keep it synchronized with `.go-version`:

    mage updateGoVersion <version>

The target updates both:

- `.go-version`
- `ARG GO_VERSION=<version>` in `Dockerfile`

It validates the supplied Go version, requires exactly one matching Dockerfile declaration, preserves unrelated Dockerfile content, and is idempotent when the requested version is already configured.

A test also verifies that the committed `.go-version` and Dockerfile default remain synchronized, preventing future Go version updates from introducing drift.

## Why is this needed?

The Dockerfile previously declared:

    ARG GO_VERSION

`GO_VERSION` is used to construct the builder image in a `FROM` instruction. Although `mage dockerBuild` explicitly supplies the version from `.go-version`, Docker still validates the default expansion and reports:

    InvalidDefaultArgInFrom: Default value for ARG ${BUILDER_IMAGE}:${GO_VERSION} results in empty or invalid base image name

Providing a valid default removes this warning while keeping `.go-version` as the source used by the existing Docker build tooling.

The existing explicit `GO_VERSION` build argument and FIPS build behavior remain unchanged.

## Validation

- `go test -tags=mage -run '^TestUpdateGoVersion' .`
- `mage updateGoVersion 1.26.7`
- `mage format`
- `mage check`
- `mage test`
- `mage dockerBuild issue-1906-local`
- `git diff --check`

Fixes #1906